### PR TITLE
Code improvements in ResourceHelper

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -354,9 +354,9 @@ class NorvigSweetingApproach(JavaEstimator, JavaMLWritable, JavaMLReadable, Anno
                      "training corpus path",
                      typeConverter=TypeConverters.toString)
 
-    corpusCol = Param(Params._dummy(),
-                       "corpusCol",
-                       "dataset col with text",
+    corpusFormat = Param(Params._dummy(),
+                       "corpusFormat",
+                       "dataset corpus format. txt or txtds allowed only",
                        typeConverter=TypeConverters.toString)
 
     slangPath = Param(Params._dummy(),
@@ -404,8 +404,8 @@ class NorvigSweetingApproach(JavaEstimator, JavaMLWritable, JavaMLReadable, Anno
         self._set(corpusPath=value)
         return self
 
-    def setCorpusCol(self, value):
-        self._set(corpusCol=value)
+    def setCorpusFormat(self, value):
+        self._set(corpusFormat=value)
         return self
 
     def setDictPath(self, value):

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -235,8 +235,8 @@ class PipelineTestSpec(unittest.TestCase):
         token_after_save = model.transform(self.data).select("token_views").take(1)[0].token_views.split("@")[2]
         lemma_after_save = model.transform(self.data).select("lemma_views").take(1)[0].lemma_views.split("@")[2]
         print(token_before_save)
-        assert token_before_save == "sad#0"
-        assert lemma_before_save == "unsad#0"
+        assert token_before_save == "sad"
+        assert lemma_before_save == "unsad"
         assert token_after_save == token_before_save
         assert lemma_after_save == lemma_before_save
         loaded_pipeline.fit(self.data).transform(self.data).show()

--- a/src/main/scala/com/jsl/nlp/Annotation.scala
+++ b/src/main/scala/com/jsl/nlp/Annotation.scala
@@ -77,7 +77,12 @@ object Annotation {
   /** dataframe annotation flatmap of metadata values */
   def flatten(vSep: String, aSep: String): UserDefinedFunction = {
     udf {
-      (annotations: Seq[Row]) => annotations.map(_.getMap[String, String](3).values.toList.mkString(vSep)).mkString(aSep)
+      (annotations: Seq[Row]) => annotations.map(r =>
+        r.getMap[String, String](3)
+          .getOrElse(
+            r.getString(0),
+            r.getMap[String, String](3).values.toList.mkString(vSep))
+      ).mkString(aSep)
     }
   }
 

--- a/src/main/scala/com/jsl/nlp/annotators/RegexTokenizer.scala
+++ b/src/main/scala/com/jsl/nlp/annotators/RegexTokenizer.scala
@@ -1,7 +1,9 @@
 package com.jsl.nlp.annotators
 
+import com.jsl.nlp.util.io.ResourceHelper
 import org.apache.spark.ml.param.Param
 import com.jsl.nlp.{Annotation, AnnotatorModel, AnnotatorType, DocumentAssembler}
+import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 
 import scala.util.matching.Regex

--- a/src/main/scala/com/jsl/nlp/annotators/pos/perceptron/PerceptronApproach.scala
+++ b/src/main/scala/com/jsl/nlp/annotators/pos/perceptron/PerceptronApproach.scala
@@ -1,16 +1,17 @@
 package com.jsl.nlp.annotators.pos.perceptron
 
+import java.io.File
+
 import com.jsl.nlp.AnnotatorApproach
-import com.jsl.nlp.annotators.RegexTokenizer
 import com.jsl.nlp.annotators.common.{TaggedSentence, TaggedWord}
-import com.jsl.nlp.annotators.sbd.pragmatic.SentenceDetectorModel
-import com.jsl.nlp.util.io.ResourceHelper
+import com.jsl.nlp.util.io.ResourceHelper.{SourceStream, pathIsDirectory}
+import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.spark.ml.param.{IntParam, Param}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.sql.Dataset
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.collection.mutable.{Map => MMap}
+import scala.collection.mutable.{ArrayBuffer, Map => MMap}
 import scala.util.Random
 
 /**
@@ -80,7 +81,7 @@ class PerceptronApproach(override val uid: String) extends AnnotatorApproach[Per
     /**
       * Generates TagBook, which holds all the word to tags mapping that are not ambiguous
       */
-    val taggedSentences: Array[TaggedSentence] = ResourceHelper.retrievePOSCorpus($(corpusPath))
+    val taggedSentences: Array[TaggedSentence] = PerceptronApproach.retrievePOSCorpus($(corpusPath))
     val taggedWordBook = buildTagBook(taggedSentences)
     /** finds all distinct tags and stores them */
     val classes = taggedSentences.flatMap(_.tags).distinct
@@ -139,10 +140,117 @@ class PerceptronApproach(override val uid: String) extends AnnotatorApproach[Per
 }
 object PerceptronApproach extends DefaultParamsReadable[PerceptronApproach] {
 
+  private val config: Config = ConfigFactory.load
+
   private[perceptron] val START = Array("-START-", "-START2-")
   private[perceptron] val END = Array("-END-", "-END2-")
 
   private[perceptron] val logger: Logger = LoggerFactory.getLogger("PerceptronTraining")
+
+  /**Standard splitter for general purpose sentences*/
+  private def wordTagSplitter(sentence: String, tagSeparator: Char):
+  Array[TaggedWord] = {
+    val taggedWords: ArrayBuffer[TaggedWord] = ArrayBuffer()
+    sentence.split("\\s+").foreach { token => {
+      val tagSplit: Array[String] = token.split('|').filter(_.nonEmpty)
+      if (tagSplit.length == 2) {
+        val word = tagSplit(0)
+        val tag = tagSplit(1)
+        taggedWords.append(TaggedWord(word, tag))
+      }
+    }}
+    taggedWords.toArray
+  }
+
+  /**
+    * Parses CORPUS for tagged sentences
+    * @param text String to process
+    * @param tagSeparator Separator for provided String
+    * @return A list of [[TaggedSentence]]
+    */
+  private def parsePOSCorpusFromText(
+                              text: String,
+                              tagSeparator: Char
+                            ): Array[TaggedSentence] = {
+    val sentences: ArrayBuffer[Array[TaggedWord]] = ArrayBuffer()
+    text.split("\n").filter(_.nonEmpty).foreach{sentence =>
+      sentences.append(wordTagSplitter(sentence, tagSeparator))
+    }
+    sentences.map(TaggedSentence(_)).toArray
+  }
+
+
+  /**
+    * Parses CORPUS for tagged sentence from any compiled source
+    * @param source for compiled corpuses, if any
+    * @param tagSeparator Tag separator for processing
+    * @return
+    */
+  private def parsePOSCorpusFromSource(
+                                        source: String,
+                                        tagSeparator: Char
+                                      ): Array[TaggedSentence] = {
+    val sourceStream = SourceStream(source)
+    val lines =
+      sourceStream.content.getLines()
+        .filter(_.nonEmpty)
+        .map(sentence => wordTagSplitter(sentence, tagSeparator))
+        .toArray
+    sourceStream.close()
+    lines.map(TaggedSentence(_))
+  }
+
+  /**
+    * Reads POS Corpus from an entire directory of compiled sources
+    * @param dirName compiled content only
+    * @param tagSeparator tag separator for all corpuses
+    * @param fileLimit limit of files to read. Can help clutter, overfitting
+    * @return
+    */
+  private def parsePOSCorpusFromDir(
+                                     dirName: String,
+                                     tagSeparator: Char,
+                                     fileLimit: Int
+                                   ): Array[TaggedSentence] = {
+    try {
+      new File(dirName).listFiles()
+        .take(fileLimit)
+        .flatMap(fileName => parsePOSCorpusFromSource(fileName.toString, tagSeparator))
+    } catch {
+      case _: NullPointerException =>
+        val sourceStream = SourceStream(dirName)
+        val res = sourceStream
+          .content
+          .getLines()
+          .take(fileLimit)
+          .flatMap(fileName => parsePOSCorpusFromSource(dirName + "/" + fileName, tagSeparator))
+          .toArray
+        sourceStream.close()
+        res
+    }
+  }
+
+  /**
+    * Retrieves Corpuses from configured compiled directory set in configuration
+    * @param fileLimit files limit to read
+    * @return TaggedSentences for POS training
+    */
+  private[perceptron] def retrievePOSCorpus(
+                                   posDirOrFilePath: String = "__default",
+                                   fileLimit: Int = 50
+                                 ): Array[TaggedSentence] = {
+    val dirOrFilePath = if (posDirOrFilePath == "__default") config.getString("nlp.posDict.dir") else posDirOrFilePath
+    val posFormat = config.getString("nlp.posDict.format")
+    val posSeparator = config.getString("nlp.posDict.separator").head
+    val result = {
+      if (pathIsDirectory(dirOrFilePath)) parsePOSCorpusFromDir(dirOrFilePath, posSeparator, fileLimit)
+      else parsePOSCorpusFromSource(dirOrFilePath, posSeparator)
+    }
+    if (result.isEmpty) throw new Exception("Empty corpus for POS")
+    result
+  }
+
+
 
   /**
     * Specific normalization rules for this POS Tagger to avoid unnecessary tagging

--- a/src/main/scala/com/jsl/nlp/annotators/sda/pragmatic/PragmaticScorer.scala
+++ b/src/main/scala/com/jsl/nlp/annotators/sda/pragmatic/PragmaticScorer.scala
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory
   * Scorer is a rule based implementation inspired on http://fjavieralba.com/basic-sentiment-analysis-with-python.html
   * Its strategy is to tag words by a dictionary in a sentence context, and later identify such context to get amplifiers
   */
-class PragmaticScorer(sentimentDict: Map[String, String] = ResourceHelper.retrieveSentimentDict()) extends Serializable {
+class PragmaticScorer(sentimentDict: Map[String, String] = SentimentDetectorModel.retrieveSentimentDict()) extends Serializable {
 
   private val logger = LoggerFactory.getLogger("PragmaticScorer")
 
@@ -103,6 +103,6 @@ object PragmaticScorer {
     new PragmaticScorer(javaSentimentDict.asScala.toMap)
   }
   def fromPath(overridePath: String) {
-    new PragmaticScorer(ResourceHelper.retrieveSentimentDict(overridePath))
+    new PragmaticScorer(SentimentDetectorModel.retrieveSentimentDict(overridePath))
   }
 }

--- a/src/main/scala/com/jsl/nlp/annotators/spell/norvig/NorvigSweetingApproach.scala
+++ b/src/main/scala/com/jsl/nlp/annotators/spell/norvig/NorvigSweetingApproach.scala
@@ -1,31 +1,28 @@
 package com.jsl.nlp.annotators.spell.norvig
 
-import com.jsl.nlp.annotators.{Normalizer, RegexTokenizer}
-import com.jsl.nlp.{AnnotatorApproach, DocumentAssembler, Finisher}
+import com.jsl.nlp.AnnotatorApproach
 import com.jsl.nlp.util.io.ResourceHelper
-import org.apache.spark.ml.Pipeline
 import org.apache.spark.ml.param.Param
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.sql.Dataset
-
-import scala.collection.mutable.{Map => MMap}
-
 
 class NorvigSweetingApproach(override val uid: String)
   extends AnnotatorApproach[NorvigSweetingModel]
     with NorvigSweetingParams {
 
   import com.jsl.nlp.AnnotatorType._
+  import com.jsl.nlp.util.io.ResourceFormat._
 
   override val description: String = "Spell checking algorithm inspired on Norvig model"
 
   val corpusPath = new Param[String](this, "corpusPath", "path to text corpus for learning")
-  val corpusCol = new Param[String](this, "corpusCol", "dataset corpus text column")
+  val corpusFormat = new Param[String](this, "corpusFormat", "dataset corpus format. txt or txtds allowed only")
   val dictPath = new Param[String](this, "dictPath", "path to dictionary of words")
   val slangPath = new Param[String](this, "slangPath", "path to custom dictionaries")
 
   setDefault(dictPath, "/spell/words.txt")
   setDefault(slangPath, "/spell/slangs.txt")
+  setDefault(corpusFormat, "TXT")
 
   setDefault(caseSensitive, false)
   setDefault(doubleVariants, false)
@@ -39,49 +36,24 @@ class NorvigSweetingApproach(override val uid: String)
 
   def setDictPath(value: String): this.type = set(dictPath, value)
 
-  def setCorpusCol(value: String): this.type = set(corpusCol, value)
+  def setCorpusFormat(value: String): this.type = set(corpusFormat, value)
 
   def setCorpusPath(value: String): this.type = set(corpusPath, value)
 
   def setSlangPath(value: String): this.type = set(slangPath, value)
 
-  private def datasetWordCount(dataset: Dataset[_]): Map[String, Int] = {
-    import dataset.sparkSession.implicits._
-    val wordCount = dataset.sparkSession.sparkContext.broadcast(MMap.empty[String, Int].withDefaultValue(0))
-    val documentAssembler = new DocumentAssembler()
-      .setInputCol($(corpusCol))
-    val tokenizer = new RegexTokenizer()
-      .setInputCols("document")
-      .setOutputCol("token")
-    val normalizer = new Normalizer()
-      .setInputCols("token")
-      .setOutputCol("normal")
-    val finisher = new Finisher()
-      .setInputCols("normal")
-      .setOutputCols("finished")
-      .setAnnotationSplitSymbol("--")
-    new Pipeline()
-      .setStages(Array(documentAssembler, tokenizer, normalizer, finisher))
-      .fit(dataset)
-      .transform(dataset)
-      .select("finished").as[String]
-      .foreach(text => text.split("--").foreach(t => {
-        wordCount.value(t) += 1
-      }))
-    val result = wordCount.value.toMap
-    wordCount.destroy()
-    result
-  }
-
   override def train(dataset: Dataset[_]): NorvigSweetingModel = {
-    val loadWords = ResourceHelper.wordCount($(dictPath), "txt")
+    val loadWords = ResourceHelper.wordCount($(dictPath), TXT)
     val corpusWordCount =
       if (get(corpusPath).isDefined) {
-        ResourceHelper.wordCount($(corpusPath), "txt")
-      } else if (get(corpusCol).isDefined) {
-        datasetWordCount(dataset)
-      }
-      else {
+        if ($(corpusFormat).toLowerCase == "txt") {
+          ResourceHelper.wordCount($(corpusPath), TXT)
+        } else if ($(corpusFormat).toLowerCase == "txtds") {
+          ResourceHelper.wordCount($(corpusPath), TXTDS)
+        } else {
+          throw new Exception("Unsupported corpusFormat. Must be txt or txtds")
+        }
+      } else {
       Map.empty[String, Int]
       }
     val loadSlangs = ResourceHelper.parseKeyValueText($(slangPath), "txt", ",")

--- a/src/main/scala/com/jsl/nlp/util/io/ResourceFormat.scala
+++ b/src/main/scala/com/jsl/nlp/util/io/ResourceFormat.scala
@@ -1,0 +1,12 @@
+package com.jsl.nlp.util.io
+
+object ResourceFormat extends Enumeration {
+  implicit def str2frmt(v: String): Format = {
+    if (v.toUpperCase == TXT.toString) TXT
+    else if (v.toUpperCase == TXTDS.toString) TXTDS
+    else if (v.toUpperCase == PARQUET.toString) PARQUET
+    else throw new Exception("Unsupported format type")
+  }
+  type Format = Value
+  val TXT, TXTDS, PARQUET = Value
+}

--- a/src/test/scala/com/jsl/nlp/annotators/pos/perceptron/PerceptronApproachBehaviors.scala
+++ b/src/test/scala/com/jsl/nlp/annotators/pos/perceptron/PerceptronApproachBehaviors.scala
@@ -15,7 +15,7 @@ trait PerceptronApproachBehaviors { this: FlatSpec =>
 
   def isolatedPerceptronTraining(trainingSentencesPath: String): Unit = {
     s"Average Perceptron tagger" should "successfully train a provided wsj corpus" in {
-      val trainingSentences = ResourceHelper.retrievePOSCorpus(trainingSentencesPath)
+      val trainingSentences = PerceptronApproach.retrievePOSCorpus(trainingSentencesPath)
       val nIterations = 5
       val tagger = new PerceptronApproach().setCorpusPath(trainingSentencesPath).fit(DataBuilder.basicDataBuild("dummy"))
       val model = tagger.getModel

--- a/src/test/scala/com/jsl/nlp/annotators/spell/norvig/NorvigSweetingBehaviors.scala
+++ b/src/test/scala/com/jsl/nlp/annotators/spell/norvig/NorvigSweetingBehaviors.scala
@@ -48,7 +48,8 @@ trait NorvigSweetingBehaviors { this: FlatSpec =>
       val spell = new NorvigSweetingApproach()
         .setInputCols(Array("normal"))
         .setOutputCol("spell")
-        .setCorpusCol("text")
+        .setCorpusPath("/spell/sherlockholmes.txt")
+        .setCorpusFormat("txt")
 
       val finisher = new Finisher()
         .setInputCols("spell")


### PR DESCRIPTION
- No impact on functionalities
- SpellChecker now defines corpusFormat for dataset training of txt files
- ResourceHelper now uses ResourceFormat
- ResourceHelper now more lightweight, annotator specific manipulation moved to annotator
- Config management moved to annotator specific

<!--- Provide a general summary of your changes in the Title above -->
ResourceHelper was doing too much too many things that should have been done by annotators  themselves

## Description
<!--- Describe your changes in detail -->
ResourceHelper now only does very general input management. It also supports one extra additional data format called TXTDS for reading text path as dataset.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It improves code clearness for input management, delegating more to annotators instead of resource helper.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests updated. There is one side effect, making Finisher smarter when generating annotators output

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Code improvement with no or little impact
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
