### PR TITLE
Fix DataMatcher param name in Python

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -454,7 +454,7 @@ class DateMatcher(AnnotatorModel):
             dateFormat="yyyy/MM/dd"
         )
 
-    def setDateFormat(self, value):
+    def setFormat(self, value):
         return self._set(dateFormat=value)
 
 

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -173,7 +173,7 @@ class DateMatcherTestSpec(unittest.TestCase):
         date_matcher = DateMatcher() \
             .setInputCols(['document']) \
             .setOutputCol("date") \
-            .setDateFormat("yyyyMM")
+            .setFormat("yyyyMM")
         assembled = document_assembler.transform(self.data)
         date_matcher.transform(assembled).show()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix DataMatcher param name in Python, this makes it in sync between Scala and Python.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pipelines train by one language, cannot be used in another language. This will fix it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
