### PR TITLE
Fix BertEmbeddings crashing on empty input

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
@@ -153,8 +153,7 @@ object Annotation {
       annotations: Seq[Row] => annotations.map(r =>
         r.getString(0) match {
           case (AnnotatorType.WORD_EMBEDDINGS |
-               AnnotatorType.SENTENCE_EMBEDDINGS |
-               AnnotatorType.CHUNK_EMBEDDINGS) if (parseEmbeddings) => r.getSeq[Float](5).mkString(vSep)
+               AnnotatorType.SENTENCE_EMBEDDINGS) if (parseEmbeddings) => r.getSeq[Float](5).mkString(vSep)
           case _ => r.getString(3)
         }
       ).mkString(aSep)
@@ -167,8 +166,7 @@ object Annotation {
       annotations: Seq[Row] => annotations.map(r =>
         r.getString(0) match {
           case (AnnotatorType.WORD_EMBEDDINGS |
-               AnnotatorType.SENTENCE_EMBEDDINGS |
-               AnnotatorType.CHUNK_EMBEDDINGS) if (parseEmbeddings) =>
+               AnnotatorType.SENTENCE_EMBEDDINGS) if (parseEmbeddings) =>
             (r.getMap[String, String](4) ++
               Map(RESULT -> r.getString(3)) ++
               Map(EMBEDDINGS -> r.getSeq[Float](5).mkString(vSep))
@@ -186,8 +184,7 @@ object Annotation {
       annotations: Seq[Row] => annotations.map(r =>
         r.getString(0) match {
           case (AnnotatorType.WORD_EMBEDDINGS |
-               AnnotatorType.SENTENCE_EMBEDDINGS |
-               AnnotatorType.CHUNK_EMBEDDINGS) if (parseEmbeddings) => r.getSeq[Float](5).mkString(" ")
+               AnnotatorType.SENTENCE_EMBEDDINGS) if (parseEmbeddings) => r.getSeq[Float](5).mkString(" ")
           case _ => r.getString(3)
         }
       )

--- a/src/main/scala/com/johnsnowlabs/nlp/AnnotatorType.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/AnnotatorType.scala
@@ -6,7 +6,6 @@ object AnnotatorType {
   val WORDPIECE = "wordpiece"
   val WORD_EMBEDDINGS = "word_embeddings"
   val SENTENCE_EMBEDDINGS = "sentence_embeddings"
-  val CHUNK_EMBEDDINGS = "chunk_embeddings"
   val DATE = "date"
   val ENTITY = "entity"
   val SENTIMENT = "sentiment"

--- a/src/main/scala/com/johnsnowlabs/nlp/EmbeddingsFinisher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/EmbeddingsFinisher.scala
@@ -50,7 +50,6 @@ class EmbeddingsFinisher(override val uid: String)
 
     val embeddingsAnnotators = Seq(
       AnnotatorType.WORD_EMBEDDINGS,
-      AnnotatorType.CHUNK_EMBEDDINGS,
       AnnotatorType.SENTENCE_EMBEDDINGS
     )
 

--- a/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
@@ -59,8 +59,7 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddingsVectors: Bo
     fullAnnotate(target).mapValues(_.map(a => {
       a.annotatorType match {
         case (AnnotatorType.WORD_EMBEDDINGS |
-             AnnotatorType.SENTENCE_EMBEDDINGS |
-             AnnotatorType.CHUNK_EMBEDDINGS) if (parseEmbeddingsVectors) =>  a.embeddings.mkString(" ")
+             AnnotatorType.SENTENCE_EMBEDDINGS) if (parseEmbeddingsVectors) =>  a.embeddings.mkString(" ")
         case _ => a.result
       }
     }))

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -127,4 +127,7 @@ package object annotator {
   type SentenceEmbeddings = com.johnsnowlabs.nlp.embeddings.SentenceEmbeddings
   object SentenceEmbeddings extends DefaultParamsReadable[SentenceEmbeddings]
 
+  type ChunkEmbeddings = com.johnsnowlabs.nlp.embeddings.ChunkEmbeddings
+  object ChunkEmbeddings extends DefaultParamsReadable[ChunkEmbeddings]
+
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -129,12 +129,16 @@ class BertEmbeddings(override val uid: String) extends
     * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
     */
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
-    val sentences = SentenceSplit.unpack(annotations)
     val tokenizedSentences = TokenizedWithSentence.unpack(annotations)
-
-    val tokenized = tokenize(sentences)
-    val withEmbeddings = getModelIfNotSet.calculateEmbeddings(tokenized, tokenizedSentences, $(poolingLayer))
-    WordpieceEmbeddingsSentence.pack(withEmbeddings)
+    /*Return empty if the real tokens are empty*/
+    if(tokenizedSentences.nonEmpty) {
+      val sentences = SentenceSplit.unpack(annotations)
+      val tokenized = tokenize(sentences)
+      val withEmbeddings = getModelIfNotSet.calculateEmbeddings(tokenized, tokenizedSentences, $(poolingLayer))
+      WordpieceEmbeddingsSentence.pack(withEmbeddings)
+    }else {
+      Seq.empty[Annotation]
+    }
   }
 
   override def afterAnnotate(dataset: DataFrame): DataFrame = {

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
@@ -5,10 +5,12 @@ import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.ml.param.Param
 
+import scala.collection.Map
+
 class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmbeddings] {
 
   import com.johnsnowlabs.nlp.AnnotatorType._
-  override val outputAnnotatorType: AnnotatorType = CHUNK_EMBEDDINGS
+  override val outputAnnotatorType: AnnotatorType = WORD_EMBEDDINGS
 
   override val inputAnnotatorTypes: Array[AnnotatorType] = Array(CHUNK, WORD_EMBEDDINGS)
 
@@ -80,7 +82,11 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
           begin = chunk.begin,
           end = chunk.end,
           result = chunk.result,
-          metadata = chunk.metadata,
+          metadata = Map("sentence" -> idx.toString,
+            "token" -> chunk.result.toString,
+            "pieceId" -> "-1",
+            "isWordStart" -> "true"
+          ),
           embeddings = calculateChunkEmbeddings(allEmbeddings)
         )
 

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
@@ -1,6 +1,6 @@
 package com.johnsnowlabs.nlp.embeddings
 
-import com.johnsnowlabs.nlp.Finisher
+import com.johnsnowlabs.nlp.{EmbeddingsFinisher, Finisher}
 import com.johnsnowlabs.nlp.annotator.{Chunker, PerceptronModel}
 import com.johnsnowlabs.nlp.annotators.{NGramGenerator, Tokenizer}
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
@@ -46,12 +46,16 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
       .setOutputCol("chunk_embeddings")
       .setPoolingStrategy("AVERAGE")
 
-    val finisher = new Finisher()
+    val sentenceEmbeddingsChunk = new SentenceEmbeddings()
+      .setInputCols(Array("document", "chunk_embeddings"))
+      .setOutputCol("sentence_embeddings_chunks")
+      .setPoolingStrategy("AVERAGE")
+
+    val finisher = new EmbeddingsFinisher()
       .setInputCols("chunk_embeddings")
       .setOutputCols("finished_embeddings")
-      .setOutputAsArray(true)
+      .setOutputAsVector(true)
       .setCleanAnnotations(false)
-
 
     val pipeline = new RecursivePipeline()
       .setStages(Array(
@@ -62,6 +66,7 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
         chunker,
         embeddings,
         chunkEmbeddings,
+        sentenceEmbeddingsChunk,
         finisher
       ))
 
@@ -78,6 +83,9 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
     println("Chunk Embeddings")
     pipelineDF.select("chunk_embeddings.embeddings").show(2)
     pipelineDF.select(size(pipelineDF("chunk_embeddings.embeddings")).as("chunk_embeddings_size")).show
+
+    pipelineDF.select("sentence_embeddings_chunks.embeddings").show(2)
+    pipelineDF.select(size(pipelineDF("sentence_embeddings_chunks.embeddings")).as("chunk_embeddings_size")).show
 
     pipelineDF.select("finished_embeddings").show(2)
     pipelineDF.select(size(pipelineDF("finished_embeddings")).as("chunk_embeddings_size")).show

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
@@ -2,10 +2,12 @@ package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.nlp.{EmbeddingsFinisher, Finisher}
 import com.johnsnowlabs.nlp.annotator.{Chunker, PerceptronModel}
-import com.johnsnowlabs.nlp.annotators.{NGramGenerator, Tokenizer}
+import com.johnsnowlabs.nlp.annotators.{NGramGenerator, StopWordsCleaner, Tokenizer}
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.base.{DocumentAssembler, RecursivePipeline}
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.util.Benchmark
+import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.functions.size
 import org.scalatest._
 
@@ -159,6 +161,76 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
 
     pipelineDF.select("finished_embeddings").show(2)
     pipelineDF.select(size(pipelineDF("finished_embeddings")).as("chunk_embeddings_size")).show
+
+  }
+
+  "ChunkEmbeddings" should "correctly work with empty tokens" in {
+
+    val smallCorpus = ResourceHelper.spark.read.option("header","true").csv("src/test/resources/embeddings/sentence_embeddings.csv")
+
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentence = new SentenceDetector()
+      .setInputCols("document")
+      .setOutputCol("sentence")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("sentence"))
+      .setOutputCol("token")
+
+    val stopWordsCleaner = new StopWordsCleaner()
+      .setInputCols("token")
+      .setOutputCol("cleanTokens")
+      .setStopWords(Array("this", "is", "my", "document", "sentence", "second", "first", ",", "."))
+      .setCaseSensitive(false)
+
+    val posTagger = PerceptronModel.pretrained()
+      .setInputCols("sentence", "cleanTokens")
+      .setOutputCol("pos")
+
+    val chunker= new Chunker()
+      .setInputCols(Array("sentence", "pos"))
+      .setOutputCol("chunk")
+      .setRegexParsers(Array("<DT>?<JJ>*<NN>+"))
+
+    val embeddings = BertEmbeddings.pretrained()
+      .setInputCols("sentence", "cleanTokens")
+      .setOutputCol("embeddings")
+      .setCaseSensitive(true)
+      .setPoolingLayer(0)
+
+    val chunkEmbeddings = new ChunkEmbeddings()
+      .setInputCols(Array("chunk", "embeddings"))
+      .setOutputCol("chunk_embeddings")
+      .setPoolingStrategy("AVERAGE")
+
+    val embeddingsSentence = new SentenceEmbeddings()
+      .setInputCols(Array("sentence", "chunk_embeddings"))
+      .setOutputCol("sentence_embeddings")
+      .setPoolingStrategy("AVERAGE")
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        documentAssembler,
+        sentence,
+        tokenizer,
+        stopWordsCleaner,
+        posTagger,
+        chunker,
+        embeddings,
+        chunkEmbeddings,
+        embeddingsSentence
+      ))
+
+    val pipelineDF = pipeline.fit(smallCorpus).transform(smallCorpus)
+    println(pipelineDF.count())
+    pipelineDF.show()
+    pipelineDF.printSchema()
+    pipelineDF.select("chunk").show(1)
+    pipelineDF.select("embeddings").show(1)
+    pipelineDF.select("sentence_embeddings").show(1)
 
   }
 


### PR DESCRIPTION
In some cases when there are no tokens due to normalizations or removing stop words. the BertEmbeddings crashes instead of resulting an empty result. This PR will fix this issue.