### PR TITLE
Re-setting the use of 4 threads in the sparkContext used for python tests

### DIFF
--- a/python/test/util.py
+++ b/python/test/util.py
@@ -1,27 +1,26 @@
 from pyspark.sql import SparkSession
 
-
 class SparkContextForTest:
     spark = SparkSession.builder \
-        .master("local[8]") \
+        .master("local[4]") \
         .config("spark.jars", 'lib/sparknlp.jar') \
         .getOrCreate()
     data = spark. \
-        read. \
-        parquet("../src/test/resources/sentiment.parquet"). \
-        limit(100)
+        read \
+        .parquet("../src/test/resources/sentiment.parquet") \
+        .limit(100)
     data.cache()
     data.count()
 
 
 class SparkContextForNER:
     spark = SparkSession.builder \
-        .master("local[8]") \
+        .master("local[4]") \
         .config("spark.jars", 'lib/sparknlp.jar') \
         .getOrCreate()
     data = spark. \
-        read. \
-        csv("../src/test/resources/ner-corpus/icdtest.txt"). \
-        limit(100)
+        read \
+        .csv("../src/test/resources/ner-corpus/icdtest.txt") \
+        .limit(100)
     data.cache()
     data.count()


### PR DESCRIPTION
## Description

The sparkContext used for testing was set to use all the available threads in a previous commit. In this commit we re-set it to 4 in order to clean a test error. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It fixes a failing tests. In the test we read a saved parquet file of 4 partitions, and we assume ordering in the dataframe. In machines with more than 4 cores, the use of read.parquet and limit(100) the test fails because the expected row that we test against is not actually there.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
