### PR TITLE
Limit the context to be used in the Language Model to score a correction.

### DIFF
--- a/ocr/src/main/scala/com/johnsnowlabs/nlp/util/io/OcrHelper.scala
+++ b/ocr/src/main/scala/com/johnsnowlabs/nlp/util/io/OcrHelper.scala
@@ -64,7 +64,7 @@ class OcrHelper extends ImageProcessing with Serializable {
   private val imageFormats = Seq(".png", ".jpg")
 
   @transient
-  private var tesseractAPI : Tesseract = _
+  private var tesseractAPI : Tesseract = null
 
   private var preferredMethod: String = OCRMethod.TEXT_LAYER
   private var fallbackMethod: Boolean = true

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -20,7 +20,5 @@ sparknlp {
       // cache_folder = "/home/robert/models"
       credentials {}
     }
-
   }
-
 }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowSpell.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowSpell.scala
@@ -21,17 +21,6 @@ class TensorflowSpell(
   /* returns the loss associated with the last word, given previous history  */
   def predict(dataset: Array[Array[Int]], cids: Array[Array[Int]], cwids:Array[Array[Int]]) = this.synchronized {
 
-    println(s"""hash: ${tensorflow.session.hashCode()}""")
-    println(s"""threadId: ${Thread.currentThread().getId}""")
-
-    val fields = tensorflow.session.getClass.getDeclaredFields
-    for (field <- fields) {
-      if (Modifier.isPrivate(field.getModifiers)) {
-        field.setAccessible(true)
-        System.out.println(field.getName + " : " + field.get(tensorflow.session))
-      }
-    }
-
     val packed = dataset.zip(cids).zip(cwids).map {
       case ((_ids, _cids), _cwids) => Array(_ids, _cids, _cwids)
     }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/SimpleTokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/SimpleTokenizer.scala
@@ -27,7 +27,9 @@ class SimpleTokenizer(override val uid: String) extends AnnotatorModel[SimpleTok
     */
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] =
     annotations.flatMap { annotation =>
-      tokenize(annotation.result).map(Annotation.apply)
+      tokenize(annotation.result).map(token => annotation.
+        copy(result = token, metadata = annotation.metadata.updated("sentence",
+          annotation.metadata.getOrElse("sentence", "0"))))
   }
 
   // hardcoded at this time

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala
@@ -66,6 +66,9 @@ class ContextSpellCheckerApproach(override val uid: String) extends
   val weightedDistPath = new Param[String](this, "weightedDistPath", "The path to the file containing the weights for the levenshtein distance.")
   def setWeights(filePath:String):this.type = set(weightedDistPath, filePath)
 
+  val maxWindowLen = new IntParam(this, "maxWindowLen", "Maximum size for the window used to remember history prior to every correction.")
+  def setMaxWindowLen(w: Int):this.type = set(maxWindowLen, w)
+
 
   setDefault(minCount -> 3.0,
     specialClasses -> List(DateToken, NumberToken),

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala
@@ -76,7 +76,8 @@ class ContextSpellCheckerApproach(override val uid: String) extends
     maxCandidates -> 6,
     languageModelClasses -> 2000,
     blacklistMinFreq -> 5,
-    tradeoff -> 18.0f
+    tradeoff -> 18.0f,
+    maxWindowLen -> 5
   )
 
   setDefault(prefixes, () => Array("'"))

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
@@ -67,7 +67,10 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
     " correction is applied on paragraphs as defined by newline characters.")
   def setUseNewLines(useIt: Boolean):this.type = set(useNewLines, useIt)
 
-  setDefault(tradeoff -> 18.0f, gamma -> 120.0f, useNewLines -> false, maxCandidates -> 6)
+  val maxWindowLen = new IntParam(this, "maxWindowLen", "Maximum size for the window used to remember history prior to every correction.")
+  def setMaxWindowLen(w: Int):this.type = set(maxWindowLen, w)
+
+  setDefault(tradeoff -> 18.0f, gamma -> 120.0f, useNewLines -> false, maxCandidates -> 6, maxWindowLen -> 2)
 
 
   // the scores for the EOS (end of sentence), and BOS (beginning of sentence)
@@ -131,7 +134,7 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
         pathsIds.map { path =>
           path :+ state
         }
-      }
+      }.map(_.takeRight($(maxWindowLen)))
 
       val cids = expPaths.map(_.map{id => $$(classes).apply(id)._1})
       val cwids = expPaths.map(_.map{id => $$(classes).apply(id)._2})

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
@@ -70,7 +70,7 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
   val maxWindowLen = new IntParam(this, "maxWindowLen", "Maximum size for the window used to remember history prior to every correction.")
   def setMaxWindowLen(w: Int):this.type = set(maxWindowLen, w)
 
-  setDefault(tradeoff -> 18.0f, gamma -> 120.0f, useNewLines -> false, maxCandidates -> 6, maxWindowLen -> 2)
+  setDefault(tradeoff -> 18.0f, gamma -> 120.0f, useNewLines -> false, maxCandidates -> 6, maxWindowLen -> 5)
 
 
   // the scores for the EOS (end of sentence), and BOS (beginning of sentence)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
@@ -252,10 +252,6 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
 
       // ask each token class for candidates, keep the one with lower cost
       var candLabelWeight = $$(specialTransducers).flatMap { specialParser =>
-        if(specialParser.transducer == null)
-          throw new RuntimeException(s"${specialParser.label}")
-        println(s"special parser:::${specialParser.label}")
-        println(s"value: ${specialParser.transducer}")
         getClassCandidates(specialParser.transducer, token, specialParser.label, getOrDefault(wordMaxDistance) - 1)
       } ++ getVocabCandidates($$(transducer), token, getOrDefault(wordMaxDistance) -1)
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
@@ -88,6 +88,7 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
       useBundle,
       tags = Array("our-graph")
     )
+    _model = None
     setModelIfNotSet(spark, tf)
   }
 
@@ -251,6 +252,10 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
 
       // ask each token class for candidates, keep the one with lower cost
       var candLabelWeight = $$(specialTransducers).flatMap { specialParser =>
+        if(specialParser.transducer == null)
+          throw new RuntimeException(s"${specialParser.label}")
+        println(s"special parser:::${specialParser.label}")
+        println(s"value: ${specialParser.transducer}")
         getClassCandidates(specialParser.transducer, token, specialParser.label, getOrDefault(wordMaxDistance) - 1)
       } ++ getVocabCandidates($$(transducer), token, getOrDefault(wordMaxDistance) -1)
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/parser/SpecialTokensParser.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/parser/SpecialTokensParser.scala
@@ -80,7 +80,6 @@ trait VocabParser extends SpecialClassParser {
 object DateToken extends RegexParser with WeightedLevenshtein with Serializable {
 
   override val regex = "(01|02|03|04|05|06|07|08|09|10|11|12)\\/([0-2][0-9]|30|31)\\/(19|20)[0-9]{2}|[0-9]{2}\\/(19|20)[0-9]{2}|[0-2][0-9]:[0-5][0-9]"
-  @transient
   override var transducer: ITransducer[Candidate] = generateTransducer
   override val label = "_DATE_"
   override val maxDist: Int = 2
@@ -105,7 +104,6 @@ object NumberToken extends RegexParser with Serializable {
   /* used during candidate generation(correction) - must be finite */
   override val regex = "([0-9]{1,3}(\\.|,)[0-9]{1,3}|[0-9]{1,2}(\\.[0-9]{1,2})?(%)?|[0-9]{1,4})"
 
-  @transient
   override var transducer: ITransducer[Candidate] = generateTransducer
 
   override val label = "_NUM_"
@@ -130,7 +128,7 @@ object NumberToken extends RegexParser with Serializable {
 
 }
 
-object MedicationClass extends VocabParser with Serializable {
+class MedicationClass extends VocabParser with Serializable {
 
   @transient
   override var vocab = Set.empty[String]
@@ -138,10 +136,10 @@ object MedicationClass extends VocabParser with Serializable {
   override val label: String = "_MED_"
   override val maxDist: Int = 3
 
-  def apply(path: String) = {
+  def this(path: String) = {
+    this()
     vocab = loadCSV(path)
     transducer = generateTransducer
-    this
   }
 
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/serialization/Feature.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/serialization/Feature.scala
@@ -271,7 +271,7 @@ class TransducerFeature(model: HasFeatures, override val name: String)
     val serializer = new PlainTextSerializer
     val dataPath = getFieldPath(path, field)
     val bytes = serializer.serialize(trans)
-    spark.sparkContext.parallelize(bytes.toSeq).saveAsObjectFile(dataPath.toString)
+    spark.sparkContext.parallelize(bytes.toSeq, 1).saveAsObjectFile(dataPath.toString)
 
   }
 
@@ -339,7 +339,7 @@ class TransducerSeqFeature(model: HasFeatures, override val name: String)
 
       // we handle the transducer separately
       val transBytes = serializer.serialize(transducer)
-      spark.sparkContext.parallelize(transBytes.toSeq).
+      spark.sparkContext.parallelize(transBytes.toSeq, 1).
         saveAsObjectFile(s"${dataPath.toString}/${label}transducer")
 
     }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
@@ -1,10 +1,15 @@
 package com.johnsnowlabs.nlp.annotators.spell.context
+import com.github.liblevenshtein.proto.LibLevenshteinProtos.DawgNode
+import com.github.liblevenshtein.serialization.PlainTextSerializer
+import com.github.liblevenshtein.transducer.{Candidate, Transducer}
 import com.johnsnowlabs.nlp.annotators.common.{PrefixedToken, SuffixedToken}
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.annotators.{Normalizer, Tokenizer}
 import com.johnsnowlabs.nlp.annotators.spell.context.parser._
 import com.johnsnowlabs.nlp.{Annotation, DocumentAssembler, LightPipeline, SparkAccessor}
+import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.ml.Pipeline
+import org.apache.spark.sql.SparkSession
 import org.scalatest._
 
 
@@ -17,6 +22,37 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
 
   trait distFile extends WeightedLevenshtein {
     val weights = loadWeights("src/test/resources/dist.psv")
+  }
+
+  "UnitClass" should "serilize/deserialize properly" in {
+
+      import SparkAccessor.spark
+      import spark.implicits._
+      val dataPathTrans = "./tmp/transducer"
+      val dataPathObject = "./tmp/object"
+      val serializer = new PlainTextSerializer
+
+      val specialClass = UnitToken
+      val transducer = specialClass.transducer
+      specialClass.setTransducer(null)
+
+      // the object per se
+      spark.sparkContext.parallelize(Seq(specialClass)).
+      saveAsObjectFile(dataPathObject)
+
+      // we handle the transducer separaely
+      val transBytes = serializer.serialize(transducer)
+      spark.sparkContext.parallelize(transBytes.toSeq, 1).
+          saveAsObjectFile(dataPathTrans)
+
+      // load transducer
+      val bytes = spark.sparkContext.objectFile[Byte](dataPathTrans).collect()
+      val trans = serializer.deserialize(classOf[Transducer[DawgNode, Candidate]], bytes)
+
+      // the object
+      //val sc = spark.sparkContext.objectFile[SpecialClassParser](path.toString.dropRight(10)).collect().head
+      //sc.setTransducer(trans)
+
   }
 
   "weighted Levenshtein distance" should "work from file" in new distFile {
@@ -204,8 +240,10 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
     import SparkAccessor.spark.implicits._
     import scala.collection.JavaConversions._
 
-    val ocrSpellModel = ContextSpellCheckerModel
-      .pretrained()
+    val ocrSpellModel = ContextSpellCheckerModel.read.load("./context_spell_med_en_2.0.0_2.4_1553552948340")
+
+    ocrSpellModel.setSpecialClassesTransducers(Seq(UnitToken))
+      //.pretrained()
 
     ocrSpellModel.write.overwrite.save("./test_spell_checker")
     val loadedModel = ContextSpellCheckerModel.read.load("./test_spell_checker")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sometimes long sentences can take too long in Context Spell Checker. This is due to the use of the context information in the Language Model.
With this PR we limit the length of the context information to be used. I checked that the smaller the window the faster the algorithm, and the lowest the accuracy. I also checked that accuracy typically starts falling with a window below 5. So '5' is the default value for the window parameter.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
