### PR TITLE
- FIX BUG: DocumentAssembler was annotating with the wrong `end` field

### DIFF
--- a/src/main/scala/com/jsl/nlp/DocumentAssembler.scala
+++ b/src/main/scala/com/jsl/nlp/DocumentAssembler.scala
@@ -49,7 +49,7 @@ class DocumentAssembler(override val uid: String)
   override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
 
   private def assemble(text: String, metadata: Map[String, String]): Seq[Annotation] = {
-    Seq(Annotation(annotatorType, 0, text.length, metadata ++ Map(annotatorType -> text)))
+    Seq(Annotation(annotatorType, 0, text.length - 1, metadata ++ Map(annotatorType -> text)))
   }
 
   private def dfAssemble: UserDefinedFunction = udf {

--- a/src/test/scala/com/jsl/nlp/DocumentAssemblerTestSpec.scala
+++ b/src/test/scala/com/jsl/nlp/DocumentAssemblerTestSpec.scala
@@ -1,0 +1,25 @@
+package com.jsl.nlp
+
+import com.jsl.nlp._
+import org.scalatest._
+import org.apache.spark.sql.Row
+import scala.language.reflectiveCalls
+import Matchers._
+
+class DocumentAssemblerTestSpec extends FlatSpec {
+  def fixture = new {
+    val text = ContentProvider.englishPhrase
+    val df = AnnotatorBuilder.withDocumentAssembler(DataBuilder.basicDataBuild(text))
+    val assembledDoc = df
+      .select("document")
+      .collect
+      .flatMap { _.getSeq[Row](0) }
+      .map { Annotation(_) }
+  }
+
+  "A DocumentAssembler" should "annotate with the correct indexes" in {
+    val f = fixture
+    f.text.head should equal (f.text(f.assembledDoc.head.begin))
+    f.text.last should equal (f.text(f.assembledDoc.head.end))
+  }
+}


### PR DESCRIPTION
DocumentAssembler was indexing the `end` field with sentence.length instead of sentence.length - 1, which is wrong as the `begin` and `end` fields are zero based.

## Description
Bugfix with a accompanying test

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> 
Unknow bugs. Found while testing

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Added new test case for the DocumentAssembler
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
