### PR TITLE
Fixed NERCRF not working when not using word embeddings

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ApproachWithWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ApproachWithWordEmbeddings.scala
@@ -71,7 +71,7 @@ abstract class ApproachWithWordEmbeddings[A <: ApproachWithWordEmbeddings[A, M],
   var wembeddings: Option[WordEmbeddings] = None
 
   def embeddings(): Option[WordEmbeddings] = {
-    if (wembeddings == null || wembeddings.isEmpty)
+    if (wembeddings != null && wembeddings.nonEmpty)
       wembeddings = Some(WordEmbeddings(localPath.get, $(embeddingsNDims)))
     wembeddings
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
User reported NER CRF not working due a None.get exception in embeddings() function. This is due the attempt of the annotator to utilize word embeddings when these have not been provided.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
