### PR TITLE
Easier ExternalResource API setters

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/EntityExtractor.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/EntityExtractor.scala
@@ -23,7 +23,11 @@ class EntityExtractor(override val uid: String) extends AnnotatorApproach[Entity
 
   setDefault(inputCols,Array(TOKEN))
 
-  def setEntities(value: ExternalResource): this.type = set(entities, value)
+  def setEntities(value: ExternalResource): this.type =
+    set(entities, value)
+
+  def setEntities(path: String, readAs: String = "LINE_BY_LINE"): this.type =
+    set(entities, ExternalResource(path, readAs, Map.empty[String, String]))
 
   /**
     * Loads entities from a provided source.

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Lemmatizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Lemmatizer.scala
@@ -45,6 +45,11 @@ class Lemmatizer(override val uid: String) extends AnnotatorApproach[LemmatizerM
     set(dictionary, value)
   }
 
+  def setDictionary(path: String, keyDelimiter: String, valueDelimiter: String, readAs: String = "LINE_BY_LINE"): this.type = {
+    require(Seq("LINE_BY_LINE", "SPARK_DATASET").contains(readAs.toUpperCase), "readAs needs to be 'LINE_BY_LINE' or 'SPARK_DATASET'")
+    set(dictionary, ExternalResource(path, readAs, Map("keyDelimiter" -> keyDelimiter, "valueDelimiter" -> valueDelimiter)))
+  }
+
   override def train(dataset: Dataset[_], recursivePipeline: Option[PipelineModel]): LemmatizerModel = {
     new LemmatizerModel()
       .setLemmaDict(ResourceHelper.flattenRevertValuesAsKeys($(dictionary)))

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexMatcher.scala
@@ -33,6 +33,11 @@ class RegexMatcher(override val uid: String) extends AnnotatorApproach[RegexMatc
     set(rules, value)
   }
 
+  def setRules(path: String, delimiter: String, readAs: String = "LINE_BY_LINE"): this.type = {
+    require(Seq("LINE_BY_LINE", "SPARK_DATASET").contains(readAs.toUpperCase), "readAs needs to be 'LINE_BY_LINE' or 'SPARK_DATASET'")
+    set(rules, ExternalResource(path, readAs, Map("delimiter" -> delimiter)))
+  }
+
   def setStrategy(value: String): this.type = set(strategy, value)
 
   def getStrategy: String = $(strategy).toString

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfApproach.scala
@@ -61,13 +61,26 @@ class NerCrfApproach(override val uid: String)
   def setLossEps(eps: Double) = set(this.lossEps, eps)
   def setMinW(w: Double) = set(this.minW, w)
 
-  def setExternalFeatures(value: ExternalResource) = set(externalFeatures, value)
+  def setExternalFeatures(value: ExternalResource) = {
+    require(value.options.contains("delimiter"), "slang dictionary is a delimited text. needs 'delimiter' in options")
+    set(externalFeatures, value)
+  }
+
+  def setExternalFeatures(path: String, readAs: String = "LINE_BY_LINE"): this.type = {
+    require(Seq("LINE_BY_LINE", "SPARK_DATASET").contains(readAs.toUpperCase), "readAs needs to be 'LINE_BY_LINE' or 'SPARK_DATASET'")
+    set(externalFeatures, ExternalResource(path, readAs, Map.empty[String, String]))
+  }
 
   def setVerbose(verbose: Int) = set(this.verbose, verbose)
   def setVerbose(verbose: Verbose.Level) = set(this.verbose, verbose.id)
   def setRandomSeed(seed: Int) = set(randomSeed, seed)
 
   def setExternalDataset(path: ExternalResource) = set(externalDataset, path)
+
+  def setExternalDataset(path: String, delimiter: String, readAs: String = "LINE_BY_LINE"): this.type = {
+    require(Seq("LINE_BY_LINE", "SPARK_DATASET").contains(readAs.toUpperCase), "readAs needs to be 'LINE_BY_LINE' or 'SPARK_DATASET'")
+    set(externalDataset, ExternalResource(path, readAs, Map("delimiter" -> delimiter)))
+  }
 
   setDefault(
     minEpochs -> 0,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronApproach.scala
@@ -40,6 +40,11 @@ class PerceptronApproach(override val uid: String) extends AnnotatorApproach[Per
     set(corpus, value)
   }
 
+  def setCorpus(path: String, delimiter: String, readAs: String = "LINE_BY_LINE"): this.type = {
+    require(Seq("LINE_BY_LINE", "SPARK_DATASET").contains(readAs.toUpperCase), "readAs needs to be 'LINE_BY_LINE' or 'SPARK_DATASET'")
+    set(corpus, ExternalResource(path, readAs, Map("delimiter" -> delimiter)))
+  }
+
   def setNIterations(value: Int): this.type = set(nIterations, value)
 
   def this() = this(Identifiable.randomUID("POS"))

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/vivekn/ViveknSentimentApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/vivekn/ViveknSentimentApproach.scala
@@ -48,9 +48,19 @@ class ViveknSentimentApproach(override val uid: String)
     set(positiveSource, value)
   }
 
+  def setPositiveSource(path: String, tokenPattern: String, readAs: String = "LINE_BY_LINE"): this.type = {
+    require(Seq("LINE_BY_LINE", "SPARK_DATASET").contains(readAs.toUpperCase), "readAs needs to be 'LINE_BY_LINE' or 'SPARK_DATASET'")
+    set(positiveSource, ExternalResource(path, readAs, Map("tokenPattern" -> tokenPattern)))
+  }
+
   def setNegativeSource(value: ExternalResource): this.type = {
     require(value.options.contains("tokenPattern"), "vivekn corpus needs 'tokenPattern' regex for tagging words. e.g. \\S+")
     set(negativeSource, value)
+  }
+
+  def setNegativeSource(path: String, tokenPattern: String, readAs: String = "LINE_BY_LINE"): this.type = {
+    require(Seq("LINE_BY_LINE", "SPARK_DATASET").contains(readAs.toUpperCase), "readAs needs to be 'LINE_BY_LINE' or 'SPARK_DATASET'")
+    set(negativeSource, ExternalResource(path, readAs, Map("tokenPattern" -> tokenPattern)))
   }
 
   def setCorpusPrune(value: Int): this.type = set(pruneCorpus, value)


### PR DESCRIPTION
- Added easier external resource API setters in scala
- Added appropriate NER CRF ExternalResource validations
- Removed unnecessary normalization in wordcount dataset pipeline
- Added support for recursive pipelines in SpellChecker

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To avoid having to import and create custom ExternalResource objects to set paths to external files, easier setters have been created to allow user directly set path and delimiters of such files for spark reading defaults.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid extra code when using ExternalResources 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
