### PR TITLE
SparkNLP annotators are now loadable on their own

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -17,3 +17,4 @@ unittest.TextTestRunner().run(SpellCheckerTestSpec())
 # Misc tests
 unittest.TextTestRunner().run(UtilitiesTestSpec())
 unittest.TextTestRunner().run(ConfigPathTestSpec())
+unittest.TextTestRunner().run(unittest.TestLoader().loadTestsFromTestCase(SerializersTestSpec))

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -1,6 +1,6 @@
 import sys
-import sparknlp.annotator
-from sparknlp.base import DocumentAssembler, Finisher
+from sparknlp import annotator
+from sparknlp.base import DocumentAssembler, Finisher, TokenAssembler
 
 sys.modules['com.johnsnowlabs.nlp.annotators'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.ner'] = annotator

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -8,7 +8,7 @@ from pyspark.ml.util import JavaMLReadable, JavaMLWritable
 from pyspark.ml.wrapper import JavaTransformer, JavaModel, JavaEstimator
 from pyspark.ml.param.shared import Param, Params, TypeConverters
 from sparknlp.common import ExternalResource
-from sparknlp.util import SparkNLPJavaMLReadable
+from sparknlp.util import AnnotatorJavaMLReadable
 
 if sys.version_info[0] == 2:
     #Needed. Delete once DA becomes an annotator in 1.1.x
@@ -72,7 +72,7 @@ class AnnotatorWithEmbeddings(Params):
         return self._set(embeddingsNDims=nDims)
 
 
-class AnnotatorTransformer(JavaModel, SparkNLPJavaMLReadable, JavaMLWritable, AnnotatorProperties):
+class AnnotatorTransformer(JavaModel, AnnotatorJavaMLReadable, JavaMLWritable, AnnotatorProperties):
 
     column_type = "array<struct<annotatorType:string,begin:int,end:int,metadata:map<string,string>>>"
 
@@ -91,7 +91,7 @@ class AnnotatorTransformer(JavaModel, SparkNLPJavaMLReadable, JavaMLWritable, An
         self.__class__._java_class_name = classname
         self._java_obj = self._new_java_obj(classname, self.uid)
 
-class AnnotatorApproach(JavaEstimator, JavaMLWritable, SparkNLPJavaMLReadable, AnnotatorProperties):
+class AnnotatorApproach(JavaEstimator, JavaMLWritable, AnnotatorJavaMLReadable, AnnotatorProperties):
     @keyword_only
     def __init__(self, classname):
         super(AnnotatorApproach, self).__init__()

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -8,6 +8,7 @@ from pyspark.ml.util import JavaMLReadable, JavaMLWritable
 from pyspark.ml.wrapper import JavaTransformer, JavaModel, JavaEstimator
 from pyspark.ml.param.shared import Param, Params, TypeConverters
 from sparknlp.common import ExternalResource
+from sparknlp.util import SparkNLPJavaMLReadable
 
 if sys.version_info[0] == 2:
     #Needed. Delete once DA becomes an annotator in 1.1.x
@@ -71,7 +72,7 @@ class AnnotatorWithEmbeddings(Params):
         return self._set(embeddingsNDims=nDims)
 
 
-class AnnotatorTransformer(JavaModel, JavaMLReadable, JavaMLWritable, AnnotatorProperties):
+class AnnotatorTransformer(JavaModel, SparkNLPJavaMLReadable, JavaMLWritable, AnnotatorProperties):
 
     column_type = "array<struct<annotatorType:string,begin:int,end:int,metadata:map<string,string>>>"
 
@@ -83,12 +84,18 @@ class AnnotatorTransformer(JavaModel, JavaMLReadable, JavaMLWritable, AnnotatorP
     @keyword_only
     def __init__(self):
         super(JavaTransformer, self).__init__()
-        
-        
-class AnnotatorApproach(JavaEstimator, JavaMLWritable, JavaMLReadable, AnnotatorProperties):
+
+    @keyword_only
+    def __init__(self, classname):
+        super(JavaTransformer, self).__init__()
+        self.__class__._java_class_name = classname
+        self._java_obj = self._new_java_obj(classname, self.uid)
+
+class AnnotatorApproach(JavaEstimator, JavaMLWritable, SparkNLPJavaMLReadable, AnnotatorProperties):
     @keyword_only
     def __init__(self, classname):
         super(AnnotatorApproach, self).__init__()
+        self.__class__._java_class_name = classname
         self._java_obj = self._new_java_obj(classname, self.uid)
 
 
@@ -130,8 +137,7 @@ class Tokenizer(AnnotatorTransformer):
 
     @keyword_only
     def __init__(self):
-        super(Tokenizer, self).__init__()
-        self._java_obj = self._new_java_obj("com.johnsnowlabs.nlp.annotators.Tokenizer", self.uid)
+        super(Tokenizer, self).__init__(classname="com.johnsnowlabs.nlp.annotators.Tokenizer")
 
     def setTargetPattern(self, value):
         return self._set(targetPattern=value)
@@ -155,8 +161,7 @@ class Stemmer(AnnotatorTransformer):
 
     @keyword_only
     def __init__(self):
-        super(Stemmer, self).__init__()
-        self._java_obj = self._new_java_obj("com.johnsnowlabs.nlp.annotators.Stemmer", self.uid)
+        super(Stemmer, self).__init__(classname="com.johnsnowlabs.nlp.annotators.Stemmer")
 
 
 class Normalizer(AnnotatorTransformer):
@@ -172,8 +177,7 @@ class Normalizer(AnnotatorTransformer):
 
     @keyword_only
     def __init__(self):
-        super(Normalizer, self).__init__()
-        self._java_obj = self._new_java_obj("com.johnsnowlabs.nlp.annotators.Normalizer", self.uid)
+        super(Normalizer, self).__init__(classname="com.johnsnowlabs.nlp.annotators.Normalizer")
 
     def setPattern(self, value):
         return self._set(pattern=value)
@@ -244,8 +248,7 @@ class DateMatcher(AnnotatorTransformer):
 
     @keyword_only
     def __init__(self):
-        super(DateMatcher, self).__init__()
-        self._java_obj = self._new_java_obj("com.johnsnowlabs.nlp.annotators.DateMatcher", self.uid)
+        super(DateMatcher, self).__init__(classname="com.johnsnowlabs.nlp.annotators.DateMatcher")
 
     def setDateFormat(self, value):
         return self._set(dateFormat=value)
@@ -332,8 +335,7 @@ class SentenceDetector(AnnotatorTransformer):
 
     @keyword_only
     def __init__(self):
-        super(SentenceDetector, self).__init__()
-        self._java_obj = self._new_java_obj("com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector", self.uid)
+        super(SentenceDetector, self).__init__(classname="com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector")
 
 
 class SentimentDetector(AnnotatorApproach):
@@ -590,7 +592,3 @@ class AssertionLogRegApproach(AnnotatorApproach, AnnotatorWithEmbeddings):
 
 class AssertionLogRegModel(AnnotatorModel):
     name = "AssertionLogRegModel"
-
-
-
-

--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -3,12 +3,13 @@ from pyspark.ml.util import JavaMLReadable, JavaMLWritable
 from pyspark.ml.wrapper import JavaTransformer, JavaEstimator
 from pyspark.ml.param.shared import Param, Params, TypeConverters
 from pyspark.ml.pipeline import Pipeline, PipelineModel, Estimator, Transformer
-from sparknlp.util import SparkNLPJavaMLReadable
+from sparknlp.util import AnnotatorJavaMLReadable
 
-class SparkNLPTransformer(JavaTransformer, SparkNLPJavaMLReadable, JavaMLWritable):
+
+class AnnotatorTransformer(JavaTransformer, AnnotatorJavaMLReadable, JavaMLWritable):
     @keyword_only
     def __init__(self, classname):
-        super(SparkNLPTransformer, self).__init__()
+        super(AnnotatorTransformer, self).__init__()
         kwargs = self._input_kwargs
         try:
             kwargs.pop('classname')
@@ -17,6 +18,7 @@ class SparkNLPTransformer(JavaTransformer, SparkNLPJavaMLReadable, JavaMLWritabl
         self.setParams(**kwargs)
         self.__class__._java_class_name = classname
         self._java_obj = self._new_java_obj(classname, self.uid)
+
 
 class JavaRecursiveEstimator(JavaEstimator):
 
@@ -105,7 +107,7 @@ class RecursivePipeline(Pipeline, JavaEstimator):
         return PipelineModel(transformers)
 
 
-class DocumentAssembler(SparkNLPTransformer):
+class DocumentAssembler(AnnotatorTransformer):
 
     inputCol = Param(Params._dummy(), "inputCol", "input column name.", typeConverter=TypeConverters.toString)
     outputCol = Param(Params._dummy(), "outputCol", "input column name.", typeConverter=TypeConverters.toString)
@@ -134,7 +136,7 @@ class DocumentAssembler(SparkNLPTransformer):
         return self._set(metadataCol=value)
 
 
-class TokenAssembler(SparkNLPTransformer):
+class TokenAssembler(AnnotatorTransformer):
 
     inputCols = Param(Params._dummy(), "inputCols", "input token annotations", typeConverter=TypeConverters.toListString)
     outputCol = Param(Params._dummy(), "outputCol", "output column name.", typeConverter=TypeConverters.toString)
@@ -155,7 +157,7 @@ class TokenAssembler(SparkNLPTransformer):
         return self._set(outputCol=value)
 
 
-class Finisher(SparkNLPTransformer):
+class Finisher(AnnotatorTransformer):
 
     inputCols = Param(Params._dummy(), "inputCols", "input annotations", typeConverter=TypeConverters.toListString)
     outputCols = Param(Params._dummy(), "outputCols", "output finished annotation cols", typeConverter=TypeConverters.toListString)

--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -3,7 +3,20 @@ from pyspark.ml.util import JavaMLReadable, JavaMLWritable
 from pyspark.ml.wrapper import JavaTransformer, JavaEstimator
 from pyspark.ml.param.shared import Param, Params, TypeConverters
 from pyspark.ml.pipeline import Pipeline, PipelineModel, Estimator, Transformer
+from sparknlp.util import SparkNLPJavaMLReadable
 
+class SparkNLPTransformer(JavaTransformer, SparkNLPJavaMLReadable, JavaMLWritable):
+    @keyword_only
+    def __init__(self, classname):
+        super(SparkNLPTransformer, self).__init__()
+        kwargs = self._input_kwargs
+        try:
+            kwargs.pop('classname')
+        except:
+            pass
+        self.setParams(**kwargs)
+        self.__class__._java_class_name = classname
+        self._java_obj = self._new_java_obj(classname, self.uid)
 
 class JavaRecursiveEstimator(JavaEstimator):
 
@@ -92,7 +105,7 @@ class RecursivePipeline(Pipeline, JavaEstimator):
         return PipelineModel(transformers)
 
 
-class DocumentAssembler(JavaTransformer, JavaMLReadable, JavaMLWritable):
+class DocumentAssembler(SparkNLPTransformer):
 
     inputCol = Param(Params._dummy(), "inputCol", "input column name.", typeConverter=TypeConverters.toString)
     outputCol = Param(Params._dummy(), "outputCol", "input column name.", typeConverter=TypeConverters.toString)
@@ -101,10 +114,7 @@ class DocumentAssembler(JavaTransformer, JavaMLReadable, JavaMLWritable):
 
     @keyword_only
     def __init__(self):
-        super(DocumentAssembler, self).__init__()
-        self._java_obj = self._new_java_obj("com.johnsnowlabs.nlp.DocumentAssembler", self.uid)
-        kwargs = self._input_kwargs
-        self.setParams(**kwargs)
+        super(DocumentAssembler, self).__init__(classname="com.johnsnowlabs.nlp.DocumentAssembler")
 
     @keyword_only
     def setParams(self):
@@ -124,17 +134,14 @@ class DocumentAssembler(JavaTransformer, JavaMLReadable, JavaMLWritable):
         return self._set(metadataCol=value)
 
 
-class TokenAssembler(JavaTransformer, JavaMLReadable, JavaMLWritable):
+class TokenAssembler(SparkNLPTransformer):
 
     inputCols = Param(Params._dummy(), "inputCols", "input token annotations", typeConverter=TypeConverters.toListString)
     outputCol = Param(Params._dummy(), "outputCol", "output column name.", typeConverter=TypeConverters.toString)
 
     @keyword_only
     def __init__(self):
-        super(TokenAssembler, self).__init__()
-        self._java_obj = self._new_java_obj("com.johnsnowlabs.nlp.TokenAssembler", self.uid)
-        kwargs = self._input_kwargs
-        self.setParams(**kwargs)
+        super(TokenAssembler, self).__init__(classname = "com.johnsnowlabs.nlp.TokenAssembler")
 
     @keyword_only
     def setParams(self):
@@ -148,7 +155,7 @@ class TokenAssembler(JavaTransformer, JavaMLReadable, JavaMLWritable):
         return self._set(outputCol=value)
 
 
-class Finisher(JavaTransformer, JavaMLReadable, JavaMLWritable):
+class Finisher(SparkNLPTransformer):
 
     inputCols = Param(Params._dummy(), "inputCols", "input annotations", typeConverter=TypeConverters.toListString)
     outputCols = Param(Params._dummy(), "outputCols", "output finished annotation cols", typeConverter=TypeConverters.toListString)
@@ -160,10 +167,7 @@ class Finisher(JavaTransformer, JavaMLReadable, JavaMLWritable):
 
     @keyword_only
     def __init__(self):
-        super(Finisher, self).__init__()
-        self._java_obj = self._new_java_obj("com.johnsnowlabs.nlp.Finisher", self.uid)
-        kwargs = self._input_kwargs
-        self.setParams(**kwargs)
+        super(Finisher, self).__init__(classname="com.johnsnowlabs.nlp.Finisher")
 
     @keyword_only
     def setParams(self):

--- a/python/sparknlp/util.py
+++ b/python/sparknlp/util.py
@@ -1,8 +1,23 @@
 import sparknlp.internal as _internal
 
+from pyspark.ml.util import JavaMLReadable, JavaMLReader
 
 def get_config_path():
     return _internal._ConfigLoaderGetter().apply()
 
 def set_config_path(path):
     _internal._ConfigLoaderSetter(path).apply()
+
+class SparkNLPJavaMLReadable(JavaMLReadable):
+    @classmethod
+    def read(cls):
+        """Returns an MLReader instance for this class."""
+        return SparkNLPJavaMLReader(cls)
+
+class SparkNLPJavaMLReader(JavaMLReader):
+    @classmethod
+    def _java_loader_class(cls, clazz):
+        if hasattr(clazz, '_java_class_name') and clazz._java_class_name is not None:
+            return clazz._java_class_name
+        else:
+            return JavaMLReader._java_loader_class(clazz)

--- a/python/sparknlp/util.py
+++ b/python/sparknlp/util.py
@@ -2,19 +2,23 @@ import sparknlp.internal as _internal
 
 from pyspark.ml.util import JavaMLReadable, JavaMLReader
 
+
 def get_config_path():
     return _internal._ConfigLoaderGetter().apply()
+
 
 def set_config_path(path):
     _internal._ConfigLoaderSetter(path).apply()
 
-class SparkNLPJavaMLReadable(JavaMLReadable):
+
+class AnnotatorJavaMLReadable(JavaMLReadable):
     @classmethod
     def read(cls):
         """Returns an MLReader instance for this class."""
-        return SparkNLPJavaMLReader(cls)
+        return AnnotatorJavaMLReader(cls)
 
-class SparkNLPJavaMLReader(JavaMLReader):
+
+class AnnotatorJavaMLReader(JavaMLReader):
     @classmethod
     def _java_loader_class(cls, clazz):
         if hasattr(clazz, '_java_class_name') and clazz._java_class_name is not None:

--- a/python/test/misc.py
+++ b/python/test/misc.py
@@ -1,7 +1,10 @@
 import unittest
 from sparknlp.common import RegexRule
 from sparknlp.util import *
+import shutil, tempfile
 
+from sparknlp.base import DocumentAssembler, TokenAssembler, Finisher
+from sparknlp.annotator import *
 
 class UtilitiesTestSpec(unittest.TestCase):
 
@@ -18,3 +21,68 @@ class ConfigPathTestSpec(unittest.TestCase):
         assert(get_config_path() == "./application.conf")
         set_config_path("./somewhere/application.conf")
         assert(get_config_path() == "./somewhere/application.conf")
+
+class SerializersTestSpec(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def serialize_them(self, cls, dirname):
+        f = self.test_dir + dirname
+        c1 = cls()
+        c1.save(f)
+        c2 = cls().load(f)
+        assert(c1.uid == c2.uid)
+
+    def test_document_assembler(self):
+        self.serialize_them(DocumentAssembler, "assembler")
+
+    def test_token_assembler(self):
+        self.serialize_them(TokenAssembler, "token_assembler")
+
+    def test_finisher(self):
+        self.serialize_them(Finisher, "finisher")
+
+    def test_tokenizer(self):
+        self.serialize_them(Tokenizer, "tokenizer")
+
+    def test_stemmer(self):
+        self.serialize_them(Stemmer, "stemmer")
+
+    def test_normalizer(self):
+        self.serialize_them(Normalizer, "normalizer")
+
+    def test_regex_matcher(self):
+        self.serialize_them(RegexMatcher, "regex_matcher")
+
+    def test_lemmatizer(self):
+        self.serialize_them(Lemmatizer, "lemmatizer")
+
+    def test_date_matcher(self):
+        self.serialize_them(DateMatcher, "date_matcher")
+
+    def test_entity_extractor(self):
+        self.serialize_them(EntityExtractor, "entity_extractor")
+
+    def test_perceptron_approach(self):
+        self.serialize_them(PerceptronApproach, "perceptron_approach")
+
+    def test_sentence_detector(self):
+        self.serialize_them(SentenceDetector, "sentence_detector")
+
+    def test_sentiment_detector(self):
+        self.serialize_them(SentimentDetector, "sentiment_detector")
+
+    def test_vivekn(self):
+        self.serialize_them(ViveknSentimentApproach, "vivekn")
+
+    def test_norvig(self):
+        self.serialize_them(NorvigSweetingApproach, "norvig")
+
+    def test_ner(self):
+        self.serialize_them(NerCrfApproach, "ner_crf")
+
+    def test_assertion_log(self):
+        self.serialize_them(AssertionLogRegApproach, "assertion_log")


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

SparkNLP annotators are now loadable on their own. New changes allow to resolve the java class name of the annotators when they are loaded via the read and load methods.

## Description
<!--- Describe your changes in detail -->
 - New SparkNLPMLReader and SparkNLPMLReadable classes to help resolving the annotators java class
 - The annotators python class now holds a "private class attribute" with the name of the java class used by the objects above.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
SparkNLP annotators were not loadable on their own

<!--- If it fixes an open issue, please link to the issue here. -->
#91 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

New python tests used for writing/reading the annotators

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
