### PR TITLE
smaller default nerdl batch size and allow_growth tensorflow gpu option

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1108,7 +1108,7 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
             maxEpochs=50,
             lr=float(0.001),
             po=float(0.005),
-            batchSize=32,
+            batchSize=8,
             dropout=float(0.5),
             verbose=2
         )

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowWrapper.scala
@@ -160,7 +160,9 @@ object TensorflowWrapper {
     //Use CPU
     //val config = Array[Byte](10, 7, 10, 3, 67, 80, 85, 16, 0)
     //Use GPU
-    val config = Array[Byte](56, 1)
+    /** log_device_placement=True, allow_soft_placement=True, gpu_options.allow_growth=True*/
+    val config = Array[Byte](50, 2, 32, 1, 56, 1, 64, 1)
+    // val config = Array[Byte](56, 1)
 
     // 3. Read file as SavedModelBundle
     val (graph, session) = if (useBundle) {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -45,7 +45,7 @@ class NerDLApproach(override val uid: String)
     maxEpochs -> 70,
     lr -> 1e-3f,
     po -> 0.005f,
-    batchSize -> 32,
+    batchSize -> 8,
     dropout -> 0.5f,
     verbose -> Verbose.Silent.id
   )
@@ -79,7 +79,8 @@ class NerDLApproach(override val uid: String)
     //Use CPU
     //val config = Array[Byte](10, 7, 10, 3, 67, 80, 85, 16, 0)
     //Use GPU
-    val config = Array[Byte](56, 1)
+    //val config = Array[Byte](56, 1)
+    val config = Array[Byte](50, 2, 32, 1, 56, 1, 64, 1)
     val graphFile = NerDLApproach.searchForSuitableGraph(labels.length, embeddingsDim, chars.length)
     val graph = TensorflowWrapper.readGraph(graphFile)
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala
@@ -87,7 +87,8 @@ class ContextSpellCheckerApproach(override val uid: String) extends
   override def train(dataset: Dataset[_], recursivePipeline: Option[PipelineModel]): ContextSpellCheckerModel = {
 
     val graph = new Graph()
-    val config = Array[Byte](56, 1)
+    //val config = Array[Byte](56, 1)
+    val config = Array[Byte](50, 2, 32, 1, 56, 1, 64, 1)
     val session = new Session(graph, config)
     val tf = new TensorflowWrapper(session, graph)
 

--- a/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
+++ b/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
@@ -46,7 +46,8 @@ object NerDLCoNLL2003 extends App {
   //Use CPU
   //val config = Array[Byte](10, 7, 10, 3, 67, 80, 85, 16, 0)
   //Use GPU
-  val config = Array[Byte](56, 1)
+  //val config = Array[Byte](56, 1)
+  val config = Array[Byte](50, 2, 32, 1, 56, 1, 64, 1)
   val graph = TensorflowWrapper.readGraph("ner-dl/blstm_10_100_128_100.pb")
   val session = new Session(graph, config)
 


### PR DESCRIPTION
allow_growth tensorflow gpu improves memory management, reduced default NerDL batch sizes for lesser memory pressure