### PR TITLE
Fix DocumentAssembler adding a 0 lower bound for the end field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,8 +299,7 @@ project/plugins/project/
 # End of https://www.gitignore.io/api/sbt,java,scala,python,eclipse,intellij,intellij+all
 
 ### Local ###
-tmp_pipeline/
 test-output-tmp/
 spark-warehouse/
 /python/python.iml
-test_crf_pipeline/
+*_pipeline/

--- a/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
@@ -14,7 +14,11 @@ import scala.collection.Map
   * @param end the index after the last character under this annotation
   * @param metadata associated metadata for this annotation
   */
-case class Annotation(annotatorType: String, start: Int, end: Int, result: String, metadata: Map[String, String])
+case class Annotation(annotatorType: String, start: Int, end: Int, result: String, metadata: Map[String, String]) {
+  require(start >= 0, "start field in Annotation class should always be gte 0")
+  require(start <= end, "start field in Annotation class should always be lte  end field")
+  require(end >= 0, "end field in Annotation class should always be gte 0")
+}
 
 object Annotation {
 
@@ -45,7 +49,6 @@ object Annotation {
     StructField("metadata", MapType(StringType, StringType), nullable = true)
   ))
 
-
   /**
     * This method converts a [[org.apache.spark.sql.Row]] into an [[Annotation]]
     * @param row spark row to be converted
@@ -60,6 +63,7 @@ object Annotation {
       row.getMap[String, String](4)
     )
   }
+
   def apply(rawText: String): Annotation = Annotation(
     AnnotatorType.DOCUMENT,
     0,
@@ -118,6 +122,4 @@ object Annotation {
       )
     }
   }
-
-
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/DocumentAssembler.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/DocumentAssembler.scala
@@ -49,7 +49,7 @@ class DocumentAssembler(override val uid: String)
   override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
 
   private def assemble(text: String, metadata: Map[String, String]): Seq[Annotation] = {
-    Seq(Annotation(annotatorType, 0, text.length - 1, text, metadata))
+    Seq(Annotation(annotatorType, 0, math.max(0, text.length - 1), text, metadata))
   }
 
   private def dfAssemble: UserDefinedFunction = udf {

--- a/src/test/scala/com/johnsnowlabs/nlp/DocumentAssemblerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/DocumentAssemblerTestSpec.scala
@@ -1,7 +1,8 @@
 package com.johnsnowlabs.nlp
 
 import org.scalatest._
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, Row}
+
 import scala.language.reflectiveCalls
 import Matchers._
 
@@ -20,5 +21,20 @@ class DocumentAssemblerTestSpec extends FlatSpec {
     val f = fixture
     f.text.head should equal (f.text(f.assembledDoc.head.start))
     f.text.last should equal (f.text(f.assembledDoc.head.end))
+  }
+
+  it should "index lower bound should be 0" in {
+    val df: DataFrame = DataBuilder.multipleDataBuild(Seq[String]("", ".", ";", s"\n", "Someday", "1"))
+    val df2 = new DocumentAssembler()
+      .setInputCol("text")
+      .transform(df)
+
+    df2
+      .select("document")
+      .collect
+      .flatMap { _.getSeq[Row](0) }
+      .foreach { a =>
+        a.getInt(2) should be >= 0
+      }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
DocumentAssembler now have a 0 lower bound for the end field for the end field when creating annotations

## Description
<!--- Describe your changes in detail -->

Simple patch when creating the annotation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

DocumentAssembler is setting the Annotation's end field to -1 for empty strings

<!--- If it fixes an open issue, please link to the issue here. -->
#122 Although it hasn't been verified that is the root of the problem.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Added an additional tests to the DocumentAssemblerTestSpec

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
