### PR TITLE
Introducing test evaluation in NerDLApproach

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1049,10 +1049,14 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     graphFolder = Param(Params._dummy(), "graphFolder", "Folder path that contain external graph files", TypeConverters.toString)
     configProtoBytes = Param(Params._dummy(), "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()", TypeConverters.toListString)
     useContrib = Param(Params._dummy(), "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.", TypeConverters.toBoolean)
-    trainValidationProp = Param(Params._dummy(), "po", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
+    trainValidationProp = Param(Params._dummy(), "trainValidationProp", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
                                 TypeConverters.toFloat)
-    validationLogExtended = Param(Params._dummy(), "po", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
+    evaluationLogExtended = Param(Params._dummy(), "evaluationLogExtended", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
                               TypeConverters.toBoolean)
+
+    testDataset = Param(Params._dummy(), "testDataset",
+                        "Path to test dataset. If set used to calculate statistic on it during training.",
+                        TypeConverters.identity)
 
     def setConfigProtoBytes(self, b):
         return self._set(configProtoBytes=b)
@@ -1092,9 +1096,12 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
         self._set(trainValidationProp=v)
         return self
 
-    def setValidationLogExtended(self, v):
-        self._set(validationLogExtended=v)
+    def setEvaluationLogExtended(self, v):
+        self._set(evaluationLogExtended=v)
         return self
+
+    def setTestDataset(self, path, read_as=ReadAs.SPARK_DATASET, options={"format": "parquet"}):
+        return self._set(testDataset=ExternalResource(path, read_as, options.copy()))
 
     @keyword_only
     def __init__(self):
@@ -1110,7 +1117,7 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
             verbose=2,
             useContrib=uc,
             trainValidationProp=float(0.0),
-            validationLogExtended=False
+            evaluationLogExtended=False
         )
 
 class NerDLModel(AnnotatorModel):

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1051,6 +1051,8 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     useContrib = Param(Params._dummy(), "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.", TypeConverters.toBoolean)
     trainValidationProp = Param(Params._dummy(), "po", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
                                 TypeConverters.toFloat)
+    validationLogExtended = Param(Params._dummy(), "po", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
+                              TypeConverters.toBoolean)
 
     def setConfigProtoBytes(self, b):
         return self._set(configProtoBytes=b)
@@ -1090,6 +1092,10 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
         self._set(trainValidationProp=v)
         return self
 
+    def setValidationLogExtended(self, v):
+        self._set(validationLogExtended=v)
+        return self
+
     @keyword_only
     def __init__(self):
         super(NerDLApproach, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ner.dl.NerDLApproach")
@@ -1103,7 +1109,8 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
             dropout=float(0.5),
             verbose=2,
             useContrib=uc,
-            trainValidationProp=float(0.0)
+            trainValidationProp=float(0.0),
+            validationLogExtended=False
         )
 
 class NerDLModel(AnnotatorModel):

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -113,7 +113,8 @@ class TensorflowNer
             endEpoch: Int,
             validation: Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = Array.empty,
             configProtoBytes: Option[Array[Byte]] = None,
-            trainValidationProp: Float = 0.0f
+            trainValidationProp: Float = 0.0f,
+            validationLogExtended: Boolean = false
            ): Unit = {
 
     log(s"Training started, trainExamples: ${trainDataset.length}, " +
@@ -172,13 +173,8 @@ class TensorflowNer
 
         val trainDatasetSample = trainDataset.take(sample)
 
-        log(s"Quality on training dataset (${trainValidationProp*100}%), validationExamples = $sample", Verbose.Epochs)
-        measure(trainDatasetSample, (s: String) => log(s, Verbose.Epochs))
-      }
-
-      if (validation.nonEmpty) {
-        log("Quality on train dataset: ", Verbose.Epochs)
-        measure(trainDataset, (s: String) => log(s, Verbose.Epochs))
+        log(s"Quality on training dataset (${trainValidationProp*100}%), trainExamples = $sample", Verbose.Epochs)
+        measure(trainDatasetSample, (s: String) => log(s, Verbose.Epochs), extended = validationLogExtended)
       }
 
       if (validation.nonEmpty) {
@@ -276,15 +272,17 @@ class TensorflowNer
     val (prec, rec, f1) = calcStat(totalTruePositives, totalFalsePositives, totalFalseNegatives)
     log(s"Total stats\t prec: $prec, rec: $rec, f1: $f1")
 
-    log("label\t prec\t rec\t f1")
+    if (extended){
+      log("label\t prec\t rec\t f1")
 
-    for (label <- notEmptyLabels) {
-      val (prec, rec, f1) = calcStat(
-        truePositives.getOrElse(label, 0),
-        falsePositives.getOrElse(label, 0),
-        falseNegatives.getOrElse(label, 0)
-      )
-      log(s"$label\t $prec\t $rec\t $f1")
+      for (label <- notEmptyLabels) {
+        val (prec, rec, f1) = calcStat(
+          truePositives.getOrElse(label, 0),
+          falsePositives.getOrElse(label, 0),
+          falseNegatives.getOrElse(label, 0)
+        )
+        log(s"$label\t $prec\t $rec\t $f1")
+      }
     }
   }
 }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -275,8 +275,6 @@ class TensorflowNer
 
     val (prec, rec, f1) = calcStat(totalTruePositives, totalFalsePositives, totalFalseNegatives)
 
-    var totPrec, totRec, totF1 = 0f
-
     if (extended) {
       log("label\t prec\t rec\t f1")
     }
@@ -287,9 +285,6 @@ class TensorflowNer
         falsePositives.getOrElse(label, 0),
         falseNegatives.getOrElse(label, 0)
       )
-      totPrec = totPrec + prec
-      totRec = totPrec + rec
-      totF1 = totPrec + f1
       if (extended) {
         log(s"$label\t $prec\t $rec\t $f1")
       }
@@ -297,6 +292,5 @@ class TensorflowNer
     log(s"Total labels in evaluation: ${notEmptyLabels.length}")
 
     log(s"Weighted stats\t prec: $prec, rec: $rec, f1: $f1")
-    log(s"Micro-average stats\t Perc: ${totPrec/labels.length}\t Recall: ${totRec/labels.length}\t F1: ${totF1/labels.length}")
   }
 }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -111,7 +111,7 @@ class TensorflowNer
             dropout: Float,
             startEpoch: Int = 0,
             endEpoch: Int,
-            graphFileName: String,
+            graphFileName: String = "",
             test: Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = Array.empty,
             configProtoBytes: Option[Array[Byte]] = None,
             trainValidationProp: Float = 0.0f,
@@ -177,12 +177,12 @@ class TensorflowNer
         val trainDatasetSample = trainDataset.take(sample)
 
         log(s"Quality on training dataset (${trainValidationProp*100}%), trainExamples = $sample", Verbose.Epochs)
-        measure(trainDatasetSample, (s: String) => log(s, Verbose.Epochs), extended = validationLogExtended)
+        measure(trainDatasetSample, (s: String) => log(s, Verbose.Epochs), extended = evaluationLogExtended)
       }
 
       if (test.nonEmpty) {
         log("Quality on test dataset: ", Verbose.Epochs)
-        measure(test, (s: String) => log(s, Verbose.Epochs), extended = validationLogExtended)
+        measure(test, (s: String) => log(s, Verbose.Epochs), extended = evaluationLogExtended)
       }
 
     }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -112,7 +112,6 @@ class TensorflowNer
             startEpoch: Int = 0,
             endEpoch: Int,
             graphFileName: String,
-            validation: Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = Array.empty,
             test: Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = Array.empty,
             configProtoBytes: Option[Array[Byte]] = None,
             trainValidationProp: Float = 0.0f,
@@ -181,9 +180,9 @@ class TensorflowNer
         measure(trainDatasetSample, (s: String) => log(s, Verbose.Epochs), extended = validationLogExtended)
       }
 
-      if (validation.nonEmpty) {
-        log("Quality on validation dataset: ", Verbose.Epochs)
-        measure(validation, (s: String) => log(s, Verbose.Epochs), extended = validationLogExtended)
+      if (test.nonEmpty) {
+        log("Quality on test dataset: ", Verbose.Epochs)
+        measure(test, (s: String) => log(s, Verbose.Epochs), extended = validationLogExtended)
       }
 
     }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -269,9 +269,9 @@ class TensorflowNer
     val labels = (correct.keys ++ predicted.keys).filter(label => label != "O").toSeq.distinct
     val notEmptyLabels = labels.filter(label => label != "O" && label.nonEmpty)
 
-    val totalTruePositives = truePositives.filterKeys(label => labels.contains(label)).values.sum
-    val totalFalsePositives = falsePositives.filterKeys(label => labels.contains(label)).values.sum
-    val totalFalseNegatives = falseNegatives.filterKeys(label => labels.contains(label)).values.sum
+    val totalTruePositives = truePositives.filterKeys(label => notEmptyLabels.contains(label)).values.sum
+    val totalFalsePositives = falsePositives.filterKeys(label => notEmptyLabels.contains(label)).values.sum
+    val totalFalseNegatives = falseNegatives.filterKeys(label => notEmptyLabels.contains(label)).values.sum
 
     val (prec, rec, f1) = calcStat(totalTruePositives, totalFalsePositives, totalFalseNegatives)
 
@@ -294,9 +294,9 @@ class TensorflowNer
         log(s"$label\t $prec\t $rec\t $f1")
       }
     }
-    log(s"Total labels in training: ${labels.length}\t Total labels in evaluation: ${notEmptyLabels.length}")
+    log(s"Total labels in evaluation: ${notEmptyLabels.length}")
 
-    log(s"Weighted stats:\t prec: $prec, rec: $rec, f1: $f1")
-    log(s"Micro-average stats:\t Perc: ${totPrec/labels.length}\t Recall: ${totRec/labels.length}\t F1: ${totF1/labels.length}")
+    log(s"Weighted stats\t prec: $prec, rec: $rec, f1: $f1")
+    log(s"Micro-average stats\t Perc: ${totPrec/labels.length}\t Recall: ${totRec/labels.length}\t F1: ${totF1/labels.length}")
   }
 }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -115,7 +115,7 @@ class TensorflowNer
             test: Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = Array.empty,
             configProtoBytes: Option[Array[Byte]] = None,
             trainValidationProp: Float = 0.0f,
-            validationLogExtended: Boolean = false
+            evaluationLogExtended: Boolean = false
            ): Unit = {
 
     log(s"Name of the selected graph: $graphFileName", Verbose.Epochs)

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -111,12 +111,15 @@ class TensorflowNer
             dropout: Float,
             startEpoch: Int = 0,
             endEpoch: Int,
+            graphFileName: String,
             validation: Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = Array.empty,
             test: Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = Array.empty,
             configProtoBytes: Option[Array[Byte]] = None,
             trainValidationProp: Float = 0.0f,
             validationLogExtended: Boolean = false
            ): Unit = {
+
+    log(s"Name of the selected graph: $graphFileName", Verbose.Epochs)
 
     log(s"Training started, trainExamples: ${trainDataset.length}, " +
       s"labels: ${encoder.tags.length} " +

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -262,7 +262,7 @@ class TensorflowNer
       }
     }
 
-    log(s"time to finish validation: ${(System.nanoTime() - started)/1e9}")
+    log(s"time to finish evaluation: ${(System.nanoTime() - started)/1e9}")
 
     val labels = (correct.keys ++ predicted.keys).toSeq.distinct
     val notEmptyLabels = labels.filter(label => label != "O" && label.nonEmpty)

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -109,9 +109,10 @@ class TensorflowNer
             po: Float,
             batchSize: Int,
             dropout: Float,
-            startEpoch: Int,
+            startEpoch: Int = 0,
             endEpoch: Int,
             validation: Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = Array.empty,
+            test: Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = Array.empty,
             configProtoBytes: Option[Array[Byte]] = None,
             trainValidationProp: Float = 0.0f,
             validationLogExtended: Boolean = false
@@ -179,8 +180,9 @@ class TensorflowNer
 
       if (validation.nonEmpty) {
         log("Quality on validation dataset: ", Verbose.Epochs)
-        measure(validation, (s: String) => log(s, Verbose.Epochs))
+        measure(validation, (s: String) => log(s, Verbose.Epochs), extended = validationLogExtended)
       }
+
     }
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -153,7 +153,6 @@ class NerDLApproach(override val uid: String)
         $(batchSize),
         $(dropout),
         validation = valid,
-        startEpoch = $(minEpochs),
         endEpoch = $(maxEpochs),
         configProtoBytes=getConfigProtoBytes,
         trainValidationProp=$(trainValidationProp),

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -146,7 +146,7 @@ class NerDLApproach(override val uid: String)
         endEpoch = $(maxEpochs),
         configProtoBytes=getConfigProtoBytes,
         trainValidationProp=$(trainValidationProp),
-        validationLogExtended=$(validationLogExtended)
+        evaluationLogExtended=$(evaluationLogExtended)
       )
       model
     }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -152,6 +152,7 @@ class NerDLApproach(override val uid: String)
         $(po),
         $(batchSize),
         $(dropout),
+        graphFileName = graphFile,
         validation = valid,
         endEpoch = $(maxEpochs),
         configProtoBytes=getConfigProtoBytes,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -39,6 +39,7 @@ class NerDLApproach(override val uid: String)
   val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
   val useContrib = new BooleanParam(this, "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.")
   val trainValidationProp = new FloatParam(this, "trainValidationProp", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.")
+  val validationLogExtended = new BooleanParam(this, "validationLogExtended", "Whether logs for validation to be extended: it displays time and evaluation of each label. Default is false.")
 
   def getLr: Float = $(this.lr)
   def getPo: Float = $(this.po)
@@ -56,6 +57,7 @@ class NerDLApproach(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]):NerDLApproach.this.type = set(this.configProtoBytes, bytes)
   def setUseContrib(value: Boolean):NerDLApproach.this.type = if (value && SystemUtils.IS_OS_WINDOWS) throw new UnsupportedOperationException("Cannot set contrib in Windows") else set(useContrib, value)
   def setTrainValidationProp(trainValidationProp: Float):NerDLApproach.this.type = set(this.trainValidationProp, trainValidationProp)
+  def setValidationLogExtended(validationLogExtended: Boolean):NerDLApproach.this.type = set(this.validationLogExtended, validationLogExtended)
 
 
   setDefault(
@@ -67,7 +69,8 @@ class NerDLApproach(override val uid: String)
     dropout -> 0.5f,
     verbose -> Verbose.Silent.id,
     useContrib -> {if (SystemUtils.IS_OS_WINDOWS) false else true},
-    trainValidationProp -> 0.0f
+    trainValidationProp -> 0.0f,
+    validationLogExtended -> false
   )
 
   override val verboseLevel = Verbose($(verbose))
@@ -115,7 +118,17 @@ class NerDLApproach(override val uid: String)
         Random.setSeed($(randomSeed))
       }
 
-      model.train(trainDataset, $(lr), $(po), $(batchSize), $(dropout), 0, $(maxEpochs), configProtoBytes=getConfigProtoBytes, trainValidationProp=$(trainValidationProp))
+      model.train(trainDataset,
+        $(lr),
+        $(po),
+        $(batchSize),
+        $(dropout),
+        startEpoch = 0,
+        endEpoch = $(maxEpochs),
+        configProtoBytes=getConfigProtoBytes,
+        trainValidationProp=$(trainValidationProp),
+        validationLogExtended=$(validationLogExtended)
+      )
       model
     }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -41,7 +41,7 @@ class NerDLApproach(override val uid: String)
   val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
   val useContrib = new BooleanParam(this, "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.")
   val trainValidationProp = new FloatParam(this, "trainValidationProp", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.")
-  val validationLogExtended = new BooleanParam(this, "validationLogExtended", "Whether logs for validation to be extended: it displays time and evaluation of each label. Default is false.")
+  val evaluationLogExtended = new BooleanParam(this, "validationLogExtended", "Whether logs for validation to be extended: it displays time and evaluation of each label. Default is false.")
   val testDataset = new ExternalResourceParam(this, "testDataset", "Path to test dataset. " +
     "If set used to calculate statistic on it during training.")
 
@@ -61,7 +61,7 @@ class NerDLApproach(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]):NerDLApproach.this.type = set(this.configProtoBytes, bytes)
   def setUseContrib(value: Boolean):NerDLApproach.this.type = if (value && SystemUtils.IS_OS_WINDOWS) throw new UnsupportedOperationException("Cannot set contrib in Windows") else set(useContrib, value)
   def setTrainValidationProp(trainValidationProp: Float):NerDLApproach.this.type = set(this.trainValidationProp, trainValidationProp)
-  def setValidationLogExtended(validationLogExtended: Boolean):NerDLApproach.this.type = set(this.validationLogExtended, validationLogExtended)
+  def setEvaluationLogExtended(evaluationLogExtended: Boolean):NerDLApproach.this.type = set(this.evaluationLogExtended, evaluationLogExtended)
   def setTestDataset(path: String,
                      readAs: ReadAs.Format = ReadAs.SPARK_DATASET,
                      options: Map[String, String] = Map("format" -> "parquet")): this.type =
@@ -79,7 +79,7 @@ class NerDLApproach(override val uid: String)
     verbose -> Verbose.Silent.id,
     useContrib -> {if (SystemUtils.IS_OS_WINDOWS) false else true},
     trainValidationProp -> 0.0f,
-    validationLogExtended -> false
+    evaluationLogExtended -> false
   )
 
   override val verboseLevel = Verbose($(verbose))

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -11,7 +11,7 @@ import com.johnsnowlabs.nlp.util.io.ReadAs._
 import com.johnsnowlabs.nlp.{DocumentAssembler, Finisher}
 import org.apache.hadoop.fs.{FileSystem, LocatedFileStatus, Path, RemoteIterator}
 import org.apache.spark.ml.{Pipeline, PipelineModel}
-import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
 import scala.collection.mutable.{ArrayBuffer, Map => MMap}
 import scala.io.BufferedSource
@@ -330,6 +330,24 @@ object ResourceHelper {
         valueAsKeys.toMap
       case _ =>
         throw new Exception("Unsupported readAs")
+    }
+  }
+
+  /**
+    * General purpose read saved Parquet
+    * Currently read only Parquet format
+    * @return
+    */
+  def readParquetSparkDatFrame(
+                           er: ExternalResource
+                         ): DataFrame = {
+    er.readAs match {
+      case SPARK_DATASET =>
+        import spark.implicits._
+        val dataset = spark.read.options(er.options).format(er.options("format")).load(er.path)
+        dataset
+      case _ =>
+        throw new Exception("Unsupported readAs - only accepts SPARK_DATASET")
     }
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
@@ -84,13 +84,13 @@ class NerDLSpec extends FlatSpec {
 
     val conll = CoNLL()
     val training_data = conll.readDataset(ResourceHelper.spark, "python/tensorflow/ner/conll2003/eng.testa")
-    val validation_data = conll.readDataset(ResourceHelper.spark, "python/tensorflow/ner/conll2003/eng.testb")
+    val test_data = conll.readDataset(ResourceHelper.spark, "python/tensorflow/ner/conll2003/eng.testb")
 
     val embeddings = WordEmbeddingsModel.pretrained().setOutputCol("embeddings")
 
     val trainData = embeddings.transform(training_data)
-    val validateData = embeddings.transform(validation_data)
-    validateData.write.mode("overwrite").parquet("./tmp_conll_validate")
+    val testData = embeddings.transform(test_data)
+    testData.write.mode("overwrite").parquet("./tmp_conll_validate")
 
     val ner = new NerDLApproach()
       .setInputCols("sentence", "token", "embeddings")
@@ -105,7 +105,7 @@ class NerDLSpec extends FlatSpec {
       .setVerbose(0)
       .setTrainValidationProp(0.1f)
       .setValidationLogExtended(true)
-      .setValidationDataset("./tmp_conll_validate/")
+      .setTestDataset("./tmp_conll_validate/")
       .fit(trainData)
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
@@ -93,13 +93,14 @@ class NerDLSpec extends FlatSpec {
       .setOutputCol("ner")
       .setLabelColumn("label")
       .setOutputCol("ner")
-      .setLr(1e-1f) //0.001
+      .setLr(1e-1f) //0.1
       .setPo(5e-3f) //0.005
       .setDropout(5e-1f) //0.5
       .setMaxEpochs(1)
       .setRandomSeed(0)
       .setVerbose(0)
       .setTrainValidationProp(0.1f)
+      .setValidationLogExtended(true)
       .fit(readyData)
 
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
@@ -104,7 +104,7 @@ class NerDLSpec extends FlatSpec {
       .setRandomSeed(0)
       .setVerbose(0)
       .setTrainValidationProp(0.1f)
-      .setValidationLogExtended(true)
+      .setEvaluationLogExtended(true)
       .setTestDataset("./tmp_conll_validate/")
       .fit(trainData)
   }


### PR DESCRIPTION
- [x] Add `validationLogExtended` feature to avoid printing all the tags on each epoch
- [x] Allow `startEpoch` to be set for an early stop
- [x] Add `testDataset` to be evaluated at each Epoch
- [x] Print full path of the selected Graph file (helpful to know if it's the right TF graph)
- [x] Add Python interfaces for NerDLApproach

Example:

```scala
val conll = CoNLL()
val training_data = conll.readDataset(ResourceHelper.spark, "python/tensorflow/ner/conll2003/eng.testa")
val test_data = conll.readDataset(ResourceHelper.spark, "python/tensorflow/ner/conll2003/eng.testb")

val embeddings = WordEmbeddingsModel.pretrained().setOutputCol("embeddings")

val trainData = embeddings.transform(training_data)
val testData = embeddings.transform(test_data)
testData.write.mode("overwrite").parquet("./tmp_conll_test")

val ner = new NerDLApproach()
      .setInputCols("sentence", "token", "embeddings")
      .setOutputCol("ner")
      .setLabelColumn("label")
      .setOutputCol("ner")
      .setLr(1e-1f) //0.1
      .setPo(5e-3f) //0.005
      .setDropout(5e-1f) //0.5
      .setMaxEpochs(1)
      .setRandomSeed(0)
      .setVerbose(0)
      .setTrainValidationProp(0.1f)
      .setEvaluationLogExtended(true)
      .setTestDataset("./tmp_conll_test/")
  }
val nerModel = ner.fit(trainData)

```