### PR TITLE
Fix IndexOutOfBoundsException in SentenceEmbeddings

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings.scala
@@ -32,16 +32,14 @@ class SentenceEmbeddings(override val uid: String) extends AnnotatorModel[Senten
 
   private def calculateSentenceEmbeddings(matrix : Array[Array[Float]]):Array[Float] = {
     val res = Array.ofDim[Float](matrix(0).length)
-    if(matrix.length > 0){
-      matrix(0).indices.foreach {
-        j =>
-          matrix.indices.foreach {
-            i =>
-              res(j) += matrix(i)(j)
-          }
-          if($(poolingStrategy) == "AVERAGE")
-            res(j) /= matrix.length
-      }
+    matrix(0).indices.foreach {
+      j =>
+        matrix.indices.foreach {
+          i =>
+            res(j) += matrix(i)(j)
+        }
+        if($(poolingStrategy) == "AVERAGE")
+          res(j) /= matrix.length
     }
     res.toArray.map(_.toFloat)
   }
@@ -60,12 +58,12 @@ class SentenceEmbeddings(override val uid: String) extends AnnotatorModel[Senten
     sentences.zipWithIndex.map { case (sentence, idx) =>
 
       val sentenceEmbeddings = embeddingsSentences.flatMap {
-          case (tokenEmbedding) =>
-            val allEmbeddings = tokenEmbedding.tokens.map { token =>
-              token.embeddings
-            }
-            calculateSentenceEmbeddings(allEmbeddings)
-        }.toArray
+        case (tokenEmbedding) =>
+          val allEmbeddings = tokenEmbedding.tokens.map { token =>
+            token.embeddings
+          }
+          calculateSentenceEmbeddings(allEmbeddings)
+      }.toArray
 
       Annotation(
         annotatorType = outputAnnotatorType,

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings.scala
@@ -41,7 +41,7 @@ class SentenceEmbeddings(override val uid: String) extends AnnotatorModel[Senten
         if($(poolingStrategy) == "AVERAGE")
           res(j) /= matrix.length
     }
-    res.toArray.map(_.toFloat)
+    res
   }
 
   /**

--- a/src/test/scala/com/johnsnowlabs/nlp/EmbeddingsFinisherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/EmbeddingsFinisherTestSpec.scala
@@ -60,11 +60,11 @@ class EmbeddingsFinisherTestSpec extends FlatSpec {
     val pipelineDF = pipeline.fit(smallCorpus).transform(smallCorpus)
 
     pipelineDF.select(size(pipelineDF("finished_embeddings")).as("sentence_embeddings_size")).show
-    pipelineDF.select("finished_embeddings").show(2 ,false)
+    pipelineDF.select("finished_embeddings").show(2)
 
 
     pipelineDF.select(size(pipelineDF("finished_sentence_embeddings")).as("sentence_embeddings_size")).show
-    pipelineDF.select("finished_sentence_embeddings").show(2 ,false)
+    pipelineDF.select("finished_sentence_embeddings").show(2)
 
     val explodedVectors = pipelineDF.select($"sentence", explode($"finished_sentence_embeddings").as("features"))
 
@@ -90,7 +90,7 @@ class EmbeddingsFinisherTestSpec extends FlatSpec {
     println("Cluster Centers: ")
     model.clusterCenters.foreach(println)
 
-    predictions.select("sentence.result", "prediction").show(false)
+    predictions.select("sentence.result", "prediction").show()
   }
 
   "EmbeddingsFinisher" should "correctly transform embeddings into Vectors and normalize it by Spark ML" in {
@@ -154,15 +154,15 @@ class EmbeddingsFinisherTestSpec extends FlatSpec {
     pielineDF.printSchema()
 
     pielineDF.select(size(pielineDF("embeddings_vectors")).as("sentence_embeddings_size")).show
-    pielineDF.select("embeddings_vectors").show(2 ,false)
+    pielineDF.select("embeddings_vectors").show(2)
 
 
     pielineDF.select(size(pielineDF("sentence_embeddings_vectors")).as("sentence_embeddings_size")).show
-    pielineDF.select("sentence_embeddings_vectors").show(2 ,false)
+    pielineDF.select("sentence_embeddings_vectors").show(2)
 
-    pielineDF.select("features").show(2 ,false)
+    pielineDF.select("features").show(2)
 
-    pielineDF.select("normFeatures").show(2 ,false)
+    pielineDF.select("normFeatures").show(2)
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
@@ -67,19 +67,19 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
 
     val pipelineDF = pipeline.fit(smallCorpus).transform(smallCorpus)
 
-    pipelineDF.select("chunk.metadata").show(2 ,truncate = 500)
-    pipelineDF.select("chunk.result").show(2 ,truncate = 500)
+    pipelineDF.select("chunk.metadata").show(2)
+    pipelineDF.select("chunk.result").show(2)
 
-    pipelineDF.select("embeddings.metadata").show(2 ,truncate = 500)
-    pipelineDF.select("embeddings.embeddings").show(2 ,truncate = 500)
-    pipelineDF.select("embeddings.result").show(2 ,truncate = 500)
+    pipelineDF.select("embeddings.metadata").show(2)
+    pipelineDF.select("embeddings.embeddings").show(2)
+    pipelineDF.select("embeddings.result").show(2)
 
-    pipelineDF.select("chunk_embeddings").show(2 ,truncate = 500)
+    pipelineDF.select("chunk_embeddings").show(2)
     println("Chunk Embeddings")
-    pipelineDF.select("chunk_embeddings.embeddings").show(2 ,false)
+    pipelineDF.select("chunk_embeddings.embeddings").show(2)
     pipelineDF.select(size(pipelineDF("chunk_embeddings.embeddings")).as("chunk_embeddings_size")).show
 
-    pipelineDF.select("finished_embeddings").show(2 ,false)
+    pipelineDF.select("finished_embeddings").show(2)
     pipelineDF.select(size(pipelineDF("finished_embeddings")).as("chunk_embeddings_size")).show
 
   }
@@ -134,22 +134,22 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
 
     val pipelineDF = pipeline.fit(smallCorpus).transform(smallCorpus)
 
-    pipelineDF.select("token.metadata").show(2 ,truncate = 500)
-    pipelineDF.select("token.result").show(2 ,truncate = 500)
+    pipelineDF.select("token.metadata").show(2)
+    pipelineDF.select("token.result").show(2)
 
-    pipelineDF.select("chunk.metadata").show(2 ,truncate = 500)
-    pipelineDF.select("chunk.result").show(2 ,truncate = 500)
+    pipelineDF.select("chunk.metadata").show(2)
+    pipelineDF.select("chunk.result").show(2)
 
-    pipelineDF.select("embeddings.metadata").show(2 ,truncate = 500)
-    pipelineDF.select("embeddings.embeddings").show(2 ,truncate = 500)
-    pipelineDF.select("embeddings.result").show(2 ,truncate = 500)
+    pipelineDF.select("embeddings.metadata").show(2)
+    pipelineDF.select("embeddings.embeddings").show(2)
+    pipelineDF.select("embeddings.result").show(2)
 
-    pipelineDF.select("chunk_embeddings").show(2 ,truncate = 500)
+    pipelineDF.select("chunk_embeddings").show(2)
     println("Chunk Embeddings")
-    pipelineDF.select("chunk_embeddings.embeddings").show(2 ,false)
+    pipelineDF.select("chunk_embeddings.embeddings").show(2)
     pipelineDF.select(size(pipelineDF("chunk_embeddings.embeddings")).as("chunk_embeddings_size")).show
 
-    pipelineDF.select("finished_embeddings").show(2 ,false)
+    pipelineDF.select("finished_embeddings").show(2)
     pipelineDF.select(size(pipelineDF("finished_embeddings")).as("chunk_embeddings_size")).show
 
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddingsTestSpec.scala
@@ -27,7 +27,7 @@ class SentenceEmbeddingsTestSpec extends FlatSpec {
       .setOutputCol("token")
 
     val embeddings = WordEmbeddingsModel.pretrained()
-      .setInputCols("document", "cleanTokens")
+      .setInputCols("document", "token")
       .setOutputCol("embeddings")
       .setCaseSensitive(false)
 
@@ -53,15 +53,15 @@ class SentenceEmbeddingsTestSpec extends FlatSpec {
 
     val pipelineDF = pipeline.fit(smallCorpus).transform(smallCorpus)
     pipelineDF.printSchema()
-    pipelineDF.select("embeddings.metadata").show(2 ,truncate = 500)
-    pipelineDF.select("embeddings.embeddings").show(2 ,truncate = 500)
-    pipelineDF.select("embeddings.result").show(2 ,truncate = 500)
+    pipelineDF.select("embeddings.metadata").show(2)
+    pipelineDF.select("embeddings.embeddings").show(2)
+    pipelineDF.select("embeddings.result").show(2)
 
-    pipelineDF.select("sentence_embeddings").show(2 ,truncate = 500)
-    pipelineDF.select("sentence_embeddings.embeddings").show(1 ,false)
+    pipelineDF.select("sentence_embeddings").show(2)
+    pipelineDF.select("sentence_embeddings.embeddings").show(1)
     pipelineDF.select(size(pipelineDF("sentence_embeddings.embeddings")).as("sentence_embeddings_size")).show
 
-    pipelineDF.select("finished_sentence_embeddings").show(1 ,false)
+    pipelineDF.select("finished_sentence_embeddings").show(1)
     pipelineDF.select(size(pipelineDF("finished_sentence_embeddings")).as("sentence_embeddings_size")).show
 
   }
@@ -108,15 +108,15 @@ class SentenceEmbeddingsTestSpec extends FlatSpec {
 
     val pipelineDF = pipeline.fit(smallCorpus).transform(smallCorpus)
     pipelineDF.printSchema()
-    pipelineDF.select("embeddings.metadata").show(2 ,truncate = 500)
-    pipelineDF.select("embeddings.embeddings").show(2 ,truncate = 500)
-    pipelineDF.select("embeddings.result").show(2 ,truncate = 500)
+    pipelineDF.select("embeddings.metadata").show(2)
+    pipelineDF.select("embeddings.embeddings").show(2)
+    pipelineDF.select("embeddings.result").show(2)
 
-    pipelineDF.select("sentence_embeddings").show(2 ,truncate = 500)
-    pipelineDF.select("sentence_embeddings.embeddings").show(1 ,false)
+    pipelineDF.select("sentence_embeddings").show(2)
+    pipelineDF.select("sentence_embeddings.embeddings").show(1)
     pipelineDF.select(size(pipelineDF("sentence_embeddings.embeddings")).as("sentence_embeddings_size")).show
 
-    pipelineDF.select("finished_embeddings").show(1 ,false)
+    pipelineDF.select("finished_embeddings").show(1)
     pipelineDF.select(size(pipelineDF("finished_embeddings")).as("sentence_embeddings_size")).show
 
   }
@@ -170,18 +170,7 @@ class SentenceEmbeddingsTestSpec extends FlatSpec {
       ))
 
     val pipelineDF = pipeline.fit(smallCorpus).transform(smallCorpus)
-    pipelineDF.printSchema()
-    pipelineDF.select("embeddings.metadata").show(2 ,truncate = 500)
-    pipelineDF.select("embeddings.embeddings").show(2 ,truncate = 500)
-    pipelineDF.select("embeddings.result").show(2 ,truncate = 500)
-
-    pipelineDF.select("sentence_embeddings").show(2 ,truncate = 500)
-    pipelineDF.select("sentence_embeddings.embeddings").show(1 ,false)
-    pipelineDF.select(size(pipelineDF("sentence_embeddings.embeddings")).as("sentence_embeddings_size")).show
-
-    pipelineDF.select("finished_sentence_embeddings").show(1 ,false)
-    pipelineDF.select(size(pipelineDF("finished_sentence_embeddings")).as("sentence_embeddings_size")).show
-
+    pipelineDF.show(2)
   }
 
 }


### PR DESCRIPTION
When the input of `SentenceEmbeddings` is empty it crashes with `IndexOutOfBoundsException`. Sometimes, the input of WordEmbeddings or BertEmbeddings can be `StopWordsCleaner` which results in not having any tokens inside the results. 
This used to crashes in `SentenceEmbeddings`, now it outputs an empty array as expected.