### PR TITLE
passing uri to retrieve the correct FileSystem

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/HasWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasWordEmbeddings.scala
@@ -50,7 +50,8 @@ trait HasWordEmbeddings extends AutoCloseable with ParamsAndFeaturesWritable {
 
 
   def deserializeEmbeddings(path: String, spark: SparkContext): Unit = {
-    val fs = FileSystem.get(spark.hadoopConfiguration)
+    val uri = new java.net.URI(path)
+    val fs = FileSystem.get(uri, spark.hadoopConfiguration)
     val src = getEmbeddingsSerializedPath(path)
 
     // 1. Copy to local file
@@ -73,7 +74,8 @@ trait HasWordEmbeddings extends AutoCloseable with ParamsAndFeaturesWritable {
   def serializeEmbeddings(path: String, spark: SparkContext): Unit = {
     if (isDefined(indexPath)) {
       val index = new Path(SparkFiles.get($(indexPath)))
-      val fs = FileSystem.get(spark.hadoopConfiguration)
+      val uri = new java.net.URI(path)
+      val fs = FileSystem.get(uri, spark.hadoopConfiguration)
 
       val dst = getEmbeddingsSerializedPath(path)
       fs.copyFromLocalFile(false, true, index, dst)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ApproachWithWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ApproachWithWordEmbeddings.scala
@@ -81,7 +81,8 @@ abstract class ApproachWithWordEmbeddings[A <: ApproachWithWordEmbeddings[A, M],
   private def indexEmbeddings(localFile: String, spark: SparkContext): Unit = {
     val formatId = $(embeddingsFormat)
 
-    val fs = FileSystem.get(spark.hadoopConfiguration)
+    val uri = new java.net.URI(localFile)
+    val fs = FileSystem.get(uri, spark.hadoopConfiguration)
 
     if (formatId == WordEmbeddingsFormat.TEXT.id) {
       val tmpFile = Files.createTempFile("embeddings", ".bin").toAbsolutePath.toString()
@@ -93,7 +94,8 @@ abstract class ApproachWithWordEmbeddings[A <: ApproachWithWordEmbeddings[A, M],
       WordEmbeddingsIndexer.indexBinary(tmpFile, localFile)
     }
     else if (formatId == WordEmbeddingsFormat.SPARKNLP.id) {
-      val hdfs = FileSystem.get(spark.hadoopConfiguration)
+      val uri = new java.net.URI(localFile)
+      val hdfs = FileSystem.get(uri, spark.hadoopConfiguration)
       hdfs.copyToLocalFile(new Path($(sourceEmbeddingsPath)), new Path(localFile))
     }
   }
@@ -117,7 +119,8 @@ object WordEmbeddingsClusterHelper {
   }
 
   def copyIndexToCluster(localFolder: String, spark: SparkContext): String = {
-    val fs = FileSystem.get(spark.hadoopConfiguration)
+    val uri = new java.net.URI(localFolder)
+    val fs = FileSystem.get(uri, spark.hadoopConfiguration)
 
     val src = new Path(localFolder)
     val dst = Path.mergePaths(fs.getHomeDirectory, getClusterFileName(localFolder))

--- a/src/main/scala/com/johnsnowlabs/nlp/serialization/Feature.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/serialization/Feature.scala
@@ -106,7 +106,8 @@ class StructFeature[TValue: ClassTag](model: HasFeatures, override val name: Str
   }
 
   override def deserializeObject(spark: SparkSession, path: String, field: String): Option[TValue] = {
-    val fs: FileSystem = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    val uri = new java.net.URI(path)
+    val fs: FileSystem = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
     val dataPath = getFieldPath(path, field)
     if (fs.exists(dataPath)) {
       Some(spark.sparkContext.objectFile[TValue](dataPath.toString).first)
@@ -121,7 +122,8 @@ class StructFeature[TValue: ClassTag](model: HasFeatures, override val name: Str
   }
 
   override def deserializeDataset(spark: SparkSession, path: String, field: String): Option[TValue] = {
-    val fs: FileSystem = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    val uri = new java.net.URI(path)
+    val fs: FileSystem = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
     val dataPath = getFieldPath(path, field)
     if (fs.exists(dataPath)) {
       Some(spark.read.parquet(dataPath.toString).as[TValue].first)
@@ -145,7 +147,8 @@ class MapFeature[TKey: ClassTag, TValue: ClassTag](model: HasFeatures, override 
 
 
   override def deserializeObject(spark: SparkSession, path: String, field: String): Option[Map[TKey, TValue]] = {
-    val fs: FileSystem = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    val uri = new java.net.URI(path)
+    val fs: FileSystem = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
     val dataPath = getFieldPath(path, field)
     if (fs.exists(dataPath)) {
       Some(spark.sparkContext.objectFile[(TKey, TValue)](dataPath.toString).collect.toMap)
@@ -163,7 +166,8 @@ class MapFeature[TKey: ClassTag, TValue: ClassTag](model: HasFeatures, override 
 
 
   override def deserializeDataset(spark: SparkSession, path: String, field: String): Option[Map[TKey, TValue]] = {
-    val fs: FileSystem = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    val uri = new java.net.URI(path)
+    val fs: FileSystem = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
     val dataPath = getFieldPath(path, field)
     if (fs.exists(dataPath)) {
       Some(spark.read.parquet(dataPath.toString).as[(TKey, TValue)].collect.toMap)
@@ -185,7 +189,8 @@ class ArrayFeature[TValue: ClassTag](model: HasFeatures, override val name: Stri
   }
 
   override def deserializeObject(spark: SparkSession, path: String, field: String): Option[Array[TValue]] = {
-    val fs: FileSystem = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    val uri = new java.net.URI(path)
+    val fs: FileSystem = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
     val dataPath = getFieldPath(path, field)
     if (fs.exists(dataPath)) {
       Some(spark.sparkContext.objectFile[TValue](dataPath.toString).collect())
@@ -200,7 +205,8 @@ class ArrayFeature[TValue: ClassTag](model: HasFeatures, override val name: Stri
   }
 
   override def deserializeDataset(spark: SparkSession, path: String, field: String): Option[Array[TValue]] = {
-    val fs: FileSystem = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    val uri = new java.net.URI(path)
+    val fs: FileSystem = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
     val dataPath = getFieldPath(path, field)
     if (fs.exists(dataPath)) {
       Some(spark.read.parquet(dataPath.toString).as[TValue].collect)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
On com.johnsnowlabs.nlp.serialization.Feature a FileSystem object is created, and used to verify that the provided path exists, if we don't pass the path at creation of the object the default filesystem is used.
We want the filesystem of the path to be used, instead.
## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #121 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I created a script that writes a model to S3, and then reads it back from the same location.
<!--- Include details of your testing environment, and the tests you ran to -->
Ubuntu.
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
