### PR TITLE
Filter empty sentences, improve error message in flush

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerTagsEncoding.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerTagsEncoding.scala
@@ -28,7 +28,8 @@ object NerTagsEncoding {
     def flushEntity(startIdx: Int, endIdx: Int): Unit = {
       val start = sentence.indexedTaggedWords(startIdx).begin - doc.begin
       val end = sentence.indexedTaggedWords(endIdx).end - doc.begin
-      require(start <= end && end <= doc.result.length, s"Failed to flush entities in NerConverter. Chunk offsets $start - $end are not within $sentence")
+      require(start <= end && end <= doc.result.length, s"Failed to flush entities in NerConverter. " +
+        s"Chunk offsets $start - $end are not within tokens:\n${sentence.words.mkString("||")}\nfor sentence:\n${doc.result}")
       val entity = NamedEntity(
         sentence.indexedTaggedWords(startIdx).begin,
         sentence.indexedTaggedWords(endIdx).end,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetector.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetector.scala
@@ -59,7 +59,7 @@ class SentenceDetector(override val uid: String) extends AnnotatorModel[Sentence
     */
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
     val docs = annotations.map(_.result)
-    val sentences = docs.flatMap(doc => tag(doc))
+    val sentences = docs.flatMap(doc => tag(doc)).filter(_.content.nonEmpty)
     SentenceSplit.pack(sentences)
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since the refactor of DocumentAssembler cleanupMode, empty sentences can happen. This avoids errors later on in the pipeline  to cleanup empty sentences from SentenceDetector