### PR TITLE
Fixes to make Scala and Python APIs consistent

### DIFF
--- a/docs/components.html
+++ b/docs/components.html
@@ -544,21 +544,19 @@ documentAssembler = new DocumentAssembler()
                                                     boundaries for better precision
                                                 </li>
                                                 <li>
-                                                    setEntitiesPath(path): Provides a file with phrases to match. Default:
-                                                    Looks up
-                                                    path in configuration
-                                                </li>
-                                                <li>
-                                                    setEntitiesFormat(format): TXT for txt files or TXTDS for text files read as dataset (allows hdfs)
-                                                    Default:
-                                                    TXT or looks up path in configuration
+                                                    setEntities(path, format, options): Provides a file with phrases to match. Default: Looks up path in configuration.</br>
+                                                    path: a path to a file that contains the entities in the specified format.</br>
+                                                    format: the format of the file, can be one of {ReadAs.LINE_BY_LINE, ReadAs.SPARK_DATASET}. Defaults to LINE_BY_LINE.</br>
+                                                    options: a map of additional parameters. Defaults to {"format": "text"}.
                                                 </li>
                                             </ul>
                                             <b>Example:</b><br>
                                             </p>
                                             <pre><code class="language-python">entity_extractor = EntityExtractor() \
-  .setMaxLen(4) \
-  .setOutputCol("entity")</code></pre>
+ .setInputCols(["inputCol"])\
+ .setOutputCol("entity")\
+ .setEntities("/path/to/file/myentities.txt")
+</code></pre>
                                         </div><!--//code-block-->
                                     </div>
                                     <div role="tabpanel" class="tab-pane" id="scala">
@@ -576,21 +574,19 @@ documentAssembler = new DocumentAssembler()
                                                     boundaries for better precision
                                                 </li>
                                                 <li>
-                                                    setEntitiesPath(path): Provides a file with phrases to match. Default:
-                                                    Looks up
-                                                    path in configuration
-                                                </li>
-                                                <li>
-                                                  setEntitiesFormat(format): TXT for txt files or TXTDS for text files read as dataset (allows hdfs)
-                                                  Default:
-                                                  TXT or looks up path in configuration
+                                                    setEntities(path, format, options): Provides a file with phrases to match. Default: Looks up path in configuration.</br>
+                                                    path: a path to a file that contains the entities in the specified format.</br>
+                                                    format: the format of the file, can be one of {ReadAs.LINE_BY_LINE, ReadAs.SPARK_DATASET}. Defaults to LINE_BY_LINE.</br>
+                                                    options: a map of additional parameters. Defaults to Map("format" -> "text").
                                                 </li>
                                             </ul>
                                             <b>Example:</b><br>
                                             </p>
                                             <pre><code class="language-python">val entityExtractor = new EntityExtractor()
-  .setMaxLen(4)
-  .setOutputCol("entity")</code></pre>
+ .setInputCols("inputCol")
+ .setOutputCol("entity")
+ .setEntities("/path/to/file/myentities.txt")
+</code></pre>
                                         </div>
                                     </div>
                                 </div>

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -263,6 +263,9 @@ class EntityExtractor(AnnotatorApproach):
     def setEntities(self, path=None, read_as="LINE_BY_LINE", options={"format": "text"}.copy()):
         return self._set(entities=ExternalResource(path, read_as, options))
 
+class ReadAs(object):
+    LINE_BY_LINE = "LINE_BY_LINE"
+    SPARK_DATASET = "SPARK_DATASET"
 
 class EntityExtractorModel(AnnotatorModel):
     name = "EntityExtractorModel"

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/EntityExtractor.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/EntityExtractor.scala
@@ -7,7 +7,7 @@ import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.sql.Dataset
 import com.johnsnowlabs.nlp.AnnotatorType._
 import com.johnsnowlabs.nlp.annotators.param.ExternalResourceParam
-import com.johnsnowlabs.nlp.util.io.{ExternalResource, ResourceHelper}
+import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
 
 class EntityExtractor(override val uid: String) extends AnnotatorApproach[EntityExtractorModel] {
 
@@ -23,7 +23,8 @@ class EntityExtractor(override val uid: String) extends AnnotatorApproach[Entity
 
   setDefault(inputCols,Array(TOKEN))
 
-  def setEntities(value: ExternalResource): this.type = set(entities, value)
+  def setEntities(path: String, format:ReadAs.Format = ReadAs.LINE_BY_LINE, options:Map[String, String] = Map("format" -> "text")): this.type =
+    set(entities, ExternalResource(path, format, options))
 
   /**
     * Loads entities from a provided source.

--- a/src/test/scala/com/johnsnowlabs/nlp/AnnotatorBuilder.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/AnnotatorBuilder.scala
@@ -71,7 +71,7 @@ object AnnotatorBuilder extends FlatSpec { this: Suite =>
   def withFullEntityExtractor(dataset: Dataset[Row], lowerCase: Boolean = true, sbd: Boolean = true): Dataset[Row] = {
     val entityExtractor = new EntityExtractor()
       .setInputCols("normalized")
-      .setEntities("/entity-extractor/test-phrases.txt", ReadAs.LINE_BY_LINE.toString, Map.empty[String, String])
+      .setEntities("/entity-extractor/test-phrases.txt", ReadAs.LINE_BY_LINE, Map.empty[String, String])
       .setOutputCol("entity")
     val data = withFullNormalizer(
       withTokenizer(dataset, sbd), lowerCase)

--- a/src/test/scala/com/johnsnowlabs/nlp/AnnotatorBuilder.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/AnnotatorBuilder.scala
@@ -71,7 +71,7 @@ object AnnotatorBuilder extends FlatSpec { this: Suite =>
   def withFullEntityExtractor(dataset: Dataset[Row], lowerCase: Boolean = true, sbd: Boolean = true): Dataset[Row] = {
     val entityExtractor = new EntityExtractor()
       .setInputCols("normalized")
-      .setEntities(ExternalResource("/entity-extractor/test-phrases.txt", ReadAs.LINE_BY_LINE, Map.empty[String, String]))
+      .setEntities("/entity-extractor/test-phrases.txt", ReadAs.LINE_BY_LINE.toString, Map.empty[String, String])
       .setOutputCol("entity")
     val data = withFullNormalizer(
       withTokenizer(dataset, sbd), lowerCase)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/EntityExtractorTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/EntityExtractorTestSpec.scala
@@ -57,7 +57,7 @@ class EntityExtractorTestSpec extends FlatSpec with EntityExtractorBehaviors {
 
     val entityExtractor = new EntityExtractor()
       .setInputCols("token")
-      .setEntities(ExternalResource("/entity-extractor/test-phrases.txt", ReadAs.LINE_BY_LINE, Map.empty[String, String]))
+      .setEntities("/entity-extractor/test-phrases.txt", ReadAs.LINE_BY_LINE, Map.empty[String, String])
       .setOutputCol("entity")
 
     val finisher = new Finisher()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the Scala API for EntityExtractor so setEntities() method receives individual parameters instead of an ExternalResource object.
This removes knowledge about internal storage of parameters from a user facing API, and makes things consistent with Python. Also updated documentation.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
