### PR TITLE
Dont copy embeddings if current filesystem is local

### DIFF
--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -289,7 +289,10 @@ class PipelineTestSpec(unittest.TestCase):
                            key_delimiter="->", value_delimiter="\t")
         finisher = Finisher() \
             .setInputCols(["token", "lemma"]) \
-            .setOutputCols(["token_views", "lemma_views"])
+            .setOutputCols(["token_views", "lemma_views"]) \
+            .setOutputAsArray(False) \
+            .setAnnotationSplitSymbol('@') \
+            .setValueSplitSymbol('#')
         pipeline = Pipeline(stages=[document_assembler, tokenizer, lemmatizer, finisher])
         model = pipeline.fit(self.data)
         token_before_save = model.transform(self.data).select("token_views").take(1)[0].token_views.split("@")[2]
@@ -397,28 +400,24 @@ class ParamsGettersTestSpec(unittest.TestCase):
 class OcrTestSpec(unittest.TestCase):
     @staticmethod
     def runTest():
-        OcrHelper.setMinTextLayer(8)
-        print("text layer is: " + str(OcrHelper.getMinTextLayer()))
+        OcrHelper.setPreferredMethod('text')
+        print("text layer is: " + str(OcrHelper.getPreferredMethod()))
         pdf_path = "file:///" + os.getcwd() + "/../ocr/src/test/resources/pdfs/"
         data = OcrHelper.createDataset(
             spark=SparkContextForTest.spark,
-            input_path=pdf_path,
-            output_col="region",
-            metadata_col="metadata")
+            input_path=pdf_path)
         data.show()
-        OcrHelper.setMinTextLayer(0)
+        OcrHelper.setPreferredMethod('image')
         print("Text layer disabled")
         data = OcrHelper.createDataset(
             spark=SparkContextForTest.spark,
-            input_path=pdf_path,
-            output_col="region",
-            metadata_col="metadata")
+            input_path=pdf_path)
         data.show()
-        OcrHelper.setMinTextLayer(10)
+        OcrHelper.setPreferredMethod('text')
         content = OcrHelper.createMap(input_path="../ocr/src/test/resources/pdfs")
         print(content)
         document_assembler = DocumentAssembler() \
-            .setInputCol("region") \
+            .setInputCol("text") \
             .setOutputCol("document")
         document_assembler.transform(data).show()
 
@@ -427,7 +426,7 @@ class DependencyParserTestSpec(unittest.TestCase):
 
     def setUp(self):
         self.data = SparkContextForTest.spark \
-                .sparkContext.parallelize([["I saw a girl with a telescope"]]).toDF().toDF("text")
+                .createDataFrame([["I saw a girl with a telescope"]]).toDF("text")
         self.corpus = os.getcwd() + "/../src/test/resources/anc-pos-corpus-small/"
         self.tree_bank = os.getcwd() + "/../src/test/resources/parser/dependency_treebank"
 
@@ -468,7 +467,7 @@ class TypedDependencyParserTestSpec(unittest.TestCase):
 
     def setUp(self):
         self.data = SparkContextForTest.spark \
-            .sparkContext.parallelize([["I saw a girl with a telescope"]]).toDF().toDF("text")
+            .createDataFrame([["I saw a girl with a telescope"]]).toDF("text")
         self.corpus = os.getcwd() + "/../src/test/resources/anc-pos-corpus-small/"
         self.tree_bank = os.getcwd() + "/../src/test/resources/parser/dependency_treebank"
         self.conll2009_file = os.getcwd() + "/../src/test/resources/parser/train/example.train"

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ApproachWithWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ApproachWithWordEmbeddings.scala
@@ -47,7 +47,7 @@ abstract class ApproachWithWordEmbeddings[A <: ApproachWithWordEmbeddings[A, M],
         $(embeddingsRef)
       )
     } else if (isSet(embeddingsRef)) {
-      preloadedEmbeddings
+      getClusterEmbeddings
     } else
       throw new IllegalArgumentException(
         s"Word embeddings not found. Either sourceEmbeddingsPath not set," +
@@ -64,6 +64,8 @@ abstract class ApproachWithWordEmbeddings[A <: ApproachWithWordEmbeddings[A, M],
     model.setCaseSensitiveEmbeddings($(caseSensitiveEmbeddings))
 
     if (isSet(embeddingsRef)) model.setEmbeddingsRef($(embeddingsRef))
+
+    getClusterEmbeddings.getLocalRetriever.close()
 
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ClusterWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ClusterWordEmbeddings.scala
@@ -1,5 +1,6 @@
 package com.johnsnowlabs.nlp.embeddings
 
+import java.io.File
 import java.nio.file.{Files, Paths}
 import java.util.UUID
 
@@ -14,11 +15,20 @@ import org.apache.spark.{SparkContext, SparkFiles}
   3. Copy Index to cluster
   4. Open RocksDb based Embeddings on local index (lazy)
  */
-class ClusterWordEmbeddings(val clusterFilePath: String, val dim: Int, val caseSensitive: Boolean) extends Serializable {
+class ClusterWordEmbeddings(val fileName: String, val dim: Int, val caseSensitive: Boolean) extends Serializable {
 
   def getLocalRetriever: WordEmbeddingsRetriever = {
-    WordEmbeddingsRetriever(SparkFiles.get(clusterFilePath), dim, caseSensitive)
+    val localPath = EmbeddingsHelper.getLocalEmbeddingsPath(fileName)
+    if (new File(localPath).exists())
+      WordEmbeddingsRetriever(localPath, dim, caseSensitive)
+    else {
+      val localFromClusterPath = SparkFiles.get(fileName)
+      require(new File(localFromClusterPath).exists(), s"Embeedings not found under given ref." +
+        s" Make sure they are properly loaded using EmbeddingsHelper and pointing towards 'embeddingsRef' param")
+      WordEmbeddingsRetriever(localFromClusterPath, dim, caseSensitive)
+    }
   }
+
 }
 
 object ClusterWordEmbeddings {
@@ -55,16 +65,9 @@ object ClusterWordEmbeddings {
     }
   }
 
-  private def copyIndexToCluster(localFile: String, clusterFilePath: String, spark: SparkContext): String = {
+  private def copyIndexToCluster(localFile: String, dst: Path, spark: SparkContext): String = {
     val fs = new Path(localFile).getFileSystem(spark.hadoopConfiguration)
-    val cfs = FileSystem.get(spark.hadoopConfiguration)
     val src = new Path(localFile)
-    val clusterTmpLocation = {
-      ConfigHelper.getConfigValue(ConfigHelper.embeddingsTmpDir).map(new Path(_)).getOrElse(
-        new Path(cfs.getScheme, "", spark.hadoopConfiguration.get("hadoop.tmp.dir"))
-      )
-    }
-    val dst = Path.mergePaths(clusterTmpLocation, new Path(clusterFilePath))
 
     fs.copyFromLocalFile(false, true, src, dst)
     fs.deleteOnExit(dst)
@@ -74,7 +77,6 @@ object ClusterWordEmbeddings {
     dst.toString
   }
 
-
   def apply(spark: SparkContext,
             sourceEmbeddingsPath: String,
             dim: Int,
@@ -82,23 +84,37 @@ object ClusterWordEmbeddings {
             format: WordEmbeddingsFormat.Format,
             embeddingsRef: String): ClusterWordEmbeddings = {
 
-    val localDestination = {
+    val tmpLocalDestination = {
       Files.createTempDirectory(UUID.randomUUID().toString.takeRight(12) + "_idx")
         .toAbsolutePath
     }
 
-    val clusterFilePath: String = {
-      EmbeddingsHelper.getClusterPath(embeddingsRef)
+    val clusterFileName: String = {
+      EmbeddingsHelper.getClusterFilename(embeddingsRef)
     }
 
-    // 1 and 2.  Copy to local and Index Word Embeddings
-    indexEmbeddings(sourceEmbeddingsPath, localDestination.toString, format, spark)
+    val destinationScheme = new Path(clusterFileName).getFileSystem(spark.hadoopConfiguration).getScheme
+    val fileSystem = FileSystem.get(spark.hadoopConfiguration)
 
-    // 2. Copy WordEmbeddings to cluster
-    copyIndexToCluster(localDestination.toString, clusterFilePath, spark)
-    FileHelper.delete(localDestination.toString)
+    val clusterTmpLocation = {
+      ConfigHelper.getConfigValue(ConfigHelper.embeddingsTmpDir).map(new Path(_)).getOrElse(
+        new Path(fileSystem.getScheme, "", spark.hadoopConfiguration.get("hadoop.tmp.dir"))
+      )
+    }
+    val clusterFilePath = Path.mergePaths(clusterTmpLocation, new Path(clusterFileName))
+
+    // 1 and 2.  Copy to local and Index Word Embeddings
+    indexEmbeddings(sourceEmbeddingsPath, tmpLocalDestination.toString, format, spark)
+
+    if (destinationScheme == "file") {
+      new File(tmpLocalDestination.toString).renameTo(new File(EmbeddingsHelper.getLocalEmbeddingsPath(clusterFileName)))
+    } else {
+      // 2. Copy WordEmbeddings to cluster
+      copyIndexToCluster(tmpLocalDestination.toString, clusterFilePath, spark)
+      FileHelper.delete(tmpLocalDestination.toString)
+    }
 
     // 3. Create Spark Embeddings
-    new ClusterWordEmbeddings(embeddingsRef, dim, caseSensitive)
+    new ClusterWordEmbeddings(clusterFileName, dim, caseSensitive)
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/EmbeddingsHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/EmbeddingsHelper.scala
@@ -67,12 +67,16 @@ object EmbeddingsHelper {
     annotator.getClusterEmbeddings
   }
 
-  def getClusterPath(embeddingsRef: String): String = {
+  def getClusterFilename(embeddingsRef: String): String = {
     Path.mergePaths(new Path("/embd_"), new Path(embeddingsRef)).toString
   }
 
-  protected def save(path: String, spark: SparkSession, indexPath: String): Unit = {
-    val index = new Path(SparkFiles.get(indexPath))
+  def getLocalEmbeddingsPath(fileName: String): String = {
+    Path.mergePaths(new Path(SparkFiles.getRootDirectory()), new Path(fileName)).toString
+  }
+
+  protected def save(path: String, spark: SparkSession, fileName: String): Unit = {
+    val index = new Path(EmbeddingsHelper.getLocalEmbeddingsPath(fileName))
 
     val uri = new java.net.URI(path.replaceAllLiterally("\\", "/"))
     val fs = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
@@ -82,7 +86,7 @@ object EmbeddingsHelper {
   }
 
   def save(path: String, embeddings: ClusterWordEmbeddings, spark: SparkSession): Unit = {
-    EmbeddingsHelper.save(path, spark, embeddings.clusterFilePath.toString)
+    EmbeddingsHelper.save(path, spark, embeddings.fileName.toString)
   }
 
   def save(fs: FileSystem, index: Path, dst: Path): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ModelWithWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ModelWithWordEmbeddings.scala
@@ -4,7 +4,6 @@ import java.io.File
 import java.nio.file.{Files, Paths}
 
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.spark.SparkFiles
 import org.apache.spark.sql.SparkSession
 
 /**
@@ -46,7 +45,7 @@ trait ModelWithWordEmbeddings extends HasEmbeddings {
 
   def serializeEmbeddings(path: String, spark: SparkSession): Unit = {
     if ($(includeEmbeddings)) {
-      val index = new Path(SparkFiles.get(getClusterEmbeddings.clusterFilePath))
+      val index = new Path(EmbeddingsHelper.getLocalEmbeddingsPath(getClusterEmbeddings.fileName))
 
       val uri = new java.net.URI(path)
       val fs = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
@@ -54,6 +53,9 @@ trait ModelWithWordEmbeddings extends HasEmbeddings {
 
       EmbeddingsHelper.save(fs, index, dst)
     }
+    else
+      require(isSet(embeddingsRef), "Models with word embeddings require 'embeddingsRef' param set if 'includedEmbeddings' is false." +
+        " Please use setEmbeddingsRef()")
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {


### PR DESCRIPTION
A problem was arising in local mode when spark files was pointing to the local filesystem in the driver location. This caused word embeddings to change during executions and making crc fail.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
