### PR TITLE
Custom bound separators

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -253,9 +253,15 @@ class NERRegexModel(JavaModel, JavaMLWritable, JavaMLReadable, AnnotatorProperti
 
 
 class SentenceDetectorModel(AnnotatorTransformer):
-    model = Param(Params._dummy(),
-                  "model",
-                  "which SBD Approach to use")
+
+    customBounds = Param(Params._dummy(),
+                         "customBounds",
+                         "characters used to explicitly mark sentence bounds",
+                         typeConverter=TypeConverters.toListString)
+
+    def setCustomBounds(self, value):
+        self._set(customBounds=value)
+        return self
 
     @keyword_only
     def __init__(self):

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -164,7 +164,8 @@ class PragmaticSBDTestSpec(unittest.TestCase):
             .setOutputCol("document")
         sentence_detector = SentenceDetectorModel() \
             .setInputCols(["document"]) \
-            .setOutputCol("sentence")
+            .setOutputCol("sentence") \
+            .setCustomBounds(["%%"])
         assembled = document_assembler.transform(self.data)
         sentence_detector.transform(assembled).show()
 

--- a/src/main/scala/com/jsl/nlp/annotators/sbd/pragmatic/PragmaticContentFormatter.scala
+++ b/src/main/scala/com/jsl/nlp/annotators/sbd/pragmatic/PragmaticContentFormatter.scala
@@ -21,6 +21,20 @@ class PragmaticContentFormatter(text: String) {
   private var wip: String = text
 
   /**
+    * Arbitrarely mark bounds with user provided characters
+    * @return
+    */
+  def formatCustomBounds(chars: Array[String]): this.type = {
+
+    val factory = new RuleFactory(MATCH_ALL, REPLACE_ALL_WITH_SYMBOL)
+    chars.foreach(char => factory.addRule(char.r, s"split character: $char"))
+
+    wip = factory.transformWithSymbol(BREAK_INDICATOR, wip)
+
+    this
+  }
+
+  /**
     * Find simple lists
     * regex should match entire enumeration
     * prepend separation symbol

--- a/src/main/scala/com/jsl/nlp/annotators/sbd/pragmatic/PragmaticMethod.scala
+++ b/src/main/scala/com/jsl/nlp/annotators/sbd/pragmatic/PragmaticMethod.scala
@@ -13,12 +13,13 @@ import com.jsl.nlp.annotators.sbd.Sentence
   */
 class PragmaticMethod(useAbbreviations: Boolean = true) extends Serializable {
 
-  def extractBounds(content: String): Array[Sentence] = {
+  def extractBounds(content: String, customBounds: Array[String]): Array[Sentence] = {
     /** this is a hardcoded order of operations
       * considered to go from those most specific non-ambiguous cases
       * down to those that are more general and can easily be ambiguous
       */
     val symbolyzedData = new PragmaticContentFormatter(content)
+      .formatCustomBounds(customBounds)
       .formatLists
       .formatAbbreviations(useAbbreviations)
       .formatNumbers

--- a/src/test/scala/com/jsl/nlp/annotators/sbd/pragmatic/PragmaticApproachTestSpec.scala
+++ b/src/test/scala/com/jsl/nlp/annotators/sbd/pragmatic/PragmaticApproachTestSpec.scala
@@ -113,6 +113,11 @@ class PragmaticApproachTestSpec extends FlatSpec with PragmaticDetectionBehavior
     * https://github.com/diasks2/pragmatic_segmenter
     */
 
+  //Custom bounds test
+  val simpleCustomBoundsAns = Array("Here now", "This is Jimmy", "Stop me here.", "And here", "Goodbye")
+  val simpleCustomBounds = "Here now%%This is Jimmy%%Stop me here. And here%%Goodbye"
+  "an isolated pragmatic detector" should behave like isolatedPDReadAndMatchResult(simpleCustomBounds, simpleCustomBoundsAns, Array("%%"))
+
   //Simple period to end sentence
   val simplePeriodAns = Array("Hello World.", "My name is Jonas.")
   val simplePeriod = "Hello World. My name is Jonas."

--- a/src/test/scala/com/jsl/nlp/annotators/sbd/pragmatic/PragmaticDetectionBehaviors.scala
+++ b/src/test/scala/com/jsl/nlp/annotators/sbd/pragmatic/PragmaticDetectionBehaviors.scala
@@ -30,13 +30,11 @@ trait PragmaticDetectionBehaviors { this: FlatSpec =>
     (2 * precision * recall) / (precision + recall)
   }
 
-  def isolatedPDReadAndMatchResult(input: String, correctAnswer: Array[String]): Unit = {
-    require(input == correctAnswer.mkString(" "),
-      s"provided bad test input\ninput:\n$input\nand correct answer:\n${correctAnswer.mkString(" ")}\ndo not match?")
+  def isolatedPDReadAndMatchResult(input: String, correctAnswer: Array[String], customBounds: Array[String] = Array.empty[String]): Unit = {
     s"pragmatic boundaries detector with ${input.take(10)}...:" should
       s"successfully identify sentences as ${correctAnswer.take(1).take(10).mkString}..." in {
       val pragmaticApproach = new PragmaticMethod
-      val result = pragmaticApproach.extractBounds(input).map(_.content)
+      val result = pragmaticApproach.extractBounds(input, customBounds).map(_.content)
       val diffInResult = result.diff(correctAnswer)
       val diffInCorrect = correctAnswer.diff(result)
       assert(
@@ -46,10 +44,10 @@ trait PragmaticDetectionBehaviors { this: FlatSpec =>
     }
   }
 
-  def isolatedPDReadScore(input: String, correctAnswer: Array[String]): Unit = {
+  def isolatedPDReadScore(input: String, correctAnswer: Array[String], customBounds: Array[String] = Array.empty[String]): Unit = {
     s"boundaries prediction" should s"have an F1 score higher than 95%" in {
       val pragmaticApproach= new PragmaticMethod
-      val result = pragmaticApproach.extractBounds(input).map(_.content)
+      val result = pragmaticApproach.extractBounds(input, customBounds).map(_.content)
       val f1 = f1Score(result, correctAnswer)
       val unmatched = result.zip(correctAnswer).toMap.mapValues("\n"+_)
       info(s"F1 Score is: $f1")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds the possibility to set a parameter to define custom text that explicitly breaks up sentence
## Description
<!--- Describe your changes in detail -->
Simply change through spark params in a String Array form that is used by the RuleFactory to split through text manually.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Many user provided text, tended to have its own separator characters on their unstructured raw data. This helps with splitting out content.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests covering self provided separators and correct example combined with normal sentence breakers. No side effects known as this is just a new parameter in sentence detection
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
