### PR TITLE
Optimize BertEmbeddings memory consumption

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -8,7 +8,7 @@ from sparknlp.common import *
 
 # Do NOT delete. Looks redundant but this is key work around for python 2 support.
 if sys.version_info[0] == 2:
-    from sparknlp.base import DocumentAssembler, Finisher, TokenAssembler
+    from sparknlp.base import DocumentAssembler, Finisher, EmbeddingsFinisher, TokenAssembler
 else:
     import com.johnsnowlabs.nlp
 

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorResources.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorResources.scala
@@ -25,7 +25,7 @@ class TensorResources {
     result
   }
 
-  def createBertTensor[T](shape: Array[Long], buf: IntBuffer): Tensor[_] = {
+  def createIntBufferTensor[T](shape: Array[Long], buf: IntBuffer): Tensor[_] = {
 
     val result = Tensor.create(shape, buf)
 

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorResources.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorResources.scala
@@ -2,8 +2,10 @@ package com.johnsnowlabs.ml.tensorflow
 
 import java.nio.{FloatBuffer, IntBuffer, LongBuffer}
 
+import com.fasterxml.jackson.annotation.JsonFormat.Shape
 import org.tensorflow.Tensor
 
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.language.existentials
 
@@ -12,12 +14,20 @@ class TensorResources {
   private val tensors = ArrayBuffer[Tensor[_]]()
 
   def createTensor[T](obj: T): Tensor[_] = {
-    val result = if (obj.isInstanceOf[String]) {
-      Tensor.create(obj.asInstanceOf[String].getBytes("UTF-8"), classOf[String])
+    val result = obj match {
+      case str: String =>
+        Tensor.create(str.getBytes("UTF-8"), classOf[String])
+      case _ =>
+        Tensor.create(obj)
     }
-    else {
-      Tensor.create(obj)
-    }
+
+    tensors.append(result)
+    result
+  }
+
+  def createBertTensor[T](shape: Array[Long], buf: IntBuffer): Tensor[_] = {
+
+    val result = Tensor.create(shape, buf)
 
     tensors.append(result)
     result
@@ -29,6 +39,14 @@ class TensorResources {
     }
 
     tensors.clear()
+  }
+
+  def clearSession(outs: mutable.Buffer[Tensor[_]]): Unit = {
+    outs.foreach(_.close())
+  }
+
+  def createIntBuffer(dim: Int): IntBuffer = {
+    IntBuffer.allocate(dim)
   }
 }
 

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
@@ -43,7 +43,7 @@ class TensorflowBert(val tensorflow: TensorflowWrapper,
     val runner = tensorflow.getSession(configProtoBytes = configProtoBytes).runner
 
     runner
-      .feed(tokenIdsKey, tensors.createBertTensor(shape, buf))
+      .feed(tokenIdsKey, tensors.createIntBufferTensor(shape, buf))
       .fetch(embeddingsKey)
 
     val outs = runner.run().asScala

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
@@ -1,6 +1,8 @@
 package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.nlp.annotators.common._
+import scala.collection.JavaConverters._
+
 
 class TensorflowBert(val tensorflow: TensorflowWrapper,
                      sentenceStartTokenId: Int,
@@ -21,36 +23,42 @@ class TensorflowBert(val tensorflow: TensorflowWrapper,
       tokens ++
       Array(sentenceEndTokenId) ++
       Array.fill(maxSentenceLength - tokens.length - 2)(0)
-
   }
 
   def tag(batch: Seq[Array[Int]], embeddingsKey: String): Seq[Array[Array[Float]]] = {
     val tensors = new TensorResources()
+    val buf = tensors.createIntBuffer(batch.length*maxSentenceLength)
+    val shape = Array(batch.length.toLong, maxSentenceLength)
 
-    //println(s"shape = ${batch.length}, ${batch(0).length}")
-    val shrink = batch.map { sentence =>
+    batch.map { sentence =>
       if (sentence.length > maxSentenceLength) {
-        sentence.take(maxSentenceLength - 1) ++ Array(sentenceEndTokenId)
+        buf.put(sentence.take(maxSentenceLength - 1) ++ Array(sentenceEndTokenId))
       }
       else {
-        sentence
+        buf.put(sentence)
       }
-    }.toArray
+    }
+    buf.flip()
 
-    val calculated = tensorflow.getSession(configProtoBytes = configProtoBytes).runner
-      .feed(tokenIdsKey, tensors.createTensor(shrink))
+    val runner = tensorflow.getSession(configProtoBytes = configProtoBytes).runner
+
+    runner
+      .feed(tokenIdsKey, tensors.createBertTensor(shape, buf))
       .fetch(embeddingsKey)
-      .run()
 
+    val outs = runner.run().asScala
+    val embeddings = TensorResources.extractFloats(outs.head)
+
+    tensors.clearSession(outs)
     tensors.clearTensors()
-
-    val embeddings = TensorResources.extractFloats(calculated.get(0))
+    buf.clear()
 
     val dim = embeddings.length / (batch.length * maxSentenceLength)
     val shrinkedEmbeddings: Array[Array[Array[Float]]] = embeddings.grouped(dim).toArray.grouped(maxSentenceLength).toArray
 
     val emptyVector = Array.fill(dim)(0f)
 
+    Seq(Array(emptyVector))
     batch.zip(shrinkedEmbeddings).map { case (ids, embeddings) =>
       if (ids.length > embeddings.length) {
         embeddings.take(embeddings.length - 1) ++
@@ -60,6 +68,7 @@ class TensorflowBert(val tensorflow: TensorflowWrapper,
         embeddings
       }
     }
+
   }
 
   def extractPoolingLayer(layer: Int): String = {
@@ -85,31 +94,31 @@ class TensorflowBert(val tensorflow: TensorflowWrapper,
     bertLayer
   }
 
-  def calculateEmbeddings(sentences: Seq[WordpieceTokenizedSentence], originalTokenSentences: Seq[TokenizedSentence], poolingLayer: Int): Seq[WordpieceEmbeddingsSentence] = {
-    // ToDo What to do with longer sentences?
+  def calculateEmbeddings(sentences: Seq[WordpieceTokenizedSentence],
+                          originalTokenSentences: Seq[TokenizedSentence],
+                          poolingLayer: Int): Seq[WordpieceEmbeddingsSentence] = {
 
-    val bertLayer = extractPoolingLayer(poolingLayer)
-
-    // Run embeddings calculation by batches
+    /*Run embeddings calculation by batches*/
     sentences.zipWithIndex.grouped(batchSize).flatMap{batch =>
       val encoded = batch.map(s => encode(s._1))
 
-      val vectors = tag(encoded, bertLayer)
+      val vectors = tag(encoded, extractPoolingLayer(poolingLayer))
 
-      // Combine tokens and calculated embeddings
+      /*Combine tokens and calculated embeddings*/
       batch.zip(vectors).map{case (sentence, tokenVectors) =>
         originalTokenSentences.length
         val tokenLength = sentence._1.tokens.length
 
-        // All wordpiece embeddings
+        /*All wordpiece embeddings*/
         val tokenEmbeddings = tokenVectors.slice(1, tokenLength + 1)
 
-        // Word-level and span-level alignment with Tokenizer
-        // https://github.com/google-research/bert#tokenization
+        /*Word-level and span-level alignment with Tokenizer
+        https://github.com/google-research/bert#tokenization*/
         val tokensWithEmbeddings = sentence._1.tokens.zip(tokenEmbeddings).flatMap{
           case (token, tokenEmbedding) =>
             val tokenWithEmbeddings = TokenPieceEmbeddings(token, tokenEmbedding)
-            val originalTokensWithEmbeddings = originalTokenSentences(sentence._2).indexedTokens.find(p => p.begin == tokenWithEmbeddings.begin).map{
+            val originalTokensWithEmbeddings = originalTokenSentences(sentence._2).indexedTokens.find(
+              p => p.begin == tokenWithEmbeddings.begin).map{
               case (token) =>
                 val originalTokenWithEmbedding = TokenPieceEmbeddings(
                   TokenPiece(wordpiece = tokenWithEmbeddings.wordpiece,

--- a/src/main/scala/com/johnsnowlabs/nlp/EmbeddingsFinisher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/EmbeddingsFinisher.scala
@@ -4,7 +4,7 @@ import org.apache.spark.ml.Transformer
 import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.ml.param.{BooleanParam, ParamMap, StringArrayParam}
-import org.apache.spark.ml.util.{DefaultParamsWritable, Identifiable}
+import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.types._
@@ -137,3 +137,4 @@ class EmbeddingsFinisher(override val uid: String)
   }
 
 }
+object EmbeddingsFinisher extends DefaultParamsReadable[EmbeddingsFinisher]

--- a/src/main/scala/com/johnsnowlabs/nlp/base.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/base.scala
@@ -19,6 +19,9 @@ object base {
   type Finisher = com.johnsnowlabs.nlp.Finisher
   object Finisher extends DefaultParamsReadable[Finisher]
 
+  type EmbeddingsFinisher = com.johnsnowlabs.nlp.EmbeddingsFinisher
+  object EmbeddingsFinisher extends DefaultParamsReadable[EmbeddingsFinisher]
+
   type RecursivePipeline = com.johnsnowlabs.nlp.RecursivePipeline
 
   type LightPipeline = com.johnsnowlabs.nlp.LightPipeline


### PR DESCRIPTION
This PR intends to deal with `BertEmbeddings` annotator memory consumption.

- [x] Create tensors by using buffer instead of an object to improve performance:
reference: https://github.com/tensorflow/tensorflow/issues/8244#issuecomment-285459455

- [x] Clear sessions output to clear memory usage/consumption by `BertEmbeddings`