### PR TITLE
import word embedding models as embeddings for compatibility

### DIFF
--- a/python/sparknlp/embeddings.py
+++ b/python/sparknlp/embeddings.py
@@ -7,6 +7,12 @@ import threading
 import time
 import sparknlp.pretrained as _pretrained
 
+
+# DONT REMOVE THIS IMPORT
+from sparknlp.annotator import WordEmbeddingsModel
+####
+
+
 class Embeddings:
     def __init__(self, embeddings):
         self.jembeddings = embeddings


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes an issue where loading a pipeline after using the `EmbeddingsHelper` would case the loading to fail due to mismatching of classnames