### PR TITLE
Fix variable reference in DocumentAssembler.setCleanupMode

### DIFF
--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -205,7 +205,7 @@ class DocumentAssembler(AnnotatorTransformer):
     def setCleanupMode(self, value):
         if value.strip().lower() not in ['disabled', 'inplace', 'inplace_full', 'shrink', 'shrink_full']:
             raise Exception("Cleanup mode possible values: disabled, inplace, inplace_full, shrink, shrink_full")
-        return self._set(trimAndClearNewLines=value)
+        return self._set(cleanupMode=value)
 
 
 class TokenAssembler(AnnotatorTransformer):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
After the change to `cleanupMode`, a reference in the Python code to `trimAndClearNewLines` was not updated. Fix this reference so code using it will not error out.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
