### PR TITLE
Correct windows backlash into S3 linux slash

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ApproachWithWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ApproachWithWordEmbeddings.scala
@@ -46,7 +46,7 @@ abstract class ApproachWithWordEmbeddings[A <: ApproachWithWordEmbeddings[A, M],
   override def beforeTraining(spark: SparkSession): Unit = {
     if (isDefined(sourceEmbeddingsPath)) {
       // 1. Create tmp file for index
-      localPath = Some(WordEmbeddingsClusterHelper.createLocalPath())
+      localPath = Some(WordEmbeddingsClusterHelper.createLocalPath()).map(_.replaceAllLiterally("\\", "/"))
       // 2. Index Word Embeddings
       indexEmbeddings(localPath.get, spark.sparkContext)
       // 3. Copy WordEmbeddings to cluster

--- a/src/main/scala/com/johnsnowlabs/pretrained/S3ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/pretrained/S3ResourceDownloader.scala
@@ -15,7 +15,7 @@ class S3ResourceDownloader(bucket: String,
 
   var lastMetadataVersion: Option[String] = None
   var metadata = List.empty[ResourceMetadata]
-  val metadataFile = Paths.get(s3Path, "metadata.json").toString
+  val metadataFile = Paths.get(s3Path, "metadata.json").toString.replaceAllLiterally("\\", "/")
 
    if (!new File(cacheFolder).exists()) {
     FileUtils.forceMkdir(new File(cacheFolder))
@@ -61,7 +61,7 @@ class S3ResourceDownloader(bucket: String,
     val link = resolveLink(name, language, libVersion, sparkVersion)
     link.flatMap {
       resource =>
-        val s3FilePath = Paths.get(s3Path, resource.fileName).toString
+        val s3FilePath = Paths.get(s3Path, resource.fileName).toString.replaceAllLiterally("\\", "/")
         val dstFile = new File(cacheFolder, resource.fileName)
         if (!client.doesObjectExist(bucket, s3FilePath)) {
           None

--- a/src/main/scala/com/johnsnowlabs/util/ZipArchiveUtil.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ZipArchiveUtil.scala
@@ -91,7 +91,7 @@ object ZipArchiveUtil {
       }
 
       // create output directory if it doesn't exist already
-      val splitPath = entry.getName.split(File.separator).dropRight(1)
+      val splitPath = entryName.split(File.separator.replace("\\", "/")).dropRight(1)
 
       val dirBuilder = new StringBuilder(destDir.getPath)
       for (part <- splitPath) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes model downloader not working under windows environment due to backlash character in path

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
