### PR TITLE
Make lowercasing by Normalizer optional

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -243,6 +243,7 @@ documentAssembler = new DocumentAssembler()
                                             <ul>
                                               <li>
                                                 setPattern(pattern): Regular expression for normalization, defaults [^A-Za-z]
+                                                setLowercase(value): lowercase tokens, default true
                                               </li>
                                             </ul>
                                                 <b>Example:</b><br>

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -115,6 +115,10 @@ class Normalizer(AnnotatorTransformer):
                     "normalization regex pattern which match will be replaced with a space",
                     typeConverter=TypeConverters.toString)
 
+    lowercase = Param(Params._dummy(),
+                      "lowercase",
+                      "whether to convert strings to lowercase")
+
     @keyword_only
     def __init__(self):
         super(Normalizer, self).__init__()
@@ -123,6 +127,8 @@ class Normalizer(AnnotatorTransformer):
     def setPattern(self, value):
         return self._set(pattern=value)
 
+    def setLowercase(self, value):
+        return self._set(lowercase=value)
 
 class RegexMatcher(AnnotatorTransformer):
 

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -76,6 +76,26 @@ class LemmatizerTestSpec(unittest.TestCase):
         lemmatizer.transform(tokenized).show()
 
 
+class NormalizerTestSpec(unittest.TestCase):
+
+    def setUp(self):
+        self.data = SparkContextForTest.data
+
+    def runTest(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+        tokenizer = RegexTokenizer() \
+            .setOutputCol("token")
+        lemmatizer = Normalizer() \
+            .setInputCols(["token"]) \
+            .setOutputCol("normalized_token") \
+            .setLowercase(False)
+        assembled = document_assembler.transform(self.data)
+        tokenized = tokenizer.transform(assembled)
+        lemmatizer.transform(tokenized).show()
+
+
 class DateMatcherTestSpec(unittest.TestCase):
 
     def setUp(self):

--- a/src/test/scala/com/johnsnowlabs/nlp/AnnotatorBuilder.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/AnnotatorBuilder.scala
@@ -46,6 +46,14 @@ object AnnotatorBuilder extends FlatSpec { this: Suite =>
     normalizer.transform(withTokenizer(dataset))
   }
 
+  def withCaseSensitiveNormalizer(dataset: Dataset[Row]): Dataset[Row] = {
+    val normalizer = new Normalizer()
+      .setInputCols(Array("token"))
+      .setOutputCol("normalized")
+      .setLowercase(false)
+    normalizer.transform(withTokenizer(dataset))
+  }
+
   def withFullLemmatizer(dataset: Dataset[Row]): Dataset[Row] = {
     val lemmatizer = new Lemmatizer()
       .setInputCols(Array("token"))

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/NormalizerBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/NormalizerBehaviors.scala
@@ -11,13 +11,34 @@ trait NormalizerBehaviors { this: FlatSpec =>
     AnnotatorBuilder.withFullNormalizer(dataset)
       .collect().foreach {
       row =>
-        row.getSeq[Row](3)
+        row.getSeq[Row](4)
           .map(Annotation(_))
           .foreach {
             case stem: Annotation if stem.annotatorType == AnnotatorType.TOKEN =>
               assert(stem.result.nonEmpty, "Annotation result exists")
             case _ =>
           }
+      }
+    }
+  }
+
+  def lowercasingNormalizerPipeline(dataset: => Dataset[Row]) {
+    "A case-sensitive Normalizer Annotator" should "successfully transform data" in {
+    AnnotatorBuilder.withCaseSensitiveNormalizer(dataset)
+      .collect().foreach {
+      row =>
+        val tokens = row.getSeq[Row](3).map(Annotation(_))
+        val normalizedAnnotations = row.getSeq[Row](4).map(Annotation(_))
+        normalizedAnnotations.foreach {
+          case stem: Annotation if stem.annotatorType == AnnotatorType.TOKEN =>
+            assert(stem.result.nonEmpty, "Annotation result exists")
+          case _ =>
+        }
+
+        normalizedAnnotations.zip(tokens).foreach {
+          case (stem: Annotation, token: Annotation) =>
+            assert(stem.result == token.result.replaceAll("[^a-zA-Z]", ""))
+        }
       }
     }
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/NormalizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/NormalizerTestSpec.scala
@@ -17,5 +17,5 @@ class NormalizerTestSpec extends FlatSpec with NormalizerBehaviors {
   val latinBodyData: Dataset[Row] = DataBuilder.basicDataBuild(ContentProvider.latinBody)
 
   "A full Normalizer pipeline with latin content" should behave like fullNormalizerPipeline(latinBodyData)
-
+  "A Normalizer pipeline with latin content and disabled lowercasing" should behave like lowercasingNormalizerPipeline(latinBodyData)
 }


### PR DESCRIPTION
## Description
I've noted that Normalizer lowercases all tokens that are fed into it. I added `lowercase` parameter that, when set to `false`, doesn't lowercase tokens. By default it's `true` so it behaves like previous version.

## Motivation and Context
It seems it could be advantageous to not lowercase some inputs (for example if someone wanted to feed output of SparkNLP pipeline to some other algorithms that are case-sensitive).

## How Has This Been Tested?
I've checked old tests for Normalizer and they still work, and I added tests for `lowercase = true`.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.