### PR TITLE
Adding support for NerDLApproach evaluation during training

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1009,6 +1009,8 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     useContrib = Param(Params._dummy(), "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.", TypeConverters.toBoolean)
     trainValidationProp = Param(Params._dummy(), "po", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
                                 TypeConverters.toFloat)
+    validationLogExtended = Param(Params._dummy(), "po", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
+                                TypeConverters.toBoolean)
 
     def setConfigProtoBytes(self, b):
         return self._set(configProtoBytes=b)
@@ -1048,6 +1050,10 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
         self._set(trainValidationProp=v)
         return self
 
+    def setValidationLogExtended(self, v):
+        self._set(validationLogExtended=v)
+        return self
+
     @keyword_only
     def __init__(self):
         super(NerDLApproach, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ner.dl.NerDLApproach")
@@ -1061,9 +1067,9 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
             dropout=float(0.5),
             verbose=2,
             useContrib=uc,
-            trainValidationProp=float(0.0)
+            trainValidationProp=float(0.0),
+            validationLogExtended=false
         )
-
 
 class NerDLModel(AnnotatorModel):
     name = "NerDLModel"

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1007,6 +1007,8 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     graphFolder = Param(Params._dummy(), "graphFolder", "Folder path that contain external graph files", TypeConverters.toString)
     configProtoBytes = Param(Params._dummy(), "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()", TypeConverters.toListString)
     useContrib = Param(Params._dummy(), "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.", TypeConverters.toBoolean)
+    trainValidationProp = Param(Params._dummy(), "po", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
+                                TypeConverters.toFloat)
 
     def setConfigProtoBytes(self, b):
         return self._set(configProtoBytes=b)
@@ -1042,6 +1044,10 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     def _create_model(self, java_model):
         return NerDLModel(java_model=java_model)
 
+    def setTrainValidationProp(self, v):
+        self._set(trainValidationProp=v)
+        return self
+
     @keyword_only
     def __init__(self):
         super(NerDLApproach, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ner.dl.NerDLApproach")
@@ -1054,7 +1060,8 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
             batchSize=8,
             dropout=float(0.5),
             verbose=2,
-            useContrib=uc
+            useContrib=uc,
+            trainValidationProp=float(0.0)
         )
 
 

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1068,7 +1068,7 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
             verbose=2,
             useContrib=uc,
             trainValidationProp=float(0.0),
-            validationLogExtended=false
+            validationLogExtended=False
         )
 
 class NerDLModel(AnnotatorModel):

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1010,7 +1010,7 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     trainValidationProp = Param(Params._dummy(), "po", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
                                 TypeConverters.toFloat)
     validationLogExtended = Param(Params._dummy(), "po", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
-                                TypeConverters.toBoolean)
+                                  TypeConverters.toBoolean)
 
     def setConfigProtoBytes(self, b):
         return self._set(configProtoBytes=b)

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1009,8 +1009,6 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     useContrib = Param(Params._dummy(), "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.", TypeConverters.toBoolean)
     trainValidationProp = Param(Params._dummy(), "po", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
                                 TypeConverters.toFloat)
-    validationLogExtended = Param(Params._dummy(), "po", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
-                                  TypeConverters.toBoolean)
 
     def setConfigProtoBytes(self, b):
         return self._set(configProtoBytes=b)
@@ -1050,10 +1048,6 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
         self._set(trainValidationProp=v)
         return self
 
-    def setValidationLogExtended(self, v):
-        self._set(validationLogExtended=v)
-        return self
-
     @keyword_only
     def __init__(self):
         super(NerDLApproach, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ner.dl.NerDLApproach")
@@ -1067,8 +1061,7 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
             dropout=float(0.5),
             verbose=2,
             useContrib=uc,
-            trainValidationProp=float(0.0),
-            validationLogExtended=False
+            trainValidationProp=float(0.0)
         )
 
 class NerDLModel(AnnotatorModel):

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -175,7 +175,7 @@ class TensorflowNer
           .map(_._2)
           .take(sample)
 
-        log(s"Quality on $validationRatio of the training dataset (trainExamples size=$sample)", Verbose.Epochs)
+        log(s"Quality on $validationRatio of the training dataset (trainExamples size = $sample)", Verbose.Epochs)
         measure(trainDatasetSample, (s: String) => log(s, Verbose.Epochs))
       }
 

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -113,8 +113,7 @@ class TensorflowNer
             endEpoch: Int,
             validation: Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = Array.empty,
             configProtoBytes: Option[Array[Byte]] = None,
-            trainValidationProp: Float = 0.0f,
-            validationLogExtended: Boolean = false
+            trainValidationProp: Float = 0.0f
            ): Unit = {
 
     log(s"Training started, trainExamples: ${trainDataset.length}, " +
@@ -170,14 +169,11 @@ class TensorflowNer
 
       if (trainValidationProp > 0.0) {
         val sample: Int = (trainDataset.length*trainValidationProp).toInt
-        //        val trainDatasetSample = trainDataset.map(x => (Random.nextFloat(), x))
-        //          .sortBy(_._1)
-        //          .map(_._2)
-        //          .take(sample)
+
         val trainDatasetSample = trainDataset.take(sample)
 
-        log(s"Quality on $trainValidationProp of the training dataset (validate size = $sample)", Verbose.Epochs)
-        measure(trainDatasetSample, (s: String) => log(s, Verbose.Epochs), extended = validationLogExtended)
+        log(s"Quality on training dataset (${trainValidationProp*100}%), validationExamples = $sample", Verbose.Epochs)
+        measure(trainDatasetSample, (s: String) => log(s, Verbose.Epochs))
       }
 
       if (validation.nonEmpty) {
@@ -268,8 +264,7 @@ class TensorflowNer
       }
     }
 
-    if (extended)
-      log(s"time: ${(System.nanoTime() - started)/1e9}")
+    log(s"time to finish validation: ${(System.nanoTime() - started)/1e9}")
 
     val labels = (correct.keys ++ predicted.keys).toSeq.distinct
     val notEmptyLabels = labels.filter(label => label != "O" && label.nonEmpty)
@@ -279,10 +274,7 @@ class TensorflowNer
     val totalFalseNegatives = falseNegatives.filterKeys(label => notEmptyLabels.contains(label)).values.sum
 
     val (prec, rec, f1) = calcStat(totalTruePositives, totalFalsePositives, totalFalseNegatives)
-    log(s"prec: $prec, rec: $rec, f1: $f1")
-
-    if (!extended)
-      return
+    log(s"Total stats\t prec: $prec, rec: $rec, f1: $f1")
 
     log("label\t prec\t rec\t f1")
 

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -113,7 +113,7 @@ class TensorflowNer
             endEpoch: Int,
             validation: Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = Array.empty,
             configProtoBytes: Option[Array[Byte]] = None,
-            validationRatio: Float
+            trainValidationRatio: Float
            ): Unit = {
 
     log(s"Training started, trainExamples: ${trainDataset.length}, " +
@@ -167,15 +167,15 @@ class TensorflowNer
 
       log(s"Done, ${(System.nanoTime() - time)/1e9} loss: $loss, batches: $batches", Verbose.Epochs)
 
-      if (validationRatio > 0.0) {
-        val sample: Int = (trainDataset.length*validationRatio).toInt
+      if (trainValidationRatio > 0.0) {
+        val sample: Int = (trainDataset.length*trainValidationRatio).toInt
 
         val trainDatasetSample = trainDataset.map(x => (Random.nextFloat(), x))
           .sortBy(_._1)
           .map(_._2)
           .take(sample)
 
-        log(s"Quality on $validationRatio of the training dataset (trainExamples size = $sample)", Verbose.Epochs)
+        log(s"Quality on $trainValidationRatio of the training dataset (trainExamples size = $sample)", Verbose.Epochs)
         measure(trainDatasetSample, (s: String) => log(s, Verbose.Epochs))
       }
 

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -170,11 +170,11 @@ class TensorflowNer
 
       if (trainValidationProp > 0.0) {
         val sample: Int = (trainDataset.length*trainValidationProp).toInt
-//        val trainDatasetSample = trainDataset.map(x => (Random.nextFloat(), x))
-//          .sortBy(_._1)
-//          .map(_._2)
-//          .take(sample)
-      val trainDatasetSample = trainDataset.take(sample)
+        //        val trainDatasetSample = trainDataset.map(x => (Random.nextFloat(), x))
+        //          .sortBy(_._1)
+        //          .map(_._2)
+        //          .take(sample)
+        val trainDatasetSample = trainDataset.take(sample)
 
         log(s"Quality on $trainValidationProp of the training dataset (validate size = $sample)", Verbose.Epochs)
         measure(trainDatasetSample, (s: String) => log(s, Verbose.Epochs), extended = validationLogExtended)
@@ -257,11 +257,11 @@ class TensorflowNer
 
             //We don't really care about true negatives at the moment
             if ((label == tag) && label != "O") {
-              truePositives(tag) = truePositives.getOrElse(label, 0) + 1
+              truePositives(label) = truePositives.getOrElse(label, 0) + 1
             } else if (label == "O" && tag != "O") {
               falsePositives(tag) = falsePositives.getOrElse(tag, 0) + 1
             } else {
-              falseNegatives(tag) = falseNegatives.getOrElse(label, 0) + 1
+              falseNegatives(label) = falseNegatives.getOrElse(label, 0) + 1
             }
 
           }
@@ -292,7 +292,6 @@ class TensorflowNer
         falsePositives.getOrElse(label, 0),
         falseNegatives.getOrElse(label, 0)
       )
-
       log(s"$label\t $prec\t $rec\t $f1")
     }
   }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -113,7 +113,7 @@ class TensorflowNer
             endEpoch: Int,
             validation: Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = Array.empty,
             configProtoBytes: Option[Array[Byte]] = None,
-            trainValidationRatio: Float
+            trainValidationProp: Float
            ): Unit = {
 
     log(s"Training started, trainExamples: ${trainDataset.length}, " +
@@ -167,15 +167,15 @@ class TensorflowNer
 
       log(s"Done, ${(System.nanoTime() - time)/1e9} loss: $loss, batches: $batches", Verbose.Epochs)
 
-      if (trainValidationRatio > 0.0) {
-        val sample: Int = (trainDataset.length*trainValidationRatio).toInt
+      if (trainValidationProp > 0.0) {
+        val sample: Int = (trainDataset.length*trainValidationProp).toInt
 
         val trainDatasetSample = trainDataset.map(x => (Random.nextFloat(), x))
           .sortBy(_._1)
           .map(_._2)
           .take(sample)
 
-        log(s"Quality on $trainValidationRatio of the training dataset (trainExamples size = $sample)", Verbose.Epochs)
+        log(s"Quality on $trainValidationProp of the training dataset (trainExamples size = $sample)", Verbose.Epochs)
         measure(trainDatasetSample, (s: String) => log(s, Verbose.Epochs))
       }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -39,7 +39,7 @@ class NerDLApproach(override val uid: String)
   val graphFolder = new Param[String](this, "graphFolder", "Folder path that contain external graph files")
   val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
   val useContrib = new BooleanParam(this, "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.")
-  val trainValidationRatio = new FloatParam(this, "trainValidationRatio", "Set the percentage of the training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.")
+  val trainValidationProp = new FloatParam(this, "trainValidationProp", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.")
 
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
@@ -52,7 +52,7 @@ class NerDLApproach(override val uid: String)
   def setGraphFolder(path: String) = set(this.graphFolder, path)
   def setConfigProtoBytes(bytes: Array[Int]) = set(this.configProtoBytes, bytes)
   def setUseContrib(value: Boolean) = if (value && SystemUtils.IS_OS_WINDOWS) throw new UnsupportedOperationException("Cannot set contrib in Windows") else set(useContrib, value)
-  def setTrainValidationRatio(trainValidationRatio: Float) = set(this.trainValidationRatio, trainValidationRatio)
+  def setTrainValidationProp(trainValidationProp: Float) = set(this.trainValidationProp, trainValidationProp)
 
   setDefault(
     minEpochs -> 0,
@@ -63,7 +63,7 @@ class NerDLApproach(override val uid: String)
     dropout -> 0.5f,
     verbose -> Verbose.Silent.id,
     useContrib -> {if (SystemUtils.IS_OS_WINDOWS) false else true},
-    trainValidationRatio -> 0.0f
+    trainValidationProp -> 0.0f
   )
 
   override val verboseLevel = Verbose($(verbose))
@@ -111,7 +111,7 @@ class NerDLApproach(override val uid: String)
         Random.setSeed($(randomSeed))
       }
 
-      model.train(trainDataset, $(lr), $(po), $(batchSize), $(dropout), 0, $(maxEpochs), configProtoBytes=getConfigProtoBytes, trainValidationRatio=$(trainValidationRatio))
+      model.train(trainDataset, $(lr), $(po), $(batchSize), $(dropout), 0, $(maxEpochs), configProtoBytes=getConfigProtoBytes, trainValidationProp=$(trainValidationProp))
       model
     }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -18,7 +18,6 @@ import org.tensorflow.Graph
 
 import scala.util.Random
 
-
 class NerDLApproach(override val uid: String)
   extends AnnotatorApproach[NerDLModel]
     with NerApproach[NerDLApproach]
@@ -30,7 +29,7 @@ class NerDLApproach(override val uid: String)
   override def getLogName: String = "NerDL"
   override val description = "Trains Tensorflow based Char-CNN-BLSTM model"
   override val inputAnnotatorTypes = Array(DOCUMENT, TOKEN, WORD_EMBEDDINGS)
-  override val outputAnnotatorType = NAMED_ENTITY
+  override val outputAnnotatorType:String = NAMED_ENTITY
 
   val lr = new FloatParam(this, "lr", "Learning Rate")
   val po = new FloatParam(this, "po", "Learning rate decay coefficient. Real Learning Rage = lr / (1 + po * epoch)")
@@ -46,15 +45,15 @@ class NerDLApproach(override val uid: String)
 
   def getUseContrib(): Boolean = $(this.useContrib)
 
-  def setLr(lr: Float) = set(this.lr, lr)
-  def setPo(po: Float) = set(this.po, po)
-  def setBatchSize(batch: Int) = set(this.batchSize, batch)
-  def setDropout(dropout: Float) = set(this.dropout, dropout)
-  def setGraphFolder(path: String) = set(this.graphFolder, path)
-  def setConfigProtoBytes(bytes: Array[Int]) = set(this.configProtoBytes, bytes)
-  def setUseContrib(value: Boolean) = if (value && SystemUtils.IS_OS_WINDOWS) throw new UnsupportedOperationException("Cannot set contrib in Windows") else set(useContrib, value)
-  def setTrainValidationProp(trainValidationProp: Float) = set(this.trainValidationProp, trainValidationProp)
-  def setValidationLogExtended(validationLogExtended: Boolean) = set(this.validationLogExtended, validationLogExtended)
+  def setLr(lr: Float):NerDLApproach.this.type = set(this.lr, lr)
+  def setPo(po: Float):NerDLApproach.this.type = set(this.po, po)
+  def setBatchSize(batch: Int):NerDLApproach.this.type = set(this.batchSize, batch)
+  def setDropout(dropout: Float):NerDLApproach.this.type = set(this.dropout, dropout)
+  def setGraphFolder(path: String):NerDLApproach.this.type = set(this.graphFolder, path)
+  def setConfigProtoBytes(bytes: Array[Int]):NerDLApproach.this.type = set(this.configProtoBytes, bytes)
+  def setUseContrib(value: Boolean):NerDLApproach.this.type = if (value && SystemUtils.IS_OS_WINDOWS) throw new UnsupportedOperationException("Cannot set contrib in Windows") else set(useContrib, value)
+  def setTrainValidationProp(trainValidationProp: Float):NerDLApproach.this.type = set(this.trainValidationProp, trainValidationProp)
+  def setValidationLogExtended(validationLogExtended: Boolean):NerDLApproach.this.type = set(this.validationLogExtended, validationLogExtended)
 
   setDefault(
     minEpochs -> 0,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -39,7 +39,6 @@ class NerDLApproach(override val uid: String)
   val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
   val useContrib = new BooleanParam(this, "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.")
   val trainValidationProp = new FloatParam(this, "trainValidationProp", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.")
-  val validationLogExtended = new BooleanParam(this, "validationLogExtended", "Whether logs for validation to be extended: it displays time and evaluation of each label. Default is false.")
 
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
@@ -53,7 +52,6 @@ class NerDLApproach(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]):NerDLApproach.this.type = set(this.configProtoBytes, bytes)
   def setUseContrib(value: Boolean):NerDLApproach.this.type = if (value && SystemUtils.IS_OS_WINDOWS) throw new UnsupportedOperationException("Cannot set contrib in Windows") else set(useContrib, value)
   def setTrainValidationProp(trainValidationProp: Float):NerDLApproach.this.type = set(this.trainValidationProp, trainValidationProp)
-  def setValidationLogExtended(validationLogExtended: Boolean):NerDLApproach.this.type = set(this.validationLogExtended, validationLogExtended)
 
   setDefault(
     minEpochs -> 0,
@@ -64,8 +62,7 @@ class NerDLApproach(override val uid: String)
     dropout -> 0.5f,
     verbose -> Verbose.Silent.id,
     useContrib -> {if (SystemUtils.IS_OS_WINDOWS) false else true},
-    trainValidationProp -> 0.0f,
-    validationLogExtended -> false
+    trainValidationProp -> 0.0f
   )
 
   override val verboseLevel = Verbose($(verbose))
@@ -113,7 +110,7 @@ class NerDLApproach(override val uid: String)
         Random.setSeed($(randomSeed))
       }
 
-      model.train(trainDataset, $(lr), $(po), $(batchSize), $(dropout), 0, $(maxEpochs), configProtoBytes=getConfigProtoBytes, trainValidationProp=$(trainValidationProp), validationLogExtended=$(validationLogExtended))
+      model.train(trainDataset, $(lr), $(po), $(batchSize), $(dropout), 0, $(maxEpochs), configProtoBytes=getConfigProtoBytes, trainValidationProp=$(trainValidationProp))
       model
     }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -39,7 +39,7 @@ class NerDLApproach(override val uid: String)
   val graphFolder = new Param[String](this, "graphFolder", "Folder path that contain external graph files")
   val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
   val useContrib = new BooleanParam(this, "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.")
-  val validationRatio = new FloatParam(this, "validationRatio", "Set the percentage of the training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.")
+  val trainValidationRatio = new FloatParam(this, "trainValidationRatio", "Set the percentage of the training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.")
 
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
@@ -52,7 +52,7 @@ class NerDLApproach(override val uid: String)
   def setGraphFolder(path: String) = set(this.graphFolder, path)
   def setConfigProtoBytes(bytes: Array[Int]) = set(this.configProtoBytes, bytes)
   def setUseContrib(value: Boolean) = if (value && SystemUtils.IS_OS_WINDOWS) throw new UnsupportedOperationException("Cannot set contrib in Windows") else set(useContrib, value)
-  def setValidationRatio(validationRatio: Float) = set(this.validationRatio, validationRatio)
+  def setTrainValidationRatio(trainValidationRatio: Float) = set(this.trainValidationRatio, trainValidationRatio)
 
   setDefault(
     minEpochs -> 0,
@@ -63,7 +63,7 @@ class NerDLApproach(override val uid: String)
     dropout -> 0.5f,
     verbose -> Verbose.Silent.id,
     useContrib -> {if (SystemUtils.IS_OS_WINDOWS) false else true},
-    validationRatio -> 0.0f
+    trainValidationRatio -> 0.0f
   )
 
   override val verboseLevel = Verbose($(verbose))
@@ -111,7 +111,7 @@ class NerDLApproach(override val uid: String)
         Random.setSeed($(randomSeed))
       }
 
-      model.train(trainDataset, $(lr), $(po), $(batchSize), $(dropout), 0, $(maxEpochs), configProtoBytes=getConfigProtoBytes, validationRatio=$(validationRatio))
+      model.train(trainDataset, $(lr), $(po), $(batchSize), $(dropout), 0, $(maxEpochs), configProtoBytes=getConfigProtoBytes, trainValidationRatio=$(trainValidationRatio))
       model
     }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -39,6 +39,7 @@ class NerDLApproach(override val uid: String)
   val graphFolder = new Param[String](this, "graphFolder", "Folder path that contain external graph files")
   val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
   val useContrib = new BooleanParam(this, "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.")
+  val validationRatio = new FloatParam(this, "validationRatio", "Set the percentage of the training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.")
 
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
@@ -51,6 +52,7 @@ class NerDLApproach(override val uid: String)
   def setGraphFolder(path: String) = set(this.graphFolder, path)
   def setConfigProtoBytes(bytes: Array[Int]) = set(this.configProtoBytes, bytes)
   def setUseContrib(value: Boolean) = if (value && SystemUtils.IS_OS_WINDOWS) throw new UnsupportedOperationException("Cannot set contrib in Windows") else set(useContrib, value)
+  def setValidationRatio(validationRatio: Float) = set(this.validationRatio, validationRatio)
 
   setDefault(
     minEpochs -> 0,
@@ -60,7 +62,8 @@ class NerDLApproach(override val uid: String)
     batchSize -> 8,
     dropout -> 0.5f,
     verbose -> Verbose.Silent.id,
-    useContrib -> {if (SystemUtils.IS_OS_WINDOWS) false else true}
+    useContrib -> {if (SystemUtils.IS_OS_WINDOWS) false else true},
+    validationRatio -> 0.0f
   )
 
   override val verboseLevel = Verbose($(verbose))
@@ -108,7 +111,7 @@ class NerDLApproach(override val uid: String)
         Random.setSeed($(randomSeed))
       }
 
-      model.train(trainDataset, $(lr), $(po), $(batchSize), $(dropout), 0, $(maxEpochs), configProtoBytes=getConfigProtoBytes)
+      model.train(trainDataset, $(lr), $(po), $(batchSize), $(dropout), 0, $(maxEpochs), configProtoBytes=getConfigProtoBytes, validationRatio=$(validationRatio))
       model
     }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -40,6 +40,7 @@ class NerDLApproach(override val uid: String)
   val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
   val useContrib = new BooleanParam(this, "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.")
   val trainValidationProp = new FloatParam(this, "trainValidationProp", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.")
+  val validationLogExtended = new BooleanParam(this, "validationLogExtended", "Whether logs for validation to be extended: it displays time and evaluation of each label. Default is false.")
 
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
@@ -53,6 +54,7 @@ class NerDLApproach(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]) = set(this.configProtoBytes, bytes)
   def setUseContrib(value: Boolean) = if (value && SystemUtils.IS_OS_WINDOWS) throw new UnsupportedOperationException("Cannot set contrib in Windows") else set(useContrib, value)
   def setTrainValidationProp(trainValidationProp: Float) = set(this.trainValidationProp, trainValidationProp)
+  def setValidationLogExtended(validationLogExtended: Boolean) = set(this.validationLogExtended, validationLogExtended)
 
   setDefault(
     minEpochs -> 0,
@@ -63,7 +65,8 @@ class NerDLApproach(override val uid: String)
     dropout -> 0.5f,
     verbose -> Verbose.Silent.id,
     useContrib -> {if (SystemUtils.IS_OS_WINDOWS) false else true},
-    trainValidationProp -> 0.0f
+    trainValidationProp -> 0.0f,
+    validationLogExtended -> false
   )
 
   override val verboseLevel = Verbose($(verbose))
@@ -111,7 +114,7 @@ class NerDLApproach(override val uid: String)
         Random.setSeed($(randomSeed))
       }
 
-      model.train(trainDataset, $(lr), $(po), $(batchSize), $(dropout), 0, $(maxEpochs), configProtoBytes=getConfigProtoBytes, trainValidationProp=$(trainValidationProp))
+      model.train(trainDataset, $(lr), $(po), $(batchSize), $(dropout), 0, $(maxEpochs), configProtoBytes=getConfigProtoBytes, trainValidationProp=$(trainValidationProp), validationLogExtended=$(validationLogExtended))
       model
     }
 

--- a/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
+++ b/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
@@ -59,7 +59,7 @@ object NerDLCoNLL2003 extends App {
   val ner = try {
     val model = new TensorflowNer(tf, encoder, 32, Verbose.All)
     for (epoch <- 0 until 150) {
-      model.train(trainDataset, 1e-3f, 0.005f, 32, 0.5f, epoch, epoch + 1, trainValidationProp=0f)
+      model.train(trainDataset, 1e-3f, 0.005f, 32, 0.5f, epoch, epoch + 1)
 
       System.out.println("\n\nQuality on train data")
       model.measure(trainDataset, (s: String) => System.out.println(s), extended = true)

--- a/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
+++ b/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
@@ -59,7 +59,7 @@ object NerDLCoNLL2003 extends App {
   val ner = try {
     val model = new TensorflowNer(tf, encoder, 32, Verbose.All)
     for (epoch <- 0 until 150) {
-      model.train(trainDataset, 1e-3f, 0.005f, 32, 0.5f, epoch, epoch + 1)
+      model.train(trainDataset, 1e-3f, 0.005f, 32, 0.5f, epoch, epoch + 1, validationRatio=0f)
 
       System.out.println("\n\nQuality on train data")
       model.measure(trainDataset, (s: String) => System.out.println(s), extended = true)

--- a/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
+++ b/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
@@ -59,7 +59,7 @@ object NerDLCoNLL2003 extends App {
   val ner = try {
     val model = new TensorflowNer(tf, encoder, 32, Verbose.All)
     for (epoch <- 0 until 150) {
-      model.train(trainDataset, 1e-3f, 0.005f, 32, 0.5f, epoch, epoch + 1, trainValidationRatio=0f)
+      model.train(trainDataset, 1e-3f, 0.005f, 32, 0.5f, epoch, epoch + 1, trainValidationProp=0f)
 
       System.out.println("\n\nQuality on train data")
       model.measure(trainDataset, (s: String) => System.out.println(s), extended = true)

--- a/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
+++ b/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
@@ -59,7 +59,7 @@ object NerDLCoNLL2003 extends App {
   val ner = try {
     val model = new TensorflowNer(tf, encoder, 32, Verbose.All)
     for (epoch <- 0 until 150) {
-      model.train(trainDataset, 1e-3f, 0.005f, 32, 0.5f, epoch, epoch + 1, validationRatio=0f)
+      model.train(trainDataset, 1e-3f, 0.005f, 32, 0.5f, epoch, epoch + 1, trainValidationRatio=0f)
 
       System.out.println("\n\nQuality on train data")
       model.measure(trainDataset, (s: String) => System.out.println(s), extended = true)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
@@ -100,6 +100,7 @@ class NerDLSpec extends FlatSpec {
       .setRandomSeed(0)
       .setVerbose(0)
       .setTrainValidationProp(0.1f)
+      .setValidationLogExtended(true)
       .fit(readyData)
 
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
@@ -99,7 +99,7 @@ class NerDLSpec extends FlatSpec {
       .setMaxEpochs(1)
       .setRandomSeed(0)
       .setVerbose(0)
-      .setValidationRatio(0.1f)
+      .setTrainValidationRatio(0.1f)
       .fit(readyData)
 
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
@@ -99,7 +99,7 @@ class NerDLSpec extends FlatSpec {
       .setMaxEpochs(1)
       .setRandomSeed(0)
       .setVerbose(0)
-      .setTrainValidationRatio(0.1f)
+      .setTrainValidationProp(0.1f)
       .fit(readyData)
 
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
@@ -100,7 +100,6 @@ class NerDLSpec extends FlatSpec {
       .setRandomSeed(0)
       .setVerbose(0)
       .setTrainValidationProp(0.1f)
-      .setValidationLogExtended(true)
       .fit(readyData)
 
   }


### PR DESCRIPTION
This pull request introduces 2 new features in NerDLApproach:

1. Evaluates the model against the proportion of training dataset after each Epoch by setting `setTrainValidationProp(Float)` - value is between `0.0` and `1.0` where `0.0` is off and `1.0` is against 100% of the training dataset

2. Add support for extended logs in the validation stage. By setting `setValidationLogExtended` to true, the validation logs will be extended to having the time it took and label by label evaluation (perc, recall, and F1). 

Example:

```scala
val ner = new NerDLApproach()
      .setInputCols("sentence", "token", "embeddings")
      .setOutputCol("ner")
      .setLabelColumn("label")
      .setOutputCol("ner")
      .setLr(1e-3f)
      .setPo(5e-3f)
      .setDropout(5e-1f)
      .setMaxEpochs(10)
      .setRandomSeed(0)
      .setVerbose(0)
      .setTrainValidationProp(0.2f)
      .setValidationLogExtended(true)
      .fit(readyData)
```

```bash
[ INFO] Quality on 0.2 of the training dataset (trainExamples size = 2808)
[ INFO] time: 9.416247322
[ INFO] Total stat: prec: 0.91393685, rec: 0.90317833, f1: 0.90852576
[ INFO] label	prec	rec	f1
[ INFO] B-LOC	0.9660297	0.9039735	0.93397194
[ INFO] I-ORG	0.85809904	0.8697422	0.8638814
[ INFO] I-MISC	0.734127	0.7805907	0.7566462
[ INFO] I-LOC	0.9162561	0.7322835	0.8140044
[ INFO] I-PER	0.97613364	0.9831731	0.9796407
[ INFO] B-MISC	0.8633721	0.8696925	0.86652076
[ INFO] B-ORG	0.8943662	0.87855494	0.8863901
[ INFO] B-PER	0.92983806	0.9710145	0.94998026
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
