### PR TITLE
Automatic generation of getters for all python annotator's params

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -3,7 +3,7 @@ from test.misc import *
 
 # Annotator tests
 
-unittest.TextTestRunner().run(BasicAnnotatorsTestSpec())
+"""unittest.TextTestRunner().run(BasicAnnotatorsTestSpec())
 unittest.TextTestRunner().run(RegexMatcherTestSpec())
 unittest.TextTestRunner().run(LemmatizerTestSpec())
 unittest.TextTestRunner().run(DateMatcherTestSpec())
@@ -12,7 +12,7 @@ unittest.TextTestRunner().run(PerceptronApproachTestSpec())
 unittest.TextTestRunner().run(PragmaticSBDTestSpec())
 unittest.TextTestRunner().run(PragmaticScorerTestSpec())
 unittest.TextTestRunner().run(PipelineTestSpec())
-unittest.TextTestRunner().run(SpellCheckerTestSpec())
+unittest.TextTestRunner().run(SpellCheckerTestSpec())"""
 unittest.TextTestRunner().run(unittest.TestLoader().loadTestsFromTestCase(ParamsGettersTestSpec))
 
 # Misc tests

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -3,7 +3,7 @@ from test.misc import *
 
 # Annotator tests
 
-"""unittest.TextTestRunner().run(BasicAnnotatorsTestSpec())
+unittest.TextTestRunner().run(BasicAnnotatorsTestSpec())
 unittest.TextTestRunner().run(RegexMatcherTestSpec())
 unittest.TextTestRunner().run(LemmatizerTestSpec())
 unittest.TextTestRunner().run(DateMatcherTestSpec())
@@ -12,7 +12,7 @@ unittest.TextTestRunner().run(PerceptronApproachTestSpec())
 unittest.TextTestRunner().run(PragmaticSBDTestSpec())
 unittest.TextTestRunner().run(PragmaticScorerTestSpec())
 unittest.TextTestRunner().run(PipelineTestSpec())
-unittest.TextTestRunner().run(SpellCheckerTestSpec())"""
+unittest.TextTestRunner().run(SpellCheckerTestSpec())
 unittest.TextTestRunner().run(unittest.TestLoader().loadTestsFromTestCase(ParamsGettersTestSpec))
 
 # Misc tests

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -13,6 +13,7 @@ unittest.TextTestRunner().run(PragmaticSBDTestSpec())
 unittest.TextTestRunner().run(PragmaticScorerTestSpec())
 unittest.TextTestRunner().run(PipelineTestSpec())
 unittest.TextTestRunner().run(SpellCheckerTestSpec())
+unittest.TextTestRunner().run(unittest.TestLoader().loadTestsFromTestCase(ParamsGettersTestSpec))
 
 # Misc tests
 unittest.TextTestRunner().run(UtilitiesTestSpec())

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -4,7 +4,7 @@
 
 import sys
 from pyspark import keyword_only
-from pyspark.ml.util import JavaMLReadable, JavaMLWritable
+from pyspark.ml.util import JavaMLWritable
 from pyspark.ml.wrapper import JavaTransformer, JavaModel, JavaEstimator
 from pyspark.ml.param.shared import Param, Params, TypeConverters
 from sparknlp.common import ExternalResource, ParamsGetters
@@ -33,13 +33,13 @@ norvig = sys.modules[__name__]
 class AnnotatorProperties(Params):
 
     inputCols = Param(Params._dummy(),
-                                "inputCols",
-                                "previous annotations columns, if renamed",
-                                typeConverter=TypeConverters.toListString)
+                      "inputCols",
+                      "previous annotations columns, if renamed",
+                      typeConverter=TypeConverters.toListString)
     outputCol = Param(Params._dummy(),
-                                "outputCol",
-                                "output annotation column. can be left default.",
-                                typeConverter=TypeConverters.toString)
+                      "outputCol",
+                      "output annotation column. can be left default.",
+                      typeConverter=TypeConverters.toString)
     requiredAnnotatorTypes = Param(Params._dummy(),
                                    "requiredAnnotatorTypes",
                                    "required input annotations",
@@ -82,14 +82,14 @@ class AnnotatorModel(JavaModel, AnnotatorJavaMLReadable, JavaMLWritable, Annotat
         return self._set(**kwargs)
 
     @keyword_only
-    def __init__(self):
-        super(JavaTransformer, self).__init__()
-
-    @keyword_only
     def __init__(self, classname):
         super(JavaTransformer, self).__init__()
         self.__class__._java_class_name = classname
         self._java_obj = self._new_java_obj(classname, self.uid)
+
+
+class _AnnotatorModel(JavaModel, AnnotatorJavaMLReadable, JavaMLWritable, AnnotatorProperties, ParamsGetters):
+    pass
 
 
 class AnnotatorApproach(JavaEstimator, JavaMLWritable, AnnotatorJavaMLReadable, AnnotatorProperties, ParamsGetters):
@@ -108,9 +108,9 @@ class ReadAs(object):
 class Tokenizer(AnnotatorModel):
 
     targetPattern = Param(Params._dummy(),
-                    "targetPattern",
-                    "pattern to grab from text as token candidates. Defaults \S+",
-                    typeConverter=TypeConverters.toString)
+                          "targetPattern",
+                          "pattern to grab from text as token candidates. Defaults \S+",
+                          typeConverter=TypeConverters.toString)
 
     prefixPattern = Param(Params._dummy(),
                           "prefixPattern",
@@ -123,14 +123,14 @@ class Tokenizer(AnnotatorModel):
                           typeConverter=TypeConverters.toString)
 
     compositeTokens = Param(Params._dummy(),
-                         "compositeTokens",
-                         "Words that won't be split in two",
-                         typeConverter=TypeConverters.toListString)
+                            "compositeTokens",
+                            "Words that won't be split in two",
+                            typeConverter=TypeConverters.toListString)
 
     infixPatterns = Param(Params._dummy(),
-                            "infixPatterns",
-                            "regex patterns that match tokens within a single target. groups identify different sub-tokens. multiple defaults",
-                            typeConverter=TypeConverters.toListString)
+                          "infixPatterns",
+                          "regex patterns that match tokens within a single target. groups identify different sub-tokens. multiple defaults",
+                          typeConverter=TypeConverters.toListString)
 
     @keyword_only
     def __init__(self):
@@ -190,9 +190,9 @@ class RegexMatcher(AnnotatorApproach):
                      "MATCH_FIRST|MATCH_ALL|MATCH_COMPLETE",
                      typeConverter=TypeConverters.toString)
     externalRules = Param(Params._dummy(),
-                  "externalRules",
-                  "external resource to rules, needs 'delimiter' in options",
-                  typeConverter=TypeConverters.identity)
+                          "externalRules",
+                          "external resource to rules, needs 'delimiter' in options",
+                          typeConverter=TypeConverters.identity)
 
     @keyword_only
     def __init__(self):
@@ -211,16 +211,16 @@ class RegexMatcher(AnnotatorApproach):
         return RegexMatcherModel(java_model)
 
 
-class RegexMatcherModel(AnnotatorModel):
+class RegexMatcherModel(_AnnotatorModel):
     name = "RegexMatcherModel"
 
 
 class Lemmatizer(AnnotatorApproach):
     dictionary = Param(Params._dummy(),
-                        "dictionary",
-                        "lemmatizer external dictionary." +
+                       "dictionary",
+                       "lemmatizer external dictionary." +
                        " needs 'keyDelimiter' and 'valueDelimiter' in options for parsing target text",
-                        typeConverter=TypeConverters.identity)
+                       typeConverter=TypeConverters.identity)
 
     @keyword_only
     def __init__(self):
@@ -238,7 +238,7 @@ class Lemmatizer(AnnotatorApproach):
         return self._set(dictionary=ExternalResource(path, read_as, opts))
 
 
-class LemmatizerModel(AnnotatorModel):
+class LemmatizerModel(_AnnotatorModel):
     name = "LemmatizerModel"
 
 
@@ -259,9 +259,9 @@ class DateMatcher(AnnotatorModel):
 class EntityExtractor(AnnotatorApproach):
 
     entities = Param(Params._dummy(),
-                         "entities",
-                         "ExternalResource for entities",
-                         typeConverter=TypeConverters.identity)
+                     "entities",
+                     "ExternalResource for entities",
+                     typeConverter=TypeConverters.identity)
 
     @keyword_only
     def __init__(self):
@@ -274,7 +274,7 @@ class EntityExtractor(AnnotatorApproach):
         return self._set(entities=ExternalResource(path, read_as, options.copy()))
 
 
-class EntityExtractorModel(AnnotatorModel):
+class EntityExtractorModel(_AnnotatorModel):
     name = "EntityExtractorModel"
 
 
@@ -285,8 +285,8 @@ class PerceptronApproach(AnnotatorApproach):
                    typeConverter=TypeConverters.toString)
 
     corpus = Param(Params._dummy(),
-                       "corpus",
-                       "POS tags delimited corpus. Needs 'delimiter' in options",
+                   "corpus",
+                   "POS tags delimited corpus. Needs 'delimiter' in options",
                    typeConverter=TypeConverters.identity)
 
     nIterations = Param(Params._dummy(),
@@ -314,7 +314,7 @@ class PerceptronApproach(AnnotatorApproach):
         return PerceptronModel(java_model)
 
 
-class PerceptronModel(AnnotatorModel):
+class PerceptronModel(_AnnotatorModel):
     name = "PerceptronModel"
 
 
@@ -345,8 +345,8 @@ class SentenceDetector(AnnotatorModel):
 
 class SentimentDetector(AnnotatorApproach):
     dictionary = Param(Params._dummy(),
-                     "dictionary",
-                     "path for dictionary to sentiment analysis")
+                       "dictionary",
+                       "path for dictionary to sentiment analysis")
 
     @keyword_only
     def __init__(self):
@@ -362,25 +362,25 @@ class SentimentDetector(AnnotatorApproach):
         return SentimentDetectorModel(java_model)
 
 
-class SentimentDetectorModel(AnnotatorModel):
+class SentimentDetectorModel(_AnnotatorModel):
     name = "SentimentDetectorModel"
 
 
 class ViveknSentimentApproach(AnnotatorApproach):
     sentimentCol = Param(Params._dummy(),
-                           "sentimentCol",
-                           "column with the sentiment result of every row. Must be 'positive' or 'negative'",
-                           typeConverter=TypeConverters.toString)
+                         "sentimentCol",
+                         "column with the sentiment result of every row. Must be 'positive' or 'negative'",
+                         typeConverter=TypeConverters.toString)
 
     positiveSource = Param(Params._dummy(),
-                     "positiveSource",
-                     "positive sentiment file or folder",
-                     typeConverter=TypeConverters.identity)
+                           "positiveSource",
+                           "positive sentiment file or folder",
+                           typeConverter=TypeConverters.identity)
 
     negativeSource = Param(Params._dummy(),
-                      "negativeSource",
-                      "negative sentiment file or folder",
-                      typeConverter=TypeConverters.identity)
+                           "negativeSource",
+                           "negative sentiment file or folder",
+                           typeConverter=TypeConverters.identity)
 
     pruneCorpus = Param(Params._dummy(),
                         "pruneCorpus",
@@ -413,20 +413,20 @@ class ViveknSentimentApproach(AnnotatorApproach):
         return ViveknSentimentModel(java_model)
 
 
-class ViveknSentimentModel(AnnotatorModel):
+class ViveknSentimentModel(_AnnotatorModel):
     name = "ViveknSentimentModel"
 
 
 class NorvigSweetingApproach(AnnotatorApproach):
     dictionary = Param(Params._dummy(),
-                        "dictionary",
-                        "dictionary needs 'tokenPattern' regex in dictionary for separating words",
-                        typeConverter=TypeConverters.identity)
+                       "dictionary",
+                       "dictionary needs 'tokenPattern' regex in dictionary for separating words",
+                       typeConverter=TypeConverters.identity)
 
     corpus = Param(Params._dummy(),
-                        "corpus",
-                        "spell checker corpus needs 'tokenPattern' regex for tagging words. e.g. [a-zA-Z]+",
-                        typeConverter=TypeConverters.identity)
+                   "corpus",
+                   "spell checker corpus needs 'tokenPattern' regex for tagging words. e.g. [a-zA-Z]+",
+                   typeConverter=TypeConverters.identity)
 
     slangDictionary = Param(Params._dummy(),
                             "slangDictionary",
@@ -483,15 +483,15 @@ class NorvigSweetingApproach(AnnotatorApproach):
         return NorvigSweetingModel(java_model)
 
 
-class NorvigSweetingModel(AnnotatorModel):
+class NorvigSweetingModel(_AnnotatorModel):
     name = "NorvigSweetingModel"
 
 
 class NerCrfApproach(AnnotatorApproach, AnnotatorWithEmbeddings):
     labelColumn = Param(Params._dummy(),
-                     "labelColumn",
-                     "Column with label per each token",
-                     typeConverter=TypeConverters.toString)
+                        "labelColumn",
+                        "Column with label per each token",
+                        typeConverter=TypeConverters.toString)
 
     entities = Param(Params._dummy(), "entities", "Entities to recognize", TypeConverters.toListString)
 
@@ -555,7 +555,7 @@ class NerCrfApproach(AnnotatorApproach, AnnotatorWithEmbeddings):
         super(NerCrfApproach, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ner.crf.NerCrfApproach")
 
 
-class NerCrfModel(AnnotatorModel):
+class NerCrfModel(_AnnotatorModel):
     name = "NerCrfModel"
 
 
@@ -591,7 +591,7 @@ class AssertionLogRegApproach(AnnotatorApproach, AnnotatorWithEmbeddings):
     def setEnet(self, enet):
         self._set(eNetParam = enet)
         return self
-    
+
     def setBefore(self, before):
         self._set(beforeParam = before)
         return self
@@ -616,5 +616,5 @@ class AssertionLogRegApproach(AnnotatorApproach, AnnotatorWithEmbeddings):
         super(AssertionLogRegApproach, self).__init__(classname="com.johnsnowlabs.nlp.annotators.assertion.logreg.AssertionLogRegApproach")
 
 
-class AssertionLogRegModel(AnnotatorModel):
+class AssertionLogRegModel(_AnnotatorModel):
     name = "AssertionLogRegModel"

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -7,7 +7,7 @@ from pyspark import keyword_only
 from pyspark.ml.util import JavaMLReadable, JavaMLWritable
 from pyspark.ml.wrapper import JavaTransformer, JavaModel, JavaEstimator
 from pyspark.ml.param.shared import Param, Params, TypeConverters
-from sparknlp.common import ExternalResource
+from sparknlp.common import ExternalResource, ParamsGetters
 
 if sys.version_info[0] == 2:
     #Needed. Delete once DA becomes an annotator in 1.1.x
@@ -71,7 +71,7 @@ class AnnotatorWithEmbeddings(Params):
         return self._set(embeddingsNDims=nDims)
 
 
-class AnnotatorTransformer(JavaModel, JavaMLReadable, JavaMLWritable, AnnotatorProperties):
+class AnnotatorTransformer(JavaModel, JavaMLReadable, JavaMLWritable, AnnotatorProperties, ParamsGetters):
 
     column_type = "array<struct<annotatorType:string,begin:int,end:int,metadata:map<string,string>>>"
 
@@ -85,7 +85,7 @@ class AnnotatorTransformer(JavaModel, JavaMLReadable, JavaMLWritable, AnnotatorP
         super(JavaTransformer, self).__init__()
         
         
-class AnnotatorApproach(JavaEstimator, JavaMLWritable, JavaMLReadable, AnnotatorProperties):
+class AnnotatorApproach(JavaEstimator, JavaMLWritable, JavaMLReadable, AnnotatorProperties, ParamsGetters):
     @keyword_only
     def __init__(self, classname):
         super(AnnotatorApproach, self).__init__()

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -72,7 +72,7 @@ class AnnotatorWithEmbeddings(Params):
         return self._set(embeddingsNDims=nDims)
 
 
-class AnnotatorTransformer(JavaModel, AnnotatorJavaMLReadable, JavaMLWritable, AnnotatorProperties, ParamsGetters):
+class AnnotatorModel(JavaModel, AnnotatorJavaMLReadable, JavaMLWritable, AnnotatorProperties, ParamsGetters):
 
     column_type = "array<struct<annotatorType:string,begin:int,end:int,metadata:map<string,string>>>"
 
@@ -91,6 +91,7 @@ class AnnotatorTransformer(JavaModel, AnnotatorJavaMLReadable, JavaMLWritable, A
         self.__class__._java_class_name = classname
         self._java_obj = self._new_java_obj(classname, self.uid)
 
+
 class AnnotatorApproach(JavaEstimator, JavaMLWritable, AnnotatorJavaMLReadable, AnnotatorProperties, ParamsGetters):
     @keyword_only
     def __init__(self, classname):
@@ -99,16 +100,12 @@ class AnnotatorApproach(JavaEstimator, JavaMLWritable, AnnotatorJavaMLReadable, 
         self._java_obj = self._new_java_obj(classname, self.uid)
 
 
-class AnnotatorModel(JavaModel, JavaMLWritable, JavaMLReadable, AnnotatorProperties):
-    pass
-
-
 class ReadAs(object):
     LINE_BY_LINE = "LINE_BY_LINE"
     SPARK_DATASET = "SPARK_DATASET"
 
 
-class Tokenizer(AnnotatorTransformer):
+class Tokenizer(AnnotatorModel):
 
     targetPattern = Param(Params._dummy(),
                     "targetPattern",
@@ -155,7 +152,7 @@ class Tokenizer(AnnotatorTransformer):
         return self._set(infixPatterns=value)
 
 
-class Stemmer(AnnotatorTransformer):
+class Stemmer(AnnotatorModel):
 
     algorithm = Param(Params._dummy(), "algorithm", "stemmer algorithm", typeConverter=TypeConverters.toString)
 
@@ -164,7 +161,7 @@ class Stemmer(AnnotatorTransformer):
         super(Stemmer, self).__init__(classname="com.johnsnowlabs.nlp.annotators.Stemmer")
 
 
-class Normalizer(AnnotatorTransformer):
+class Normalizer(AnnotatorModel):
 
     pattern = Param(Params._dummy(),
                     "pattern",
@@ -245,7 +242,7 @@ class LemmatizerModel(AnnotatorModel):
     name = "LemmatizerModel"
 
 
-class DateMatcher(AnnotatorTransformer):
+class DateMatcher(AnnotatorModel):
     dateFormat = Param(Params._dummy(),
                        "dateFormat",
                        "desired format for dates extracted",
@@ -321,7 +318,7 @@ class PerceptronModel(AnnotatorModel):
     name = "PerceptronModel"
 
 
-class SentenceDetector(AnnotatorTransformer):
+class SentenceDetector(AnnotatorModel):
 
     useAbbreviations = Param(Params._dummy(),
                              "useAbbreviations",

--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -1,5 +1,5 @@
 from pyspark import keyword_only
-from pyspark.ml.util import JavaMLReadable, JavaMLWritable
+from pyspark.ml.util import JavaMLWritable
 from pyspark.ml.wrapper import JavaTransformer, JavaEstimator
 from pyspark.ml.param.shared import Param, Params, TypeConverters
 from pyspark.ml.pipeline import Pipeline, PipelineModel, Estimator, Transformer
@@ -7,15 +7,13 @@ from sparknlp.common import ParamsGetters
 from sparknlp.util import AnnotatorJavaMLReadable
 
 
-class AnnotatorTransformer(JavaTransformer, AnnotatorJavaMLReadable, JavaMLWritable):
+class AnnotatorTransformer(JavaTransformer, AnnotatorJavaMLReadable, JavaMLWritable, ParamsGetters):
     @keyword_only
     def __init__(self, classname):
         super(AnnotatorTransformer, self).__init__()
         kwargs = self._input_kwargs
-        try:
+        if 'classname' in kwargs:
             kwargs.pop('classname')
-        except:
-            pass
         self.setParams(**kwargs)
         self.__class__._java_class_name = classname
         self._java_obj = self._new_java_obj(classname, self.uid)
@@ -108,7 +106,7 @@ class RecursivePipeline(Pipeline, JavaEstimator):
         return PipelineModel(transformers)
 
 
-class DocumentAssembler(AnnotatorTransformer, ParamsGetters):
+class DocumentAssembler(AnnotatorTransformer):
 
     inputCol = Param(Params._dummy(), "inputCol", "input column name.", typeConverter=TypeConverters.toString)
     outputCol = Param(Params._dummy(), "outputCol", "input column name.", typeConverter=TypeConverters.toString)
@@ -137,7 +135,7 @@ class DocumentAssembler(AnnotatorTransformer, ParamsGetters):
         return self._set(metadataCol=value)
 
 
-class TokenAssembler(AnnotatorTransformer, ParamsGetters):
+class TokenAssembler(AnnotatorTransformer):
 
     inputCols = Param(Params._dummy(), "inputCols", "input token annotations", typeConverter=TypeConverters.toListString)
     outputCol = Param(Params._dummy(), "outputCol", "output column name.", typeConverter=TypeConverters.toString)
@@ -158,7 +156,7 @@ class TokenAssembler(AnnotatorTransformer, ParamsGetters):
         return self._set(outputCol=value)
 
 
-class Finisher(AnnotatorTransformer, ParamsGetters):
+class Finisher(AnnotatorTransformer):
 
     inputCols = Param(Params._dummy(), "inputCols", "input annotations", typeConverter=TypeConverters.toListString)
     outputCols = Param(Params._dummy(), "outputCols", "output finished annotation cols", typeConverter=TypeConverters.toListString)

--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -3,7 +3,7 @@ from pyspark.ml.util import JavaMLReadable, JavaMLWritable
 from pyspark.ml.wrapper import JavaTransformer, JavaEstimator
 from pyspark.ml.param.shared import Param, Params, TypeConverters
 from pyspark.ml.pipeline import Pipeline, PipelineModel, Estimator, Transformer
-
+from sparknlp.common import ParamsGetters
 
 class JavaRecursiveEstimator(JavaEstimator):
 
@@ -92,7 +92,7 @@ class RecursivePipeline(Pipeline, JavaEstimator):
         return PipelineModel(transformers)
 
 
-class DocumentAssembler(JavaTransformer, JavaMLReadable, JavaMLWritable):
+class DocumentAssembler(JavaTransformer, JavaMLReadable, JavaMLWritable, ParamsGetters):
 
     inputCol = Param(Params._dummy(), "inputCol", "input column name.", typeConverter=TypeConverters.toString)
     outputCol = Param(Params._dummy(), "outputCol", "input column name.", typeConverter=TypeConverters.toString)
@@ -124,7 +124,7 @@ class DocumentAssembler(JavaTransformer, JavaMLReadable, JavaMLWritable):
         return self._set(metadataCol=value)
 
 
-class TokenAssembler(JavaTransformer, JavaMLReadable, JavaMLWritable):
+class TokenAssembler(JavaTransformer, JavaMLReadable, JavaMLWritable, ParamsGetters):
 
     inputCols = Param(Params._dummy(), "inputCols", "input token annotations", typeConverter=TypeConverters.toListString)
     outputCol = Param(Params._dummy(), "outputCol", "output column name.", typeConverter=TypeConverters.toString)
@@ -148,7 +148,7 @@ class TokenAssembler(JavaTransformer, JavaMLReadable, JavaMLWritable):
         return self._set(outputCol=value)
 
 
-class Finisher(JavaTransformer, JavaMLReadable, JavaMLWritable):
+class Finisher(JavaTransformer, JavaMLReadable, JavaMLWritable, ParamsGetters):
 
     inputCols = Param(Params._dummy(), "inputCols", "input annotations", typeConverter=TypeConverters.toListString)
     outputCols = Param(Params._dummy(), "outputCols", "output finished annotation cols", typeConverter=TypeConverters.toListString)

--- a/python/sparknlp/common.py
+++ b/python/sparknlp/common.py
@@ -1,5 +1,6 @@
 import sparknlp.internal as _internal
-
+from pyspark.ml.param import *
+import re
 
 def RegexRule(rule, identifier):
     return _internal._RegexRule(rule, identifier).apply()
@@ -7,3 +8,23 @@ def RegexRule(rule, identifier):
 def ExternalResource(path, read_as, options):
     return _internal._ExternalResource(path, read_as, options).apply()
 
+"""
+Helper class used to generate the getters for all params
+"""
+class ParamsGetters(Params):
+    getter_attrs = []
+
+    def __init__(self):
+        super(ParamsGetters, self).__init__()
+        for param in self.params:
+            param_name = param.name
+            f_attr = "get" + re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), param_name)
+            setattr(self, f_attr, self.getParamValue(param_name))
+
+    def getParamValue(self, paramName):
+        def r():
+            try:
+                return self.getOrDefault(paramName)
+            except:
+                return None
+        return r

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -1,6 +1,6 @@
 import unittest
 import os
-
+import re
 from sparknlp.annotator import *
 from sparknlp.base import *
 from test.util import SparkContextForTest
@@ -259,3 +259,15 @@ class SpellCheckerTestSpec(unittest.TestCase):
         tokenized = tokenizer.transform(assembled)
         checked = spell_checker.transform(tokenized)
         checked.show()
+
+class ParamsGettersTestSpec(unittest.TestCase):
+    def test_multiple(self):
+        annotators = [ DocumentAssembler, PerceptronApproach, Lemmatizer, TokenAssembler, NorvigSweetingApproach, Tokenizer ]
+        for annotator in annotators:
+            a = annotator()
+            for param in a.params:
+                param_name = param.name
+                camelized_param = re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), param_name)
+                assert(hasattr(a, param_name))
+                param_value = getattr(a, "get" + camelized_param)()
+                assert(param_value is None or param_value is not None)

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -260,9 +260,10 @@ class SpellCheckerTestSpec(unittest.TestCase):
         checked = spell_checker.transform(tokenized)
         checked.show()
 
+
 class ParamsGettersTestSpec(unittest.TestCase):
     def test_multiple(self):
-        annotators = [ DocumentAssembler, PerceptronApproach, Lemmatizer, TokenAssembler, NorvigSweetingApproach, Tokenizer ]
+        annotators = [DocumentAssembler, PerceptronApproach, Lemmatizer, TokenAssembler, NorvigSweetingApproach, Tokenizer]
         for annotator in annotators:
             a = annotator()
             for param in a.params:
@@ -271,3 +272,10 @@ class ParamsGettersTestSpec(unittest.TestCase):
                 assert(hasattr(a, param_name))
                 param_value = getattr(a, "get" + camelized_param)()
                 assert(param_value is None or param_value is not None)
+        # Try a random getter
+        sentence_detector = SentenceDetector() \
+            .setInputCols(["document"]) \
+            .setOutputCol("sentence") \
+            .setCustomBounds(["%%"])
+        assert(sentence_detector.getOutputCol() == "sentence")
+        assert(sentence_detector.getCustomBounds() == ["%%"])

--- a/python/test/misc.py
+++ b/python/test/misc.py
@@ -7,8 +7,8 @@ class UtilitiesTestSpec(unittest.TestCase):
 
     @staticmethod
     def runTest():
-        regex_rule = RegexRule("\\w+", "word split")
-        print(regex_rule.rule())
+        regex_rule = RegexRule("\w+", "word split")
+        assert(regex_rule.rule() == "\w+")
 
 
 class ConfigPathTestSpec(unittest.TestCase):

--- a/python/test/misc.py
+++ b/python/test/misc.py
@@ -1,10 +1,13 @@
 import unittest
+import shutil
+import tempfile
+
 from sparknlp.common import RegexRule
 from sparknlp.util import *
-import shutil, tempfile
 
-from sparknlp.base import DocumentAssembler, TokenAssembler, Finisher
+from sparknlp.base import TokenAssembler
 from sparknlp.annotator import *
+
 
 class UtilitiesTestSpec(unittest.TestCase):
 
@@ -21,6 +24,7 @@ class ConfigPathTestSpec(unittest.TestCase):
         assert(get_config_path() == "./application.conf")
         set_config_path("./somewhere/application.conf")
         assert(get_config_path() == "./somewhere/application.conf")
+
 
 class SerializersTestSpec(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Automatic generation of getters for all python annotator's params

## Description
<!--- Describe your changes in detail -->

 - Added a new class ParamsGetters which creates a callback to resolve "get*" methods for the python annotators returning the corresponding param (*) value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Python annotators didn't provide getters for the params

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Specific tests in the python test suite
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
