### PR TITLE
fix explode annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 env:
-  - JAVA_OPTS="-XX:+UseG1GC"      
-  - DOCKER_SPARK_NLP_SCALA="${DOCKER_USERNAME}/spark-nlp-scala-${TRAVIS_BUILD_ID}"
+  - DOCKER_SPARK_NLP_SCALA="${DOCKER_USERNAME}/spark-nlp-scala-${TRAVIS_BUILD_ID}" JAVA_OPTS="-XX:+UseG1GC"
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 env:
+  - JAVA_OPTS="-XX:+UseG1GC"      
   - DOCKER_SPARK_NLP_SCALA="${DOCKER_USERNAME}/spark-nlp-scala-${TRAVIS_BUILD_ID}"
 
 sudo: required

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ RUN wget -qO- "https://cocl.us/sbt-$SBT_VERSION.tgz" \
 
 COPY . /app/spark-nlp
 
+ENV JAVA_OPTS="-Xmx2012m -XX:+UseG1GC"
 WORKDIR /app/spark-nlp/
 RUN sbt publish-local

--- a/src/main/scala/com/johnsnowlabs/nlp/functions.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/functions.scala
@@ -39,9 +39,9 @@ object functions {
     def explodeAnnotations[T: TypeTag](column: String, outputCol:String): DataFrame = {
       val meta = dataset.schema(column).metadata
       dataset.
-        withColumn(column, explode(col(column))).
-        withColumn(column, array(col(outputCol)).as(outputCol, meta))
-      }
+        withColumn(outputCol, explode(col(column))).
+        withColumn(outputCol, array(col(outputCol)).as(outputCol, meta))
+    }
   }
 
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/SpellCheckersPerfTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/SpellCheckersPerfTest.scala
@@ -10,6 +10,8 @@ import org.scalatest._
 
 class SpellCheckersPerfTest extends FlatSpec {
 
+  System.gc()
+
   "Norvig pipeline" should "be fast" ignore {
 
     ResourceHelper.spark

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
@@ -19,6 +19,8 @@ import spark.implicits._
 
 class ContextSpellCheckerTestSpec extends FlatSpec {
 
+  System.gc()
+
   trait Scope extends WeightedLevenshtein {
     val weights = Map("1" -> Map("l" -> 0.5f), "!" -> Map("l" -> 0.4f),
       "F" -> Map("P" -> 0.2f))

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingTestSpec.scala
@@ -5,6 +5,8 @@ import org.scalatest._
 
 class NorvigSweetingTestSpec extends FlatSpec with NorvigSweetingBehaviors{
 
+  System.gc()
+
   "A norvig sweeting approach" should behave like testDefaultTokenCorpusParameter
 
  "An isolated spell checker" should behave like isolatedNorvigChecker(

--- a/src/test/scala/com/johnsnowlabs/util/ExportCSVToolTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/util/ExportCSVToolTestSpec.scala
@@ -7,6 +7,8 @@ class ExportCSVToolTestSpec extends FlatSpec with ExportCSVToolBehaviors {
 
   import SparkAccessor.spark.implicits._
 
+  System.gc()
+
   val document = Seq(
     "EU rejects German call to boycott British lamb",
     "Peter Blackburn"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Before, the explodeAnnotations() function only worked when the two input parameters were the same. Now it will work both for the case when the user wants to replace the existing column with the exploded one(column == outputCol), and for the case when the user wants to create a new column for the exploded annotations(column != outputCol).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
