### PR TITLE
Removed finishers default delimiters

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/Finisher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Finisher.scala
@@ -43,8 +43,7 @@ class Finisher(override val uid: String)
   def getIncludeMetadata: Boolean = $(includeMetadata)
   def getOutputAsArray: Boolean = $(outputAsArray)
 
-  setDefault(valueSplitSymbol -> "#",
-    annotationSplitSymbol -> "@",
+  setDefault(
     cleanAnnotations -> true,
     includeMetadata -> false,
     outputAsArray -> true)

--- a/src/test/scala/com/johnsnowlabs/nlp/FinisherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/FinisherTestSpec.scala
@@ -23,6 +23,8 @@ class FinisherTestSpec extends FlatSpec {
     val finisher = new Finisher()
       .setInputCols("token")
       .setOutputAsArray(false)
+      .setAnnotationSplitSymbol("@")
+      .setValueSplitSymbol("#")
 
     val pipeline = new Pipeline()
       .setStages(Array(

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/NormalizerBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/NormalizerBehaviors.scala
@@ -68,6 +68,8 @@ trait NormalizerBehaviors { this: FlatSpec =>
         .setInputCols("normalized")
         .setOutputAsArray(false)
         .setIncludeMetadata(false)
+        .setAnnotationSplitSymbol("@")
+        .setValueSplitSymbol("#")
 
       val pipeline = new Pipeline()
         .setStages(Array(
@@ -110,6 +112,8 @@ trait NormalizerBehaviors { this: FlatSpec =>
         .setInputCols("normalized")
         .setOutputAsArray(false)
         .setIncludeMetadata(false)
+        .setAnnotationSplitSymbol("@")
+        .setValueSplitSymbol("#")
 
       val pipeline = new Pipeline()
         .setStages(Array(
@@ -160,6 +164,8 @@ trait NormalizerBehaviors { this: FlatSpec =>
         .setInputCols("normal")
         .setOutputAsArray(false)
         .setIncludeMetadata(false)
+        .setAnnotationSplitSymbol("@")
+        .setValueSplitSymbol("#")
 
       val pipeline = new Pipeline()
         .setStages(Array(

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteBehaviors.scala
@@ -277,6 +277,8 @@ trait SymmetricDeleteBehaviors { this: FlatSpec =>
         .setInputCols("spell")
         .setOutputAsArray(false)
         .setIncludeMetadata(false)
+        .setAnnotationSplitSymbol("@")
+        .setValueSplitSymbol("#")
 
       val pipeline = new Pipeline()
         .setStages(Array(
@@ -338,6 +340,8 @@ trait SymmetricDeleteBehaviors { this: FlatSpec =>
         .setInputCols("spell")
         .setOutputAsArray(false)
         .setIncludeMetadata(false)
+        .setAnnotationSplitSymbol("@")
+        .setValueSplitSymbol("#")
 
       val pipeline = new Pipeline()
         .setStages(Array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Default delimiter strings for finisher when output is String caused confusion and errors. This branch removes those default delimiters and forces user to set his own delimiters when running Finisher in String mode

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
