### PR TITLE
Fixed race condition in word embeddings setup and load

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/SparkWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/SparkWordEmbeddings.scala
@@ -25,16 +25,18 @@ class SparkWordEmbeddings(val clusterFilePath: String, val dim: Int) extends Ser
   private var wordEmbeddingsValue: WordEmbeddings = null
 
   def wordEmbeddings: WordEmbeddings = {
-    if (wordEmbeddingsValue == null) {
-      if (!new File(workPath).exists()) {
-        require(new File(src).exists(), s"file $src must be added to sparkContext")
-        FileUtil.deepCopy(new File(src), new File(workPath), null, false)
+    synchronized {
+      if (wordEmbeddingsValue == null) {
+        if (!new File(workPath).exists()) {
+          require(new File(src).exists(), s"file $src must be added to sparkContext")
+          FileUtil.deepCopy(new File(src), new File(workPath), null, false)
+        }
+
+        wordEmbeddingsValue = WordEmbeddings(workPath, dim)
       }
 
-      wordEmbeddingsValue = WordEmbeddings(workPath, dim)
+      wordEmbeddingsValue
     }
-
-    wordEmbeddingsValue
   }
 }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddings.scala
@@ -25,7 +25,9 @@ case class WordEmbeddings(dbFile: String,
   }
 
   def getEmbeddings(word: String): Array[Float] = {
-    lru.getOrElseUpdate(word, getEmbeddingsFromDb(word))
+    synchronized {
+      lru.getOrElseUpdate(word, getEmbeddingsFromDb(word))
+    }
   }
 
   override def close(): Unit = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Most common when using Light Pipelines, loading word embeddings generates a race condition within an executor when trying to create and load appropriate temporary files

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sporadically, loading word embeddings based models returned a Null Pointer exception when executors tried to utilize the same resources at the same time. This ensures loading the files is not overlapped.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
