### PR TITLE
fixing typos in POSTagger documentation

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -643,7 +643,7 @@ documentAssembler = new DocumentAssembler()
                                                     word|tag in sentence per line
                                                 </li>
                                                 <li>
-                                                    setIterations: Number of iterations for training. May improve
+                                                    setNIterations: Number of iterations for training. May improve
                                                     accuracy but
                                                     takes longer. Default 5.
                                                 </li>
@@ -1201,4 +1201,3 @@ documentAssembler = new DocumentAssembler()
 </script>
 </body>
 </html>
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There is a typo in documentations for POSTagger annotator. 
Current: `setIterations`
Fixed: `setNIterations`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
