### PR TITLE
Prepend infix patterns added via `addInfixPatterns` in Pyspark

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -4,6 +4,7 @@ from test.misc import *
 # Annotator tests
 unittest.TextTestRunner().run(BasicAnnotatorsTestSpec())
 unittest.TextTestRunner().run(RegexMatcherTestSpec())
+unittest.TextTestRunner().run(TokenizerTestSpec())
 unittest.TextTestRunner().run(LemmatizerTestSpec())
 unittest.TextTestRunner().run(DateMatcherTestSpec())
 unittest.TextTestRunner().run(TextMatcherTestSpec())

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -159,7 +159,7 @@ class Tokenizer(AnnotatorModel):
 
     def addInfixPattern(self, value):
         infix_patterns = self.getInfixPatterns()
-        infix_patterns.append(value)
+        infix_patterns.insert(0, value)
         return self._set(infixPatterns=infix_patterns)
 
 


### PR DESCRIPTION
Fixes https://github.com/JohnSnowLabs/spark-nlp/issues/227

## Description
Simple change to prepend the infix patterns rather than append. Unit test is added to verify correctness.
