### PR TITLE
Infer embeddings filesystem from path not configuration

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/assertion/dl/TensorflowSerializeModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/assertion/dl/TensorflowSerializeModel.scala
@@ -18,7 +18,8 @@ trait WriteTensorflowModel{
 
   def writeTensorflowModel(path: String, spark: SparkSession, tensorflow: TensorflowWrapper, suffix: String): Unit = {
 
-    val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    val uri = new java.net.URI(path)
+    val fs = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
 
     // 1. Create tmp folder
     val tmpFolder = Files.createTempDirectory(UUID.randomUUID().toString.takeRight(12) + suffix)
@@ -42,7 +43,8 @@ trait ReadTensorflowModel {
 
   def readTensorflowModel(path: String, spark: SparkSession, suffix: String): TensorflowWrapper = {
 
-    val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    val uri = new java.net.URI(path)
+    val fs = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
 
     // 1. Create tmp directory
     val tmpFolder = Files.createTempDirectory(UUID.randomUUID().toString.takeRight(12) + suffix)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLPythonReader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLPythonReader.scala
@@ -56,7 +56,8 @@ object NerDLModelPythonReader {
             useBundle: Boolean = false,
             tags: Array[String] = Array.empty[String]): NerDLModel = {
 
-    val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    val uri = new java.net.URI(folder)
+    val fs = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
 
     val tmpFolder = Files.createTempDirectory(UUID.randomUUID().toString.takeRight(12) + "_bundle")
       .toAbsolutePath.toString

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/SparkWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/SparkWordEmbeddings.scala
@@ -77,8 +77,13 @@ object SparkWordEmbeddings {
   private def copyIndexToCluster(localFile: String, clusterFilePath: String, spark: SparkContext): String = {
     val uri = new java.net.URI(localFile)
     val fs = FileSystem.get(uri, spark.hadoopConfiguration)
+    val uridst = new java.net.URI(clusterFilePath)
+    val fsdt = FileSystem.get(uridst, spark.hadoopConfiguration)
     val src = new Path(localFile)
-    val dst = Path.mergePaths(new Path(fs.getScheme, "", spark.hadoopConfiguration.get("hadoop.tmp.dir")), new Path(clusterFilePath))
+    val dst = Path.mergePaths(
+      new Path(fsdt.getScheme, "",
+        spark.hadoopConfiguration.get("hadoop.tmp.dir")), new Path(clusterFilePath)
+    )
 
     fs.copyFromLocalFile(false, true, src, dst)
     fs.deleteOnExit(dst)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/SparkWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/SparkWordEmbeddings.scala
@@ -77,13 +77,9 @@ object SparkWordEmbeddings {
   private def copyIndexToCluster(localFile: String, clusterFilePath: String, spark: SparkContext): String = {
     val uri = new java.net.URI(localFile)
     val fs = FileSystem.get(uri, spark.hadoopConfiguration)
-    val uridst = new java.net.URI(clusterFilePath)
-    val fsdt = FileSystem.get(uridst, spark.hadoopConfiguration)
+    val cfs = FileSystem.get(spark.hadoopConfiguration)
     val src = new Path(localFile)
-    val dst = Path.mergePaths(
-      new Path(fsdt.getScheme, "",
-        spark.hadoopConfiguration.get("hadoop.tmp.dir")), new Path(clusterFilePath)
-    )
+    val dst = Path.mergePaths(new Path(cfs.getScheme, "", spark.hadoopConfiguration.get("hadoop.tmp.dir")), new Path(clusterFilePath))
 
     fs.copyFromLocalFile(false, true, src, dst)
     fs.deleteOnExit(dst)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/SparkWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/SparkWordEmbeddings.scala
@@ -47,7 +47,8 @@ object SparkWordEmbeddings {
                               format: WordEmbeddingsFormat.Format,
                               spark: SparkContext): Unit = {
 
-    val fs = FileSystem.get(spark.hadoopConfiguration)
+    val uri = new java.net.URI(sourceEmbeddingsPath)
+    val fs = FileSystem.get(uri, spark.hadoopConfiguration)
 
     if (format == WordEmbeddingsFormat.TEXT) {
 
@@ -65,8 +66,7 @@ object SparkWordEmbeddings {
     }
     else if (format == WordEmbeddingsFormat.SPARKNLP) {
 
-      val hdfs = FileSystem.get(spark.hadoopConfiguration)
-      hdfs.copyToLocalFile(new Path(sourceEmbeddingsPath), new Path(localFile))
+      fs.copyToLocalFile(new Path(sourceEmbeddingsPath), new Path(localFile))
       val fileName = new Path(sourceEmbeddingsPath).getName
 
       FileUtil.deepCopy(Paths.get(localFile, fileName).toFile, Paths.get(localFile).toFile, null, true)
@@ -75,7 +75,8 @@ object SparkWordEmbeddings {
   }
 
   private def copyIndexToCluster(localFile: String, clusterFilePath: String, spark: SparkContext): String = {
-    val fs = FileSystem.get(spark.hadoopConfiguration)
+    val uri = new java.net.URI(localFile)
+    val fs = FileSystem.get(uri, spark.hadoopConfiguration)
     val src = new Path(localFile)
     val dst = Path.mergePaths(new Path(fs.getScheme, "", spark.hadoopConfiguration.get("hadoop.tmp.dir")), new Path(clusterFilePath))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Infer embeddings filesystem from path not configuration

May solve @S_L issue of embeddings being read from hdfs instead of s3 when utilized 

REQUIRES cluster testing

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
