### PR TITLE
setting the max buffer limit for kyroserializer

### DIFF
--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -36,7 +36,8 @@ def start(include_ocr=False):
         .appName("Spark NLP") \
         .master("local[*]") \
         .config("spark.driver.memory", "6G") \
-        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer", "600M")
+        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer") \
+        .config("spark.kryoserializer.buffer.max", "600M")
 
 
 

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -36,7 +36,9 @@ def start(include_ocr=False):
         .appName("Spark NLP") \
         .master("local[*]") \
         .config("spark.driver.memory", "6G") \
-        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer", "600M")
+
+
 
     if include_ocr:
         builder \


### PR DESCRIPTION
setting the max buffer limit for kyroserializer while initializing the spark with sparknlp
<!--- Provide a general summary of your changes in the Title above -->

## Description
max buffer set to 600M to get over kyroserializer error while integrating SparkML transformers within SparkNLP annotaters in the same pipeline
<!--- Describe your changes in detail -->


## Motivation and Context
when I tried to start the session with SparkSession  and set the configs properly (kyroserializer etc), I am not able to use sparknlp annotators.. for example, DocumentAssembler() is not callable.. but when I start the session with sparknlp.start(), it's fine.. However, in that case, I am not able to use sparkML transformers such as Word2Vec inside the pipeline with sparkNLP annotators.. it gives kyroserializer not enough buffer error.. so we may need to set max buffer while init Spark through SparkNLP.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] Code improvements with no or little impact
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
