### PR TITLE
Added python generator for setters and getters at model layer

### DIFF
--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -3,12 +3,12 @@ from pyspark.ml.util import JavaMLWritable
 from pyspark.ml.wrapper import JavaTransformer, JavaEstimator
 from pyspark.ml.param.shared import Param, Params, TypeConverters
 from pyspark.ml.pipeline import Pipeline, PipelineModel, Estimator, Transformer
-from sparknlp.common import ParamsGetters
+from sparknlp.common import ParamsGettersSetters
 from sparknlp.util import AnnotatorJavaMLReadable
 import sparknlp.internal as _internal
 
 
-class AnnotatorTransformer(JavaTransformer, AnnotatorJavaMLReadable, JavaMLWritable, ParamsGetters):
+class AnnotatorTransformer(JavaTransformer, AnnotatorJavaMLReadable, JavaMLWritable, ParamsGettersSetters):
     @keyword_only
     def __init__(self, classname):
         super(AnnotatorTransformer, self).__init__()

--- a/python/sparknlp/common.py
+++ b/python/sparknlp/common.py
@@ -14,23 +14,36 @@ def ExternalResource(path, read_as=ReadAs.LINE_BY_LINE, options={}):
     return _internal._ExternalResource(path, read_as, options).apply()
 
 
-"""
-Helper class used to generate the getters for all params
-"""
-class ParamsGetters(Params):
+# Helper class used to generate the getters for all params
+class ParamsGettersSetters(Params):
     getter_attrs = []
 
     def __init__(self):
-        super(ParamsGetters, self).__init__()
+        super(ParamsGettersSetters, self).__init__()
         for param in self.params:
             param_name = param.name
-            f_attr = "get" + re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), param_name)
-            setattr(self, f_attr, self.getParamValue(param_name))
+            fg_attr = "get" + re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), param_name)
+            fs_attr = "set" + re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), param_name)
+            # Generates getter and setter only if not exists
+            try:
+                getattr(self, fg_attr)
+            except AttributeError:
+                setattr(self, fg_attr, self.getParamValue(param_name))
+            try:
+                getattr(self, fs_attr)
+            except AttributeError:
+                setattr(self, fs_attr, self.setParamValue(param_name))
 
     def getParamValue(self, paramName):
         def r():
             try:
                 return self.getOrDefault(paramName)
-            except:
+            except KeyError:
                 return None
+        return r
+
+    def setParamValue(self, paramName):
+        def r(v):
+            self.set(self.getParam(paramName), v)
+            return self
         return r


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We have some missing getters from annotators, but Python get's its worse since it doesnt have direct Param API implementation.

This PR adds auto-generation of param setters to Python annotators (i.e. in AnnotatorModels), starting from declared Params. Making easier and not having to explicitly declare getters and setters in python annotators (unless required)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
