### PR TITLE
Users infix patterns should include non covered surroundings

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -131,28 +131,22 @@ class Tokenizer(AnnotatorModel):
         return self.getOrDefault("includeDefaults")
 
     def getInfixPatterns(self):
-        if self.getIncludeDefaults():
-            return self.getOrDefault("infixPatterns") + self.infixDefaults
-        else:
-            return self.getOrDefault("infixPatterns")
+        return self.getOrDefault("infixPatterns")
 
     def getSuffixPattern(self):
-        if self.getIncludeDefaults():
-            if self.isDefined("suffixPattern"):
-                return self.getOrDefault("suffixPattern")
-            else:
-                return self.suffixDefault
-        else:
-            return self.getOrDefault("suffixPattern")
+        return self.getOrDefault("suffixPattern")
 
     def getPrefixPattern(self):
-        if self.getIncludeDefaults():
-            if self.isDefined("prefixPattern"):
-                return self.getOrDefault("prefixPattern")
-            else:
-                return self.prefixDefault
-        else:
-            return self.getOrDefault("prefixPattern")
+        return self.getOrDefault("prefixPattern")
+
+    def getDefaultPatterns(self):
+        return Tokenizer.infixDefaults
+
+    def getDefaultPrefix(self):
+        return Tokenizer.prefixDefault
+
+    def getDefaultSuffix(self):
+        return Tokenizer.suffixDefault
 
 
 class ChunkTokenizer(Tokenizer):

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
@@ -45,13 +45,19 @@ class Tokenizer(override val uid: String) extends AnnotatorModel[Tokenizer] {
 
   def getCompositeTokens: Array[String] = $(compositeTokens)
 
-  def getInfixPatterns: Array[String] = if ($(includeDefaults)) $(infixPatterns) ++ infixDefaults else $(infixPatterns)
+  def getInfixPatterns: Array[String] = $(infixPatterns)
 
-  def getPrefixPattern: String = if ($(includeDefaults)) get(prefixPattern).getOrElse(prefixDefault) else $(prefixPattern)
+  def getPrefixPattern: String = $(prefixPattern)
 
-  def getSuffixPattern: String = if ($(includeDefaults)) get(suffixPattern).getOrElse(suffixDefault) else $(suffixPattern)
+  def getSuffixPattern: String = $(suffixPattern)
 
   def getTargetPattern: String = $(targetPattern)
+
+  def getDefaultPatterns: Array[String] = infixDefaults
+
+  def getDefaultPrefix: String = prefixDefault
+
+  def getDefaultSuffix: String = suffixDefault
 
   def getIncludeDefaults: Boolean = $(includeDefaults)
 
@@ -80,8 +86,8 @@ class Tokenizer(override val uid: String) extends AnnotatorModel[Tokenizer] {
   lazy private val ruleFactory = {
     val rules = ArrayBuffer.empty[String]
     require(getInfixPatterns.forall(ip => ip.contains("(") && ip.contains(")")),
-      "infix patterns must use regex group. Notice each group will result in separate token")
-    getInfixPatterns.foreach(ip => {
+      "infix patterns must use regex group (parenthesis). Notice each group will result in separate token")
+    (getInfixPatterns.map(ip => "(.*)"+ip+"(.*)")++{if ($(includeDefaults)) infixDefaults else Array.empty[String]}).foreach(ip => {
       val rule = new StringBuilder
       get(prefixPattern).orElse(if (!$(includeDefaults)) None else Some(prefixDefault)).foreach(pp => {
         require(pp.startsWith("\\A"), "prefixPattern must begin with \\A to ensure it is the beginning of the string")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If a user provides an infix pattern such as `(\\\\n)`, without this fix, most matches wouldn't work unless this pattern covered the entire target. A text like `\\n2.` would not match the infix since it is not covering the entire target. User should add this infix pattern instead `(.*)(\\\\n)(.*)` to allow the rest of the target to be tokenized normally.

This branch helps the user to make infix pattern more intuitive.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
