### PR TITLE
Light pipelines prefetch annotation results in pyspark

### DIFF
--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -102,20 +102,16 @@ class LightPipeline:
         return result
 
     def annotate(self, target):
-        def extract(text_annotations):
-            kas = {}
-            for atype, text in text_annotations.items():
-                kas[atype] = text
-            return kas
+
+        def reformat(annotations):
+            return {k: list(v) for k, v in annotations.items()}
 
         annotations = self._lightPipeline.annotateJava(target)
 
         if type(target) is str:
-            result = extract(annotations)
+            result = reformat(annotations)
         elif type(target) is list:
-            result = []
-            for row_annotations in annotations:
-                result.append(extract(row_annotations))
+            result = list(map(lambda a: reformat(a), list(annotations)))
         else:
             raise TypeError("target for annotation may be 'str' or 'list'")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Light Pipelines in python are significantly slower than their scala counterpart. This change prefetches results son annotating large arrays doesn't hit in run-time but only once when called, and put into python memory. Shows performance boost.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
