### PR TITLE
fixed issue related to issue #321

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -72,6 +72,14 @@ object ResourceDownloader {
   var defaultDownloader: ResourceDownloader = new S3ResourceDownloader(s3Bucket, s3Path, cacheFolder, credentials)
 
   /**
+    * Reset the cache and recreate ResourceDownloader S3 credentials
+    */
+  def resetResourceDownloader(): Unit ={
+    cache.empty
+    this.defaultDownloader = new S3ResourceDownloader(s3Bucket, s3Path, cacheFolder, credentials)
+  }
+
+  /**
     * Loads resource to path
     * @param name Name of Resource
     * @param folder Subfolder in s3 where to search model (e.g. medicine)

--- a/src/main/scala/com/johnsnowlabs/util/ConfigLoader.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigLoader.scala
@@ -2,18 +2,24 @@ package com.johnsnowlabs.util
 
 import java.io.File
 
+import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
 import com.typesafe.config.{Config, ConfigFactory}
 
 object ConfigLoader {
 
-  private val defaultConfig = ConfigFactory.load()
+  private var defaultConfig = ConfigFactory.load()
   private var overrideConfigPath = defaultConfig.getString("sparknlp.settings.overrideConfigPath")
 
-  def setConfigPath(path: String): Unit = overrideConfigPath = path
+  def setConfigPath(path: String): Unit = {
+    overrideConfigPath = path
+    ResourceDownloader.resetResourceDownloader()
+  }
 
   def getConfigPath: String = overrideConfigPath
 
-  def retrieve: Config = ConfigFactory
-    .parseFile(new File(overrideConfigPath))
-    .withFallback(defaultConfig)
+  def retrieve: Config =
+    ConfigFactory
+      .parseFile(new File(overrideConfigPath))
+      .withFallback(defaultConfig)
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fixed #321 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. When spark session already started, and no application.conf has been set. After setting it, with wrong credentials of s3 should give credential error in resource downloader
2. Changing the aws key in application conf and set the config path again. 
3. Now download of pretrained models should work.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
