### PR TITLE
Python eval ner

### DIFF
--- a/eval/src/main/scala/com/johnsnowlabs/nlp/eval/ner/NerCrfEvaluation.scala
+++ b/eval/src/main/scala/com/johnsnowlabs/nlp/eval/ner/NerCrfEvaluation.scala
@@ -35,7 +35,9 @@ class NerCrfEvaluation(sparkSession: SparkSession, testFile: String, tagLevel: S
   }
 
   def computeAccuracyAnnotator(trainFile:String, nerInputCols: Array[String], nerOutputCol: String,
-                               randomSeed: Int, labelColumn: String,
+                               labelColumn: String, entities: Array[String], minEpochs: Int, maxEpochs: Int,
+                               verbose: Int, randomSeed: Int, l2: Double, c0: Int, lossEps: Double,
+                               minW: Double, includeConfidence: Boolean,
                                embeddingsInputCols: Array[String], embeddingsOutputCol: String,
                                embeddingsPath: String, dimension: Int, format: Int): Unit = {
 
@@ -43,7 +45,16 @@ class NerCrfEvaluation(sparkSession: SparkSession, testFile: String, tagLevel: S
       .setInputCols(nerInputCols)
       .setOutputCol(nerOutputCol)
       .setLabelColumn(labelColumn)
+      .setEntities(entities)
+      .setMinEpochs(minEpochs)
+      .setMaxEpochs(maxEpochs)
+      .setVerbose(verbose)
       .setRandomSeed(randomSeed)
+      .setL2(l2)
+      .setC0(c0)
+      .setLossEps(lossEps)
+      .setMinW(minW)
+      .setIncludeConfidence(includeConfidence)
 
     val wordEmbeddings = new WordEmbeddings()
       .setInputCols(embeddingsInputCols)

--- a/eval/src/main/scala/com/johnsnowlabs/nlp/eval/ner/NerCrfEvaluation.scala
+++ b/eval/src/main/scala/com/johnsnowlabs/nlp/eval/ner/NerCrfEvaluation.scala
@@ -41,11 +41,10 @@ class NerCrfEvaluation(sparkSession: SparkSession, testFile: String, tagLevel: S
                                embeddingsInputCols: Array[String], embeddingsOutputCol: String,
                                embeddingsPath: String, dimension: Int, format: Int): Unit = {
 
-    val ner = new NerCrfApproach()
+    val nerCrfApproach = new NerCrfApproach()
       .setInputCols(nerInputCols)
       .setOutputCol(nerOutputCol)
       .setLabelColumn(labelColumn)
-      .setEntities(entities)
       .setMinEpochs(minEpochs)
       .setMaxEpochs(maxEpochs)
       .setVerbose(verbose)
@@ -53,16 +52,24 @@ class NerCrfEvaluation(sparkSession: SparkSession, testFile: String, tagLevel: S
       .setL2(l2)
       .setC0(c0)
       .setLossEps(lossEps)
-      .setMinW(minW)
       .setIncludeConfidence(includeConfidence)
+
+    if (entities != null) {
+      nerCrfApproach.setEntities(entities)
+    }
+
+    if (minW.isNaN) {
+      nerCrfApproach.setMinW(minW)
+    }
 
     val wordEmbeddings = new WordEmbeddings()
       .setInputCols(embeddingsInputCols)
       .setOutputCol(embeddingsOutputCol)
       .setEmbeddingsSource(embeddingsPath, dimension, format)
 
-    computeAccuracyAnnotator(trainFile, ner, wordEmbeddings)
+    computeAccuracyAnnotator(trainFile, nerCrfApproach, wordEmbeddings)
   }
+
 
   private def computeAccuracy(nerEvalCrfConfiguration: NerEvalCrfConfiguration): Unit = {
     import sparkSession.implicits._

--- a/eval/src/main/scala/com/johnsnowlabs/nlp/eval/ner/NerDLEvaluation.scala
+++ b/eval/src/main/scala/com/johnsnowlabs/nlp/eval/ner/NerDLEvaluation.scala
@@ -35,22 +35,42 @@ class NerDLEvaluation(sparkSession: SparkSession, testFile: String, tagLevel: St
   }
 
   def computeAccuracyAnnotator(trainFile:String, nerInputCols: Array[String], nerOutputCol: String,
-                               randomSeed: Int, labelColumn: String,
+                               labelColumn: String, entities: Array[String], minEpochs: Int, maxEpochs: Int,
+                               verbose: Int, randomSeed: Int, lr: Float, po: Float, batchSize: Int, dropout: Float,
+                               graphFolder: String, configProtoBytes: Array[Int], userContrib: Boolean,
+                               trainValidationProp: Float, evaluationLogExtended: Boolean, enableOutputLogs: Boolean,
+                               testDataSet: String, includeConfidence: Boolean,
                                embeddingsInputCols: Array[String], embeddingsOutputCol: String,
                                embeddingsPath: String, dimension: Int, format: Int): Unit = {
 
-    val ner = new NerDLApproach()
+    val nerDLApproach = new NerDLApproach()
       .setInputCols(nerInputCols)
       .setOutputCol(nerOutputCol)
       .setLabelColumn(labelColumn)
+      .setEntities(entities)
+      .setMinEpochs(minEpochs)
+      .setMaxEpochs(maxEpochs)
+      .setVerbose(verbose)
       .setRandomSeed(randomSeed)
+      .setLr(lr)
+      .setPo(po)
+      .setBatchSize(batchSize)
+      .setDropout(dropout)
+      .setGraphFolder(graphFolder)
+      .setConfigProtoBytes(configProtoBytes)
+      .setUseContrib(userContrib)
+      .setTrainValidationProp(trainValidationProp)
+      .setEvaluationLogExtended(evaluationLogExtended)
+      .setEnableOutputLogs(enableOutputLogs)
+      .setTestDataset(testDataSet)
+      .setIncludeConfidence(includeConfidence)
 
     val wordEmbeddings = new WordEmbeddings()
         .setInputCols(embeddingsInputCols)
         .setOutputCol(embeddingsOutputCol)
         .setEmbeddingsSource(embeddingsPath, dimension, format)
 
-    computeAccuracyAnnotator(trainFile, ner, wordEmbeddings)
+    computeAccuracyAnnotator(trainFile, nerDLApproach, wordEmbeddings)
   }
 
   def computeAccuracy(nerEvalDLConfiguration: NerEvalDLConfiguration): Unit = {

--- a/eval/src/main/scala/com/johnsnowlabs/nlp/eval/ner/NerDLEvaluation.scala
+++ b/eval/src/main/scala/com/johnsnowlabs/nlp/eval/ner/NerDLEvaluation.scala
@@ -35,9 +35,9 @@ class NerDLEvaluation(sparkSession: SparkSession, testFile: String, tagLevel: St
   }
 
   def computeAccuracyAnnotator(trainFile:String, nerInputCols: Array[String], nerOutputCol: String,
-                               labelColumn: String, entities: Array[String], minEpochs: Int, maxEpochs: Int,
+                               labelColumn: String, minEpochs: Int, maxEpochs: Int,
                                verbose: Int, randomSeed: Int, lr: Float, po: Float, batchSize: Int, dropout: Float,
-                               graphFolder: String, configProtoBytes: Array[Int], userContrib: Boolean,
+                               graphFolder: String, userContrib: Boolean,
                                trainValidationProp: Float, evaluationLogExtended: Boolean, enableOutputLogs: Boolean,
                                testDataSet: String, includeConfidence: Boolean,
                                embeddingsInputCols: Array[String], embeddingsOutputCol: String,
@@ -47,23 +47,29 @@ class NerDLEvaluation(sparkSession: SparkSession, testFile: String, tagLevel: St
       .setInputCols(nerInputCols)
       .setOutputCol(nerOutputCol)
       .setLabelColumn(labelColumn)
-      .setEntities(entities)
-      .setMinEpochs(minEpochs)
       .setMaxEpochs(maxEpochs)
+      .setMinEpochs(minEpochs)
       .setVerbose(verbose)
       .setRandomSeed(randomSeed)
       .setLr(lr)
       .setPo(po)
       .setBatchSize(batchSize)
       .setDropout(dropout)
-      .setGraphFolder(graphFolder)
-      .setConfigProtoBytes(configProtoBytes)
       .setUseContrib(userContrib)
       .setTrainValidationProp(trainValidationProp)
       .setEvaluationLogExtended(evaluationLogExtended)
       .setEnableOutputLogs(enableOutputLogs)
-      .setTestDataset(testDataSet)
       .setIncludeConfidence(includeConfidence)
+
+    if (testDataSet != null) {
+      nerDLApproach
+        .setTestDataset(testDataSet)
+    }
+
+    if (graphFolder != null) {
+      nerDLApproach
+      .setGraphFolder(graphFolder)
+    }
 
     val wordEmbeddings = new WordEmbeddings()
         .setInputCols(embeddingsInputCols)

--- a/eval/src/main/scala/com/johnsnowlabs/nlp/eval/spell/NorvigSpellEvaluation.scala
+++ b/eval/src/main/scala/com/johnsnowlabs/nlp/eval/spell/NorvigSpellEvaluation.scala
@@ -26,11 +26,25 @@ class NorvigSpellEvaluation(sparkSession: SparkSession, testFile: String, ground
     loggingData.closeLog()
   }
 
-  def computeAccuracyAnnotator(trainFile: String, inputCols: Array[String], outputCol: String, dictionary: String): Unit = {
-   val spell = new NorvigSweetingApproach()
-     .setInputCols(inputCols)
-     .setOutputCol(outputCol)
-     .setDictionary(dictionary)
+  def computeAccuracyAnnotator(trainFile: String, inputCols: Array[String], outputCol: String, dictionary: String,
+                              caseSensitive: Boolean, doubleVariants: Boolean, shortCircuit: Boolean,
+                               frequencyPriority: Boolean, wordSizeIgnore: Int, dupsLimit: Int, reductLimit: Int,
+                               intersections: Int, vowelSwapLimit: Int): Unit = {
+
+    val spell = new NorvigSweetingApproach()
+      .setInputCols(inputCols)
+      .setOutputCol(outputCol)
+      .setDictionary(dictionary)
+      .setCaseSensitive(caseSensitive)
+      .setDoubleVariants(doubleVariants)
+      .setShortCircuit(shortCircuit)
+      .setFrequencyPriority(frequencyPriority)
+      .setWordSizeIgnore(wordSizeIgnore)
+      .setDupsLimit(dupsLimit)
+      .setReductLimit(reductLimit)
+      .setIntersections(intersections)
+      .setVowelSwapLimit(vowelSwapLimit)
+
     computeAccuracyAnnotator(trainFile, spell)
   }
 

--- a/eval/src/main/scala/com/johnsnowlabs/nlp/eval/spell/SymSpellEvaluation.scala
+++ b/eval/src/main/scala/com/johnsnowlabs/nlp/eval/spell/SymSpellEvaluation.scala
@@ -25,11 +25,19 @@ class SymSpellEvaluation(sparkSession: SparkSession, testFile: String, groundTru
     loggingData.closeLog()
   }
 
-  def computeAccuracyAnnotator(trainFile: String, inputCols: Array[String], outputCol: String, dictionary: String): Unit = {
+  def computeAccuracyAnnotator(trainFile: String, inputCols: Array[String], outputCol: String, dictionary: String,
+                               maxEditDistance: Int, frequencyThreshold: Int, deletesThreshold: Int, dupsLimit: Int
+                              ): Unit = {
+
     val spell = new SymmetricDeleteApproach()
       .setInputCols(inputCols)
       .setOutputCol(outputCol)
       .setDictionary(dictionary)
+      .setMaxEditDistance(maxEditDistance)
+      .setFrequencyThreshold(frequencyThreshold)
+      .setDeletesThreshold(deletesThreshold)
+      .setDupsLimit(dupsLimit)
+
     computeAccuracyAnnotator(trainFile, spell)
   }
 

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1012,21 +1012,37 @@ class NerApproach(Params):
     def setRandomSeed(self, seed):
         return self._set(randomSeed=seed)
 
-    def getRandomSeed(self):
-        return self.getOrDefault(self.randomSeed)
-
     def getLabelColumn(self):
         return self.getOrDefault(self.labelColumn)
+
+    def getEntities(self):
+        return self.getOrDefault(self.entities)
+
+    def getMinEpochs(self):
+        return self.getOrDefault(self.minEpochs)
+
+    def getMaxEpochs(self):
+        return self.getOrDefault(self.maxEpochs)
+
+    def getVerbose(self):
+        return self.getOrDefault(self.verbose)
+
+    def getRandomSeed(self):
+        return self.getOrDefault(self.randomSeed)
 
 
 class NerCrfApproach(AnnotatorApproach, NerApproach):
 
     l2 = Param(Params._dummy(), "l2", "L2 regularization coefficient", TypeConverters.toFloat)
+
     c0 = Param(Params._dummy(), "c0", "c0 params defining decay speed for gradient", TypeConverters.toInt)
+
     lossEps = Param(Params._dummy(), "lossEps", "If Epoch relative improvement less than eps then training is stopped",
                     TypeConverters.toFloat)
+
     minW = Param(Params._dummy(), "minW", "Features with less weights then this param value will be filtered",
                  TypeConverters.toFloat)
+
     includeConfidence = Param(Params._dummy(), "includeConfidence", "external features is a delimited text. needs 'delimiter' in options",
                               TypeConverters.toBoolean)
 
@@ -1053,6 +1069,21 @@ class NerCrfApproach(AnnotatorApproach, NerApproach):
 
     def setIncludeConfidence(self, b):
         return self._set(includeConfidence=b)
+
+    def getL2(self):
+        return self.getOrDefault(self.l2)
+
+    def getC0(self):
+        return self.getOrDefault(self.c0)
+
+    def getLossEps(self):
+        return self.getOrDefault(self.lossEps)
+
+    def getMinW(self):
+        return self.getOrDefault(self.minW)
+
+    def getIncludeConfidence(self):
+        return self.getOrDefault(self.includeConfidence)
 
     def _create_model(self, java_model):
         return NerCrfModel(java_model=java_model)
@@ -1095,17 +1126,23 @@ class NerCrfModel(AnnotatorModel):
 class NerDLApproach(AnnotatorApproach, NerApproach):
 
     lr = Param(Params._dummy(), "lr", "Learning Rate", TypeConverters.toFloat)
+
     po = Param(Params._dummy(), "po", "Learning rate decay coefficient. Real Learning Rage = lr / (1 + po * epoch)",
                TypeConverters.toFloat)
+
     batchSize = Param(Params._dummy(), "batchSize", "Batch size", TypeConverters.toInt)
+
     dropout = Param(Params._dummy(), "dropout", "Dropout coefficient", TypeConverters.toFloat)
-    minProba = Param(Params._dummy(), "minProba",
-                     "Minimum probability. Used only if there is no CRF on top of LSTM layer", TypeConverters.toFloat)
+
     graphFolder = Param(Params._dummy(), "graphFolder", "Folder path that contain external graph files", TypeConverters.toString)
+
     configProtoBytes = Param(Params._dummy(), "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()", TypeConverters.toListString)
+
     useContrib = Param(Params._dummy(), "useContrib", "whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy.", TypeConverters.toBoolean)
+
     trainValidationProp = Param(Params._dummy(), "trainValidationProp", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
                                 TypeConverters.toFloat)
+
     evaluationLogExtended = Param(Params._dummy(), "evaluationLogExtended", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
                                   TypeConverters.toBoolean)
 
@@ -1116,6 +1153,7 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     includeConfidence = Param(Params._dummy(), "includeConfidence",
                               "whether to include confidence scores in annotation metadata",
                               TypeConverters.toBoolean)
+
     enableOutputLogs = Param(Params._dummy(), "enableOutputLogs",
                               "Whether to use stdout in addition to Spark logs.",
                               TypeConverters.toBoolean)
@@ -1147,13 +1185,6 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
         self._set(dropout=v)
         return self
 
-    def setMinProbability(self, v):
-        self._set(minProba=v)
-        return self
-
-    def _create_model(self, java_model):
-        return NerDLModel(java_model=java_model)
-
     def setTrainValidationProp(self, v):
         self._set(trainValidationProp=v)
         return self
@@ -1170,6 +1201,45 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
 
     def setEnableOutputLogs(self, value):
         return self._set(enableOutputLogs=value)
+
+    def getLr(self):
+        return self.getOrDefault(self.lr)
+
+    def getPo(self):
+        return self.getOrDefault(self.po)
+
+    def getBatchSize(self):
+        return self.getOrDefault(self.batchSize)
+
+    def getDropout(self):
+        return self.getOrDefault(self.dropout)
+
+    def getGraphFolder(self):
+        return self.getOrDefault(self.graphFolder)
+
+    def getConfigProtoBytes(self):
+        return self.getOrDefault(self.configProtoBytes)
+
+    def getUseContrib(self):
+        return self.getOrDefault(self.useContrib)
+
+    def getTranValidationProp(self):
+        return self.getOrDefault(self.trainValidationProp)
+
+    def getEvaluationLogExtended(self):
+        return self.getOrDefault(self.evaluationLogExtended)
+
+    def getEnableOutputLogs(self):
+        return self.getOrDefault(self.enableOutputLogs)
+
+    def getTestDataset(self):
+        return self.getOrDefault(self.testDataset)
+
+    def getIncludeConfidence(self):
+        return self.getOrDefault(self.includeConfidence)
+
+    def _create_model(self, java_model):
+        return NerDLModel(java_model=java_model)
 
     @keyword_only
     def __init__(self):

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1098,7 +1098,9 @@ class NerCrfApproach(AnnotatorApproach, NerApproach):
             c0=2250000,
             lossEps=float(1e-3),
             verbose=4,
-            includeConfidence=False
+            includeConfidence=False,
+            entities=[],
+            minW=float('NaN')
         )
 
 
@@ -1257,7 +1259,10 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
             trainValidationProp=float(0.0),
             evaluationLogExtended=False,
             includeConfidence=False,
-            enableOutputLogs=False
+            enableOutputLogs=False,
+            configProtoBytes=[],
+            graphFolder=None,
+            testDataset=None
         )
 
 

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -879,6 +879,33 @@ class NorvigSweetingApproach(AnnotatorApproach):
     def setFrequencyPriority(self, value):
         return self._set(frequencyPriority=value)
 
+    def getCaseSensitive(self):
+        return self.getOrDefault(self.caseSensitive)
+
+    def getDoubleVariants(self):
+        return self.getOrDefault(self.doubleVariants)
+
+    def getShortCircuit(self):
+        return self.getOrDefault(self.shortCircuit)
+
+    def getFrequencyPriority(self):
+        return self.getOrDefault(self.frequencyPriority)
+
+    def getWordSizeIgnore(self):
+        return self.getOrDefault(self.wordSizeIgnore)
+
+    def getDupsLimit(self):
+        return self.getOrDefault(self.dupsLimit)
+
+    def getReductLimit(self):
+        return self.getOrDefault(self.reductLimit)
+
+    def getIntersections(self):
+        return self.getOrDefault(self.intersections)
+
+    def getVowelSwapLimit(self):
+        return self.getOrDefault(self.vowelSwapLimit)
+
     def _create_model(self, java_model):
         return NorvigSweetingModel(java_model=java_model)
 
@@ -938,12 +965,6 @@ class SymmetricDeleteApproach(AnnotatorApproach):
         self._setDefault(maxEditDistance=3, frequencyThreshold=0, deletesThreshold=0, dupsLimit=2)
         self.dictionary_path = ""
 
-    def setCorpus(self, path, token_pattern="\S+", read_as=ReadAs.LINE_BY_LINE, options={"format": "text"}):
-        opts = options.copy()
-        if "tokenPattern" not in opts:
-            opts["tokenPattern"] = token_pattern
-        return self._set(corpus=ExternalResource(path, read_as, opts))
-
     def setDictionary(self, path, token_pattern="\S+", read_as=ReadAs.LINE_BY_LINE, options={"format": "text"}):
         self.dictionary_path = path
         opts = options.copy()
@@ -959,6 +980,18 @@ class SymmetricDeleteApproach(AnnotatorApproach):
 
     def setDeletesThreshold(self, v):
         return self._set(deletesThreshold=v)
+
+    def getMaxEditDistance(self):
+        return self.getOrDefault(self.maxEditDistance)
+
+    def getFrequencyThreshold(self):
+        return self.getOrDefault(self.frequencyThreshold)
+
+    def getDeletesThreshold(self):
+        return self.getOrDefault(self.deletesThreshold)
+
+    def getDupsLimit(self):
+        return self.getOrDefault(self.dupsLimit)
 
     def _create_model(self, java_model):
         return SymmetricDeleteModel(java_model=java_model)

--- a/python/sparknlp/eval.py
+++ b/python/sparknlp/eval.py
@@ -43,13 +43,12 @@ class NerDLEvaluation(ExtendedJavaWrapper):
         ner_params = self.__getNerParams(ner)
         embeddings_params = self.__getEmbeddingsParams(embeddings)
         return self._java_obj.computeAccuracyAnnotator(train_file, ner_params['input_cols'], ner_params['output_col'],
-                                                       ner_params['label_column'], ner_params['entities'],
+                                                       ner_params['label_column'],
                                                        ner_params['min_epochs'], ner_params['max_epochs'],
                                                        ner_params['verbose'], ner_params['random_seed'],
                                                        ner_params['lr'], ner_params['po'], ner_params['batch_size'],
                                                        ner_params['dropout'], ner_params['graph_folder'],
-                                                       ner_params['config_proto_bytes'], ner_params['user_contrib'],
-                                                       ner_params['train_validation_prop'],
+                                                       ner_params['user_contrib'], ner_params['train_validation_prop'],
                                                        ner_params['evaluation_log_extended'],
                                                        ner_params['enable_output_logs'], ner_params['test_dataset'],
                                                        ner_params['include_confidence'],
@@ -60,12 +59,9 @@ class NerDLEvaluation(ExtendedJavaWrapper):
     def __getNerParams(self, ner):
         ner_params = dict()
         input_cols = ner.getInputCols()
-        entities = ner.getEntities()
-        config_proto_bytes = ner.getConfigProtoBytes()
         ner_params['input_cols'] = self.new_java_array_string(input_cols)
         ner_params['output_col'] = ner.getOutputCol()
         ner_params['label_column'] = ner.getLabelColumn()
-        ner_params['entities'] = self.new_java_array_string(entities)
         ner_params['min_epochs'] = ner.getMinEpochs()
         ner_params['max_epochs'] = ner.getMaxEpochs()
         ner_params['verbose'] = ner.getVerbose()
@@ -75,7 +71,6 @@ class NerDLEvaluation(ExtendedJavaWrapper):
         ner_params['batch_size'] = ner.getBatchSize()
         ner_params['dropout'] = ner.getDropout()
         ner_params['graph_folder'] = ner.getGraphFolder()
-        ner_params['config_proto_bytes'] = self.new_java_array_integer(config_proto_bytes)
         ner_params['user_contrib'] = ner.getUseContrib()
         ner_params['train_validation_prop'] = ner.getTranValidationProp()
         ner_params['evaluation_log_extended'] = ner.getEvaluationLogExtended()

--- a/python/sparknlp/eval.py
+++ b/python/sparknlp/eval.py
@@ -43,7 +43,16 @@ class NerDLEvaluation(ExtendedJavaWrapper):
         ner_params = self.__getNerParams(ner)
         embeddings_params = self.__getEmbeddingsParams(embeddings)
         return self._java_obj.computeAccuracyAnnotator(train_file, ner_params['input_cols'], ner_params['output_col'],
-                                                       ner_params['random_seed'], ner_params['label_column'],
+                                                       ner_params['label_column'], ner_params['entities'],
+                                                       ner_params['min_epochs'], ner_params['max_epochs'],
+                                                       ner_params['verbose'], ner_params['random_seed'],
+                                                       ner_params['lr'], ner_params['po'], ner_params['batch_size'],
+                                                       ner_params['dropout'], ner_params['graph_folder'],
+                                                       ner_params['config_proto_bytes'], ner_params['user_contrib'],
+                                                       ner_params['train_validation_prop'],
+                                                       ner_params['evaluation_log_extended'],
+                                                       ner_params['enable_output_logs'], ner_params['test_dataset'],
+                                                       ner_params['include_confidence'],
                                                        embeddings_params['input_cols'], embeddings_params['output_col'],
                                                        embeddings_params['path'], embeddings_params['dimension'],
                                                        embeddings_params['format'])
@@ -51,10 +60,28 @@ class NerDLEvaluation(ExtendedJavaWrapper):
     def __getNerParams(self, ner):
         ner_params = dict()
         input_cols = ner.getInputCols()
+        entities = ner.getEntities()
+        config_proto_bytes = ner.getConfigProtoBytes()
         ner_params['input_cols'] = self.new_java_array_string(input_cols)
         ner_params['output_col'] = ner.getOutputCol()
         ner_params['label_column'] = ner.getLabelColumn()
+        ner_params['entities'] = self.new_java_array_string(entities)
+        ner_params['min_epochs'] = ner.getMinEpochs()
+        ner_params['max_epochs'] = ner.getMaxEpochs()
+        ner_params['verbose'] = ner.getVerbose()
         ner_params['random_seed'] = ner.getRandomSeed()
+        ner_params['lr'] = ner.getLr()
+        ner_params['po'] = ner.getPo()
+        ner_params['batch_size'] = ner.getBatchSize()
+        ner_params['dropout'] = ner.getDropout()
+        ner_params['graph_folder'] = ner.getGraphFolder()
+        ner_params['config_proto_bytes'] = self.new_java_array_integer(config_proto_bytes)
+        ner_params['user_contrib'] = ner.getUseContrib()
+        ner_params['train_validation_prop'] = ner.getTranValidationProp()
+        ner_params['evaluation_log_extended'] = ner.getEvaluationLogExtended()
+        ner_params['enable_output_logs'] = ner.getEnableOutputLogs()
+        ner_params['test_dataset'] = ner.getTestDataset()
+        ner_params['include_confidence'] = ner.getIncludeConfidence()
         return ner_params
 
     def __getEmbeddingsParams(self, embeddings):
@@ -80,7 +107,11 @@ class NerCrfEvaluation(ExtendedJavaWrapper):
         ner_params = self.__getNerParams(ner)
         embeddings_params = self.__getEmbeddingsParams(embeddings)
         return self._java_obj.computeAccuracyAnnotator(train_file, ner_params['input_cols'], ner_params['output_col'],
-                                                       ner_params['random_seed'], ner_params['label_column'],
+                                                       ner_params['label_column'], ner_params['entities'],
+                                                       ner_params['min_epochs'], ner_params['max_epochs'],
+                                                       ner_params['verbose'], ner_params['random_seed'],
+                                                       ner_params['l2'], ner_params['c0'], ner_params['loss_eps'],
+                                                       ner_params['min_w'], ner_params['include_confidence'],
                                                        embeddings_params['input_cols'], embeddings_params['output_col'],
                                                        embeddings_params['path'], embeddings_params['dimension'],
                                                        embeddings_params['format'])
@@ -88,10 +119,20 @@ class NerCrfEvaluation(ExtendedJavaWrapper):
     def __getNerParams(self, ner):
         ner_params = dict()
         input_cols = ner.getInputCols()
+        entities = ner.getEntities()
         ner_params['input_cols'] = self.new_java_array_string(input_cols)
         ner_params['output_col'] = ner.getOutputCol()
         ner_params['label_column'] = ner.getLabelColumn()
+        ner_params['entities'] = self.new_java_array_string(entities)
+        ner_params['min_epochs'] = ner.getMinEpochs()
+        ner_params['max_epochs'] = ner.getMaxEpochs()
+        ner_params['verbose'] = ner.getVerbose()
         ner_params['random_seed'] = ner.getRandomSeed()
+        ner_params['l2'] = ner.getL2()
+        ner_params['c0'] = ner.getC0()
+        ner_params['loss_eps'] = ner.getLossEps()
+        ner_params['min_w'] = ner.getMinW()
+        ner_params['include_confidence'] = ner.getIncludeConfidence()
         return ner_params
 
     def __getEmbeddingsParams(self, embeddings):

--- a/python/sparknlp/eval.py
+++ b/python/sparknlp/eval.py
@@ -4,13 +4,34 @@ from sparknlp.internal import ExtendedJavaWrapper
 class NorvigSpellEvaluation(ExtendedJavaWrapper):
 
     def __init__(self, spark, test_file, ground_truth_file):
-        ExtendedJavaWrapper.__init__(self, "com.johnsnowlabs.nlp.eval.spell.NorvigSpellEvaluation", spark._jsparkSession, test_file, ground_truth_file)
+        ExtendedJavaWrapper.__init__(self, "com.johnsnowlabs.nlp.eval.spell.NorvigSpellEvaluation",
+                                     spark._jsparkSession, test_file, ground_truth_file)
 
     def computeAccuracyAnnotator(self, train_file, spell):
-        input_cols = spell.getInputCols()
-        output_col = spell.getOutputCol()
-        java_input_cols = self.new_java_array_string(input_cols)
-        return self._java_obj.computeAccuracyAnnotator(train_file, java_input_cols, output_col, spell.dictionary_path)
+        spell_params = self.__getNorvigParams(spell)
+        return self._java_obj \
+            .computeAccuracyAnnotator(train_file, spell_params['input_cols'], spell_params['output_col'],
+                                      spell.dictionary_path, spell_params['case_sensitive'],
+                                      spell_params['double_variants'], spell_params['short_circuit'],
+                                      spell_params['frequency_priority'], spell_params['word_size_ignore'],
+                                      spell_params['dups_limit'], spell_params['reduct_limit'],
+                                      spell_params['intersections'], spell_params['vowel_swap_limit'])
+
+    def __getNorvigParams(self, norvig):
+        spell_params = dict()
+        input_cols = norvig.getInputCols()
+        spell_params['input_cols'] = self.new_java_array_string(input_cols)
+        spell_params['output_col'] = norvig.getOutputCol()
+        spell_params['case_sensitive'] = norvig.getCaseSensitive()
+        spell_params['double_variants'] = norvig.getDoubleVariants()
+        spell_params['short_circuit'] = norvig.getShortCircuit()
+        spell_params['frequency_priority'] = norvig.getFrequencyPriority()
+        spell_params['word_size_ignore'] = norvig.getWordSizeIgnore()
+        spell_params['dups_limit'] = norvig.getDupsLimit()
+        spell_params['reduct_limit'] = norvig.getReductLimit()
+        spell_params['intersections'] = norvig.getIntersections()
+        spell_params['vowel_swap_limit'] = norvig.getVowelSwapLimit()
+        return spell_params
 
     def computeAccuracyModel(self, spell):
         return self._java_obj.computeAccuracyModel(spell._java_obj)
@@ -19,13 +40,27 @@ class NorvigSpellEvaluation(ExtendedJavaWrapper):
 class SymSpellEvaluation(ExtendedJavaWrapper):
 
     def __init__(self, spark, test_file, ground_truth_file):
-        ExtendedJavaWrapper.__init__(self, "com.johnsnowlabs.nlp.eval.spell.SymSpellEvaluation", spark._jsparkSession, test_file, ground_truth_file)
+        ExtendedJavaWrapper.__init__(self, "com.johnsnowlabs.nlp.eval.spell.SymSpellEvaluation", spark._jsparkSession,
+                                     test_file, ground_truth_file)
 
     def computeAccuracyAnnotator(self, train_file, spell):
+        spell_params = self.__getSymSpellParams(spell)
+        return self._java_obj \
+            .computeAccuracyAnnotator(train_file, spell_params['input_cols'], spell_params['output_col'],
+                                      spell.dictionary_path, spell_params['max_edit_distance'],
+                                      spell_params['frequency_threshold'], spell_params['deletes_threshold'],
+                                      spell_params['dups_limit'])
+
+    def __getSymSpellParams(self, spell):
+        spell_params = dict()
         input_cols = spell.getInputCols()
-        output_col = spell.getOutputCol()
-        java_input_cols = self.new_java_array_string(input_cols)
-        return self._java_obj.computeAccuracyAnnotator(train_file, java_input_cols, output_col, spell.dictionary_path)
+        spell_params['input_cols'] = self.new_java_array_string(input_cols)
+        spell_params['output_col'] = spell.getOutputCol()
+        spell_params['max_edit_distance'] = spell.getMaxEditDistance()
+        spell_params['frequency_threshold'] = spell.getFrequencyThreshold()
+        spell_params['deletes_threshold'] = spell.getDeletesThreshold()
+        spell_params['dups_limit'] = spell.getDupsLimit()
+        return spell_params
 
     def computeAccuracyModel(self, spell):
         return self._java_obj.computeAccuracyModel(spell._java_obj)
@@ -34,7 +69,8 @@ class SymSpellEvaluation(ExtendedJavaWrapper):
 class NerDLEvaluation(ExtendedJavaWrapper):
 
     def __init__(self, spark, test_file, tag_level=""):
-        ExtendedJavaWrapper.__init__(self, "com.johnsnowlabs.nlp.eval.ner.NerDLEvaluation", spark._jsparkSession, test_file, tag_level)
+        ExtendedJavaWrapper.__init__(self, "com.johnsnowlabs.nlp.eval.ner.NerDLEvaluation", spark._jsparkSession,
+                                     test_file, tag_level)
 
     def computeAccuracyModel(self, ner):
         return self._java_obj.computeAccuracyModel(ner._java_obj)

--- a/python/sparknlp/internal.py
+++ b/python/sparknlp/internal.py
@@ -33,6 +33,10 @@ class ExtendedJavaWrapper(JavaWrapper):
         java_array = self._new_java_array(pylist, self.sc._gateway.jvm.java.lang.String)
         return java_array
 
+    def new_java_array_integer(self, pylist):
+        java_array = self._new_java_array(pylist, self.sc._gateway.jvm.java.lang.Integer)
+        return java_array
+
 
 class _RegexRule(ExtendedJavaWrapper):
     def __init__(self, rule, identifier):

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerApproach.scala
@@ -22,6 +22,7 @@ trait NerApproach[T <: NerApproach[_]] extends Params {
 
   def getMinEpochs: Int = $(minEpochs)
   def getMaxEpochs: Int = $(maxEpochs)
+  def getVerbose: Int = $(verbose)
   def getRandomSeed: Int = $(randomSeed)
 
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingApproach.scala
@@ -1,13 +1,12 @@
 package com.johnsnowlabs.nlp.annotators.spell.norvig
 
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorApproach}
 import com.johnsnowlabs.nlp.annotators.param.ExternalResourceParam
+import com.johnsnowlabs.nlp.util.io.ResourceHelper.spark.implicits._
 import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorApproach}
 import org.apache.spark.ml.PipelineModel
-import org.apache.spark.ml.param.IntParam
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.sql.{AnalysisException, Dataset}
-import ResourceHelper.spark.implicits._
 
 class NorvigSweetingApproach(override val uid: String)
   extends AnnotatorApproach[NorvigSweetingModel]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Includes changes to use the parameters set by the user when training annotators in the evaluation module for python side.

## Description
<!--- Describe your changes in detail -->
Added getters and default parameter values on annotator.py and update the call to compute the accuracy of annotators on eval.py

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, eval module in case of annotators is trained just with default values when using python. This change will allow the module to take the values set by the user on annotators.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and python notebooks

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
