### PR TITLE
Aws credentials load

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,12 @@ lazy val testDependencies = Seq(
 lazy val utilDependencies = Seq(
   "com.typesafe" % "config" % "1.3.0",
   "org.rocksdb" % "rocksdbjni" % "5.17.2",
-  "com.amazonaws" % "aws-java-sdk" % "1.7.4"
+  "org.apache.hadoop" % "hadoop-aws" %  "2.7.3"
+    exclude("com.fasterxml.jackson.core", "jackson-annotations")
+    exclude("com.fasterxml.jackson.core", "jackson-databind")
+    exclude("commons-configuration","commons-configuration")
+    exclude("org.apache.hadoop" ,"hadoop-common"),
+  "com.amazonaws" % "aws-java-sdk" % "1.11.568"
     exclude("commons-codec", "commons-codec")
     exclude("com.fasterxml.jackson.core", "jackson-core")
     exclude("com.fasterxml.jackson.core", "jackson-annotations")
@@ -165,6 +170,8 @@ val ocrMergeRules: String => MergeStrategy  = {
 
 assemblyMergeStrategy in assembly := {
   case PathList("apache.commons.lang3", _ @ _*)  => MergeStrategy.discard
+  case PathList("org.apache.hadoop", _ @ _*)  => MergeStrategy.last
+  case PathList("com.amazonaws", _ @ _*)  => MergeStrategy.last
   case PathList("com.fasterxml.jackson") => MergeStrategy.first
   case PathList("META-INF", "io.netty.versions.properties")  => MergeStrategy.first
   case PathList("org", "tensorflow", _ @ _*)  => MergeStrategy.first

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/EmbeddingsHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/EmbeddingsHelper.scala
@@ -2,6 +2,7 @@ package com.johnsnowlabs.nlp.embeddings
 
 import java.nio.file.{Files, Paths, StandardCopyOption}
 
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
 import com.johnsnowlabs.util.ConfigHelper
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -42,20 +43,22 @@ object EmbeddingsHelper {
     //if the path contains s3a download to local cache if not present
     if (uri.getScheme != null) {
       if (uri.getScheme.equals("s3a")) {
-        val accessKeyId = ConfigHelper.getConfigValue(ConfigHelper.accessKeyId)
-        val secretAccessKey = ConfigHelper.getConfigValue(ConfigHelper.secretAccessKey)
-        if (accessKeyId.isEmpty || secretAccessKey.isEmpty)
-          throw new SecurityException("AWS credentials not set in config")
-        else {
-          var old_key = ""
-          var old_secret = ""
-          if (spark.sparkContext.hadoopConfiguration.get("fs.s3a.access.key") != null) {
-            old_key = spark.sparkContext.hadoopConfiguration.get("fs.s3a.access.key")
-            old_secret = spark.sparkContext.hadoopConfiguration.get("fs.s3a.secret.key")
-          }
-          try {
-            val dst = new Path(ResourceDownloader.cacheFolder, src.getName)
-            if (!Files.exists(Paths.get(dst.toUri.getPath))) {
+        var accessKeyId = ConfigHelper.getConfigValue(ConfigHelper.accessKeyId)
+        var secretAccessKey = ConfigHelper.getConfigValue(ConfigHelper.secretAccessKey)
+        if (accessKeyId.isEmpty || secretAccessKey.isEmpty) {
+          val defaultCred = new DefaultAWSCredentialsProviderChain().getCredentials
+          accessKeyId = Some(defaultCred.getAWSAccessKeyId)
+          secretAccessKey = Some(defaultCred.getAWSSecretKey)
+        }
+        var old_key = ""
+        var old_secret = ""
+        if (spark.sparkContext.hadoopConfiguration.get("fs.s3a.access.key") != null) {
+          old_key = spark.sparkContext.hadoopConfiguration.get("fs.s3a.access.key")
+          old_secret = spark.sparkContext.hadoopConfiguration.get("fs.s3a.secret.key")
+        }
+        try {
+          val dst = new Path(ResourceDownloader.cacheFolder, src.getName)
+          if (!Files.exists(Paths.get(dst.toUri.getPath))) {
             //download s3 resource locally using config keys
             spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", accessKeyId.get)
             spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", secretAccessKey.get)
@@ -64,35 +67,35 @@ object EmbeddingsHelper {
             val dst_tmp = new Path(ResourceDownloader.cacheFolder, src.getName + "_tmp")
 
 
-              s3fs.copyToLocalFile(src, dst_tmp)
-              // rename to original file
-              val path = Files.move(
-                Paths.get(dst_tmp.toUri.getRawPath),
-                Paths.get(dst.toUri.getRawPath),
-                StandardCopyOption.REPLACE_EXISTING
-              )
+            s3fs.copyToLocalFile(src, dst_tmp)
+            // rename to original file
+            val path = Files.move(
+              Paths.get(dst_tmp.toUri.getRawPath),
+              Paths.get(dst.toUri.getRawPath),
+              StandardCopyOption.REPLACE_EXISTING
+            )
 
-            }
-            src = new Path(dst.toUri.getPath)
           }
-          finally {
-            //reset the keys
-              if (!old_key.equals("")) {
-                spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", old_key)
-                spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", old_secret)
-            }
+          src = new Path(dst.toUri.getPath)
+        }
+        finally {
+          //reset the keys
+          if (!old_key.equals("")) {
+            spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", old_key)
+            spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", old_secret)
           }
         }
+
       }
     }
     ClusterWordEmbeddings(
-        spark.sparkContext,
-        src.toUri.toString,
-        nDims,
-        caseSensitiveEmbeddings,
-        format,
-        embeddingsRef
-      )
+      spark.sparkContext,
+      src.toUri.toString,
+      nDims,
+      caseSensitiveEmbeddings,
+      format,
+      embeddingsRef
+    )
   }
 
   def load(

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -1,5 +1,7 @@
 package com.johnsnowlabs.nlp.pretrained
 
+import com.amazonaws.AmazonClientException
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{DefaultAWSCredentialsProviderChain, _}
 import com.johnsnowlabs.nlp.DocumentAssembler
 import com.johnsnowlabs.nlp.annotators._
@@ -28,8 +30,9 @@ trait ResourceDownloader {
 
   /**
     * Download resource to local file
-    * @param request      Resource request
-    * @return             downloaded file or None if resource is not found
+    *
+    * @param request Resource request
+    * @return downloaded file or None if resource is not found
     */
   def download(request: ResourceRequest): Option[String]
 
@@ -44,20 +47,37 @@ object ResourceDownloader {
   val fs = FileSystem.get(ResourceHelper.spark.sparkContext.hadoopConfiguration)
 
   def s3Bucket = ConfigHelper.getConfigValueOrElse(ConfigHelper.pretrainedS3BucketKey, "auxdata.johnsnowlabs.com")
+
   def s3Path = ConfigHelper.getConfigValueOrElse(ConfigHelper.pretrainedS3PathKey, "")
+
   def cacheFolder = ConfigHelper.getConfigValueOrElse(ConfigHelper.pretrainedCacheFolder, fs.getHomeDirectory + "/cache_pretrained")
 
   def credentials: Option[AWSCredentials] = if (ConfigHelper.hasPath(ConfigHelper.awsCredentials)) {
     val accessKeyId = ConfigHelper.getConfigValue(ConfigHelper.accessKeyId)
     val secretAccessKey = ConfigHelper.getConfigValue(ConfigHelper.secretAccessKey)
     if (accessKeyId.isEmpty || secretAccessKey.isEmpty) {
-      //Some(new AnonymousAWSCredentials()\E
-      Some(new DefaultAWSCredentialsProviderChain().getCredentials)
+      try {
+
+        Some(new DefaultAWSCredentialsProviderChain().getCredentials)
+      } catch {
+        case awse: AmazonClientException => {
+          if (ResourceHelper.spark.sparkContext.hadoopConfiguration.get("fs.s3a.access.key") != null) {
+
+            val key = ResourceHelper.spark.sparkContext.hadoopConfiguration.get("fs.s3a.access.key")
+            val secret = ResourceHelper.spark.sparkContext.hadoopConfiguration.get("fs.s3a.secret.key")
+
+            Some(new BasicAWSCredentials(key, secret))
+          }else{
+            throw awse
+          }
+        }
+        case e: Exception => throw e
+
+      }
     }
     else
       Some(new BasicAWSCredentials(accessKeyId.get, secretAccessKey.get))
-
-    }
+  }
   else {
     Some(new DefaultAWSCredentialsProviderChain().getCredentials)
   }
@@ -80,15 +100,16 @@ object ResourceDownloader {
   /**
     * Reset the cache and recreate ResourceDownloader S3 credentials
     */
-  def resetResourceDownloader(): Unit ={
+  def resetResourceDownloader(): Unit = {
     cache.empty
     this.defaultDownloader = new S3ResourceDownloader(s3Bucket, s3Path, cacheFolder, credentials)
   }
 
   /**
     * Loads resource to path
-    * @param name Name of Resource
-    * @param folder Subfolder in s3 where to search model (e.g. medicine)
+    *
+    * @param name     Name of Resource
+    * @param folder   Subfolder in s3 where to search model (e.g. medicine)
     * @param language Desired language of Resource
     * @return path of downloaded resource
     */
@@ -98,6 +119,7 @@ object ResourceDownloader {
 
   /**
     * Loads resource to path
+    *
     * @param request Request for resource
     * @return path of downloaded resource
     */
@@ -167,7 +189,7 @@ case class ResourceRequest
 /* convenience accessor for Py4J calls */
 object PythonResourceDownloader {
 
-  val keyToReader : Map[String, DefaultParamsReadable[_]] = Map(
+  val keyToReader: Map[String, DefaultParamsReadable[_]] = Map(
     "DocumentAssembler" -> DocumentAssembler,
     "SentenceDetector" -> SentenceDetector,
     "Tokenizer" -> Tokenizer,
@@ -189,9 +211,9 @@ object PythonResourceDownloader {
     "BertEmbeddings" -> BertEmbeddings,
     "DependencyParserModel" -> DependencyParserModel,
     "TypedDependencyParserModel" -> TypedDependencyParserModel
-    )
+  )
 
-  def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String  = null): PipelineStage = {
+  def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {
     val reader = keyToReader.getOrElse(readerStr, throw new RuntimeException(s"Unsupported Model: $readerStr"))
     val correctedFolder = Option(remoteLoc).getOrElse(ResourceDownloader.publicLoc)
     ResourceDownloader.downloadModel(reader.asInstanceOf[DefaultParamsReadable[PipelineStage]], name, Option(language), correctedFolder)

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -1,6 +1,6 @@
 package com.johnsnowlabs.nlp.pretrained
 
-import com.amazonaws.auth.{AWSCredentials, AnonymousAWSCredentials, BasicAWSCredentials}
+import com.amazonaws.auth.{DefaultAWSCredentialsProviderChain, _}
 import com.johnsnowlabs.nlp.DocumentAssembler
 import com.johnsnowlabs.nlp.annotators._
 import com.johnsnowlabs.nlp.annotators.ner.crf.NerCrfModel
@@ -8,18 +8,18 @@ import com.johnsnowlabs.nlp.annotators.ner.dl.NerDLModel
 import com.johnsnowlabs.nlp.annotators.parser.dep.DependencyParserModel
 import com.johnsnowlabs.nlp.annotators.parser.typdep.TypedDependencyParserModel
 import com.johnsnowlabs.nlp.annotators.pos.perceptron.PerceptronModel
-import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.util.{Build, ConfigHelper, Version}
-import org.apache.spark.ml.{PipelineModel, PipelineStage}
-import org.apache.spark.ml.util.DefaultParamsReadable
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.annotators.sda.pragmatic.SentimentDetectorModel
 import com.johnsnowlabs.nlp.annotators.sda.vivekn.ViveknSentimentModel
 import com.johnsnowlabs.nlp.annotators.spell.context.ContextSpellCheckerModel
 import com.johnsnowlabs.nlp.annotators.spell.norvig.NorvigSweetingModel
 import com.johnsnowlabs.nlp.annotators.spell.symmetric.SymmetricDeleteModel
-import com.johnsnowlabs.nlp.embeddings.{WordEmbeddingsModel, BertEmbeddings}
+import com.johnsnowlabs.nlp.embeddings.{BertEmbeddings, WordEmbeddingsModel}
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.util.{Build, ConfigHelper, Version}
 import org.apache.hadoop.fs.FileSystem
+import org.apache.spark.ml.util.DefaultParamsReadable
+import org.apache.spark.ml.{PipelineModel, PipelineStage}
 
 import scala.collection.mutable
 
@@ -50,13 +50,16 @@ object ResourceDownloader {
   def credentials: Option[AWSCredentials] = if (ConfigHelper.hasPath(ConfigHelper.awsCredentials)) {
     val accessKeyId = ConfigHelper.getConfigValue(ConfigHelper.accessKeyId)
     val secretAccessKey = ConfigHelper.getConfigValue(ConfigHelper.secretAccessKey)
-    if (accessKeyId.isEmpty || secretAccessKey.isEmpty)
-      Some(new AnonymousAWSCredentials())
+    if (accessKeyId.isEmpty || secretAccessKey.isEmpty) {
+      //Some(new AnonymousAWSCredentials()\E
+      Some(new DefaultAWSCredentialsProviderChain().getCredentials)
+    }
     else
       Some(new BasicAWSCredentials(accessKeyId.get, secretAccessKey.get))
+
     }
   else {
-    None
+    Some(new DefaultAWSCredentialsProviderChain().getCredentials)
   }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Now AWS credentials can be passed using the default chain instead of application.conf.
for details on AWS chain please check https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html

If AWS credentials are not set using any option provided above it will also look into spark Hadoop configuration for keys at "fs.s3n.awsAccessKeyId" and "fs.s3n.awsSecretAccessKey" these can be set using the following code in pyspark
```
sc=spark.sparkContext
hadoop_conf=sc._jsc.hadoopConfiguration()
hadoop_conf.set("fs.s3n.awsAccessKeyId", access_id)
hadoop_conf.set("fs.s3n.awsSecretAccessKey", access_key)
```

## Description
<!--- Describe your changes in detail -->
If application.conf does not contain the AWS credentials then the DefaultAWSChain is used to access the resources. If none of the options of DefaultAWSChain is set then the hadoop configuration is used for getting the aws keys. If none of these is set then an exception is thrown.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves the problem of keeping sensitive AWS credentials in a file
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
