### PR TITLE
Making the metadata field isOOV optional to handle previously transfo…

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceWithEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceWithEmbeddings.scala
@@ -61,7 +61,7 @@ object  WordpieceEmbeddingsSentence extends Annotated[WordpieceEmbeddingsSentenc
           token = token.metadata("token"),
           pieceId = token.metadata("pieceId").toInt,
           isWordStart = token.metadata("isWordStart").toBoolean,
-          isOOV = token.metadata("isOOV").toBoolean,
+          isOOV = token.metadata.getOrElse("isOOV", "false").toBoolean,
           embeddings = token.embeddings,
           begin = token.begin,
           end = token.end


### PR DESCRIPTION
…rmed dataframes

<!--- Provide a general summary of your changes in the Title above -->

## Description
Just using getOrElse for Metadata's isOOV field for backwards compatibility


## Motivation and Context
Backwards compatibility

## How Has This Been Tested?
Scala Tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
