### PR TITLE
explodeAnnotations logic added for Finisher

### DIFF
--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -319,6 +319,7 @@ class Finisher(AnnotatorTransformer):
     cleanAnnotations = Param(Params._dummy(), "cleanAnnotations", "whether to remove annotation columns", typeConverter=TypeConverters.toBoolean)
     includeMetadata = Param(Params._dummy(), "includeMetadata", "annotation metadata format", typeConverter=TypeConverters.toBoolean)
     outputAsArray = Param(Params._dummy(), "outputAsArray", "finisher generates an Array with the results instead of string", typeConverter=TypeConverters.toBoolean)
+    explodedCol = Param(Params._dummy(), "explodedCol", "name of the column that will be exploded")
 
     name = "Finisher"
 
@@ -328,7 +329,8 @@ class Finisher(AnnotatorTransformer):
         self._setDefault(
             cleanAnnotations=True,
             includeMetadata=False,
-            outputAsArray=True
+            outputAsArray=True,
+            explodedCol=""
         )
 
     @keyword_only
@@ -356,3 +358,6 @@ class Finisher(AnnotatorTransformer):
 
     def setOutputAsArray(self, value):
         return self._set(outputAsArray=value)
+
+    def setExplodeAnnotations(self, value):
+        return self._set(explodedCol=value)

--- a/src/main/scala/com/johnsnowlabs/nlp/Finisher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Finisher.scala
@@ -24,6 +24,8 @@ class Finisher(override val uid: String)
     new BooleanParam(this, "includeMetadata", "annotation metadata format")
   protected val outputAsArray: BooleanParam =
     new BooleanParam(this, "outputAsArray", "finisher generates an Array with the results instead of string")
+  protected val explodedCol:  Param[String] =
+    new Param(this, "explodedCol", "name of the column that will be exploded")
 
   def setInputCols(value: Array[String]): this.type = set(inputCols, value)
   def setInputCols(value: String*): this.type = setInputCols(value.toArray)
@@ -34,6 +36,7 @@ class Finisher(override val uid: String)
   def setCleanAnnotations(value: Boolean): this.type = set(cleanAnnotations, value)
   def setIncludeMetadata(value: Boolean): this.type = set(includeMetadata, value)
   def setOutputAsArray(value: Boolean): this.type = set(outputAsArray, value)
+  def setExplodeAnnotations(value: String): this.type = set(explodedCol, value)
 
   def getOutputCols: Array[String] = get(outputCols).getOrElse(getInputCols.map("finished_" + _))
   def getInputCols: Array[String] = $(inputCols)
@@ -42,11 +45,13 @@ class Finisher(override val uid: String)
   def getCleanAnnotations: Boolean = $(cleanAnnotations)
   def getIncludeMetadata: Boolean = $(includeMetadata)
   def getOutputAsArray: Boolean = $(outputAsArray)
+  def getExplodeAnnotations: String = $(explodedCol)
 
   setDefault(
     cleanAnnotations -> true,
     includeMetadata -> false,
-    outputAsArray -> true)
+    outputAsArray -> true,
+    explodedCol -> "")
 
   def this() = this(Identifiable.randomUID("finisher"))
 
@@ -117,6 +122,14 @@ class Finisher(override val uid: String)
       flattened.schema.fields
         .filter(_.dataType == ArrayType(Annotation.dataType))
         .map(_.name):_*)
+
+    if (flattened.schema.fieldNames.contains($(explodedCol))) 
+      /* if explodedCol is not specified, it will be empty as a default and 
+    ignored as it's already not in the filed names. 
+    So, any string that's not inside filednames will be ignored and will not trigger anything.
+    This will also override the previous steps and the only filds returned will be the exploded struct fields */
+      flattened.withColumn(
+        "tmp", explode(col($(explodedCol)))).select(col("tmp.*"))
       
     else flattened.toDF()
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

adding explodeAnnotations param to finisher so that it can be used not just at the end but whenever it's required across the pipelines.

## Description
<!--- Describe your changes in detail -->
explodedCol is added as a param and if it is not specified, it will be empty as a default and ignored as it's already not in the flled names. 
So, any string that's not inside fieldnames will be ignored and will not trigger anything.
This will also override the previous steps and the only fields returned will be the exploded struct fields.

## Motivation and Context

sometimes we need to export the processed output to csv or somewhere.. so it would make Finisher an intermediary solution that can be used across the pipeline.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
local test applied but I didn't update the test scripts in repo. We may also need to specify if the type of explodedCol is Array. Otherwise it would fail.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
