### PR TITLE
Reverted embeddings move to copy due to crc issue

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ClusterWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ClusterWordEmbeddings.scala
@@ -102,7 +102,6 @@ object ClusterWordEmbeddings {
       EmbeddingsHelper.getClusterFilename(embeddingsRef)
     }
 
-    val destinationScheme = new Path(clusterFileName).getFileSystem(spark.hadoopConfiguration).getScheme
     val fileSystem = FileSystem.get(spark.hadoopConfiguration)
 
     val clusterTmpLocation = {
@@ -115,13 +114,9 @@ object ClusterWordEmbeddings {
     // 1 and 2.  Copy to local and Index Word Embeddings
     indexEmbeddings(sourceEmbeddingsPath, tmpLocalDestination.toString, format, spark)
 
-    if (destinationScheme == "file") {
-      new File(tmpLocalDestination.toString).renameTo(new File(EmbeddingsHelper.getLocalEmbeddingsPath(clusterFileName)))
-    } else {
       // 2. Copy WordEmbeddings to cluster
-      copyIndexToCluster(tmpLocalDestination.toString, clusterFilePath, spark)
-      FileHelper.delete(tmpLocalDestination.toString)
-    }
+    copyIndexToCluster(tmpLocalDestination.toString, clusterFilePath, spark)
+    FileHelper.delete(tmpLocalDestination.toString)
 
     // 3. Create Spark Embeddings
     new ClusterWordEmbeddings(clusterFileName, dim, caseSensitive)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ClusterWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ClusterWordEmbeddings.scala
@@ -69,6 +69,7 @@ object ClusterWordEmbeddings {
       fs.copyToLocalFile(new Path(sourceEmbeddingsPath), new Path(localFile))
       val fileName = new Path(sourceEmbeddingsPath).getName
 
+      /** If we remove this deepCopy line, word embeddings will fail (needs research) - moving it instead of copy also fails*/
       FileUtil.deepCopy(Paths.get(localFile, fileName).toFile, Paths.get(localFile).toFile, null, true)
       FileHelper.delete(Paths.get(localFile, fileName).toString)
     }
@@ -78,6 +79,7 @@ object ClusterWordEmbeddings {
     val fs = new Path(localFile).getFileSystem(spark.hadoopConfiguration)
     val src = new Path(localFile)
 
+    /** This fails if working on local file system, because spark.addFile will detect simoultaneous writes on same location and fail */
     fs.copyFromLocalFile(false, true, src, dst)
     fs.deleteOnExit(dst)
 
@@ -87,6 +89,7 @@ object ClusterWordEmbeddings {
   }
 
   private def copyIndexToLocal(source: Path, destination: Path, context: SparkContext) = {
+    /** if we don't do a copy, and just move, it will all fail when re-saving utilized embeddings because of bad crc */
     val fs = source.getFileSystem(context.hadoopConfiguration)
     fs.copyFromLocalFile(false, true, source, destination)
     fs.deleteOnExit(source)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddings.scala
@@ -51,14 +51,14 @@ class WordEmbeddings(override val uid: String) extends AnnotatorApproach[WordEmb
   override def beforeTraining(sparkSession: SparkSession): Unit = {
     if (isDefined(sourceEmbeddingsPath)) {
       if (!isLoaded()) {
-        EmbeddingsHelper.load(
+        preloadedEmbeddings = Some(EmbeddingsHelper.load(
           $(sourceEmbeddingsPath),
           sparkSession,
           WordEmbeddingsFormat($(embeddingsFormat)).toString,
           $(dimension),
           $(caseSensitive),
           $(embeddingsRef)
-        )
+        ))
         setAsLoaded()
       }
     } else if (isSet(embeddingsRef)) {

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
@@ -28,14 +28,17 @@ class WordEmbeddingsModel(override val uid: String)
     if ($(includeEmbeddings)) {
       val src = getEmbeddingsSerializedPath(path)
 
-      EmbeddingsHelper.load(
-        src.toUri.toString,
-        spark,
-        WordEmbeddingsFormat.SPARKNLP.toString,
-        $(dimension),
-        $(caseSensitive),
-        $(embeddingsRef)
-      )
+      if (!isLoaded()) {
+        preloadedEmbeddings = Some(EmbeddingsHelper.load(
+          src.toUri.toString,
+          spark,
+          WordEmbeddingsFormat.SPARKNLP.toString,
+          $(dimension),
+          $(caseSensitive),
+          $(embeddingsRef)
+        ))
+        setAsLoaded()
+      }
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In some local mode scenarios, saving embeddings to disk yielded `crc` checksum errors. This is due to a move optimization made in the past. This optimization is now reverted in favor of stability.