### PR TITLE
Finisher output as Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ This library has been uploaded to the spark-packages repository https://spark-pa
 To use the most recent version just add the `--packages JohnSnowLabs:spark-nlp:1.0.0` to you spark command
 
 ```sh
-spark-shell --packages JohnSnowLabs:spark-nlp:1.2.1
+spark-shell --packages JohnSnowLabs:spark-nlp:1.2.2
 ```
 
 ```sh
-pyspark --packages JohnSnowLabs:spark-nlp:1.2.1
+pyspark --packages JohnSnowLabs:spark-nlp:1.2.2
 ```
 
 ```sh
-spark-submit --packages JohnSnowLabs:spark-nlp:1.2.1
+spark-submit --packages JohnSnowLabs:spark-nlp:1.2.2
 ```
 
 Check the package for the published versions if you want to use and old version.

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val sparkVer = "2.1.1"
+val sparkVer = "2.1.2"
 val scalaVer = "2.11.11"
 val scalaTestVersion = "3.0.0"
 
@@ -7,7 +7,7 @@ name := "spark-nlp"
 
 organization := "com.johnsnowlabs.nlp"
 
-version := "1.2.1"
+version := "1.2.2"
 
 scalaVersion := scalaVer
 

--- a/docs/components.html
+++ b/docs/components.html
@@ -1025,6 +1025,9 @@ documentAssembler = new DocumentAssembler()
                                                     setIncludeKeys(False) -> Whether to include metadata keys. Sometimes
                                                     useful in some annotations
                                                 </li>
+                                                <li>
+                                                  setOutputAsArray(False) -> Whether to output as Array. Useful as input for other Spark transformers.
+                                                </li>
                                             </ul>
                                         </div><!--//code-block-->
                                     </div>
@@ -1051,7 +1054,7 @@ documentAssembler = new DocumentAssembler()
                                                     setOutputCols()
                                                 </li>
                                                 <li>
-                                                    setCleanAnnotations(True) -> Whether to remove intermediate
+                                                    setCleanAnnotations(true) -> Whether to remove intermediate
                                                     annotations
                                                 </li>
                                                 <li>
@@ -1063,8 +1066,11 @@ documentAssembler = new DocumentAssembler()
                                                     character
                                                 </li>
                                                 <li>
-                                                    setIncludeKeys(False) -> Whether to include metadata keys. Sometimes
+                                                    setIncludeKeys(false) -> Whether to include metadata keys. Sometimes
                                                     useful in some annotations
+                                                </li>
+                                                <li>
+                                                  setOutputAsArray(false) -> Whether to output as Array. Useful as input for other Spark transformers.
                                                 </li>
                                             </ul>
                                         </div><!--//code-block--></div>

--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -68,6 +68,7 @@ class Finisher(JavaTransformer, JavaMLReadable, JavaMLWritable):
     annotationSplitSymbol = Param(Params._dummy(), "annotationSplitSymbol", "character separating annotations", typeConverter=TypeConverters.toString)
     cleanAnnotations = Param(Params._dummy(), "cleanAnnotations", "whether to remove annotation columns", typeConverter=TypeConverters.toBoolean)
     includeKeys = Param(Params._dummy(), "includeKeys", "annotation metadata format", typeConverter=TypeConverters.toBoolean)
+    outputAsArray = Param(Params._dummy(), "outputAsArray", "finisher generates an Array with the results instead of string", typeConverter=TypeConverters.toBoolean)
 
     @keyword_only
     def __init__(self):
@@ -98,3 +99,6 @@ class Finisher(JavaTransformer, JavaMLReadable, JavaMLWritable):
 
     def setIncludeKeys(self, value):
         return self._set(includeKeys=value)
+
+    def setOutputAsArray(self, value):
+        return self._set(outputAsArray=value)

--- a/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
@@ -110,5 +110,14 @@ object Annotation {
     }
   }
 
+  /** dataframe annotation flatmap of metadata values as ArrayType */
+  def flattenArray: UserDefinedFunction = {
+    udf {
+      (annotations: Seq[Row]) => annotations.map(r =>
+        r.getString(3)
+      )
+    }
+  }
+
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/FinisherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/FinisherTestSpec.scala
@@ -2,6 +2,7 @@ package com.johnsnowlabs.nlp
 
 import com.johnsnowlabs.nlp.annotators.RegexTokenizer
 import org.apache.spark.ml.Pipeline
+import org.apache.spark.ml.feature.StopWordsRemover
 import org.scalatest._
 
 class FinisherTestSpec extends FlatSpec {
@@ -60,6 +61,33 @@ class FinisherTestSpec extends FlatSpec {
     assert(result.columns.contains("token_out"))
     result.select("token_out").as[String].collect.foreach(s => assert(s.contains("%"), "because % separator string was not found"))
     result.select("token_out").as[String].collect.foreach(s => assert(s.contains("->"), "because -> key value was not found"))
+
+  }
+
+  "A Finisher with array output" should "behave accordingly with SparkML StopWords" in {
+
+    val finisher = new Finisher()
+      .setInputCols("token")
+      .setOutputCols("token_out")
+      .setOutputAsArray(true)
+
+    val stopWords = new StopWordsRemover()
+      .setInputCol("token_out")
+      .setOutputCol("stopped")
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        documentAssembler,
+        tokenizer,
+        finisher,
+        stopWords
+      ))
+
+    val result = pipeline.fit(data).transform(data)
+
+    result.show()
+    assert(result.columns.length == 5, "because finisher removed annotations or did not return proper columns")
+    assert(result.columns.contains("stopped"))
 
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow the finisher to output an array type column which may be useful for other SparkML transformers

## Description
<!--- Describe your changes in detail -->
Add a parameter setting which defines the output type of the Finisher. Defaults to StringType

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It allows using the annotations result in other transformers that may need the result in the specific form of array. For example, SparkML StopWordsRemover transformer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests updated

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
