### PR TITLE
fix the use of the OcrHelper in QuickStart.md

### DIFF
--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -307,7 +307,9 @@ You can use OcrHelper to directly create spark dataframes from PDF. This will ho
 ```scala
 import com.johnsnowlabs.nlp.util.io.OcrHelper
 
-val data = OcrHelper.createDataset(spark, "/pdfs/", "text", "metadata")
+val myOcrHelper = new OcrHelper
+
+val data = myOcrHelper.createDataset(spark, "/pdfs/")
 
 val documentAssembler = new DocumentAssembler().setInputCol("text").setMetadataCol("metadata")
 
@@ -321,7 +323,9 @@ Another way, would be to simply create an array of strings. This is useful for e
 ```scala
 import com.johnsnowlabs.nlp.util.io.OcrHelper
 
-val raw = OcrHelper.createMap("/pdfs/")
+val myOcrHelper = new OcrHelper
+
+val raw = myOcrHelper.createMap("/pdfs/")
 
 val documentAssembler = new DocumentAssembler().setInputCol("text").setOutputCol("document")
 


### PR DESCRIPTION

## Description
The utilization of the OcrHelper in the documentation is wrong.

The OcrHelper is a class and can't be used without instantiating.   

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
