### PR TITLE
Aws profile name resource download

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -70,10 +70,10 @@ object ResourceDownloader {
       return Some(new ProfileCredentialsProvider(awsProfile.get).getCredentials)
     }
     if (accessKeyId.isEmpty || secretAccessKey.isEmpty) {
-      fetchcredentials
+      return fetchcredentials
     }
     else
-      Some(new BasicAWSCredentials(accessKeyId.get, secretAccessKey.get))
+      return Some(new BasicAWSCredentials(accessKeyId.get, secretAccessKey.get))
   }
   else {
     fetchcredentials

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -81,23 +81,31 @@ object ResourceDownloader {
 
   private def fetchcredentials(): Option[AWSCredentials] = {
     try {
-
-      Some(new DefaultAWSCredentialsProviderChain().getCredentials)
+      //check if default profile name works if not try 
+      return Some(new ProfileCredentialsProvider("spark_nlp").getCredentials)
     } catch {
-      case awse: AmazonClientException => {
-        if (ResourceHelper.spark.sparkContext.hadoopConfiguration.get("fs.s3a.access.key") != null) {
+      case e: Exception => {
+        try {
 
-          val key = ResourceHelper.spark.sparkContext.hadoopConfiguration.get("fs.s3a.access.key")
-          val secret = ResourceHelper.spark.sparkContext.hadoopConfiguration.get("fs.s3a.secret.key")
+          Some(new DefaultAWSCredentialsProviderChain().getCredentials)
+        } catch {
+          case awse: AmazonClientException => {
+            if (ResourceHelper.spark.sparkContext.hadoopConfiguration.get("fs.s3a.access.key") != null) {
 
-          Some(new BasicAWSCredentials(key, secret))
-        } else {
-          Some(new AnonymousAWSCredentials())
+              val key = ResourceHelper.spark.sparkContext.hadoopConfiguration.get("fs.s3a.access.key")
+              val secret = ResourceHelper.spark.sparkContext.hadoopConfiguration.get("fs.s3a.secret.key")
+
+              Some(new BasicAWSCredentials(key, secret))
+            } else {
+              Some(new AnonymousAWSCredentials())
+            }
+          }
+          case e: Exception => throw e
+
         }
       }
-      case e: Exception => throw e
-
     }
+
   }
 
   val publicLoc = "public/models"

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -67,7 +67,7 @@ object ResourceDownloader {
     val secretAccessKey = ConfigHelper.getConfigValue(ConfigHelper.secretAccessKey)
     val awsProfile = ConfigHelper.getConfigValue(ConfigHelper.awsProfileName)
     if (awsProfile.isDefined) {
-      Some(new ProfileCredentialsProvider(awsProfile.get))
+      return Some(new ProfileCredentialsProvider(awsProfile.get).getCredentials)
     }
     if (accessKeyId.isEmpty || secretAccessKey.isEmpty) {
       fetchcredentials

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -1,6 +1,7 @@
 package com.johnsnowlabs.nlp.pretrained
 
 import com.amazonaws.AmazonClientException
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{DefaultAWSCredentialsProviderChain, _}
 import com.johnsnowlabs.nlp.DocumentAssembler
 import com.johnsnowlabs.nlp.annotators._
@@ -64,6 +65,10 @@ object ResourceDownloader {
   def credentials: Option[AWSCredentials] = if (ConfigHelper.hasPath(ConfigHelper.awsCredentials)) {
     val accessKeyId = ConfigHelper.getConfigValue(ConfigHelper.accessKeyId)
     val secretAccessKey = ConfigHelper.getConfigValue(ConfigHelper.secretAccessKey)
+    val awsProfile = ConfigHelper.getConfigValue(ConfigHelper.awsProfileName)
+    if (awsProfile.isDefined) {
+      Some(new ProfileCredentialsProvider(awsProfile.get))
+    }
     if (accessKeyId.isEmpty || secretAccessKey.isEmpty) {
       fetchcredentials
     }

--- a/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
@@ -35,6 +35,7 @@ object ConfigHelper {
   // Stores credentials for AWS S3 private models
   val awsCredentials = "sparknlp.settings.pretrained.credentials"
 
+
   val accessKeyId = awsCredentials + ".access_key_id"
   val secretAccessKey = awsCredentials + ".secret_access_key"
   val awsProfileName = awsCredentials + ".aws_profile_name"

--- a/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
@@ -37,6 +37,7 @@ object ConfigHelper {
 
   val accessKeyId = awsCredentials + ".access_key_id"
   val secretAccessKey = awsCredentials + ".secret_access_key"
+  val awsProfileName = awsCredentials + ".aws_profile_name"
 
   val s3SocketTimeout = "sparknlp.settings.pretrained.s3_socket_timeout"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
If sparknlp.settings.pretrained.credentials.aws_profile_name setting is set then the profile name will be used to make s3 connection.
## Description
<!--- Describe your changes in detail -->
The credential method will now give the first priority to the aws profile name set in application conf for variable sparknlp.settings.pretrained.credentials.aws_profile_name. Followed by the AWS Keys i.e sparknlp.settings.pretrained.credentials.access_key_id and sparknlp.settings.pretrained.credentials.secret_access_key

if the settings are not found it will then lookup default profile with name spark_nlp. If Even that is not found then it will use the AWS Default credential chain lookup.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
it will allow user to have a specific profile in there aws config or set up spark_nlp as a profile name in aws config which can be automatically looked up if set.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
tested locally on notebook
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
