### PR TITLE
Limit the context information for Context Spell Checker

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala
@@ -66,6 +66,9 @@ class ContextSpellCheckerApproach(override val uid: String) extends
   val weightedDistPath = new Param[String](this, "weightedDistPath", "The path to the file containing the weights for the levenshtein distance.")
   def setWeights(filePath:String):this.type = set(weightedDistPath, filePath)
 
+  val maxWindowLen = new IntParam(this, "maxWindowLen", "Maximum size for the window used to remember history prior to every correction.")
+  def setMaxWindowLen(w: Int):this.type = set(maxWindowLen, w)
+
 
   setDefault(minCount -> 3.0,
     specialClasses -> List(DateToken, NumberToken),
@@ -73,7 +76,8 @@ class ContextSpellCheckerApproach(override val uid: String) extends
     maxCandidates -> 6,
     languageModelClasses -> 2000,
     blacklistMinFreq -> 5,
-    tradeoff -> 18.0f
+    tradeoff -> 18.0f,
+    maxWindowLen -> 5
   )
 
   setDefault(prefixes, () => Array("'"))

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
@@ -134,7 +134,7 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
         pathsIds.map { path =>
           path :+ state
         }
-      }
+      }.map(_.takeRight($(maxWindowLen)))
 
       val cids = expPaths.map(_.map{id => $$(classes).apply(id)._1})
       val cwids = expPaths.map(_.map{id => $$(classes).apply(id)._2})

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
@@ -67,7 +67,10 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
     " correction is applied on paragraphs as defined by newline characters.")
   def setUseNewLines(useIt: Boolean):this.type = set(useNewLines, useIt)
 
-  setDefault(tradeoff -> 18.0f, gamma -> 120.0f, useNewLines -> false, maxCandidates -> 6)
+  val maxWindowLen = new IntParam(this, "maxWindowLen", "Maximum size for the window used to remember history prior to every correction.")
+  def setMaxWindowLen(w: Int):this.type = set(maxWindowLen, w)
+
+  setDefault(tradeoff -> 18.0f, gamma -> 120.0f, useNewLines -> false, maxCandidates -> 6, maxWindowLen -> 5)
 
 
   // the scores for the EOS (end of sentence), and BOS (beginning of sentence)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For long text the Context Spell Checker can have poor performance. By limiting the number of tokens the Spell Checker uses for deciding the best correction candidate, running time is bounded.
The default value is 5. This value has been shown to keep accuracy almost unmodified and still be ~ twice faster than the no limit situation in some test datasets.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
