### PR TITLE
Finisher and Light Pipelines deal with embeddings accordingly

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
@@ -1,5 +1,6 @@
 package com.johnsnowlabs.nlp
 
+import com.johnsnowlabs.nlp.embeddings.HasEmbeddings
 import org.apache.spark.ml.{PipelineModel, Transformer}
 import org.apache.spark.sql.{DataFrame, Dataset}
 
@@ -56,7 +57,12 @@ class LightPipeline(val pipelineModel: PipelineModel) {
   }
 
   def annotate(target: String): Map[String, Seq[String]] = {
-    fullAnnotate(target).mapValues(_.map(_.result))
+    fullAnnotate(target).mapValues(_.map(a => {
+      a.annotatorType match {
+        case AnnotatorType.WORD_EMBEDDINGS =>  a.embeddings.mkString(",")
+        case _ => a.result
+      }
+    }))
   }
 
   def annotate(targets: Array[String]): Array[Map[String, Seq[String]]] = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As of 2.0, `Finisher` and `LightPipeline` show the token string when the embeddings column is part of the output, it should now show the embeddings instead.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
