### PR TITLE
Fixed NerCRF not training properly due to DocumentAssembler trim

### DIFF
--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -160,10 +160,11 @@ class RecursivePipeline(Pipeline, JavaEstimator):
 
 class DocumentAssembler(AnnotatorTransformer):
 
-    inputCol = Param(Params._dummy(), "inputCol", "input column name.", typeConverter=TypeConverters.toString)
-    outputCol = Param(Params._dummy(), "outputCol", "input column name.", typeConverter=TypeConverters.toString)
-    idCol = Param(Params._dummy(), "idCol", "input column name.", typeConverter=TypeConverters.toString)
-    metadataCol = Param(Params._dummy(), "metadataCol", "input column name.", typeConverter=TypeConverters.toString)
+    inputCol = Param(Params._dummy(), "inputCol", "input column name", typeConverter=TypeConverters.toString)
+    outputCol = Param(Params._dummy(), "outputCol", "output column name", typeConverter=TypeConverters.toString)
+    idCol = Param(Params._dummy(), "idCol", "column for setting an id to such string in row", typeConverter=TypeConverters.toString)
+    metadataCol = Param(Params._dummy(), "metadataCol", "String to String map column to use as metadata", typeConverter=TypeConverters.toString)
+    trimAndClearNewLines = Param(Params._dummy(), "trimAndClearNewLines", "whether to clear out new lines and trim context to remove leadng and trailing white spaces", typeConverter=TypeConverters.toBoolean)
     name = 'DocumentAssembler'
 
     @keyword_only
@@ -187,6 +188,9 @@ class DocumentAssembler(AnnotatorTransformer):
 
     def setMetadataCol(self, value):
         return self._set(metadataCol=value)
+
+    def setTrimAndClearNewLines(self, value):
+        return self._set(trimAndClearNewLines=value)
 
 
 class TokenAssembler(AnnotatorTransformer):

--- a/src/main/scala/com/johnsnowlabs/nlp/DocumentAssembler.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/DocumentAssembler.scala
@@ -49,6 +49,10 @@ class DocumentAssembler(override val uid: String)
 
   def getMetadataCol: String = $(metadataCol)
 
+  def setTrimAndClearNewLines(value: Boolean): this.type = set(trimAndClearNewLines, value)
+
+  def getTrimAndClearNewLines: Boolean = $(trimAndClearNewLines)
+
   def this() = this(Identifiable.randomUID("document"))
 
   override def copy(extra: ParamMap): Transformer = defaultCopy(extra)


### PR DESCRIPTION
Fixed disabling trim for NerCRF training. Added missing getters and setters.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes very low accuracy bug, introduced in 1.6.0. Causing very low performance in NerCRF when training new models.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
