### PR TITLE
Keep original index for the sentence-token columns pair

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/EmbeddingsWithSentence.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/EmbeddingsWithSentence.scala
@@ -24,15 +24,15 @@ object EmbeddingsWithSentence extends Annotated[TokenizedSentence] {
         token.begin >= sentence.start & token.end <= sentence.end
       ).map(token => IndexedToken(token.result, token.begin, token.end))
       sentenceTokens
-    }).filter(_.nonEmpty).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}
+    }).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}.filter(_.indexedTokens.nonEmpty)
 
   }
 
   override def pack(sentences: Seq[TokenizedSentence]): Seq[Annotation] = {
-    sentences.zipWithIndex.flatMap{case (sentence, index) =>
+    sentences.flatMap{sentence =>
         sentence.indexedTokens.map{token =>
         Annotation(annotatorType, token.begin, token.end, token.token,
-          Map("sentence" -> index.toString))
+          Map("sentence" -> sentence.sentenceIndex.toString))
     }}
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceWithEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceWithEmbeddings.scala
@@ -71,15 +71,15 @@ object  WordpieceEmbeddingsSentence extends Annotated[WordpieceEmbeddingsSentenc
   }
 
   override def pack(sentences: Seq[WordpieceEmbeddingsSentence]): Seq[Annotation] = {
-    sentences.zipWithIndex.flatMap{case (sentence, sentenceIndex) =>
+    sentences.flatMap{sentence =>
       var isFirstToken = true
-      sentence.tokens.map{token =>
+      sentence.tokens.map{ token =>
         // Store embeddings for token
         val embeddings = token.embeddings
 
         isFirstToken = false
         Annotation(annotatorType, token.begin, token.end, token.token,
-          Map("sentence" -> sentenceIndex.toString,
+          Map("sentence" -> sentence.sentenceId.toString,
             "token" -> token.token,
             "pieceId" -> token.pieceId.toString,
             "isWordStart" -> token.isWordStart.toString,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
@@ -24,8 +24,7 @@ object TokenizedWithSentence extends Annotated[TokenizedSentence] {
         token.begin >= sentence.start & token.end <= sentence.end
       ).map(token => IndexedToken(token.result, token.begin, token.end))
       sentenceTokens
-    }).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}
-
+    }).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}.filter(_.indexedTokens.length > 0)
   }
 
   override def pack(sentences: Seq[TokenizedSentence]): Seq[Annotation] = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
@@ -24,7 +24,7 @@ object TokenizedWithSentence extends Annotated[TokenizedSentence] {
         token.begin >= sentence.start & token.end <= sentence.end
       ).map(token => IndexedToken(token.result, token.begin, token.end))
       sentenceTokens
-    }).filter(_.nonEmpty).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}
+    }).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}
 
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
@@ -24,14 +24,14 @@ object TokenizedWithSentence extends Annotated[TokenizedSentence] {
         token.begin >= sentence.start & token.end <= sentence.end
       ).map(token => IndexedToken(token.result, token.begin, token.end))
       sentenceTokens
-    }).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}.filter(_.indexedTokens.length > 0)
+    }).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}.filter(_.indexedTokens.nonEmpty)
   }
 
   override def pack(sentences: Seq[TokenizedSentence]): Seq[Annotation] = {
-    sentences.zipWithIndex.flatMap{case (sentence, index) =>
+    sentences.flatMap{ sentence =>
         sentence.indexedTokens.map{token =>
         Annotation(annotatorType, token.begin, token.end, token.token,
-          Map("sentence" -> index.toString))
+          Map("sentence" -> sentence.sentenceIndex.toString))
     }}
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
@@ -72,12 +72,12 @@ class WordEmbeddingsModel(override val uid: String)
     */
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
     val sentences = TokenizedWithSentence.unpack(annotations)
-    val withEmbeddings = sentences.zipWithIndex.map{case (s, idx) =>
-      val tokens = s.indexedTokens.map {token =>
+    val withEmbeddings = sentences.map{ s =>
+      val tokens = s.indexedTokens.map { token =>
         val vectorOption = this.getEmbeddings.getEmbeddingsVector(token.token)
         TokenPieceEmbeddings(token.token, token.token, -1, true, vectorOption, this.getEmbeddings.zeroArray, token.begin, token.end)
       }
-      WordpieceEmbeddingsSentence(tokens, idx)
+      WordpieceEmbeddingsSentence(tokens, s.sentenceIndex)
     }
 
     WordpieceEmbeddingsSentence.pack(withEmbeddings)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TextMatcherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TextMatcherTestSpec.scala
@@ -15,7 +15,7 @@ class TextMatcherTestSpec extends FlatSpec with TextMatcherBehaviors {
     assert(entityExtractor.outputAnnotatorType == CHUNK)
   }
 
-  "An TextMatcher" should "extract entities with and without sentences" in {
+  "A TextMatcher" should "extract entities with and without sentences" in {
     val dataset = DataBuilder.basicDataBuild("Hello dolore magna aliqua. Lorem ipsum dolor. sit in laborum")
     val result = AnnotatorBuilder.withFullTextMatcher(dataset)
     val resultNoSentence = AnnotatorBuilder.withFullTextMatcher(dataset, sbd = false)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Just avoiding the filtering of sentences with no tokens. Filtering sentences seems to have no use case at all, it actually makes everything from then on untraceable.


## Motivation and Context
To be consistent with sentence indexing all throught the annotation Pipeline

## How Has This Been Tested?
Same tests run

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
