### PR TITLE
Load contrib to cluster when reading a python bert model

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -5,6 +5,7 @@ import java.io.File
 import com.johnsnowlabs.ml.tensorflow._
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.annotators.ner.dl.LoadsContrib
 import com.johnsnowlabs.nlp.annotators.tokenizer.wordpiece.{BasicTokenizer, WordpieceEncoder}
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
 import com.johnsnowlabs.nlp.serialization.MapFeature
@@ -138,6 +139,8 @@ trait ReadBertTensorflowModel extends ReadTensorflowModel {
     require(f.exists, s"Folder ${folder} not found")
     require(f.isDirectory, s"File ${folder} is not folder")
     require(vocab.exists(), s"Vocabulary file vocab.txt not found in folder ${folder}")
+
+    LoadsContrib.loadContribToCluster(spark)
 
     val wrapper = TensorflowWrapper.read(folder, zipped = false)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Loading a BERT model from source, was not triggering contrib to be loaded. This is a fix for it.