### PR TITLE
Java pretrained compliant

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/HasInputAnnotationCols.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasInputAnnotationCols.scala
@@ -1,7 +1,6 @@
 package com.johnsnowlabs.nlp
 
 import org.apache.spark.ml.param.{Params, StringArrayParam}
-import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.types.StructType
 
 trait HasInputAnnotationCols extends Params {

--- a/src/main/scala/com/johnsnowlabs/nlp/HasPretrained.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasPretrained.scala
@@ -9,11 +9,11 @@ trait HasPretrained[M <: PipelineStage] {
   /** Only MLReader types can use this interface */
   this: { def read: MLReader[M] } =>
 
-  protected val defaultModelName: String
+  val defaultModelName: String
 
-  protected val defaultLang: String = "en"
+  val defaultLang: String = "en"
 
-  protected val defaultLoc: String = ResourceDownloader.publicLoc
+  val defaultLoc: String = ResourceDownloader.publicLoc
 
   implicit private val companion = this.asInstanceOf[DefaultParamsReadable[M]]
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -1,6 +1,6 @@
 package com.johnsnowlabs.nlp
 
-import com.johnsnowlabs.nlp.annotators.ReadablePretrainedTokenizer
+import com.johnsnowlabs.nlp.annotators.{ReadablePretrainedTokenizer, ReadablePretrainedLemmatizer}
 import com.johnsnowlabs.nlp.annotators.ner.crf.ReadablePretrainedNerCrf
 import com.johnsnowlabs.nlp.annotators.ner.dl.{ReadablePretrainedNerDL, ReadsNERGraph, WithGraphResolver}
 import com.johnsnowlabs.nlp.annotators.parser.dep.ReadablePretrainedDependency
@@ -9,7 +9,7 @@ import com.johnsnowlabs.nlp.annotators.pos.perceptron.ReadablePretrainedPerceptr
 import com.johnsnowlabs.nlp.annotators.sda.vivekn.ReadablePretrainedVivekn
 import com.johnsnowlabs.nlp.annotators.spell.norvig.ReadablePretrainedNorvig
 import com.johnsnowlabs.nlp.annotators.spell.symmetric.ReadablePretrainedSymmetric
-import com.johnsnowlabs.nlp.embeddings.{EmbeddingsReadable, ReadablePretrainedBertModel, ReadablePretrainedWordEmbeddings, EmbeddingsCoverage, ReadBertTensorflowModel}
+import com.johnsnowlabs.nlp.embeddings.{EmbeddingsCoverage, EmbeddingsReadable, ReadBertTensorflowModel, ReadablePretrainedBertModel, ReadablePretrainedWordEmbeddings}
 import org.apache.spark.ml.util.DefaultParamsReadable
 
 package object annotator {
@@ -52,7 +52,7 @@ package object annotator {
   type Lemmatizer = com.johnsnowlabs.nlp.annotators.Lemmatizer
   object Lemmatizer extends DefaultParamsReadable[Lemmatizer]
   type LemmatizerModel = com.johnsnowlabs.nlp.annotators.LemmatizerModel
-  object LemmatizerModel extends ReadablePretrainedTokenizer
+  object LemmatizerModel extends ReadablePretrainedLemmatizer
 
   type StopWordsCleaner = com.johnsnowlabs.nlp.annotators.StopWordsCleaner
   object StopWordsCleaner extends DefaultParamsReadable[StopWordsCleaner]

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -9,7 +9,7 @@ import com.johnsnowlabs.nlp.annotators.pos.perceptron.ReadablePretrainedPerceptr
 import com.johnsnowlabs.nlp.annotators.sda.vivekn.ReadablePretrainedVivekn
 import com.johnsnowlabs.nlp.annotators.spell.norvig.ReadablePretrainedNorvig
 import com.johnsnowlabs.nlp.annotators.spell.symmetric.ReadablePretrainedSymmetric
-import com.johnsnowlabs.nlp.embeddings.{EmbeddingsCoverage, EmbeddingsReadable, ReadBertTensorflowModel, ReadablePretrainedBertModel, ReadablePretrainedWordEmbeddings}
+import com.johnsnowlabs.nlp.embeddings.{EmbeddingsCoverage, ReadBertTensorflowModel, ReadablePretrainedBertModel, ReadablePretrainedWordEmbeddings}
 import org.apache.spark.ml.util.DefaultParamsReadable
 
 package object annotator {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/LemmatizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/LemmatizerModel.scala
@@ -37,6 +37,12 @@ class LemmatizerModel(override val uid: String) extends AnnotatorModel[Lemmatize
 
 trait ReadablePretrainedLemmatizer extends ParamsAndFeaturesReadable[LemmatizerModel] with HasPretrained[LemmatizerModel] {
   override val defaultModelName = "lemma_antbnc"
+
+  /** Java compliant-overrides */
+  override def pretrained(): LemmatizerModel = super.pretrained()
+  override def pretrained(name: String): LemmatizerModel = super.pretrained(name)
+  override def pretrained(name: String, lang: String): LemmatizerModel = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): LemmatizerModel = super.pretrained(name, lang, remoteLoc)
 }
 
 object LemmatizerModel extends ReadablePretrainedLemmatizer

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/LemmatizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/LemmatizerModel.scala
@@ -35,8 +35,8 @@ class LemmatizerModel(override val uid: String) extends AnnotatorModel[Lemmatize
 
 }
 
-trait ReadableWithPretrained extends ParamsAndFeaturesReadable[LemmatizerModel] with HasPretrained[LemmatizerModel] {
+trait ReadablePretrainedLemmatizer extends ParamsAndFeaturesReadable[LemmatizerModel] with HasPretrained[LemmatizerModel] {
   override val defaultModelName = "lemma_antbnc"
 }
 
-object LemmatizerModel extends ReadablePretrainedTokenizer
+object LemmatizerModel extends ReadablePretrainedLemmatizer

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/TokenizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/TokenizerModel.scala
@@ -114,6 +114,11 @@ class TokenizerModel(override val uid: String) extends AnnotatorModel[TokenizerM
 
 trait ReadablePretrainedTokenizer extends ParamsAndFeaturesReadable[TokenizerModel] with HasPretrained[TokenizerModel] {
   override val defaultModelName = "token_rules"
+  /** Java compliant-overrides */
+  override def pretrained(): TokenizerModel = super.pretrained()
+  override def pretrained(name: String): TokenizerModel = super.pretrained(name)
+  override def pretrained(name: String, lang: String): TokenizerModel = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): TokenizerModel = super.pretrained(name, lang, remoteLoc)
 }
 
 object TokenizerModel extends ReadablePretrainedTokenizer

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfModel.scala
@@ -94,6 +94,11 @@ class NerCrfModel(override val uid: String) extends AnnotatorModel[NerCrfModel] 
 
 trait ReadablePretrainedNerCrf extends ParamsAndFeaturesReadable[NerCrfModel] with HasPretrained[NerCrfModel] {
   override protected val defaultModelName: String = "ner_crf"
+  /** Java compliant-overrides */
+  override def pretrained(): NerCrfModel = super.pretrained()
+  override def pretrained(name: String): NerCrfModel = super.pretrained(name)
+  override def pretrained(name: String, lang: String): NerCrfModel = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): NerCrfModel = super.pretrained(name, lang, remoteLoc)
 }
 
 object NerCrfModel extends ReadablePretrainedNerCrf

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
@@ -137,6 +137,10 @@ trait ReadablePretrainedNerDL extends ParamsAndFeaturesReadable[NerDLModel] with
     else name
     ResourceDownloader.downloadModel(NerDLModel, finalName, Option(lang), remoteLoc)
   }
+  /** Java compliant-overrides */
+  override def pretrained(): NerDLModel = pretrained(defaultModelName, defaultLang, defaultLoc)
+  override def pretrained(name: String): NerDLModel = pretrained(name, defaultLang, defaultLoc)
+  override def pretrained(name: String, lang: String): NerDLModel = pretrained(name, lang, defaultLoc)
 }
 
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserModel.scala
@@ -35,6 +35,11 @@ class DependencyParserModel(override val uid: String) extends AnnotatorModel[Dep
 
 trait ReadablePretrainedDependency extends ParamsAndFeaturesReadable[DependencyParserModel] with HasPretrained[DependencyParserModel] {
   override protected val defaultModelName: String = "dependency_conllu"
+  /** Java compliant-overrides */
+  override def pretrained(): DependencyParserModel = super.pretrained()
+  override def pretrained(name: String): DependencyParserModel = super.pretrained(name)
+  override def pretrained(name: String, lang: String): DependencyParserModel = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): DependencyParserModel = super.pretrained(name, lang, remoteLoc)
 }
 
 object DependencyParserModel extends ReadablePretrainedDependency

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/parser/typdep/TypedDependencyParserModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/parser/typdep/TypedDependencyParserModel.scala
@@ -129,6 +129,11 @@ TypedDependencyParserModel(override val uid: String) extends AnnotatorModel[Type
 
 trait ReadablePretrainedTypedDependency extends ParamsAndFeaturesReadable[TypedDependencyParserModel] with HasPretrained[TypedDependencyParserModel] {
   override protected val defaultModelName: String = "dependency_typed_conllu"
+  /** Java compliant-overrides */
+  override def pretrained(): TypedDependencyParserModel = super.pretrained()
+  override def pretrained(name: String): TypedDependencyParserModel = super.pretrained(name)
+  override def pretrained(name: String, lang: String): TypedDependencyParserModel = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): TypedDependencyParserModel = super.pretrained(name, lang, remoteLoc)
 }
 
 object TypedDependencyParserModel extends ReadablePretrainedTypedDependency

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronModel.scala
@@ -69,6 +69,11 @@ class PerceptronModel(override val uid: String) extends AnnotatorModel[Perceptro
 
 trait ReadablePretrainedPerceptron extends ParamsAndFeaturesReadable[PerceptronModel] with HasPretrained[PerceptronModel] {
   override protected val defaultModelName: String = "pos_anc"
+  /** Java compliant-overrides */
+  override def pretrained(): PerceptronModel = super.pretrained()
+  override def pretrained(name: String): PerceptronModel = super.pretrained(name)
+  override def pretrained(name: String, lang: String): PerceptronModel = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): PerceptronModel = super.pretrained(name, lang, remoteLoc)
 }
 
 object PerceptronModel extends ReadablePretrainedPerceptron

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/vivekn/ViveknSentimentModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/vivekn/ViveknSentimentModel.scala
@@ -100,6 +100,11 @@ class ViveknSentimentModel(override val uid: String) extends AnnotatorModel[Vive
 
 trait ReadablePretrainedVivekn extends ParamsAndFeaturesReadable[ViveknSentimentModel] with HasPretrained[ViveknSentimentModel] {
   override protected val defaultModelName: String = "sentiment_vivekn"
+  /** Java compliant-overrides */
+  override def pretrained(): ViveknSentimentModel = super.pretrained()
+  override def pretrained(name: String): ViveknSentimentModel = super.pretrained(name)
+  override def pretrained(name: String, lang: String): ViveknSentimentModel = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): ViveknSentimentModel = super.pretrained(name, lang, remoteLoc)
 }
 
 object ViveknSentimentModel extends ReadablePretrainedVivekn

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingModel.scala
@@ -240,6 +240,11 @@ class NorvigSweetingModel(override val uid: String) extends AnnotatorModel[Norvi
 
 trait ReadablePretrainedNorvig extends ParamsAndFeaturesReadable[NorvigSweetingModel] with HasPretrained[NorvigSweetingModel] {
   override protected val defaultModelName: String = "spellcheck_norvig"
+  /** Java compliant-overrides */
+  override def pretrained(): NorvigSweetingModel = super.pretrained()
+  override def pretrained(name: String): NorvigSweetingModel = super.pretrained(name)
+  override def pretrained(name: String, lang: String): NorvigSweetingModel = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): NorvigSweetingModel = super.pretrained(name, lang, remoteLoc)
 }
 
 object NorvigSweetingModel extends ReadablePretrainedNorvig

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModel.scala
@@ -284,6 +284,11 @@ class SymmetricDeleteModel(override val uid: String) extends AnnotatorModel[Symm
 
 trait ReadablePretrainedSymmetric extends ParamsAndFeaturesReadable[SymmetricDeleteModel] with HasPretrained[SymmetricDeleteModel] {
   override protected val defaultModelName: String = "spellcheck_sd"
+  /** Java compliant-overrides */
+  override def pretrained(): SymmetricDeleteModel = super.pretrained()
+  override def pretrained(name: String): SymmetricDeleteModel = super.pretrained(name)
+  override def pretrained(name: String, lang: String): SymmetricDeleteModel = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): SymmetricDeleteModel = super.pretrained(name, lang, remoteLoc)
 }
 
 object SymmetricDeleteModel extends ReadablePretrainedSymmetric

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -153,6 +153,11 @@ class BertEmbeddings(override val uid: String) extends
 
 trait ReadablePretrainedBertModel extends ParamsAndFeaturesReadable[BertEmbeddings] with HasPretrained[BertEmbeddings] {
   override protected val defaultModelName: String = "bert_base_cased"
+  /** Java compliant-overrides */
+  override def pretrained(): BertEmbeddings = super.pretrained()
+  override def pretrained(name: String): BertEmbeddings = super.pretrained(name)
+  override def pretrained(name: String, lang: String): BertEmbeddings = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): BertEmbeddings = super.pretrained(name, lang, remoteLoc)
 }
 
 trait ReadBertTensorflowModel extends ReadTensorflowModel {

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
@@ -90,6 +90,11 @@ class WordEmbeddingsModel(override val uid: String)
 
 trait ReadablePretrainedWordEmbeddings extends EmbeddingsReadable[WordEmbeddingsModel] with HasPretrained[WordEmbeddingsModel] {
   override protected val defaultModelName: String = "glove_100d"
+  /** Java compliant-overrides */
+  override def pretrained(): WordEmbeddingsModel = super.pretrained()
+  override def pretrained(name: String): WordEmbeddingsModel = super.pretrained(name)
+  override def pretrained(name: String, lang: String): WordEmbeddingsModel = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): WordEmbeddingsModel = super.pretrained(name, lang, remoteLoc)
 }
 
 trait EmbeddingsCoverage {

--- a/src/test/java/com/johnsnowlabs/nlp/GeneralAnnotationsTest.java
+++ b/src/test/java/com/johnsnowlabs/nlp/GeneralAnnotationsTest.java
@@ -46,7 +46,7 @@ public class GeneralAnnotationsTest {
         PretrainedPipeline pretrained = new PretrainedPipeline("explain_document_dl");
         pretrained.transform(data).show();
 
-        LemmatizerModel lemmatizer = (LemmatizerModel) LemmatizerModel.pretrained("lemma_antbnc");
+        LemmatizerModel lemmatizer = LemmatizerModel.pretrained("lemma_antbnc");
         lemmatizer.setInputCols(new String[] {"token"});
         lemmatizer.setOutputCol("lemma");
 

--- a/src/test/java/com/johnsnowlabs/nlp/GeneralAnnotationsTest.java
+++ b/src/test/java/com/johnsnowlabs/nlp/GeneralAnnotationsTest.java
@@ -40,12 +40,17 @@ public class GeneralAnnotationsTest {
 
         PipelineModel pipelineModel = pipeline.fit(data);
 
-        pipelineModel.transform(data).show();
+        Dataset<Row> transformed = pipelineModel.transform(data);
+        transformed.show();
 
         PretrainedPipeline pretrained = new PretrainedPipeline("explain_document_dl");
         pretrained.transform(data).show();
 
-        LemmatizerModel.pretrained();
+        LemmatizerModel lemmatizer = (LemmatizerModel) LemmatizerModel.pretrained("lemma_antbnc");
+        lemmatizer.setInputCols(new String[] {"token"});
+        lemmatizer.setOutputCol("lemma");
+
+        lemmatizer.transform(transformed).show();
 
         LightPipeline lightPipeline = new LightPipeline(pipelineModel, true);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In java, calling an AnnotatorModels `pretrained()` would return `PipelineStage` type instead of itself. This adds Java compliant overrides to solve that case.