### PR TITLE
Symspell empty dataset

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteApproach.scala
@@ -141,6 +141,8 @@ class SymmetricDeleteApproach(override val uid: String)
       import ResourceHelper.spark.implicits._
       import org.apache.spark.sql.functions._
 
+      require(!dataset.rdd.isEmpty(), "corpus not provided and dataset for training is empty")
+
       val trainDataset = dataset.select($(inputCols).head).as[Array[Annotation]]
                         .flatMap(_.map(_.result))
       val wordFrequencies = trainDataset.groupBy("value").count().as[(String, Long)].collect.toList

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteBehaviors.scala
@@ -11,7 +11,7 @@ import SparkAccessor.spark.implicits._
 import com.johnsnowlabs.util.Benchmark
 
 
-trait   SymmetricDeleteBehaviors { this: FlatSpec =>
+trait SymmetricDeleteBehaviors { this: FlatSpec =>
 
   val spellChecker = new SymmetricDeleteApproach()
     .setCorpus(ExternalResource("src/test/resources/spell/sherlockholmes.txt",
@@ -153,9 +153,6 @@ trait   SymmetricDeleteBehaviors { this: FlatSpec =>
         .setOutputCol("token")
 
       val corpusPath = "src/test/resources/spell/sherlockholmes.txt"
-      // val corpusPath = "/home/danilo/IdeaProjects/spark-nlp-models/src/main/resources/spell/wiki1_en.txt"
-      // val corpusPath = "/home/danilo/PycharmProjects/SymSpell/coca2017.txt"
-      // val corpusPath = "/home/danilo/IdeaProjects/spark-nlp-models/src/main/resources/spell/coca2017/2017_spok.txt"
 
       val spell = new SymmetricDeleteApproach()
         .setInputCols(Array("token"))
@@ -287,7 +284,6 @@ trait   SymmetricDeleteBehaviors { this: FlatSpec =>
         ))
 
       /**Not cool to do this. Fit calls transform early, and will look for text column. Spark limitation...*/
-      //corpusData.show()
       val model = pipeline.fit(corpusData.select(corpusData.col("value").as("text")))
 
       Benchmark.time("without dictionary") { //to measure processing time

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModelTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModelTestSpec.scala
@@ -49,4 +49,6 @@ class SymmetricDeleteModelTestSpec extends FlatSpec with SymmetricDeleteBehavior
 
   "a loaded model " should behave like testLoadModel()
 
+  "a symmetric spell checker with empty dataset" should behave like testEmptyDataset
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes in SymmetricDelete annotator to handle an empty dataset

## Description
<!--- Describe your changes in detail -->
A require validation for a non-empty dataset was included when corpus parameter is not set

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
An error reported by a user in spark-nlp Slack in questions channel

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With the unit test testEmptyDataset

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
