### PR TITLE
Fixed default value getters in pyspark

### DIFF
--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -117,6 +117,7 @@ class DocumentAssembler(AnnotatorTransformer):
     @keyword_only
     def __init__(self):
         super(DocumentAssembler, self).__init__(classname="com.johnsnowlabs.nlp.DocumentAssembler")
+        self._setDefault(outputCol="document")
 
     @keyword_only
     def setParams(self):
@@ -170,6 +171,13 @@ class Finisher(AnnotatorTransformer):
     @keyword_only
     def __init__(self):
         super(Finisher, self).__init__(classname="com.johnsnowlabs.nlp.Finisher")
+        self._setDefault(
+            valueSplitSymbol="#",
+            annotationSplitSymbol="@",
+            cleanAnnotations=True,
+            includeKeys=False,
+            outputAsArray=False
+        )
 
     @keyword_only
     def setParams(self):

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -18,7 +18,8 @@ class BasicAnnotatorsTestSpec(unittest.TestCase):
             .setOutputCol("document")
         tokenizer = Tokenizer()\
             .setOutputCol("token") \
-            .setCompositeTokens(["New York"])
+            .setCompositeTokens(["New York"]) \
+            .addInfixPattern("(%\\d+)")
         stemmer = Stemmer() \
             .setInputCols(["token"]) \
             .setOutputCol("stem")
@@ -273,10 +274,13 @@ class ParamsGettersTestSpec(unittest.TestCase):
                 assert(hasattr(a, param_name))
                 param_value = getattr(a, "get" + camelized_param)()
                 assert(param_value is None or param_value is not None)
-        # Try a random getter
+        # Try a getter
         sentence_detector = SentenceDetector() \
             .setInputCols(["document"]) \
             .setOutputCol("sentence") \
             .setCustomBounds(["%%"])
         assert(sentence_detector.getOutputCol() == "sentence")
         assert(sentence_detector.getCustomBounds() == ["%%"])
+        # Try a default getter
+        document_assembler = DocumentAssembler()
+        assert(document_assembler.getOutputCol() == "document")

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Stemmer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Stemmer.scala
@@ -18,16 +18,16 @@ class Stemmer(override val uid: String) extends AnnotatorModel[Stemmer] {
 
   import com.johnsnowlabs.nlp.AnnotatorType._
 
-  val algorithm: Param[String] = new Param(this, "language", "this is the language of the text")
-  setDefault(algorithm, "english")
+  val language: Param[String] = new Param(this, "language", "this is the language of the text")
+  setDefault(language, "english")
 
   override val annotatorType: AnnotatorType = TOKEN
 
   override val requiredAnnotatorTypes: Array[AnnotatorType] = Array(TOKEN)
 
-  def setPattern(value: String): Stemmer = set(algorithm, value)
+  def setLanguage(value: String): Stemmer = set(language, value)
 
-  def getPattern: String = $(algorithm)
+  def getLanguage: String = $(language)
 
   def this() = this(Identifiable.randomUID("STEMMER"))
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
@@ -19,7 +19,7 @@ class Tokenizer(override val uid: String) extends AnnotatorModel[Tokenizer] {
 
   val compositeTokens: StringArrayParam = new StringArrayParam(this, "compositeTokens", "Words that won't be split in two")
   val targetPattern: Param[String] = new Param(this, "targetPattern", "pattern to grab from text as token candidates. Defaults \\S+")
-  val infixPatterns: StringArrayParam = new StringArrayParam(this, "infixPattern", "regex patterns that match tokens within a single target. groups identify different sub-tokens. multiple defaults")
+  val infixPatterns: StringArrayParam = new StringArrayParam(this, "infixPatterns", "regex patterns that match tokens within a single target. groups identify different sub-tokens. multiple defaults")
   val prefixPattern: Param[String] = new Param[String](this, "prefixPattern", "regex with groups and begins with \\A to match target prefix. Defaults to \\A([^\\s\\p{L}$\\.]*)")
   val suffixPattern: Param[String] = new Param[String](this, "suffixPattern", "regex with groups and ends with \\z to match target suffix. Defaults to ([^\\s\\p{L}]?)([^\\s\\p{L}]*)\\z")
 


### PR DESCRIPTION
-pyspark getters now properly work when accessing default values
-fixed stemmer language param name
-fixed tokenizer infix param name
-added addInfix param into pyspark

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
User reported missing addInfixPattern in pyspark and this lead to discovery that default value getters weren't working. This fixes all related issues.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
