### PR TITLE
fix of lemmatizer bad trait

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -1,6 +1,6 @@
 package com.johnsnowlabs.nlp
 
-import com.johnsnowlabs.nlp.annotators.ReadablePretrainedTokenizer
+import com.johnsnowlabs.nlp.annotators.{ReadablePretrainedTokenizer, ReadablePretrainedLemmatizer}
 import com.johnsnowlabs.nlp.annotators.ner.crf.ReadablePretrainedNerCrf
 import com.johnsnowlabs.nlp.annotators.ner.dl.{ReadablePretrainedNerDL, ReadsNERGraph, WithGraphResolver}
 import com.johnsnowlabs.nlp.annotators.parser.dep.ReadablePretrainedDependency
@@ -9,7 +9,7 @@ import com.johnsnowlabs.nlp.annotators.pos.perceptron.ReadablePretrainedPerceptr
 import com.johnsnowlabs.nlp.annotators.sda.vivekn.ReadablePretrainedVivekn
 import com.johnsnowlabs.nlp.annotators.spell.norvig.ReadablePretrainedNorvig
 import com.johnsnowlabs.nlp.annotators.spell.symmetric.ReadablePretrainedSymmetric
-import com.johnsnowlabs.nlp.embeddings.{EmbeddingsReadable, ReadablePretrainedBertModel, ReadablePretrainedWordEmbeddings, EmbeddingsCoverage, ReadBertTensorflowModel}
+import com.johnsnowlabs.nlp.embeddings.{EmbeddingsCoverage, EmbeddingsReadable, ReadBertTensorflowModel, ReadablePretrainedBertModel, ReadablePretrainedWordEmbeddings}
 import org.apache.spark.ml.util.DefaultParamsReadable
 
 package object annotator {
@@ -52,7 +52,7 @@ package object annotator {
   type Lemmatizer = com.johnsnowlabs.nlp.annotators.Lemmatizer
   object Lemmatizer extends DefaultParamsReadable[Lemmatizer]
   type LemmatizerModel = com.johnsnowlabs.nlp.annotators.LemmatizerModel
-  object LemmatizerModel extends ReadablePretrainedTokenizer
+  object LemmatizerModel extends ReadablePretrainedLemmatizer
 
   type StopWordsCleaner = com.johnsnowlabs.nlp.annotators.StopWordsCleaner
   object StopWordsCleaner extends DefaultParamsReadable[StopWordsCleaner]

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/LemmatizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/LemmatizerModel.scala
@@ -35,8 +35,8 @@ class LemmatizerModel(override val uid: String) extends AnnotatorModel[Lemmatize
 
 }
 
-trait ReadableWithPretrained extends ParamsAndFeaturesReadable[LemmatizerModel] with HasPretrained[LemmatizerModel] {
+trait ReadablePretrainedLemmatizer extends ParamsAndFeaturesReadable[LemmatizerModel] with HasPretrained[LemmatizerModel] {
   override val defaultModelName = "lemma_antbnc"
 }
 
-object LemmatizerModel extends ReadablePretrainedTokenizer
+object LemmatizerModel extends ReadablePretrainedLemmatizer

--- a/src/test/java/com/johnsnowlabs/nlp/GeneralAnnotationsTest.java
+++ b/src/test/java/com/johnsnowlabs/nlp/GeneralAnnotationsTest.java
@@ -40,12 +40,17 @@ public class GeneralAnnotationsTest {
 
         PipelineModel pipelineModel = pipeline.fit(data);
 
-        pipelineModel.transform(data).show();
+        Dataset<Row> transformed = pipelineModel.transform(data);
+        transformed.show();
 
         PretrainedPipeline pretrained = new PretrainedPipeline("explain_document_dl");
         pretrained.transform(data).show();
 
-        LemmatizerModel.pretrained();
+        LemmatizerModel lemmatizer = (LemmatizerModel) LemmatizerModel.pretrained("lemma_antbnc");
+        lemmatizer.setInputCols(new String[] {"token"});
+        lemmatizer.setOutputCol("lemma");
+
+        lemmatizer.transform(transformed).show();
 
         LightPipeline lightPipeline = new LightPipeline(pipelineModel, true);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed bad Lemmatizer trait caused Lemmatizer to download a Tokenizer model instead and fail.

Workaround is to call `LemmatizerModel.pretrained("lemma_antbnc")`