### PR TITLE
Fixed stand alone annotator models not readable from disk

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -10,6 +10,8 @@ from pyspark.ml.param.shared import Param, Params, TypeConverters
 from sparknlp.common import ExternalResource, ParamsGetters, ReadAs
 from sparknlp.util import AnnotatorJavaMLReadable
 
+# Do NOT delete. Looks redundant but this is a workaround for model deSer from disk
+import com.johnsnowlabs.nlp
 # Do NOT delete. Looks redundant but this is key work around for python 2 support.
 if sys.version_info[0] == 2:
     from sparknlp.base import DocumentAssembler, Finisher, TokenAssembler
@@ -83,10 +85,6 @@ class AnnotatorModel(JavaModel, AnnotatorJavaMLReadable, JavaMLWritable, Annotat
         super(JavaTransformer, self).__init__()
         self.__class__._java_class_name = classname
         self._java_obj = self._new_java_obj(classname, self.uid)
-
-
-class _AnnotatorModel(JavaModel, AnnotatorJavaMLReadable, JavaMLWritable, AnnotatorProperties, ParamsGetters):
-    pass
 
 
 class AnnotatorApproach(JavaEstimator, JavaMLWritable, AnnotatorJavaMLReadable, AnnotatorProperties, ParamsGetters):
@@ -239,7 +237,10 @@ class RegexMatcher(AnnotatorApproach):
         return RegexMatcherModel(java_model)
 
 
-class RegexMatcherModel(_AnnotatorModel):
+class RegexMatcherModel(AnnotatorModel):
+    @keyword_only
+    def __init__(self):
+        super(RegexMatcherModel, self).__init__(classname="com.johnsnowlabs.nlp.annotators.RegexMatcherModel")
     name = "RegexMatcherModel"
 
 
@@ -266,7 +267,10 @@ class Lemmatizer(AnnotatorApproach):
         return self._set(dictionary=ExternalResource(path, read_as, opts))
 
 
-class LemmatizerModel(_AnnotatorModel):
+class LemmatizerModel(AnnotatorModel):
+    @keyword_only
+    def __init__(self):
+        super(LemmatizerModel, self).__init__(classname="com.johnsnowlabs.nlp.annotators.LemmatizerModel")
     name = "LemmatizerModel"
 
     @staticmethod
@@ -314,7 +318,11 @@ class TextMatcher(AnnotatorApproach):
         return self._set(entities=ExternalResource(path, read_as, options.copy()))
 
 
-class TextMatcherModel(_AnnotatorModel):
+class TextMatcherModel(AnnotatorModel):
+    @keyword_only
+    def __init__(self):
+        super(TextMatcherModel, self).__init__(classname="com.johnsnowlabs.nlp.annotators.TextMatcherModel")
+        self._setDefault(inputCols=["token"])
     name = "TextMatcherModel"
 
 
@@ -356,7 +364,10 @@ class PerceptronApproach(AnnotatorApproach):
         return PerceptronModel(java_model)
 
 
-class PerceptronModel(_AnnotatorModel):
+class PerceptronModel(AnnotatorModel):
+    @keyword_only
+    def __init__(self):
+        super(PerceptronModel, self).__init__(classname="com.johnsnowlabs.nlp.annotators.pos.perceptron.PerceptronModel")
     name = "PerceptronModel"
 
     @staticmethod
@@ -418,7 +429,10 @@ class SentimentDetector(AnnotatorApproach):
         return SentimentDetectorModel(java_model)
 
 
-class SentimentDetectorModel(_AnnotatorModel):
+class SentimentDetectorModel(AnnotatorModel):
+    @keyword_only
+    def __init__(self):
+        super(SentimentDetectorModel, self).__init__(classname="com.johnsnowlabs.nlp.annotators.sda.pragmatic.SentimentDetectorModel")
     name = "SentimentDetectorModel"
 
 
@@ -470,7 +484,10 @@ class ViveknSentimentApproach(AnnotatorApproach):
         return ViveknSentimentModel(java_model)
 
 
-class ViveknSentimentModel(_AnnotatorModel):
+class ViveknSentimentModel(AnnotatorModel):
+    @keyword_only
+    def __init__(self):
+        super(ViveknSentimentModel, self).__init__(classname="com.johnsnowlabs.nlp.annotators.sda.vivekn.ViveknSentimentModel")
     name = "ViveknSentimentModel"
 
 
@@ -541,8 +558,11 @@ class NorvigSweetingApproach(AnnotatorApproach):
         return NorvigSweetingModel(java_model)
 
 
-class NorvigSweetingModel(_AnnotatorModel):
+class NorvigSweetingModel(AnnotatorModel):
     name = "NorvigSweetingModel"
+    @keyword_only
+    def __init__(self):
+        super(NorvigSweetingModel, self).__init__(classname="com.johnsnowlabs.nlp.annotators.spell.norvig.NorvigSweetingModel")
 
     @staticmethod
     def pretrained(name="spell_fast", language="en"):
@@ -631,8 +651,11 @@ class NerCrfApproach(AnnotatorApproach, AnnotatorWithEmbeddings, NerApproach):
         )
 
 
-class NerCrfModel(_AnnotatorModel):
+class NerCrfModel(AnnotatorModel):
     name = "NerCrfModel"
+    @keyword_only
+    def __init__(self):
+        super(NerCrfModel, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ner.crf.NerCrfModel")
 
     @staticmethod
     def pretrained(name="ner_fast", language="en"):
@@ -671,7 +694,7 @@ class AssertionLogRegApproach(AnnotatorApproach, AnnotatorWithEmbeddings):
     def setEnet(self, enet):
         self._set(eNetParam = enet)
         return self
-    
+
     def setBefore(self, before):
         self._set(beforeParam = before)
         return self
@@ -697,9 +720,12 @@ class AssertionLogRegApproach(AnnotatorApproach, AnnotatorWithEmbeddings):
         self._setDefault(label="label", beforeParam=11, afterParam=13)
 
 
-class AssertionLogRegModel(_AnnotatorModel):
+class AssertionLogRegModel(AnnotatorModel):
+    @keyword_only
+    def __init__(self):
+        super(AssertionLogRegModel, self).__init__(classname="com.johnsnowlabs.nlp.annotators.assertion.logreg.AssertionLogRegModel")
     name = "AssertionLogRegModel"
-    
+
     @staticmethod
     def pretrained(name="as_fast", language="en"):
         from sparknlp.pretrained import ResourceDownloader
@@ -761,12 +787,12 @@ class NerDLApproach(AnnotatorApproach, AnnotatorWithEmbeddings, NerApproach):
         )
 
 
-class NerDLModel(_AnnotatorModel):
+class NerDLModel(AnnotatorModel):
     name = "NerDLModel"
-    @staticmethod
-    def pretrained(name="ner_precise", language="en"):
-        from sparknlp.pretrained import ResourceDownloader
-        return ResourceDownloader.downloadModel(NerDLModel, name, language)
+
+    @keyword_only
+    def __init__(self):
+        super(NerDLModel, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ner.dl.NerDLModel")
 
 
 class NerConverter(AnnotatorModel):
@@ -822,7 +848,7 @@ class AssertionDLApproach(AnnotatorApproach, AnnotatorWithEmbeddings):
     def setDropout(self, rate):
         self._set(dropout = rate)
         return self
-    
+
     def _create_model(self, java_model):
         return AssertionDLModel(java_model)
 
@@ -832,8 +858,11 @@ class AssertionDLApproach(AnnotatorApproach, AnnotatorWithEmbeddings):
         self._setDefault(label="label", target="target", start="start", end="end", batchSize=64, epochs=5, learningRate=0.0012, dropout=0.05)
 
 
-class AssertionDLModel(_AnnotatorModel):
+class AssertionDLModel(AnnotatorModel):
     name = "AssertionDLModel"
+    @keyword_only
+    def __init__(self):
+        super(AssertionDLModel, self).__init__(classname="com.johnsnowlabs.nlp.annotators.assertion.dl.AssertionDLModel")
     @staticmethod
     def pretrained(name="as_fast", language="en"):
         from sparknlp.pretrained import ResourceDownloader

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -1,10 +1,10 @@
 package com.johnsnowlabs.nlp
 
 import com.johnsnowlabs.nlp.annotators.PretrainedLemmatizer
-import com.johnsnowlabs.nlp.annotators.assertion.dl.{AssertionDLModel, PretrainedDLAssertionStatus, ReadsAssertionGraph}
-import com.johnsnowlabs.nlp.annotators.assertion.logreg.{AssertionLogRegModel, PretrainedAssertionLogRegModel}
+import com.johnsnowlabs.nlp.annotators.assertion.dl.{PretrainedDLAssertionStatus, ReadsAssertionGraph}
+import com.johnsnowlabs.nlp.annotators.assertion.logreg.PretrainedAssertionLogRegModel
 import com.johnsnowlabs.nlp.annotators.ner.crf.PretrainedNerCrf
-import com.johnsnowlabs.nlp.annotators.ner.dl.{NerDLModel, PretrainedNerDL, ReadsNERGraph, WithGraphResolver}
+import com.johnsnowlabs.nlp.annotators.ner.dl.{ReadsNERGraph, WithGraphResolver}
 import com.johnsnowlabs.nlp.annotators.pos.perceptron.PretrainedPerceptronModel
 import com.johnsnowlabs.nlp.annotators.spell.norvig.PretrainedNorvigSweeting
 import com.johnsnowlabs.nlp.embeddings.EmbeddingsReadable
@@ -80,7 +80,7 @@ object annotator {
   type NerDLApproach = com.johnsnowlabs.nlp.annotators.ner.dl.NerDLApproach
   object NerDLApproach extends DefaultParamsReadable[NerDLApproach] with WithGraphResolver
   type NerDLModel = com.johnsnowlabs.nlp.annotators.ner.dl.NerDLModel
-  object NerDLModel extends EmbeddingsReadable[NerDLModel] with ReadsNERGraph with PretrainedNerDL
+  object NerDLModel extends EmbeddingsReadable[NerDLModel] with ReadsNERGraph
 
   type AssertionDLApproach = com.johnsnowlabs.nlp.annotators.assertion.dl.AssertionDLApproach
   object AssertionDLApproach extends DefaultParamsReadable[AssertionDLApproach]

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
@@ -114,10 +114,4 @@ trait ReadsNERGraph extends ParamsAndFeaturesReadable[NerDLModel] with ReadTenso
   addReader(readNerGraph)
 }
 
-trait PretrainedNerDL {
-  def pretrained(name: String = "ner_precise", language: Option[String] = Some("en"), folder: String = ResourceDownloader.publicFolder): NerDLModel =
-    ResourceDownloader.downloadModel(NerDLModel, name, language, folder)
-}
-
-
-object NerDLModel extends EmbeddingsReadable[NerDLModel] with ReadsNERGraph with PretrainedNerDL
+object NerDLModel extends EmbeddingsReadable[NerDLModel] with ReadsNERGraph


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Single annotator models are failing to be loaded from disk, it was caused due to a bad pyspark class hierarchy

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
