### PR TITLE
Dumped rocksdb version to make it run on databricks platform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,7 @@ lazy val testDependencies = Seq(
 
 lazy val utilDependencies = Seq(
   "com.typesafe" % "config" % "1.3.0",
-  "org.rocksdb" % "rocksdbjni" % "5.8.0",
+  "org.rocksdb" % "rocksdbjni" % "5.2.1",
   "org.slf4j" % "slf4j-api" % "1.7.25",
   "org.apache.commons" % "commons-compress" % "1.15"
 )

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddings.scala
@@ -7,13 +7,10 @@ import org.rocksdb._
 
 case class WordEmbeddings(dbFile: String,
                           nDims: Int,
-                          cacheSizeMB: Int = 100,
                           lruCacheSize: Int = 100000) extends Closeable{
-  val options = new Options()
-  options.setRowCache(new LRUCache(cacheSizeMB * 1 << 20))
   RocksDB.loadLibrary()
 
-  val db = RocksDB.openReadOnly(options, dbFile)
+  val db = RocksDB.openReadOnly(dbFile)
 
   val zeroArray = Array.fill[Float](nDims)(0f)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Dumped rocksdb version to 5.2.1 to match the one present in the Databricks classpath.
In this older version LRU cache is set on native code, so that option cannot be passed to the library, that's why it was removed.
I tested for performance and the change in the cache seems not to affect the times.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
