### PR TITLE
deepCopy was causing bottleneck and race conditions

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ClusterWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ClusterWordEmbeddings.scala
@@ -16,7 +16,7 @@ import org.apache.spark.{SparkContext, SparkFiles}
  */
 class ClusterWordEmbeddings(val clusterFilePath: String, val dim: Int, val caseSensitive: Boolean) extends Serializable {
 
-  lazy val getLocalRetriever: WordEmbeddingsRetriever = {
+  def getLocalRetriever: WordEmbeddingsRetriever = {
     WordEmbeddingsRetriever(SparkFiles.get(clusterFilePath), dim, caseSensitive)
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ClusterWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ClusterWordEmbeddings.scala
@@ -1,6 +1,5 @@
 package com.johnsnowlabs.nlp.embeddings
 
-import java.io.File
 import java.nio.file.{Files, Paths}
 import java.util.UUID
 
@@ -17,19 +16,8 @@ import org.apache.spark.{SparkContext, SparkFiles}
  */
 class ClusterWordEmbeddings(val clusterFilePath: String, val dim: Int, val caseSensitive: Boolean) extends Serializable {
 
-  def getLocalRetriever: WordEmbeddingsRetriever = {
-
-    /** Synchronized removed. Verify */
-    // Have to copy file because RockDB changes it and Spark rises Exception
-    val src = SparkFiles.get(clusterFilePath)
-    val workPath = src + "_work"
-
-    if (!new File(workPath).exists()) {
-      require(new File(src).exists(), s"Indexed embeddings at $src not found or not included. Call EmbeddingsHelper.load()")
-      FileUtil.deepCopy(new File(src), new File(workPath), null, true)
-    }
-
-    WordEmbeddingsRetriever(workPath, dim, caseSensitive)
+  lazy val getLocalRetriever: WordEmbeddingsRetriever = {
+    WordEmbeddingsRetriever(SparkFiles.get(clusterFilePath), dim, caseSensitive)
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Word embeddings are being copied to local executors. But in high parallelism, more than one container may be launched on the same process. Copying cluster files to local may block the process and or return errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
