### PR TITLE
Fix symmetric delete annotator serialization

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingModel.scala
@@ -243,7 +243,8 @@ class NorvigSweetingModel(override val uid: String) extends AnnotatorModel[Norvi
 }
 
 trait PretrainedNorvigSweeting {
-  def pretrained(name: String = "spell_fast", language: Option[String] = Some("en"), folder: String = ResourceDownloader.publicFolder): NorvigSweetingModel =
+  def pretrained(name: String = "spell_fast", language: Option[String] = Some("en"),
+                 folder: String = ResourceDownloader.publicFolder): NorvigSweetingModel =
     ResourceDownloader.downloadModel(NorvigSweetingModel, name, language, folder)
 }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteApproach.scala
@@ -168,7 +168,7 @@ class SymmetricDeleteApproach(override val uid: String)
                                             maxEditDistance = $(maxEditDistance))
 
     val model = new SymmetricDeleteModel()
-      .setDerivedWords(wordFeatures.derivedWords.toMap)
+      .setDerivedWords(wordFeatures.derivedWords.mapValues(f => (f._1.toList, f._2)).toMap)
       .setLongestWordLength(wordFeatures.longestWordLength)
 
     if (possibleDict.isDefined)
@@ -178,5 +178,5 @@ class SymmetricDeleteApproach(override val uid: String)
   }
 
 }
-// This objects reads the class' properties, it enables reding the model after it is stored
+// This objects reads the class' properties, it enables reading the model after it is stored
 object SymmetricDeleteApproach extends DefaultParamsReadable[SymmetricDeleteApproach]

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModel.scala
@@ -10,8 +10,7 @@ import scala.collection.immutable.HashSet
 import scala.collection.mutable.{ListBuffer, Map => MMap}
 import scala.util.control.Breaks._
 import scala.math._
-import org.apache.spark.ml.param.Param
-
+import org.apache.spark.ml.param.IntParam
 
 /** Created by danilo 16/04/2018,
   * inspired on https://github.com/wolfgarbe/SymSpell
@@ -31,12 +30,13 @@ class SymmetricDeleteModel(override val uid: String) extends AnnotatorModel[Symm
 
   override val requiredAnnotatorTypes: Array[AnnotatorType] = Array(TOKEN)
 
-  protected val derivedWords: MapFeature[String, (ListBuffer[String], Long)] =
+  protected val derivedWords: MapFeature[String, (List[String], Long)] =
     new MapFeature(this, "derivedWords")
 
   protected val dictionary: MapFeature[String, Long] = new MapFeature(this, "dictionary")
 
-  val longestWordLength = new Param[Int](this, "longestWordLength", "length of longest word in corpus")
+  val longestWordLength = new IntParam(this, "longestWordLength",
+                                "length of longest word in corpus")
 
   def getLongestWordLength: Int = $(longestWordLength)
 
@@ -53,7 +53,7 @@ class SymmetricDeleteModel(override val uid: String) extends AnnotatorModel[Symm
 
   def this() = this(Identifiable.randomUID("SYMSPELL"))
 
-  def setDerivedWords(value: Map[String, (ListBuffer[String], Long)]):
+  def setDerivedWords(value: Map[String, (List[String], Long)]):
   this.type = set(derivedWords, value)
 
 
@@ -198,9 +198,9 @@ class SymmetricDeleteModel(override val uid: String) extends AnnotatorModel[Symm
 
 }
 
-trait PretrainedSymmetricDelete { // ask if the name spell_sd_fast it's ok
-  def pretrained(name: String = "spell_sd_fast", folder: String = "",
-                 language: Option[String] = Some("en")): SymmetricDeleteModel =
+trait PretrainedSymmetricDelete {
+  def pretrained(name: String = "spell_sd_fast", language: Option[String] = Some("en"),
+                 folder: String = ResourceDownloader.publicFolder): SymmetricDeleteModel =
     ResourceDownloader.downloadModel(SymmetricDeleteModel, name, language, folder)
 }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteBehaviors.scala
@@ -235,11 +235,10 @@ trait SymmetricDeleteBehaviors { this: FlatSpec =>
       val data = Seq("Hello World").toDS.toDF("text")
       data.show()
       val pretrainedPipeline = new BasicPipeline().pretrained
-      val homePath = "/Users/dburbano/IdeaProjects/spark-nlp-models/models/"
-      val modelSpell = NorvigSweetingModel.load(homePath+"spell_fast_en_1.5_2_1525210767728")
+      val modelSpell = NorvigSweetingModel.load("./tmp_spell")
       println("Spell Checker")
       modelSpell.transform(pretrainedPipeline.transform(data)).show(5)
-      val modelSymSpell = SymmetricDeleteModel.load(homePath+"spell_sd_fast_en_1.5_2_1525210888717")
+      val modelSymSpell = SymmetricDeleteModel.load("./tmp_symspell")
       println("SymSpell Checker")
       modelSymSpell.transform(pretrainedPipeline.transform(data)).show(5)
     }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteBehaviors.scala
@@ -4,11 +4,12 @@ import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs}
 import com.johnsnowlabs.nlp.annotators.Tokenizer
 import com.johnsnowlabs.nlp._
 import org.scalatest._
-import org.apache.spark.ml.Pipeline
+import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.apache.spark.sql.functions._
 import SparkAccessor.spark.implicits._
+import com.johnsnowlabs.nlp.annotator.NorvigSweetingModel
 import com.johnsnowlabs.util.Benchmark
-
+import com.johnsnowlabs.nlp.pretrained.pipelines.en._
 
 trait SymmetricDeleteBehaviors { this: FlatSpec =>
 
@@ -225,6 +226,22 @@ trait SymmetricDeleteBehaviors { this: FlatSpec =>
       val resource = resourceList.map(_.toLowerCase)
       println(resource.size)
 
+    }
+  }
+
+  def testLoadModel(): Unit = {
+    s"a SymSpellChecker annotator with load model of" should
+      "successfully correct words" in {
+      val data = Seq("Hello World").toDS.toDF("text")
+      data.show()
+      val pretrainedPipeline = new BasicPipeline().pretrained
+      val homePath = "/Users/dburbano/IdeaProjects/spark-nlp-models/models/"
+      val modelSpell = NorvigSweetingModel.load(homePath+"spell_fast_en_1.5_2_1525210767728")
+      println("Spell Checker")
+      modelSpell.transform(pretrainedPipeline.transform(data)).show(5)
+      val modelSymSpell = SymmetricDeleteModel.load(homePath+"spell_sd_fast_en_1.5_2_1525210888717")
+      println("SymSpell Checker")
+      modelSymSpell.transform(pretrainedPipeline.transform(data)).show(5)
     }
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModelTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModelTestSpec.scala
@@ -37,8 +37,8 @@ class SymmetricDeleteModelTestSpec extends FlatSpec with SymmetricDeleteBehavior
 
   "a good sized dataframe with Spark pipeline and spell checker dictionary" should behave like testBigPipelineDict
 
-  "a dataset of individual words with Spark pipeleine" should behave like testIndividualWords
+  "a dataset of individual words with Spark pipeline" should behave like testIndividualWords
 
   // "a spark dataset " should behave like testSparkDataset()
-
+  "a loaded model " should behave like testLoadModel()
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes serialization of Symmetric delete annotator, which is not working in 1.5.2


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
