### PR TITLE
Introducing EmbeddingsFinisher Transformer

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -30,6 +30,7 @@ unittest.TextTestRunner().run(SentenceEmbeddingsTestSpec())
 unittest.TextTestRunner().run(StopWordsCleanerTestSpec())
 unittest.TextTestRunner().run(NGramGeneratorTestSpec())
 unittest.TextTestRunner().run(ChunkEmbeddingsTestSpec())
+unittest.TextTestRunner().run(EmbeddingsFinisherTestSpec())
 
 # Misc tests
 unittest.TextTestRunner().run(UtilitiesTestSpec())

--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -343,3 +343,44 @@ class Finisher(AnnotatorTransformer):
 
     def setParseEmbeddingsVectors(self, value):
         return self._set(parseEmbeddingsVectors=value)
+
+
+class EmbeddingsFinisher(AnnotatorTransformer):
+
+    inputCols = Param(Params._dummy(), "inputCols", "name of input annotation cols containing embeddings", typeConverter=TypeConverters.toListString)
+    outputCols = Param(Params._dummy(), "outputCols", "output EmbeddingsFinisher ouput cols", typeConverter=TypeConverters.toListString)
+    cleanAnnotations = Param(Params._dummy(), "cleanAnnotations", "whether to remove all the existing annotation columns", typeConverter=TypeConverters.toBoolean)
+    outputAsVector = Param(Params._dummy(), "outputAsVector", "if enabled it will output the embeddings as Vectors instead of arrays", typeConverter=TypeConverters.toBoolean)
+
+    name = "EmbeddingsFinisher"
+
+    @keyword_only
+    def __init__(self):
+        super(EmbeddingsFinisher, self).__init__(classname="com.johnsnowlabs.nlp.EmbeddingsFinisher")
+        self._setDefault(
+            cleanAnnotations=False,
+            outputAsVector=False
+        )
+
+    @keyword_only
+    def setParams(self):
+        kwargs = self._input_kwargs
+        return self._set(**kwargs)
+
+    def setInputCols(self, *value):
+        if len(value) == 1 and type(value[0]) == list:
+            return self._set(inputCols=value[0])
+        else:
+            return self._set(inputCols=list(value))
+
+    def setOutputCols(self, *value):
+        if len(value) == 1 and type(value[0]) == list:
+            return self._set(outputCols=value[0])
+        else:
+            return self._set(outputCols=list(value))
+
+    def setCleanAnnotations(self, value):
+        return self._set(cleanAnnotations=value)
+
+    def setOutputAsVector(self, value):
+        return self._set(outputAsVector=value)

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -4,6 +4,8 @@ from sparknlp.annotator import *
 from sparknlp.base import *
 from sparknlp.embeddings import *
 from test.util import SparkContextForTest
+from pyspark.ml.feature import SQLTransformer
+from pyspark.ml.clustering import KMeans
 
 
 class BasicAnnotatorsTestSpec(unittest.TestCase):
@@ -907,3 +909,49 @@ class ChunkEmbeddingsTestSpec(unittest.TestCase):
 
         model = pipeline.fit(self.data)
         model.transform(self.data).show()
+
+
+class EmbeddingsFinisherTestSpec(unittest.TestCase):
+
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+    def runTest(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+        sentence_detector = SentenceDetector() \
+            .setInputCols(["document"]) \
+            .setOutputCol("sentence")
+        tokenizer = Tokenizer() \
+            .setInputCols(["sentence"]) \
+            .setOutputCol("token")
+        glove = WordEmbeddingsModel.pretrained() \
+            .setInputCols(["sentence", "token"]) \
+            .setOutputCol("embeddings")
+        sentence_embeddings = SentenceEmbeddings() \
+            .setInputCols(["sentence", "embeddings"]) \
+            .setOutputCol("sentence_embeddings") \
+            .setPoolingStrategy("AVERAGE")
+        embeddings_finisher = EmbeddingsFinisher() \
+            .setInputCols("sentence_embeddings") \
+            .setOutputCols("sentence_embeddings_vectors") \
+            .setOutputAsVector(True)
+        explode_vectors = SQLTransformer(statement="SELECT EXPLODE(sentence_embeddings_vectors) AS features, * FROM __THIS__")
+        kmeans = KMeans().setK(2).setSeed(1).setFeaturesCol("features")
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            sentence_detector,
+            tokenizer,
+            glove,
+            sentence_embeddings,
+            embeddings_finisher,
+            explode_vectors,
+            kmeans
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()
+

--- a/src/main/scala/com/johnsnowlabs/nlp/EmbeddingsFinisher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/EmbeddingsFinisher.scala
@@ -21,7 +21,7 @@ class EmbeddingsFinisher(override val uid: String)
   protected val cleanAnnotations: BooleanParam =
     new BooleanParam(this, "cleanAnnotations", "whether to remove all the existing annotation columns")
   protected val outputAsVector: BooleanParam =
-    new BooleanParam(this, "outputAsVector", "if it is enabled it will output the embeddings as array of Vectors instead of array of arrays")
+    new BooleanParam(this, "outputAsVector", "if enabled it will output the embeddings as Vectors instead of arrays")
 
   def setInputCols(value: Array[String]): this.type = set(inputCols, value)
   def setInputCols(value: String*): this.type = setInputCols(value.toArray)

--- a/src/main/scala/com/johnsnowlabs/nlp/EmbeddingsFinisher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/EmbeddingsFinisher.scala
@@ -1,0 +1,139 @@
+package com.johnsnowlabs.nlp
+
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
+import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.ml.param.{BooleanParam, ParamMap, StringArrayParam}
+import org.apache.spark.ml.util.{DefaultParamsWritable, Identifiable}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Dataset, Row}
+
+class EmbeddingsFinisher(override val uid: String)
+  extends Transformer
+    with DefaultParamsWritable {
+
+  protected val inputCols: StringArrayParam =
+    new StringArrayParam(this, "inputCols", "name of input annotation cols containing embeddings")
+  protected val outputCols: StringArrayParam =
+    new StringArrayParam(this, "outputCols", "name of EmbeddingsFinisher output cols")
+  protected val cleanAnnotations: BooleanParam =
+    new BooleanParam(this, "cleanAnnotations", "whether to remove all the existing annotation columns")
+  protected val outputAsVector: BooleanParam =
+    new BooleanParam(this, "outputAsVector", "if it is enabled it will output the embeddings as array of Vectors instead of array of arrays")
+
+  def setInputCols(value: Array[String]): this.type = set(inputCols, value)
+  def setInputCols(value: String*): this.type = setInputCols(value.toArray)
+  def setOutputCols(value: Array[String]): this.type = set(outputCols, value)
+  def setOutputCols(value: String*): this.type = setOutputCols(value.toArray)
+  def setCleanAnnotations(value: Boolean): this.type = set(cleanAnnotations, value)
+  def setOutputAsVector(value: Boolean): this.type = set(outputAsVector, value)
+
+  def getOutputCols: Array[String] = get(outputCols).getOrElse(getInputCols.map("finished_" + _))
+  def getInputCols: Array[String] = $(inputCols)
+  def getCleanAnnotations: Boolean = $(cleanAnnotations)
+  def getOutputAsVector: Boolean = $(outputAsVector)
+
+  setDefault(
+    cleanAnnotations -> true,
+    outputAsVector -> false
+  )
+
+  def this() = this(Identifiable.randomUID("embeddings_finisher"))
+
+  override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
+
+  override def transformSchema(schema: StructType): StructType = {
+
+    require(getInputCols.length == getOutputCols.length, "inputCols and outputCols length must match")
+
+    val embeddingsAnnotators = Seq(
+      AnnotatorType.WORD_EMBEDDINGS,
+      AnnotatorType.CHUNK_EMBEDDINGS,
+      AnnotatorType.SENTENCE_EMBEDDINGS
+    )
+
+    getInputCols.foreach {
+      annotationColumn =>
+
+        /**
+          * Check if the inpuptCols exist
+          */
+        require(getInputCols.forall(schema.fieldNames.contains),
+          s"pipeline annotator stages incomplete. " +
+            s"expected: ${getInputCols.mkString(", ")}, " +
+            s"found: ${schema.fields.filter(_.dataType == ArrayType(Annotation.dataType)).map(_.name).mkString(", ")}, " +
+            s"among available: ${schema.fieldNames.mkString(", ")}")
+
+        /**
+          * Check if the annotationColumn is(are) Spark NLP annotations
+          */
+        require(schema(annotationColumn).dataType == ArrayType(Annotation.dataType),
+          s"column [$annotationColumn] must be an NLP Annotation column")
+
+        /**
+          * Check if the annotationColumn has embeddings
+          * It must be at least of one these annotators: WordEmbeddings, BertEmbeddings, ChunkEmbeddings, or SentenceEmbeddings
+          */
+        require(embeddingsAnnotators.contains(schema(annotationColumn).metadata.getString("annotatorType")),
+          s"column [$annotationColumn] must be a type of either WordEmbeddings, BertEmbeddings, ChunkEmbeddings, or SentenceEmbeddings")
+
+    }
+    val metadataFields =  getOutputCols.flatMap(outputCol => {
+      if ($(outputAsVector))
+        Some(StructField(outputCol + "_metadata", MapType(StringType, StringType), nullable = false))
+      else
+        None
+    })
+
+    val outputFields = schema.fields ++
+      getOutputCols.map(outputCol => {
+        if ($(outputAsVector))
+          StructField(outputCol, ArrayType(VectorType), nullable = false)
+        else
+          StructField(outputCol, ArrayType(FloatType), nullable = false)
+      }) ++ metadataFields
+
+    val cleanFields = if ($(cleanAnnotations)) outputFields.filterNot(f =>
+      f.dataType == ArrayType(Annotation.dataType)
+    ) else outputFields
+    StructType(cleanFields)
+  }
+
+  private def vectorsAsArray: UserDefinedFunction = udf { embeddings: Seq[Seq[Float]] =>
+    embeddings
+  }
+
+  private def vectorsAsVectorType: UserDefinedFunction = udf { embeddings: Seq[Seq[Float]] =>
+    embeddings.map(embedding =>
+      Vectors.dense(embedding.toArray.map(_.toDouble))
+    )
+  }
+
+  override def transform(dataset: Dataset[_]): Dataset[Row] = {
+    require(getInputCols.length == getOutputCols.length, "inputCols and outputCols length must match")
+
+    val cols = getInputCols.zip(getOutputCols)
+    var flattened = dataset
+    cols.foreach { case (inputCol, outputCol) =>
+      flattened = {
+        flattened.withColumn(
+          outputCol, {
+            if ($(outputAsVector))
+              vectorsAsVectorType(flattened.col(inputCol + ".embeddings"))
+            else
+              vectorsAsArray(flattened.col(inputCol + ".embeddings"))
+          }
+        )
+      }
+    }
+
+    if ($(cleanAnnotations)) flattened.drop(
+      flattened.schema.fields
+        .filter(_.dataType == ArrayType(Annotation.dataType))
+        .map(_.name):_*)
+    else flattened.toDF()
+  }
+
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/EmbeddingsFinisherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/EmbeddingsFinisherTestSpec.scala
@@ -153,12 +153,12 @@ class EmbeddingsFinisherTestSpec extends FlatSpec {
     pielineDF.show()
     pielineDF.printSchema()
 
-    pielineDF.select(size(pielineDF("finished_embeddings")).as("sentence_embeddings_size")).show
-    pielineDF.select("finished_embeddings").show(2 ,false)
+    pielineDF.select(size(pielineDF("embeddings_vectors")).as("sentence_embeddings_size")).show
+    pielineDF.select("embeddings_vectors").show(2 ,false)
 
 
-    pielineDF.select(size(pielineDF("finished_sentence_embeddings")).as("sentence_embeddings_size")).show
-    pielineDF.select("finished_sentence_embeddings").show(2 ,false)
+    pielineDF.select(size(pielineDF("sentence_embeddings_vectors")).as("sentence_embeddings_size")).show
+    pielineDF.select("sentence_embeddings_vectors").show(2 ,false)
 
     pielineDF.select("features").show(2 ,false)
 

--- a/src/test/scala/com/johnsnowlabs/nlp/EmbeddingsFinisherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/EmbeddingsFinisherTestSpec.scala
@@ -1,0 +1,169 @@
+package com.johnsnowlabs.nlp
+
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
+import com.johnsnowlabs.nlp.embeddings.{SentenceEmbeddings, WordEmbeddingsModel}
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import org.apache.spark.ml.clustering.KMeans
+import org.apache.spark.ml.evaluation.ClusteringEvaluator
+import org.apache.spark.ml.feature.{Normalizer, SQLTransformer}
+import org.apache.spark.sql.functions.{explode, size}
+import org.scalatest._
+
+class EmbeddingsFinisherTestSpec extends FlatSpec {
+
+  "EmbeddingsFinisher" should "correctly transform embeddings into array of floats for K-Mean in Spark ML" in {
+
+    import ResourceHelper.spark.implicits._
+
+    val smallCorpus = ResourceHelper.spark.read.option("header","true").csv("src/test/resources/embeddings/sentence_embeddings.csv")
+
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentence = new SentenceDetector()
+      .setInputCols("document")
+      .setOutputCol("sentence")
+      .setExplodeSentences(false)
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("sentence"))
+      .setOutputCol("token")
+
+    val embeddings = WordEmbeddingsModel.pretrained()
+      .setInputCols("sentence", "token")
+      .setOutputCol("embeddings")
+      .setCaseSensitive(false)
+
+    val embeddingsSentence = new SentenceEmbeddings()
+      .setInputCols(Array("sentence", "embeddings"))
+      .setOutputCol("sentence_embeddings")
+      .setPoolingStrategy("AVERAGE")
+
+    val embeddingsFinisher = new EmbeddingsFinisher()
+      .setInputCols("sentence_embeddings", "embeddings")
+      .setOutputCols("finished_sentence_embeddings", "finished_embeddings")
+      .setOutputAsVector(false)
+      .setCleanAnnotations(false)
+
+    val pipeline = new RecursivePipeline()
+      .setStages(Array(
+        documentAssembler,
+        sentence,
+        tokenizer,
+        embeddings,
+        embeddingsSentence,
+        embeddingsFinisher
+      ))
+
+    val pipelineDF = pipeline.fit(smallCorpus).transform(smallCorpus)
+
+    pipelineDF.select(size(pipelineDF("finished_embeddings")).as("sentence_embeddings_size")).show
+    pipelineDF.select("finished_embeddings").show(2 ,false)
+
+
+    pipelineDF.select(size(pipelineDF("finished_sentence_embeddings")).as("sentence_embeddings_size")).show
+    pipelineDF.select("finished_sentence_embeddings").show(2 ,false)
+
+    val explodedVectors = pipelineDF.select($"sentence", explode($"finished_sentence_embeddings").as("features"))
+
+    explodedVectors.select("features").show
+
+    pipelineDF.printSchema()
+    explodedVectors.printSchema()
+
+    // Trains a k-means model.
+    val kmeans = new KMeans().setK(2).setSeed(1L).setMaxIter(1).setFeaturesCol("features")
+    val model = kmeans.fit(explodedVectors)
+
+    // Make predictions
+    val predictions = model.transform(explodedVectors)
+
+    // Evaluate clustering by computing Silhouette score
+    val evaluator = new ClusteringEvaluator()
+
+    val silhouette = evaluator.evaluate(predictions)
+    println(s"Silhouette with squared euclidean distance = $silhouette")
+
+    // Shows the result.
+    println("Cluster Centers: ")
+    model.clusterCenters.foreach(println)
+
+    predictions.select("sentence.result", "prediction").show(false)
+  }
+
+  "EmbeddingsFinisher" should "correctly transform embeddings into Vectors and normalize it by Spark ML" in {
+
+    val smallCorpus = ResourceHelper.spark.read.option("header","true").csv("src/test/resources/embeddings/sentence_embeddings.csv")
+
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentence = new SentenceDetector()
+      .setInputCols("document")
+      .setOutputCol("sentence")
+      .setExplodeSentences(false)
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("sentence"))
+      .setOutputCol("token")
+
+    val embeddings = WordEmbeddingsModel.pretrained()
+      .setInputCols("sentence", "token")
+      .setOutputCol("embeddings")
+      .setCaseSensitive(false)
+
+    val embeddingsSentence = new SentenceEmbeddings()
+      .setInputCols(Array("sentence", "embeddings"))
+      .setOutputCol("sentence_embeddings")
+      .setPoolingStrategy("AVERAGE")
+
+    val embeddingsFinisher = new EmbeddingsFinisher()
+      .setInputCols("sentence_embeddings", "embeddings")
+      .setOutputCols("sentence_embeddings_vectors", "embeddings_vectors")
+      .setOutputAsVector(true)
+      .setCleanAnnotations(false)
+
+    val explodeVectors = new SQLTransformer().setStatement(
+      "SELECT EXPLODE(sentence_embeddings_vectors) AS features, * FROM __THIS__")
+
+    // Normalize each Vector using $L^1$ norm.
+    val vectorNormalizer = new Normalizer()
+      .setInputCol("features")
+      .setOutputCol("normFeatures")
+      .setP(1.0)
+
+    val pipeline = new RecursivePipeline()
+      .setStages(Array(
+        documentAssembler,
+        sentence,
+        tokenizer,
+        embeddings,
+        embeddingsSentence,
+        embeddingsFinisher,
+        explodeVectors,
+        vectorNormalizer
+      ))
+
+    val pipelineModel = pipeline.fit(smallCorpus)
+    val pielineDF = pipelineModel.transform(smallCorpus)
+
+    pielineDF.show()
+    pielineDF.printSchema()
+
+    pielineDF.select(size(pielineDF("finished_embeddings")).as("sentence_embeddings_size")).show
+    pielineDF.select("finished_embeddings").show(2 ,false)
+
+
+    pielineDF.select(size(pielineDF("finished_sentence_embeddings")).as("sentence_embeddings_size")).show
+    pielineDF.select("finished_sentence_embeddings").show(2 ,false)
+
+    pielineDF.select("features").show(2 ,false)
+
+    pielineDF.select("normFeatures").show(2 ,false)
+
+  }
+
+}


### PR DESCRIPTION
`EmbeddingsFinisher` transforms annotators with embeddings into an acceptable schema for Spark ML. It can be both `Array[Array[Float]]` or `Array[Vector]` which both are acceptable in Spark ML functions whenever Vectors `features` are expected.

- [x] Implement `EmbeddingsFinisher` in Scala
- [x] Implement `EmbeddingsFinisher` in Python
- [x] Implement unit test in Scala
- [x] Implement unit test in Python


```scala
val embeddingsFinisher = new EmbeddingsFinisher()
      .setInputCols("sentence_embeddings", "embeddings")
      .setOutputCols("finished_sentence_embeddings", "finished_embeddings")
      .setOutputAsVector(true)
      .setCleanAnnotations(false)
```