### PR TITLE
added support for s3 file location in embeddings helper load method

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/EmbeddingsHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/EmbeddingsHelper.scala
@@ -2,21 +2,28 @@ package com.johnsnowlabs.nlp.embeddings
 
 import java.io.FileNotFoundException
 
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.{AnonymousAWSCredentials, BasicAWSCredentials}
+import com.amazonaws.regions.RegionUtils
+import com.amazonaws.services.s3.AmazonS3Client
+import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
+
+import com.johnsnowlabs.util.ConfigHelper
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.SparkFiles
+import org.apache.spark.sql.SparkSession
 
 object EmbeddingsHelper {
 
 
   def load(
-                      path: String,
-                      spark: SparkSession,
-                      format: String,
-                      embeddingsRef: String,
-                      nDims: Int,
-                      caseSensitiveEmbeddings: Boolean
-                    ): ClusterWordEmbeddings = {
+            path: String,
+            spark: SparkSession,
+            format: String,
+            embeddingsRef: String,
+            nDims: Int,
+            caseSensitiveEmbeddings: Boolean
+          ): ClusterWordEmbeddings = {
     import WordEmbeddingsFormat._
     load(
       path,
@@ -29,15 +36,33 @@ object EmbeddingsHelper {
   }
 
   def load(
-                    path: String,
-                    spark: SparkSession,
-                    format: WordEmbeddingsFormat.Format,
-                    nDims: Int,
-                    caseSensitiveEmbeddings: Boolean,
-                    embeddingsRef: String): ClusterWordEmbeddings = {
+            path: String,
+            spark: SparkSession,
+            format: WordEmbeddingsFormat.Format,
+            nDims: Int,
+            caseSensitiveEmbeddings: Boolean,
+            embeddingsRef: String): ClusterWordEmbeddings = {
 
     val uri = new java.net.URI(path.replaceAllLiterally("\\", "/"))
+    //if the path contains s3a setup the aws credentials from config if not already present
+    if(path.startsWith("s3a")){
+      if(spark.sparkContext.hadoopConfiguration.get("fs.s3a.access.key")==null) {
+        val accessKeyId = ConfigHelper.getConfigValue(ConfigHelper.accessKeyId)
+        val secretAccessKey = ConfigHelper.getConfigValue(ConfigHelper.secretAccessKey)
+
+
+        if (accessKeyId.isEmpty || secretAccessKey.isEmpty)
+          throw new SecurityException("AWS credentials not set in config")
+        else {
+
+          spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", accessKeyId.get)
+          spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", secretAccessKey.get)
+        }
+
+      }
+    }
     val fs = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
+
     val src = new Path(path)
 
     if (fs.exists(src)) {
@@ -56,10 +81,10 @@ object EmbeddingsHelper {
   }
 
   def load(
-                    indexPath: String,
-                    nDims: Int,
-                    caseSensitive: Boolean
-                    ): ClusterWordEmbeddings = {
+            indexPath: String,
+            nDims: Int,
+            caseSensitive: Boolean
+          ): ClusterWordEmbeddings = {
     new ClusterWordEmbeddings(indexPath, nDims, caseSensitive)
   }
 
@@ -71,6 +96,10 @@ object EmbeddingsHelper {
     Path.mergePaths(new Path("/embd_"), new Path(embeddingsRef)).toString
   }
 
+  def save(path: String, embeddings: ClusterWordEmbeddings, spark: SparkSession): Unit = {
+    EmbeddingsHelper.save(path, spark, embeddings.clusterFilePath.toString)
+  }
+
   protected def save(path: String, spark: SparkSession, indexPath: String): Unit = {
     val index = new Path(SparkFiles.get(indexPath))
 
@@ -79,10 +108,6 @@ object EmbeddingsHelper {
     val dst = new Path(path)
 
     save(fs, index, dst)
-  }
-
-  def save(path: String, embeddings: ClusterWordEmbeddings, spark: SparkSession): Unit = {
-    EmbeddingsHelper.save(path, spark, embeddings.clusterFilePath.toString)
   }
 
   def save(fs: FileSystem, index: Path, dst: Path): Unit = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added support for providing the s3 location directly in EmbeddingHelpers.load method. It will use the aws credentials sets in the application.conf file

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Earlier to work with pubmed embeddings which are available on s3 the files need to downloaded seperately to a local location and then read in EmbeddingsHelper. Now the file could be directly read from s3 url. The user needs to provide s3a://the path to the file
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The feature was testing by providing s3a uri (s3a://auxdata.johnsnowlabs.com/clinical/resources/PubMed-shuffle-win-2.bin) to EmbeddingsHelper.load method .
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
