### PR TITLE
Allow single string argument for corpus parameter (fix git issue 345)

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingApproach.scala
@@ -49,7 +49,7 @@ class NorvigSweetingApproach(override val uid: String)
   }
 
   def setCorpus(path: String,
-                tokenPattern: String,
+                tokenPattern: String = "\\S+",
                 readAs: ReadAs.Format = ReadAs.LINE_BY_LINE,
                 options: Map[String, String] = Map("format" -> "text")): this.type =
     set(corpus, ExternalResource(path, readAs, options ++ Map("tokenPattern" -> tokenPattern)))

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteApproach.scala
@@ -34,7 +34,7 @@ class SymmetricDeleteApproach(override val uid: String)
   }
 
   def setCorpus(path: String,
-                tokenPattern: String,
+                tokenPattern: String = "\\S+",
                 readAs: ReadAs.Format = ReadAs.LINE_BY_LINE,
                 options: Map[String, String] = Map("format" -> "text")): this.type =
     set(corpus, ExternalResource(path, readAs, options ++ Map("tokenPattern" -> tokenPattern)))

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingTestSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest._
 
 class NorvigSweetingTestSpec extends FlatSpec with NorvigSweetingBehaviors{
 
+  "A norvig sweeting approach" should behave like testDefaultTokenCorpusParameter
 
  "an isolated spell checker" should behave like isolatedNorvigChecker(
     Seq(

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteBehaviors.scala
@@ -577,4 +577,41 @@ trait SymmetricDeleteBehaviors { this: FlatSpec =>
     }
   }
 
+  def testDefaultTokenCorpusParameter(): Unit = {
+    s"using a corpus with default token parameter" should "successfully correct words" in {
+      val data = ContentProvider.parquetData.limit(3000)
+      val corpusData = Seq.empty[String].toDS
+
+      val documentAssembler = new DocumentAssembler()
+        .setInputCol("text")
+        .setOutputCol("document")
+
+      val tokenizer = new Tokenizer()
+        .setInputCols(Array("document"))
+        .setOutputCol("token")
+
+      val spell = new SymmetricDeleteApproach()
+        .setInputCols(Array("token"))
+        .setOutputCol("spell")
+        .setCorpus("src/test/resources/spell/sherlockholmes.txt")
+        .setDictionary("src/test/resources/spell/words.txt")
+
+      val finisher = new Finisher()
+        .setInputCols("spell")
+
+      val pipeline = new Pipeline()
+        .setStages(Array(
+          documentAssembler,
+          tokenizer,
+          spell,
+          finisher
+        ))
+
+      val model = pipeline.fit(corpusData.select(corpusData.col("value").as("text")))
+
+      assert(model.transform(data).isInstanceOf[DataFrame])
+
+    }
+  }
+
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModelTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModelTestSpec.scala
@@ -10,6 +10,8 @@ class SymmetricDeleteModelTestSpec extends FlatSpec with SymmetricDeleteBehavior
 
   //testLevenshteinDistance()
 
+  "A symmetric delete approach" should behave like testDefaultTokenCorpusParameter
+
   "a lower case word " should behave like obtainLowerCaseTypeFromALowerCaseWord
 
   it should behave like transformLowerCaseTypeWordIntoLowerCase


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The documentation for the SymmetricDeleteApproach.setCorpus method suggests that it can be called with a single String argument. This is true in Python, but not in Scala.

## Description
<!--- Describe your changes in detail -->
Refer to [issue 345](https://github.com/JohnSnowLabs/spark-nlp/issues/345)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
