### PR TITLE
Tokenizer revisited

### DIFF
--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -174,13 +174,13 @@ class DocumentAssembler(AnnotatorTransformer):
     idCol = Param(Params._dummy(), "idCol", "column for setting an id to such string in row", typeConverter=TypeConverters.toString)
     metadataCol = Param(Params._dummy(), "metadataCol", "String to String map column to use as metadata", typeConverter=TypeConverters.toString)
     calculationsCol = Param(Params._dummy(), "calculationsCol", "String to Float vector map column to use as embeddigns and other representations", typeConverter=TypeConverters.toString)
-    trimAndClearNewLines = Param(Params._dummy(), "trimAndClearNewLines", "whether to clear out new lines and trim context to remove leadng and trailing white spaces", typeConverter=TypeConverters.toBoolean)
+    cleanupMode = Param(Params._dummy(), "cleanupMode", "possible values: disabled, inplace, inplace_full, shrink, shrink_full", typeConverter=TypeConverters.toString)
     name = 'DocumentAssembler'
 
     @keyword_only
     def __init__(self):
         super(DocumentAssembler, self).__init__(classname="com.johnsnowlabs.nlp.DocumentAssembler")
-        self._setDefault(outputCol="document", trimAndClearNewLines=True)
+        self._setDefault(outputCol="document", cleanupMode='disabled')
 
     @keyword_only
     def setParams(self):
@@ -202,8 +202,9 @@ class DocumentAssembler(AnnotatorTransformer):
     def setCalculationsCol(self, value):
         return self._set(metadataCol=value)
 
-
-    def setTrimAndClearNewLines(self, value):
+    def setCleanupMode(self, value):
+        if value.strip().lower() not in ['disabled', 'inplace', 'inplace_full', 'shrink', 'shrink_full']:
+            raise Exception("Cleanup mode possible values: disabled, inplace, inplace_full, shrink, shrink_full")
         return self._set(trimAndClearNewLines=value)
 
 

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -20,9 +20,8 @@ class BasicAnnotatorsTestSpec(unittest.TestCase):
         tokenizer = Tokenizer() \
             .setInputCols(["document"]) \
             .setOutputCol("token") \
-            .setCompositeTokensPatterns(["New York"]) \
-            .addInfixPattern("(%\\d+)") \
-            .setIncludeDefaults(True)
+            .setCompositeTokens(["New York"]) \
+            .addInfixPattern("(%\\d+)")
         stemmer = Stemmer() \
             .setInputCols(["token"]) \
             .setOutputCol("stem")

--- a/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
@@ -35,6 +35,10 @@ case class Annotation(annotatorType: String,
       case _ => false
     }
   }
+
+  override def toString: String = {
+    s"Annotation(type: $annotatorType, begin: $begin, end: $end, result: $result)"
+  }
 }
 
 case class JavaAnnotation(annotatorType: String,

--- a/src/main/scala/com/johnsnowlabs/nlp/DocumentAssembler.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/DocumentAssembler.scala
@@ -32,7 +32,7 @@ class DocumentAssembler(override val uid: String)
 
   setDefault(
     outputCol -> DOCUMENT,
-    trimAndClearNewLines -> true //mdba original is set to true
+    trimAndClearNewLines -> false
   )
 
   override val outputAnnotatorType: AnnotatorType = DOCUMENT

--- a/src/main/scala/com/johnsnowlabs/nlp/DocumentAssembler.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/DocumentAssembler.scala
@@ -28,11 +28,19 @@ class DocumentAssembler(override val uid: String)
 
   val metadataCol: Param[String] = new Param[String](this, "metadataCol", "metadata for document column")
 
-  val trimAndClearNewLines: BooleanParam = new BooleanParam(this, "trimAndClearNewLines", "whether to clear out new lines and trim context to remove leadng and trailing white spaces")
+  /**
+    * cleanupMode:
+    * * disabled: keep original. Useful if need to head back to source later
+    * * inplace: remove new lines and tabs, but not stringified, don't shrink
+    * * inplace_full: remove new lines and tabs, including stringified, don't shrink
+    * * shrink: remove new lines and tabs, but not stringified, do shrink
+    * * shrink_full: remove new lines and tabs, stringified ones too, shrink all whitespaces
+    */
+  val cleanupMode: Param[String] = new Param[String](this, "cleanupMode", "possible values: disabled, inplace, inplace_full, shrink, shrink_full")
 
   setDefault(
     outputCol -> DOCUMENT,
-    trimAndClearNewLines -> false
+    cleanupMode -> "disabled"
   )
 
   override val outputAnnotatorType: AnnotatorType = DOCUMENT
@@ -49,21 +57,33 @@ class DocumentAssembler(override val uid: String)
 
   def getMetadataCol: String = $(metadataCol)
 
-  def setTrimAndClearNewLines(value: Boolean): this.type = set(trimAndClearNewLines, value)
+  def setCleanupMode(v: String): this.type = {
+    v.trim.toLowerCase() match {
+      case "disabled" => set(cleanupMode, "disabled")
+      case "inplace" => set(cleanupMode, "inplace")
+      case "inplace_full" => set(cleanupMode, "inplace_full")
+      case "shrink" => set(cleanupMode, "shrink")
+      case "shrink_full" => set(cleanupMode, "shrink_full")
+      case b => throw new IllegalArgumentException(s"Special Character Cleanup supports only: disabled, inplace, inplace_full, shrink, shrink_full. Received: $b")
+    }
+  }
 
-  def getTrimAndClearNewLines: Boolean = $(trimAndClearNewLines)
+  def getCleanupMode: String = $(cleanupMode)
 
   def this() = this(Identifiable.randomUID("document"))
 
   override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
 
   private[nlp] def assemble(text: String, metadata: Map[String, String]): Seq[Annotation] = {
-    if ($(trimAndClearNewLines)) {
-      val cleanText = text.replaceAll(System.lineSeparator(), " ").trim.replaceAll("\\s+", " ")
-      Seq(Annotation(outputAnnotatorType, 0, cleanText.length - 1, cleanText, metadata))
+    val possiblyCleaned = $(cleanupMode) match {
+      case "disabled" => text
+      case "inplace" => text.replaceAll("\\s", " ")
+      case "inplace_full" => text.replaceAll("\\s|(?:\\\\r){0,1}(?:\\\\n)|(?:\\\\t)", " ")
+      case "shrink" => text.trim.replaceAll("\\s+", " ")
+      case "shrink_full" => text.trim.replaceAll("\\s+|(?:\\\\r)*(?:\\\\n)+|(?:\\\\t)+", " ")
+      case b => throw new IllegalArgumentException(s"Special Character Cleanup supports only: disabled, inplace, inplace_full, shrink, shrink_full. Received: $b")
     }
-    else
-      Seq(Annotation(outputAnnotatorType, 0, text.length - 1, text, metadata))
+    Seq(Annotation(outputAnnotatorType, 0, possiblyCleaned.length - 1, possiblyCleaned, metadata))
   }
 
   private[nlp] def assembleFromArray(texts: Seq[String]): Seq[Annotation] = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
@@ -18,11 +18,13 @@ class Tokenizer(override val uid: String) extends AnnotatorModel[Tokenizer] {
   import com.johnsnowlabs.nlp.AnnotatorType._
 
   val compositeTokens: StringArrayParam = new StringArrayParam(this, "compositeTokens", "Words that won't be split in two")
+  val exceptionTokens: StringArrayParam = new StringArrayParam(this, "exceptionTokens", "Words that won't be affected by tokenization rules")
+  val contextChars: StringArrayParam = new StringArrayParam(this, "contextChars", "character list used to separate from token surroundings")
+  val innerChars: StringArrayParam = new StringArrayParam(this, "innerChars", "character list used to separate from the inside of tokens")
   val targetPattern: Param[String] = new Param(this, "targetPattern", "pattern to grab from text as token candidates. Defaults \\S+")
   val infixPatterns: StringArrayParam = new StringArrayParam(this, "infixPatterns", "regex patterns that match tokens within a single target. groups identify different sub-tokens. multiple defaults")
-  val prefixPattern: Param[String] = new Param[String](this, "prefixPattern", "regex with groups and begins with \\A to match target prefix. Defaults to \\A([^\\s\\p{L}$\\.]*)")
-  val suffixPattern: Param[String] = new Param[String](this, "suffixPattern", "regex with groups and ends with \\z to match target suffix. Defaults to ([^\\s\\p{L}]?)([^\\s\\p{L}]*)\\z")
-  val includeDefaults: BooleanParam = new BooleanParam(this, "includeDefaults", "whether to include default patterns or only use user provided ones. Defaults to true.")
+  val prefixPattern: Param[String] = new Param[String](this, "prefixPattern", "regex with groups and begins with \\A to match target prefix. Overrides contextCharacters Param")
+  val suffixPattern: Param[String] = new Param[String](this, "suffixPattern", "regex with groups and ends with \\z to match target suffix. Overrides contextCharacters Param")
 
   override val outputAnnotatorType: AnnotatorType = TOKEN
 
@@ -41,62 +43,61 @@ class Tokenizer(override val uid: String) extends AnnotatorModel[Tokenizer] {
 
   def setSuffixPattern(value: String): this.type = set(suffixPattern, value)
 
-  def setCompositeTokensPatterns(value: Array[String]): this.type = set(compositeTokens, value)
+  def setCompositeTokens(value: Array[String]): this.type = set(compositeTokens, value)
 
   def getCompositeTokens: Array[String] = $(compositeTokens)
 
-  def getInfixPatterns: Array[String] = if ($(includeDefaults)) $(infixPatterns) ++ infixDefaults else $(infixPatterns)
+  def setExceptionTokens(value: Array[String]): this.type = set(compositeTokens, value)
 
-  def getPrefixPattern: String = if ($(includeDefaults)) get(prefixPattern).getOrElse(prefixDefault) else $(prefixPattern)
+  def getExceptionTokens: Array[String] = $(compositeTokens)
 
-  def getSuffixPattern: String = if ($(includeDefaults)) get(suffixPattern).getOrElse(suffixDefault) else $(suffixPattern)
+  def getInfixPatterns: Array[String] = $(infixPatterns)
+
+  def getPrefixPattern: String = $(prefixPattern)
+
+  def getSuffixPattern: String = $(suffixPattern)
 
   def getTargetPattern: String = $(targetPattern)
 
-  def getIncludeDefaults: Boolean = $(includeDefaults)
-
-  def setIncludeDefaults(value: Boolean): this.type = set(includeDefaults, value)
-
-  setDefault(includeDefaults, true)
-  setDefault(targetPattern, "\\S+")
-  setDefault(infixPatterns, Array.empty[String])
-
-  /** Check here for explanation on this default pattern */
-  private val infixDefaults =  Array(
-    "([\\$#]?\\d+(?:[^\\s\\d]{1}\\d+)*)", // Money, Phone number and dates -> http://rubular.com/r/ihCCgJiX4e
-    "((?:\\p{L}\\.)+)", // Abbreviations -> http://rubular.com/r/nMf3n0axfQ
-    "(\\p{L}+)(n't\\b)", // Weren't -> http://rubular.com/r/coeYJFt8eM
-    "(\\p{L}+)('{1}\\p{L}+)", // I'll -> http://rubular.com/r/N84PYwYjQp
-    "((?:\\p{L}+[^\\s\\p{L}]{1})+\\p{L}+)", // foo-bar -> http://rubular.com/r/cjit4R6uWd
-    "([\\p{L}\\w]+)" // basic word token
+  setDefault(
+    targetPattern -> "\\S+",
+    contextChars -> Array("\\.", ",", ";", ":", "!", "?", "\\*", "\\-", "\\\\(", "\\\\)", "\"")
   )
-  /** These catch everything before and after a word, as a separate token*/
-  private val prefixDefault = "\\A([^\\s\\p{L}\\d\\$\\.#]*)"
-  private val suffixDefault = "([^\\s\\p{L}\\d]?)([^\\s\\p{L}\\d]*)\\z"
 
   /** Clears out rules and constructs a new rule for every combination of rules provided */
   /** The strategy is to catch one token per regex group */
   /** User may add its own groups if needs targets to be tokenized separately from the rest */
   lazy private val ruleFactory = {
     val rules = ArrayBuffer.empty[String]
-    require(getInfixPatterns.forall(ip => ip.contains("(") && ip.contains(")")),
+
+    lazy val context = $(contextChars).mkString("")
+    lazy val inner = get(innerChars).map(i => i.mkString(""))
+    lazy val uniqueContext = get(innerChars).getOrElse(Array.empty[String]).union($(contextChars)).distinct.mkString("")
+
+    val processedPrefix = get(prefixPattern).getOrElse(s"\\A([$context]*)")
+    require(processedPrefix.startsWith("\\A"), "prefixPattern must begin with \\A to ensure it is the beginning of the string")
+
+    val processedSuffix = get(suffixPattern).getOrElse(s"([$context]*)\\z")
+    require(processedSuffix.endsWith("\\z"), "suffixPattern must end with \\z to ensure it is the end of the string")
+
+    val processedInfixes = get(infixPatterns).getOrElse({
+      if (inner.isDefined)
+        Array(s"([^$uniqueContext]+)([${inner.get}]*)([^$uniqueContext]*)")
+      else
+        Array(s"([^$uniqueContext]+)")
+    })
+
+    require(processedInfixes.forall(ip => ip.contains("(") && ip.contains(")")),
       "infix patterns must use regex group. Notice each group will result in separate token")
-    getInfixPatterns.foreach(ip => {
-      val rule = new StringBuilder
-      get(prefixPattern).orElse(if (!$(includeDefaults)) None else Some(prefixDefault)).foreach(pp => {
-        require(pp.startsWith("\\A"), "prefixPattern must begin with \\A to ensure it is the beginning of the string")
-        require(pp.contains("(") && pp.contains(")"), "prefixPattern must contain regex groups. Each group will return in separate token")
-        rule.append(pp)
-      })
-      rule.append(ip)
-      get(suffixPattern).orElse(if (!$(includeDefaults)) None else Some(suffixDefault)).foreach(sp => {
-        require(sp.endsWith("\\z"), "suffixPattern must end with \\z to ensure it is the end of the string")
-        require(sp.contains("(") && sp.contains(")"), "suffixPattern must contain regex groups. Each group will return in separate token")
-        rule.append(sp)
-      })
-      rules.append(rule.toString)
+    processedInfixes.foreach(infix => {
+      val ruleBuilder = new StringBuilder
+      ruleBuilder.append(processedPrefix)
+      ruleBuilder.append(infix)
+      ruleBuilder.append(processedSuffix)
+      rules.append(ruleBuilder.toString)
     })
     rules.foldLeft(new RuleFactory(MatchStrategy.MATCH_FIRST))((factory, rule) => factory.addRule(rule.r, rule))
+
   }
 
   private val PROTECT_CHAR = "ↈ"
@@ -124,6 +125,12 @@ class Tokenizer(override val uid: String) extends AnnotatorModel[Tokenizer] {
             text.content.slice(text.start + candidate.start, text.start + candidate.end),
             text.start + candidate.start,
             text.start + candidate.end - 1
+          ))
+        } else if (get(exceptionTokens).isDefined && $(exceptionTokens).contains(candidate.matched)) {
+          Seq(IndexedToken(
+            candidate.matched,
+            candidate.start,
+            candidate.end - 1
           ))
         }
         else {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
@@ -25,7 +25,7 @@ object TokenizedWithSentence extends Annotated[TokenizedSentence] {
     sentences.zipWithIndex.flatMap{case (sentence, index) =>
         sentence.indexedTokens.map{token =>
         Annotation(annotatorType, token.begin, token.end, token.token,
-          Map("sentence" -> index.toString, "chunk" -> index.toString))
+          Map("sentence" -> index.toString))
     }}
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/util/regex/RuleFactory.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/regex/RuleFactory.scala
@@ -29,7 +29,6 @@ class RuleFactory(matchStrategy: MatchStrategy.MatchStrategy,
   import MatchStrategy._
 
   /** Helper functions to identify context in a word for debugging */
-  private val logger = LoggerFactory.getLogger("RuleFactory")
   private def logSubStartHelper(start: Int): Int = if (start > 10) start - 10 else  0
   private def logSubEndHelper(sourceLength: Int, end: Int): Int = if (sourceLength - end > 10) end + 10 else sourceLength
 
@@ -71,35 +70,15 @@ class RuleFactory(matchStrategy: MatchStrategy.MatchStrategy,
 
   private val transformWithSymbolFunc = (symbol: String, text: String) => transformStrategy match {
     case APPEND_WITH_SYMBOL => rules.foldLeft(text)((target, rule) => transformMatch(target, rule.regex)({ m =>
-      logger.debug("Matched: {} from: {} using rule {} with strategy {}",
-        m.matched,
-        m.source.subSequence(logSubStartHelper(m.start),logSubEndHelper(m.source.length, m.end)),
-        rule.identifier,
-        APPEND_WITH_SYMBOL)
       "$0" + symbol
     }))
     case PREPEND_WITH_SYMBOL => rules.foldLeft(text)((target, rule) => transformMatch(target, rule.regex)({ m =>
-      logger.debug("Matched: {} from: {} using rule {} with strategy {}",
-        m.matched,
-        m.source.subSequence(logSubStartHelper(m.start),logSubEndHelper(m.source.length, m.end)),
-        rule.identifier,
-        PREPEND_WITH_SYMBOL)
       symbol + "$0"
     }))
     case REPLACE_ALL_WITH_SYMBOL => rules.foldLeft(text)((target, rule) => transformMatch(target, rule.regex)({ m =>
-      logger.debug("Matched: {} from: {} using rule {} with strategy {}",
-        m.matched,
-        m.source.subSequence(logSubStartHelper(m.start), logSubEndHelper(m.source.length, m.end)),
-        rule.identifier,
-        REPLACE_ALL_WITH_SYMBOL)
       symbol
     }))
     case REPLACE_WITH_SYMBOL_AND_BREAK => rules.foldLeft(text)((target, rule) => transformMatch(target, rule.regex)({ m =>
-      logger.debug("Matched: {} from: {} using rule {} with strategy {}",
-        m.matched,
-        m.source.subSequence(logSubStartHelper(m.start), logSubEndHelper(m.source.length, m.end)),
-        rule.identifier,
-        REPLACE_WITH_SYMBOL_AND_BREAK)
       symbol + BREAK_INDICATOR
     }))
     case _ => throw new IllegalArgumentException("Invalid strategy for rule factory")
@@ -107,36 +86,16 @@ class RuleFactory(matchStrategy: MatchStrategy.MatchStrategy,
 
   private val transformWithSymbolicRulesFunc = (text: String) => transformStrategy match {
     case REPLACE_EACH_WITH_SYMBOL => symbolRules.foldLeft(text)((target, rule) => transformMatch(target, rule._2.regex)({ m =>
-      logger.debug("Matched: {} from: {} using rule {} with strategy {}",
-        m.matched,
-        m.source.subSequence(logSubStartHelper(m.start), logSubEndHelper(m.source.length, m.end)),
-        rule._2.identifier,
-        REPLACE_EACH_WITH_SYMBOL)
       rule._1
     }))
     case REPLACE_EACH_WITH_SYMBOL_AND_BREAK => symbolRules.foldLeft(text)((target, rule) => rule._2.regex replaceAllIn(
       target, m => {
-      logger.debug("Matched: {} from: {} using rule {} with strategy {}",
-        m.matched,
-        m.source.subSequence(logSubStartHelper(m.start), logSubEndHelper(m.source.length, m.end)),
-        rule._2.identifier,
-        REPLACE_EACH_WITH_SYMBOL_AND_BREAK)
       rule._1 + BREAK_INDICATOR
     }))
     case PROTECT_FROM_BREAK => rules.foldLeft(text)((target, rule) => transformMatch(target, rule.regex)({ m =>
-      logger.debug("Matched: {} from: {} using rule {} with strategy {}",
-        m.matched,
-        m.source.subSequence(logSubStartHelper(m.start), logSubEndHelper(m.source.length, m.end)),
-        rule.identifier,
-        PROTECT_FROM_BREAK)
       PROTECTION_MARKER_OPEN + m.matched + PROTECTION_MARKER_CLOSE
     }))
     case BREAK_AND_PROTECT_FROM_BREAK => rules.foldLeft(text)((target, rule) => transformMatch(target, rule.regex)({ m =>
-      logger.debug("Matched: {} from: {} using rule {} with strategy {}",
-        m.matched,
-        m.source.subSequence(logSubStartHelper(m.start), logSubEndHelper(m.source.length, m.end)),
-        rule.identifier,
-        PROTECT_FROM_BREAK)
       BREAK_INDICATOR + PROTECTION_MARKER_OPEN + m.matched + PROTECTION_MARKER_CLOSE
     }))
     case _ => throw new IllegalArgumentException("Invalid strategy for rule factory")

--- a/src/test/scala/com/johnsnowlabs/nlp/AnnotatorBuilder.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/AnnotatorBuilder.scala
@@ -23,9 +23,10 @@ import org.scalatest._
   */
 object AnnotatorBuilder extends FlatSpec { this: Suite =>
 
-  def withDocumentAssembler(dataset: Dataset[Row]): Dataset[Row] = {
+  def withDocumentAssembler(dataset: Dataset[Row], cleanupMode: String = "disabled"): Dataset[Row] = {
     val documentAssembler = new DocumentAssembler()
       .setInputCol("text")
+      .setCleanupMode(cleanupMode)
     documentAssembler.transform(dataset)
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/DataBuilder.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/DataBuilder.scala
@@ -11,9 +11,9 @@ object DataBuilder extends FlatSpec with BeforeAndAfterAll { this: Suite =>
 
   import SparkAccessor.spark.implicits._
 
-  def basicDataBuild(content: String*): Dataset[Row] = {
+  def basicDataBuild(content: String*)(implicit cleanupMode: String = "disabled"): Dataset[Row] = {
     val data = SparkAccessor.spark.sparkContext.parallelize(content).toDS().toDF("text")
-    AnnotatorBuilder.withDocumentAssembler(data)
+    AnnotatorBuilder.withDocumentAssembler(data, cleanupMode)
   }
 
   def multipleDataBuild(content: Seq[String]): Dataset[Row] = {

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -16,67 +16,16 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
 
   val regexTokenizer = new Tokenizer
 
-  "a Tokenizer" should s"be of type ${AnnotatorType.TOKEN}" ignore {
+  "a Tokenizer" should s"be of type ${AnnotatorType.TOKEN}" in {
     assert(regexTokenizer.outputAnnotatorType == AnnotatorType.TOKEN)
   }
-
-
-  val targetText1 = "Hello, I won't be from New York in the U.S.A. (and you know it héroe). Give me my horse! or $100" +
-    " bucks 'He said', I'll defeat markus-crassus. You understand. Goodbye George E. Bush. www.google.com."
-  val expected1 = Array(
-    "Hello", ",", "I", "wo", "n't", "be", "from", "New York", "in", "the", "U.S.A.", "(", "and", "you", "know", "it",
-    "héroe", ")", ".", "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "'", ",", "I", "'ll",
-    "defeat", "markus-crassus", ".", "You", "understand", ".", "Goodbye", "George", "E.", "Bush", ".", "www.google.com", "."
-  )
-
-  val targetText2 = "I'd like to say we didn't expect that. Jane's boyfriend."
-  val expected2 = Array(
-    Annotation(AnnotatorType.TOKEN, 0, 0, "I", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 1, 2, "'d", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 19, 21, "did", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 22, 24, "n't", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 33, 36, "that", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 37, 37, ".", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 39, 42, "Jane", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 43, 44, "'s", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 46, 54, "boyfriend", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 55, 55, ".", Map("sentence" -> "0"))
-  )
 
   val ls = System.lineSeparator
   val lsl = ls.length
 
-  val targetText3 = s"I'd      like to say${ls}we didn't${ls+ls}" +
-    s" expect\nthat. ${ls+ls} " +
-    s"Jane's\\nboyfriend\tsaid.${ls+ls}"
-  val expected3 = Array(
-    Annotation(AnnotatorType.TOKEN, 0, 0, "I", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 1, 2, "'d", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 4+5, 7+5, "like", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 9+5, 10+5, "to", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 12+5, 14+5, "say", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 15+5+lsl, 16+5+lsl, "we", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 18+5+lsl, 20+5+lsl, "did", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 21+5+lsl, 23+5+lsl, "n't", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 25+5+(lsl*3), 30+5+(lsl*3), "expect", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 32+5+(lsl*3), 35+5+(lsl*3), "that", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 36+5+(lsl*3), 36+5+(lsl*3), ".", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 39+5+(lsl*5), 42+5+(lsl*5), "Jane", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 43+5+(lsl*5), 44+5+(lsl*5), "'s", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 46+5+(lsl*5), 54+5+(lsl*5), "boyfriend", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 46+5+(lsl*5), 54+5+(lsl*5), "said", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 56+5+(lsl*5), 56+5+(lsl*5), ".", Map("sentence" -> "0"))
-  )
-
   def getTokenizerOutput[T](tokenizer: Tokenizer, data: DataFrame, mode: String = "finisher"): Array[T] = {
-    val document = new DocumentAssembler().setInputCol("text").setOutputCol("document").setTrimAndClearNewLines(false)
     val finisher = new Finisher().setInputCols("token").setOutputAsArray(true).setCleanAnnotations(false).setOutputCols("output")
-    val pipeline = new Pipeline().setStages(Array(document, tokenizer, finisher))
+    val pipeline = new Pipeline().setStages(Array(tokenizer, finisher))
     val pip = pipeline.fit(data).transform(data)
     if (mode == "finisher") {
       pip.select("output").as[Array[String]].collect.flatten.asInstanceOf[Array[T]]
@@ -85,7 +34,21 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
     }
   }
 
-  "a Tokenizer" should "correctly tokenize target text on its defaults parameters with composite" ignore {
+
+  val targetText1 = "Hello, I won't be from New York in the U.S.A. (and you know it héroe). Give me my horse! or $100" +
+    " bucks 'He said', I'll defeat markus-crassus. You understand. Goodbye George E. Bush. www.google.com."
+  val expected1 = Array(
+    "Hello", ",", "I", "won't", "be", "from", "New York", "in", "the", "U.S.A", ".", "(", "and", "you", "know", "it",
+    "héroe", ").", "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "',", "I'll",
+    "defeat", "markus-crassus", ".", "You", "understand", ".", "Goodbye", "George", "E", ".", "Bush", ".", "www.google.com", "."
+  )
+  val expected1b = Array(
+    "Hello", ",", "I", "won't", "be", "from", "New York", "in", "the", "U.S.A", ".", "(", "and", "you", "know", "it",
+    "héroe", ").", "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "',", "I'll",
+    "defeat", "markus", "-", "crassus", ".", "You", "understand", ".", "Goodbye", "George", "E", ".", "Bush", ".", "www.google.com", "."
+  )
+
+  "a Tokenizer" should "correctly tokenize target text on its defaults parameters with composite" in {
 
     val data = DataBuilder.basicDataBuild(targetText1)
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokens(Array("New York"))
@@ -101,29 +64,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
     })
   }
 
-  "a Tokenizer" should s"correctly label ${targetText2.take(10).mkString("")+"..."}" in {
-    val data = DataBuilder.basicDataBuild(targetText2)
-    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokens(Array("New York"))
-    val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
-    assert(
-      result.sameElements(expected2),
-      s"because result tokens differ: " +
-        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected2.mkString("|")}"
-    )
-  }
-
-  "a Tokenizer" should s"correctly label ${targetText3.take(10).mkString("")+"..."}" in {
-    val data = DataBuilder.basicDataBuild(targetText3)
-    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokens(Array("New York"))
-    val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
-    assert(
-      result.sameElements(expected3),
-      s"because result tokens differ: " +
-        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected3.mkString("|")}"
-    )
-  }
-
-  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite" ignore {
+  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite" in {
     val data = DataBuilder.basicDataBuild(targetText1)
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokens(Array("New York"))
     val result = getTokenizerOutput[String](tokenizer, data)
@@ -134,7 +75,168 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
     )
   }
 
-  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite and different target pattern" ignore {
+  "a Tokenizer" should "correctly tokenize target sentences with split chars" in {
+    val data = DataBuilder.basicDataBuild(targetText1)
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token")
+      .setCompositeTokens(Array("New York"))
+      .addSplitChars("-")
+    val result = getTokenizerOutput[String](tokenizer, data)
+    assert(
+      result.sameElements(expected1b),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected1b.mkString("|")}"
+    )
+  }
+
+
+  val targetText2 = "I'd like to say we didn't expect that. Jane's boyfriend."
+  val expected2 = Array(
+    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 19, 24, "didn't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 33, 36, "that", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 37, 37, ".", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39, 44, "Jane's", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 46, 54, "boyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 55, 55, ".", Map("sentence" -> "0"))
+  )
+
+  "a Tokenizer" should s"correctly tokenize a simple sentence on defaults" in {
+    val data = DataBuilder.basicDataBuild(targetText2)
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token")
+    val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
+    assert(
+      result.sameElements(expected2),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected2.mkString("|")}"
+    )
+  }
+
+  val targetText3 = s"I'd      like to say${ls}we didn't${ls+ls}" +
+    s" expect\nthat. ${ls+ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls+ls}"
+  val expected3 = Array(
+    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 4+5, 7+5, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9+5, 10+5, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12+5, 14+5, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 15+5+lsl, 16+5+lsl, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 18+5+lsl, 23+5+lsl, "didn't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 25+5+(lsl*3), 30+5+(lsl*3), "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 32+5+(lsl*3), 35+5+(lsl*3), "that", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 36+5+(lsl*3), 36+5+(lsl*3), ".", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39+5+(lsl*5), 55+5+(lsl*5), "Jane's\\nboyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 57+5+(lsl*5), 60+5+(lsl*5), "said", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 61+5+(lsl*5), 61+5+(lsl*5), ".", Map("sentence" -> "0"))
+  )
+
+  "a Tokenizer" should s"correctly tokenize a sentence with breaking characters on defaults" in {
+    val data = DataBuilder.basicDataBuild(targetText3)
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token")
+    val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
+    assert(
+      result.sameElements(expected3),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected3.mkString("|")}"
+    )
+  }
+
+  val targetText4 = s"I'd      like to say${ls}we didn't${ls+ls}" +
+    s" expect\nthat. ${ls+ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls+ls}"
+  val expected4 = Array(
+    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 19, 24, "didn't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 33, 36, "that", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 37, 37, ".", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39, 55, "Jane's\\nboyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 57, 60, "said", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 61, 61, ".", Map("sentence" -> "0"))
+  )
+
+  "a Tokenizer" should s"correctly tokenize a sentence with breaking characters on shrink cleanup" in {
+    val data = DataBuilder.basicDataBuild(targetText4)(cleanupMode="shrink")
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token")
+    val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
+    assert(
+      result.sameElements(expected4),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected4.mkString("|")}"
+    )
+  }
+
+  val targetText5 = s"I'd      like to say${ls}we didn't${ls+ls}" +
+    s" expect\nthat. ${ls+ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls+ls}"
+  val expected5 = Array(
+    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 19, 24, "didn't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 33, 36, "that", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 37, 37, ".", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39, 44, "Jane's", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 46, 54, "boyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 56, 59, "said", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 60, 60, ".", Map("sentence" -> "0"))
+  )
+
+  "a Tokenizer" should s"correctly tokenize a sentence with breaking characters on shrink_full cleanup" in {
+    val data = DataBuilder.basicDataBuild(targetText5)(cleanupMode="shrink_full")
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token")
+    val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
+    assert(
+      result.sameElements(expected5),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected5.mkString("|")}"
+    )
+  }
+
+  val targetText6 = s"I'd      like to say${ls}we didn't${ls+ls}" +
+    s" expect\nthat. ${ls+ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls+ls}"
+  val expected6 = Array(
+    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 19, 24, "didn't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 33, 37, "that.", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39, 54, "Jane's boyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 56, 59, "said", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 60, 60, ".", Map("sentence" -> "0"))
+  )
+
+  "a Tokenizer" should s"correctly tokenize cleanup with composite and exceptions" in {
+    val data = DataBuilder.basicDataBuild(targetText6)(cleanupMode="shrink_full")
+    val tokenizer = new Tokenizer()
+      .setInputCols("document")
+      .setOutputCol("token")
+      .addCompositeTokens("Jane's boyfriend")
+      .addExceptionTokens("that.")
+    val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
+    assert(
+      result.sameElements(expected6),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected6.mkString("|")}"
+    )
+  }
+
+  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite and different target pattern" in {
     val data = DataBuilder.basicDataBuild("Hello New York and Goodbye")
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setTargetPattern("\\w+").setCompositeTokens(Array("New York"))
     val result = getTokenizerOutput[String](tokenizer, data)
@@ -145,7 +247,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
     )
   }
 
-  "a spark based tokenizer" should "resolve big data" ignore {
+  "a spark based tokenizer" should "resolve big data" in {
     val data = ContentProvider.parquetData.limit(500000)
       .repartition(16)
 
@@ -168,7 +270,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
 
   "A full Tokenizer pipeline with latin content" should behave like fullTokenizerPipeline(latinBodyData)
 
-  "a tokenizer" should "handle composite tokens with special chars" ignore {
+  "a tokenizer" should "handle composite tokens with special chars" in {
 
     val data = DataBuilder.basicDataBuild("Are you kidding me ?!?! what is this for !?")
     val documentAssembler = new DocumentAssembler()
@@ -185,13 +287,12 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
     val result = tokenized.collect()
   }
 
-  "a silly tokenizer" should "split suffixes" ignore {
+  "a silly tokenizer" should "split suffixes" in {
 
     val data = DataBuilder.basicDataBuild("One, after the\n\nOther, (and) again.\nPO, QAM,")
     val documentAssembler = new DocumentAssembler()
       .setInputCol("text")
       .setOutputCol("doc")
-      .setTrimAndClearNewLines(false)
 
     val assembled = documentAssembler.transform(data)
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -1,11 +1,10 @@
 package com.johnsnowlabs.nlp.annotators
 
 import com.johnsnowlabs.nlp._
-import org.apache.spark.sql.{Dataset, Row}
+import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.scalatest._
 import java.util.Date
 
-import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import org.apache.spark.ml.Pipeline
 
 /**
@@ -17,76 +16,135 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
 
   val regexTokenizer = new Tokenizer
 
-  "a Tokenizer" should s"be of type ${AnnotatorType.TOKEN}" in {
+  "a Tokenizer" should s"be of type ${AnnotatorType.TOKEN}" ignore {
     assert(regexTokenizer.outputAnnotatorType == AnnotatorType.TOKEN)
   }
 
 
-  val targetText = "Hello, I won't be from New York in the U.S.A. (and you know it héroe). Give me my horse! or $100" +
+  val targetText1 = "Hello, I won't be from New York in the U.S.A. (and you know it héroe). Give me my horse! or $100" +
     " bucks 'He said', I'll defeat markus-crassus. You understand. Goodbye George E. Bush. www.google.com."
-  val expected = Array(
+  val expected1 = Array(
     "Hello", ",", "I", "wo", "n't", "be", "from", "New York", "in", "the", "U.S.A.", "(", "and", "you", "know", "it",
     "héroe", ")", ".", "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "'", ",", "I", "'ll",
     "defeat", "markus-crassus", ".", "You", "understand", ".", "Goodbye", "George", "E.", "Bush", ".", "www.google.com", "."
   )
 
-  "a Tokenizer" should "correctly tokenize target text on its defaults parameters with composite" in {
-    val data = DataBuilder.basicDataBuild(targetText)
-    val document = new DocumentAssembler().setInputCol("text").setOutputCol("document")
-    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokensPatterns(Array("New York"))
+  val targetText2 = "I'd like to say we didn't expect that. Jane's boyfriend."
+  val expected2 = Array(
+    Annotation(AnnotatorType.TOKEN, 0, 0, "I", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 1, 2, "'d", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 19, 21, "did", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 22, 24, "n't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 33, 36, "that", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 37, 37, ".", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39, 42, "Jane", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 43, 44, "'s", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 46, 54, "boyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 55, 55, ".", Map("sentence" -> "0"))
+  )
+
+  val ls = System.lineSeparator
+  val lsl = ls.length
+
+  val targetText3 = s"I'd      like to say${ls}we didn't${ls+ls}" +
+    s" expect that. ${ls+ls} " +
+    s"Jane's\\nboyfriend.${ls+ls}"
+  val expected3 = Array(
+    Annotation(AnnotatorType.TOKEN, 0, 0, "I", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 1, 2, "'d", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 4+5, 7+5, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9+5, 10+5, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12+5, 14+5, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 15+5+lsl, 16+5+lsl, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 18+5+lsl, 20+5+lsl, "did", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 21+5+lsl, 23+5+lsl, "n't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 25+5+(lsl*3), 30+5+(lsl*3), "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 32+5+(lsl*3), 35+5+(lsl*3), "that", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 36+5+(lsl*3), 36+5+(lsl*3), ".", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39+5+(lsl*5), 42+5+(lsl*5), "Jane", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 43+5+(lsl*5), 44+5+(lsl*5), "'s", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 46+5+(lsl*5), 54+5+(lsl*5), "boyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 56+5+(lsl*5), 56+5+(lsl*5), ".", Map("sentence" -> "0"))
+  )
+
+  def getTokenizerOutput[T](tokenizer: Tokenizer, data: DataFrame, mode: String = "finisher"): Array[T] = {
+    val document = new DocumentAssembler().setInputCol("text").setOutputCol("document").setTrimAndClearNewLines(false)
     val finisher = new Finisher().setInputCols("token").setOutputAsArray(true).setCleanAnnotations(false).setOutputCols("output")
     val pipeline = new Pipeline().setStages(Array(document, tokenizer, finisher))
     val pip = pipeline.fit(data).transform(data)
-    val result = pip
-      .select("output").as[Array[String]]
-      .collect.flatten
+    if (mode == "finisher") {
+      pip.select("output").as[Array[String]].collect.flatten.asInstanceOf[Array[T]]
+    } else {
+      pip.select("token").as[Array[Annotation]].collect.flatten.asInstanceOf[Array[T]]
+    }
+  }
+
+  "a Tokenizer" should "correctly tokenize target text on its defaults parameters with composite" ignore {
+
+    val data = DataBuilder.basicDataBuild(targetText1)
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokensPatterns(Array("New York"))
+    val result = getTokenizerOutput[String](tokenizer, data)
     assert(
-      result.sameElements(expected),
+      result.sameElements(expected1),
       s"because result tokens differ: " +
-        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected.mkString("|")}"
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected1.mkString("|")}"
     )
-    pip
-      .select("token").as[Array[Annotation]]
-      .collect.foreach(annotations => {
-      annotations.foreach(annotation => {
-        assert(targetText.slice(annotation.begin, annotation.end + 1) == annotation.result)
-      })
+    val result2 = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
+    result2.foreach(annotation => {
+      assert(targetText1.slice(annotation.begin, annotation.end + 1) == annotation.result)
     })
   }
 
-  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite" in {
-    val data = DataBuilder.basicDataBuild(targetText)
-    val document = new DocumentAssembler().setInputCol("text").setOutputCol("document")
-    val sentence = new SentenceDetector().setInputCols("document").setOutputCol("sentence")
-    val tokenizer = new Tokenizer().setInputCols("sentence").setOutputCol("token").setCompositeTokensPatterns(Array("New York"))
-    val finisher = new Finisher().setInputCols("token").setOutputAsArray(true).setOutputCols("output")
-    val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, finisher))
-    val result = pipeline.fit(data).transform(data).select("output").as[Array[String]]
-      .collect.flatten
+  "a Tokenizer" should s"correctly label ${targetText2.take(10).mkString("")+"..."}" in {
+    val data = DataBuilder.basicDataBuild(targetText2)
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokensPatterns(Array("New York"))
+    val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
     assert(
-      result.sameElements(expected),
+      result.sameElements(expected2),
       s"because result tokens differ: " +
-        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected.mkString("|")}"
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected2.mkString("|")}"
     )
   }
 
-  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite and different target pattern" in {
+  "a Tokenizer" should s"correctly label ${targetText3.take(10).mkString("")+"..."}" in {
+    val data = DataBuilder.basicDataBuild(targetText3)
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokensPatterns(Array("New York"))
+    val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
+    assert(
+      result.sameElements(expected3),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected3.mkString("|")}"
+    )
+  }
+
+  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite" ignore {
+    val data = DataBuilder.basicDataBuild(targetText1)
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokensPatterns(Array("New York"))
+    val result = getTokenizerOutput[String](tokenizer, data)
+    assert(
+      result.sameElements(expected1),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected1.mkString("|")}"
+    )
+  }
+
+  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite and different target pattern" ignore {
     val data = DataBuilder.basicDataBuild("Hello New York and Goodbye")
-    val document = new DocumentAssembler().setInputCol("text").setOutputCol("document")
-    val sentence = new SentenceDetector().setInputCols("document").setOutputCol("sentence")
-    val tokenizer = new Tokenizer().setInputCols("sentence").setOutputCol("token").setTargetPattern("\\w+").setCompositeTokensPatterns(Array("New York"))
-    val finisher = new Finisher().setInputCols("token").setOutputAsArray(true).setOutputCols("output")
-    val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, finisher))
-    val result = pipeline.fit(data).transform(data).select("output").as[Array[String]]
-      .collect.flatten
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setTargetPattern("\\w+").setCompositeTokensPatterns(Array("New York"))
+    val result = getTokenizerOutput[String](tokenizer, data)
     assert(
       result.sameElements(Seq("Hello", "New York", "and", "Goodbye")),
       s"because result tokens differ: " +
-        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected.mkString("|")}"
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected1.mkString("|")}"
     )
   }
 
-  "a spark based tokenizer" should "resolve big data" in {
+  "a spark based tokenizer" should "resolve big data" ignore {
     val data = ContentProvider.parquetData.limit(500000)
       .repartition(16)
 
@@ -109,7 +167,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
 
   "A full Tokenizer pipeline with latin content" should behave like fullTokenizerPipeline(latinBodyData)
 
-  "a tokenizer" should "handle composite tokens with special chars" in {
+  "a tokenizer" should "handle composite tokens with special chars" ignore {
 
     val data = DataBuilder.basicDataBuild("Are you kidding me ?!?! what is this for !?")
     val documentAssembler = new DocumentAssembler()
@@ -126,7 +184,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
     val result = tokenized.collect()
   }
 
-  "a silly tokenizer" should "split suffixes" in {
+  "a silly tokenizer" should "split suffixes" ignore {
 
     val data = DataBuilder.basicDataBuild("One, after the\n\nOther, (and) again.\nPO, QAM,")
     val documentAssembler = new DocumentAssembler()

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -52,8 +52,8 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
   val lsl = ls.length
 
   val targetText3 = s"I'd      like to say${ls}we didn't${ls+ls}" +
-    s" expect that. ${ls+ls} " +
-    s"Jane's\\nboyfriend.${ls+ls}"
+    s" expect\nthat. ${ls+ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls+ls}"
   val expected3 = Array(
     Annotation(AnnotatorType.TOKEN, 0, 0, "I", Map("sentence" -> "0")),
     Annotation(AnnotatorType.TOKEN, 1, 2, "'d", Map("sentence" -> "0")),
@@ -69,6 +69,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
     Annotation(AnnotatorType.TOKEN, 39+5+(lsl*5), 42+5+(lsl*5), "Jane", Map("sentence" -> "0")),
     Annotation(AnnotatorType.TOKEN, 43+5+(lsl*5), 44+5+(lsl*5), "'s", Map("sentence" -> "0")),
     Annotation(AnnotatorType.TOKEN, 46+5+(lsl*5), 54+5+(lsl*5), "boyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 46+5+(lsl*5), 54+5+(lsl*5), "said", Map("sentence" -> "0")),
     Annotation(AnnotatorType.TOKEN, 56+5+(lsl*5), 56+5+(lsl*5), ".", Map("sentence" -> "0"))
   )
 
@@ -87,7 +88,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
   "a Tokenizer" should "correctly tokenize target text on its defaults parameters with composite" ignore {
 
     val data = DataBuilder.basicDataBuild(targetText1)
-    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokensPatterns(Array("New York"))
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokens(Array("New York"))
     val result = getTokenizerOutput[String](tokenizer, data)
     assert(
       result.sameElements(expected1),
@@ -102,7 +103,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
 
   "a Tokenizer" should s"correctly label ${targetText2.take(10).mkString("")+"..."}" in {
     val data = DataBuilder.basicDataBuild(targetText2)
-    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokensPatterns(Array("New York"))
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokens(Array("New York"))
     val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
     assert(
       result.sameElements(expected2),
@@ -113,7 +114,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
 
   "a Tokenizer" should s"correctly label ${targetText3.take(10).mkString("")+"..."}" in {
     val data = DataBuilder.basicDataBuild(targetText3)
-    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokensPatterns(Array("New York"))
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokens(Array("New York"))
     val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
     assert(
       result.sameElements(expected3),
@@ -124,7 +125,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
 
   "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite" ignore {
     val data = DataBuilder.basicDataBuild(targetText1)
-    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokensPatterns(Array("New York"))
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setCompositeTokens(Array("New York"))
     val result = getTokenizerOutput[String](tokenizer, data)
     assert(
       result.sameElements(expected1),
@@ -135,7 +136,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
 
   "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite and different target pattern" ignore {
     val data = DataBuilder.basicDataBuild("Hello New York and Goodbye")
-    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setTargetPattern("\\w+").setCompositeTokensPatterns(Array("New York"))
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").setTargetPattern("\\w+").setCompositeTokens(Array("New York"))
     val result = getTokenizerOutput[String](tokenizer, data)
     assert(
       result.sameElements(Seq("Hello", "New York", "and", "Goodbye")),
@@ -178,7 +179,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
     val tokenizer = new Tokenizer()
       .setInputCols("document")
       .setOutputCol("token")
-      .setCompositeTokensPatterns(Array("Are you"))
+      .setCompositeTokens(Array("Are you"))
 
     val tokenized = tokenizer.transform(assembled)
     val result = tokenized.collect()

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
@@ -184,7 +184,6 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
     val tokenizer: Tokenizer = new Tokenizer()
       .setInputCols(Array("doc"))
       .setOutputCol("token")
-      .setIncludeDefaults(false)
       .setTargetPattern("[a-zA-Z0-9]+|\n|\n\n|\\(|\\)|\\.|\\,")
 
     val spellChecker = ContextSpellCheckerModel

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
@@ -178,8 +178,7 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
     val documentAssembler =
       new DocumentAssembler().
         setInputCol("text").
-        setOutputCol("doc").
-        setTrimAndClearNewLines(false)
+        setOutputCol("doc")
 
     val tokenizer: Tokenizer = new Tokenizer()
       .setInputCols(Array("doc"))
@@ -212,8 +211,7 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
     val documentAssembler =
       new DocumentAssembler().
         setInputCol("text").
-        setOutputCol("doc").
-        setTrimAndClearNewLines(false)
+        setOutputCol("doc")
 
     val sentenceDetector = new SentenceDetector()
       .setInputCols(Array("doc"))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
based on the long user feedback on DocumentAssembler and Tokenizer, we were having the following troubles:

1. People reported wrong start/end offsets relative to the original document
2. People reported Tokenizer difficult to customize and use
3. People reported confusion regarding language agnostic Tokenizer
4. People reported difficulties understanding Document default cleanup rules, hard to follow new lines cleanup

Given this, the following changes are being planned and implemented for release 2.1:

1. DocumentAssembler no longer applies clean up by default. Default will be to keep source as is (i.e. new lines, tabs, junk)

2. DocumentAssembler will receive a cleanup parameter that will allow it to be customized in the way it cleans up
    * disabled -> will leave document untouched (default)
    * inplace -> will remove new lines and tabs but will leave text on its original position
    * inplace_full -> same than above but will also remove stringified new lines and tabs (i.e. \\n from csv)
    * shrink -> will remove new lines and tabs and replace all multiple spacing with single spacing
    * shrink_full -> same but will also handle stringified special characters

3. Tokenizer will no longer apply english grammar rules by default. It will resort back to very basic tokenization. English rules will be part of the -pretrained- english model available for download

4. Tokenizer will have two layers of customization. The  "easy" one and the "advanced" one >>
    * easy -> By default it will tokenize removing contextual punctuation, nothing else
              -> Param contextChars will be a list of punctuations to remove from bounds. Defaults to things like ( ) ? ! . , ; : " ' etc
              -> Param splitChars will be a list of characters to split tokens into two. No default is provided. Hypens and such can be used
              -> Param exceptionTokens will be a list of user provided tokens not to be altered by standard rules
              -> Param compositeTokens will be a list of user provided tokens to not split, i.e. New York as a single token

    * advanced -> old params prefixPattern, infixPatterns and suffixPattern will override any previous rules from the easy mode. Allows advanced regex management of the Tokenizer. By default they will now come disabled, and use only easy params

5. Tokenizer will also have other language pretrained models

Welcome any feedback in regard

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
