### PR TITLE
added spell checker score to metadata

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
@@ -233,7 +233,8 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
           (dPathA ++ Seq(System.lineSeparator) ++ dPathB, pCostA + pCostB)
         })
       }.getOrElse(decodeViterbi(computeTrellis(sentTokens)))
-      sentTokens.zip(decodedPath).map{case (orig, correct) => orig.copy(result = correct)}
+      sentTokens.zip(decodedPath).map{case (orig, correct) =>
+        orig.copy(result = correct, metadata = orig.metadata.updated("cost", cost.toString))}
     }
 
     decodedSentPaths.values.flatten.toSeq


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds the Spell Checker score to the annotation metadata structure. The score represents the penalty that is connected to recognizing text by the Spell Checker. 
The higher the value the more difficult it was for the algorithm to recognize the text as valid English. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
