### PR TITLE
enableScore flag for SentimentDetector/Model to output score as double

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -705,11 +705,17 @@ class SentimentDetector(AnnotatorApproach):
                               "multiplier for revert sentiments. Defaults -1.0",
                               typeConverter=TypeConverters.toFloat)
 
+    enableScore = Param(Params._dummy(),
+                        "enableScore",
+                        "if true, score will show as the double value, else will output string \"positive\" or \"negative\". Defaults false",
+                        typeConverter=TypeConverters.toBoolean)
+
+
     def __init__(self):
         super(SentimentDetector, self).__init__(
             classname="com.johnsnowlabs.nlp.annotators.sda.pragmatic.SentimentDetector")
         self._setDefault(positiveMultiplier=1.0, negativeMultiplier=-1.0, incrementMultiplier=2.0,
-                         decrementMultiplier=-2.0, reverseMultiplier=-1.0)
+                         decrementMultiplier=-2.0, reverseMultiplier=-1.0, enableScore=False)
 
     def setDictionary(self, path, delimiter, read_as=ReadAs.LINE_BY_LINE, options={'format': 'text'}):
         opts = options.copy()

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/SentimentDetector.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/SentimentDetector.scala
@@ -5,7 +5,7 @@ import com.johnsnowlabs.nlp.AnnotatorType.{DOCUMENT, SENTIMENT, TOKEN}
 import com.johnsnowlabs.nlp.annotators.param.ExternalResourceParam
 import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
 import org.apache.spark.ml.PipelineModel
-import org.apache.spark.ml.param.DoubleParam
+import org.apache.spark.ml.param.{DoubleParam, BooleanParam}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.sql.Dataset
 
@@ -24,6 +24,7 @@ class SentimentDetector(override val uid: String) extends AnnotatorApproach[Sent
   val incrementMultiplier = new DoubleParam(this, "incrementMultiplier", "multiplier for increment sentiments. Defaults 2.0")
   val decrementMultiplier = new DoubleParam(this, "decrementMultiplier", "multiplier for decrement sentiments. Defaults -2.0")
   val reverseMultiplier = new DoubleParam(this, "reverseMultiplier", "multiplier for revert sentiments. Defaults -1.0")
+  val enableScore = new BooleanParam(this, "enableScore", "if true, score will show as the double value, else will output string \"positive\" or \"negative\". Defaults false")
 
   val dictionary = new ExternalResourceParam(this, "dictionary", "delimited file with a list sentiment tags per word. Requires 'delimiter' in options")
 
@@ -32,7 +33,8 @@ class SentimentDetector(override val uid: String) extends AnnotatorApproach[Sent
     negativeMultiplier -> -1.0,
     incrementMultiplier -> 2.0,
     decrementMultiplier -> -2.0,
-    reverseMultiplier -> -1.0
+    reverseMultiplier -> -1.0,
+    enableScore -> false
   )
 
   def setPositiveMultiplier(v: Double): this.type = set(positiveMultiplier, v)
@@ -40,6 +42,7 @@ class SentimentDetector(override val uid: String) extends AnnotatorApproach[Sent
   def setIncrementMultiplier(v: Double): this.type = set(incrementMultiplier, v)
   def setDecrementMultiplier(v: Double): this.type = set(decrementMultiplier, v)
   def setReverseMultiplier(v: Double): this.type = set(reverseMultiplier, v)
+  def setEnableScore(v: Boolean): this.type = set(enableScore, v)
 
   def setDictionary(value: ExternalResource): this.type = {
     require(value.options.contains("delimiter"), "dictionary needs 'delimiter' in order to separate words from sentiment tags")
@@ -59,6 +62,7 @@ class SentimentDetector(override val uid: String) extends AnnotatorApproach[Sent
       .setPositiveMultipler($(positiveMultiplier))
       .setNegativeMultipler($(negativeMultiplier))
       .setReverseMultipler($(reverseMultiplier))
+      .setEnableScore($(enableScore))
       .setSentimentDict(ResourceHelper.parseKeyValueText($(dictionary)))
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/SentimentDetectorModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/SentimentDetectorModel.scala
@@ -63,7 +63,7 @@ class SentimentDetectorModel(override val uid: String) extends AnnotatorModel[Se
       outputAnnotatorType,
       0,
       0,
-      { if ($(enableScore)) score.toString() else if (score >= 0) "positive" else "negative"},
+      { if ($(enableScore)) score.toString else if (score >= 0) "positive" else "negative"},
       Map.empty[String, String]
     ))
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/SentimentDetectorModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/SentimentDetectorModel.scala
@@ -63,7 +63,7 @@ class SentimentDetectorModel(override val uid: String) extends AnnotatorModel[Se
       outputAnnotatorType,
       0,
       0,
-      { if (enableScore) score else if (score >= 0) "positive" else "negative"},
+      { if (enableScore.equals(true)) score.toString() else if (score >= 0) "positive" else "negative"},
       Map.empty[String, String]
     ))
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/SentimentDetectorModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/SentimentDetectorModel.scala
@@ -3,7 +3,7 @@ package com.johnsnowlabs.nlp.annotators.sda.pragmatic
 import com.johnsnowlabs.nlp.annotators.common.TokenizedWithSentence
 import com.johnsnowlabs.nlp.serialization.MapFeature
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, ParamsAndFeaturesReadable}
-import org.apache.spark.ml.param.DoubleParam
+import org.apache.spark.ml.param.{DoubleParam, BooleanParam}
 import org.apache.spark.ml.util.Identifiable
 
 /**
@@ -35,12 +35,14 @@ class SentimentDetectorModel(override val uid: String) extends AnnotatorModel[Se
   val incrementMultiplier = new DoubleParam(this, "incrementMultiplier", "multiplier for increment sentiments. Defaults 2.0")
   val decrementMultiplier = new DoubleParam(this, "decrementMultiplier", "multiplier for decrement sentiments. Defaults -2.0")
   val reverseMultiplier = new DoubleParam(this, "reverseMultiplier", "multiplier for revert sentiments. Defaults -1.0")
+  val enableScore = new BooleanParam(this, "enableScore", "if true, score will show as the double value, else will output string \"positive\" or \"negative\". Defaults false")
 
   def setPositiveMultipler(v: Double): this.type = set(positiveMultiplier, v)
   def setNegativeMultipler(v: Double): this.type = set(negativeMultiplier, v)
   def setIncrementMultipler(v: Double): this.type = set(incrementMultiplier, v)
   def setDecrementMultipler(v: Double): this.type = set(decrementMultiplier, v)
   def setReverseMultipler(v: Double): this.type = set(reverseMultiplier, v)
+  def setEnableScore(v: Boolean): this.type = set(enableScore, v)
 
   def setSentimentDict(value: Map[String, String]): this.type = set(sentimentDict, value)
 
@@ -61,7 +63,7 @@ class SentimentDetectorModel(override val uid: String) extends AnnotatorModel[Se
       outputAnnotatorType,
       0,
       0,
-      { if (score >= 0) "positive" else "negative"},
+      { if (enableScore) score else if (score >= 0) "positive" else "negative"},
       Map.empty[String, String]
     ))
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/SentimentDetectorModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/SentimentDetectorModel.scala
@@ -35,7 +35,7 @@ class SentimentDetectorModel(override val uid: String) extends AnnotatorModel[Se
   val incrementMultiplier = new DoubleParam(this, "incrementMultiplier", "multiplier for increment sentiments. Defaults 2.0")
   val decrementMultiplier = new DoubleParam(this, "decrementMultiplier", "multiplier for decrement sentiments. Defaults -2.0")
   val reverseMultiplier = new DoubleParam(this, "reverseMultiplier", "multiplier for revert sentiments. Defaults -1.0")
-  val enableScore = new BooleanParam(this, "enableScore", "if true, score will show as the double value, else will output string \"positive\" or \"negative\". Defaults false")
+  val enableScore = new BooleanParam(this, "enableScore", "if true, score will show as a string type containing a double value, else will output string \"positive\" or \"negative\". Defaults false")
 
   def setPositiveMultipler(v: Double): this.type = set(positiveMultiplier, v)
   def setNegativeMultipler(v: Double): this.type = set(negativeMultiplier, v)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/SentimentDetectorModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/SentimentDetectorModel.scala
@@ -63,7 +63,7 @@ class SentimentDetectorModel(override val uid: String) extends AnnotatorModel[Se
       outputAnnotatorType,
       0,
       0,
-      { if (enableScore.equals(true)) score.toString() else if (score >= 0) "positive" else "negative"},
+      { if ($(enableScore)) score.toString() else if (score >= 0) "positive" else "negative"},
       Map.empty[String, String]
     ))
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/PragmaticSentimentTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/PragmaticSentimentTestSpec.scala
@@ -28,6 +28,7 @@ class PragmaticSentimentBigTestSpec extends FlatSpec {
       .setInputCols(Array("token", "sentence"))
       .setOutputCol("my_sda_scores")
       .setDictionary(ExternalResource("src/test/resources/sentiment-corpus/default-sentiment-dict.txt", ReadAs.LINE_BY_LINE, Map("delimiter" -> ",")))
+      .setEnableScore(false)
       .fit(readyData)
       .transform(readyData)
 


### PR DESCRIPTION
Added a flag to allow for the score from the SentimentDetector/Model to output as a double rather than the current "positive" or "negative". I also added the python support.

## Motivation and Context
This change allows for sorting and comparing sentiment scores on articles, rather than the binary positive or negative before. It will allow greater analysis and insight into the text.

## How Has This Been Tested?
I built and deployed this change on a Spark cluster and tested the functionality with success. The cluster are all linux boxes. I also then disabled the flag (by letting it default) and ran it again, with the original expected result.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. <-- I'm happy to update it, I just don't know how I can. Should be only a sentence, if that.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. <-- "sbt test" ran without issue
