### PR TITLE
Fixed tokenizer stop words and composite token recognition bugs

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
@@ -83,10 +83,10 @@ class Tokenizer(override val uid: String) extends AnnotatorModel[Tokenizer] {
   /** Check here for explanation on this default pattern */
   setDefault(infixPatterns, Array(
     "([\\$#]?\\d+(?:[^\\s\\d]{1}\\d+)*)", // Money, Phone number and dates -> http://rubular.com/r/ihCCgJiX4e
-    "((?:\\p{L}+\\.)+)", // Abbreviations -> http://rubular.com/r/cRBtGuLlF6
+    "((?:\\p{L}\\.)+)", // Abbreviations -> http://rubular.com/r/nMf3n0axfQ
     "(\\p{L}+)(n't\\b)", // Weren't -> http://rubular.com/r/coeYJFt8eM
     "(\\p{L}+)('{1}\\p{L}+)", // I'll -> http://rubular.com/r/N84PYwYjQp
-    "((?:\\p{L}+[^\\s\\p{L}]{1})+\\p{L}+)", // foo-bar -> http://rubular.com/r/wOvQcey9e3
+    "((?:\\p{L}+[^\\s\\p{L}]{1})+\\p{L}+)", // foo-bar -> http://rubular.com/r/cjit4R6uWd
     "([\\p{L}\\w]+)" // basic word token
   ))
   /** These catch everything before and after a word, as a separate token*/

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -22,10 +22,12 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
   }
 
 
-  val targetText = "Hello, I won't be from New York in the U.S.A. (and you know it héroe). Give me my horse! or $100 bucks 'He said', I'll defeat markus-crassus."
+  val targetText = "Hello, I won't be from New York in the U.S.A. (and you know it héroe). Give me my horse! or $100" +
+    " bucks 'He said', I'll defeat markus-crassus. You understand. Goodbye George E. Bush. www.google.com."
   val expected = Array(
-    "Hello", ",", "I", "wo", "n't", "be", "from", "New York", "in", "the", "U.S.A.", "(", "and", "you", "know", "it", "héroe", ")", ".",
-    "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "'", ",", "I", "'ll", "defeat", "markus-crassus", "."
+    "Hello", ",", "I", "wo", "n't", "be", "from", "New York", "in", "the", "U.S.A.", "(", "and", "you", "know", "it",
+    "héroe", ")", ".", "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "'", ",", "I", "'ll",
+    "defeat", "markus-crassus", ".", "You", "understand", ".", "Goodbye", "George", "E.", "Bush", ".", "www.google.com", "."
   )
 
   "a Tokenizer" should "correctly tokenize target text on its defaults parameters with exceptions" in {

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -30,7 +30,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
     "defeat", "markus-crassus", ".", "You", "understand", ".", "Goodbye", "George", "E.", "Bush", ".", "www.google.com", "."
   )
 
-  "a Tokenizer" should "correctly tokenize target text on its defaults parameters with exceptions" in {
+  "a Tokenizer" should "correctly tokenize target text on its defaults parameters with composite" in {
     val data = DataBuilder.basicDataBuild(targetText)
     val document = new DocumentAssembler().setInputCol("text").setOutputCol("document")
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokens(Array("New York"))
@@ -54,7 +54,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
     })
   }
 
-  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with exceptions" in {
+  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite" in {
     val data = DataBuilder.basicDataBuild(targetText)
     val document = new DocumentAssembler().setInputCol("text").setOutputCol("document")
     val sentence = new SentenceDetector().setInputCols("document").setOutputCol("sentence")
@@ -65,6 +65,22 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
       .collect.flatten
     assert(
       result.sameElements(expected),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected.mkString("|")}"
+    )
+  }
+
+  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite and different target pattern" in {
+    val data = DataBuilder.basicDataBuild("Hello New York and Goodbye")
+    val document = new DocumentAssembler().setInputCol("text").setOutputCol("document")
+    val sentence = new SentenceDetector().setInputCols("document").setOutputCol("sentence")
+    val tokenizer = new Tokenizer().setInputCols("sentence").setOutputCol("token").setTargetPattern("\\w+").setCompositeTokens(Array("New York"))
+    val finisher = new Finisher().setInputCols("token").setOutputAsArray(true).setOutputCols("output")
+    val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, finisher))
+    val result = pipeline.fit(data).transform(data).select("output").as[Array[String]]
+      .collect.flatten
+    assert(
+      result.sameElements(Seq("Hello", "New York", "and", "Goodbye")),
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected.mkString("|")}"
     )
@@ -85,7 +101,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
 
     val date1 = new Date().getTime
     Annotation.take(tokenized, "token", 5000)
-    info(s"Collected 5000 tokens took ${(new Date().getTime - date1) / 1000} seconds")
+    info(s"Collected 5000 tokens took ${(new Date().getTime - date1) / 1000.0} seconds")
   }
 
   val latinBodyData: Dataset[Row] = DataBuilder.basicDataBuild(ContentProvider.latinBody)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fixed stop words dots not being recognized properly as sub tokens
- Fixed composite tokens not working properly when the user changes the default target pattern


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It improves tokenization accuracy overall

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
