### PR TITLE
233 release candidate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,33 @@
 ========
+2.3.3
+========
+---------------
+Overview
+---------------
+This release addresses multiple bug fixes and some enhancements regarding memory consumption in BertEmbeddings annotator.
+Thanks for your feedback and reports!
+
+---------------
+Bugfixes
+---------------
+* Fix missing EmbeddingsFinisher in Scala and Python
+* Reverted embeddings move to copy due to CRC issue
+* Fix IndexOutOfBoundsException in SentenceEmbeddings
+
+---------------
+Enhancement
+---------------
+* For flexibility reasons, the inner jvm downloader may now be overriden
+
+
+---------------
+New Features
+---------------
+* NER overwriter annotator
+* Add `map_annotations`, `map_annotations_strict`, `map_annotations_col`, `filter_by_annotations_col` and `explode_annotations_col` to python side. 
+Renamed Scala side functions to be the same.
+
+========
 2.3.2
 ========
 ---------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,28 +4,27 @@
 ---------------
 Overview
 ---------------
-This release addresses multiple bug fixes and some enhancements regarding memory consumption in BertEmbeddings annotator.
+This release addresses multiple bug fixes, enhancements and new features.
 Thanks for your feedback and reports!
 
 ---------------
 Bugfixes
 ---------------
-* Fix missing EmbeddingsFinisher in Scala and Python
-* Reverted embeddings move to copy due to CRC issue
-* Fix IndexOutOfBoundsException in SentenceEmbeddings
-
+* Fix BertEmbeddings crashing on empty input
+* Keep original index for the sentence-token columns pair
+* Fixed typos in docs
+* Fixed bad deprecated OCR and spell paths
 ---------------
 Enhancement
 ---------------
-* For flexibility reasons, the inner jvm downloader may now be overriden
-
+* Make ChunkEmbeddings output to be compatible with SentenceEmbeddings
 
 ---------------
 New Features
 ---------------
 * NER overwriter annotator
 * Add `map_annotations`, `map_annotations_strict`, `map_annotations_col`, `filter_by_annotations_col` and `explode_annotations_col` to python side. 
-Renamed Scala side functions to be the same.
+Renamed Scala's side functions to be the same.
 
 ========
 2.3.2

--- a/README.md
+++ b/README.md
@@ -75,16 +75,15 @@ Output: ['Mona Lisa', 'Leonardo', 'Louvre', 'Paris']
 
 For more examples you can visit our dedicated [repository](https://github.com/JohnSnowLabs/spark-nlp-workshop) to showcase all Spark NLP use cases!
 
-
 ## Usage
 
 ## Apache Spark Support
 
-Spark NLP *2.3.2* has been built on top of Apache Spark 2.4.4
+Spark NLP *2.3.3* has been built on top of Apache Spark 2.4.4
 
-| Spark NLP   |   Spark 2.3.x         | Spark 2.4    |
+| Spark NLP   |   Spark 2.3.x         | Spark 2.4   |
 |-------------|-------------------------------------|--------------|
-| 2.x.x       |YES                                   |YES           |
+| 2.x.x       |YES                                  |YES           |
 | 1.8.x       |Partially                            |YES           |
 | 1.7.3       |YES                                  |N/A           |
 | 1.6.3       |YES                                  |N/A           |
@@ -94,7 +93,7 @@ Find out more about `Spark NLP` versions from our [release notes](https://github
 
 **Note:** that pre-build Spark NLP is not retrocompatible with older Spark 2.x.x, so models and environments might not work.
 
-If you are still stuck on Spark 2.x.x, you should re-build the library yourself with the desired Apache Spark version. Feel free to use [this assembly jar](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/public/spark-2.3.2-nlp-assembly-1.8.0.jar) for such version.
+If you are still stuck on Spark 2.x.x, you should re-build the library yourself with the desired Apache Spark version.
 
 ## Spark Packages
 
@@ -104,18 +103,18 @@ This library has been uploaded to the [spark-packages repository](https://spark-
 
 Benefit of spark-packages is that makes it available for both Scala-Java and Python
 
-To use the most recent version just add the `--packages JohnSnowLabs:spark-nlp:2.3.2` to you spark command
+To use the most recent version just add the `--packages JohnSnowLabs:spark-nlp:2.3.3` to you spark command
 
 ```sh
-spark-shell --packages JohnSnowLabs:spark-nlp:2.3.2
+spark-shell --packages JohnSnowLabs:spark-nlp:2.3.3
 ```
 
 ```sh
-pyspark --packages JohnSnowLabs:spark-nlp:2.3.2
+pyspark --packages JohnSnowLabs:spark-nlp:2.3.3
 ```
 
 ```sh
-spark-submit --packages JohnSnowLabs:spark-nlp:2.3.2
+spark-submit --packages JohnSnowLabs:spark-nlp:2.3.3
 ```
 
 This can also be used to create a SparkSession manually by using the `spark.jars.packages` option in both Python and Scala
@@ -169,7 +168,7 @@ Our package is deployed to maven central. In order to add this package as a depe
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp_2.11</artifactId>
-    <version>2.3.2</version>
+    <version>2.3.3</version>
 </dependency>
 ```
 
@@ -180,7 +179,7 @@ Our package is deployed to maven central. In order to add this package as a depe
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp-gpu_2.11</artifactId>
-    <version>2.3.2</version>
+    <version>2.3.3</version>
 </dependency>
 ```
 
@@ -190,14 +189,14 @@ Our package is deployed to maven central. In order to add this package as a depe
 
 ```sbtshell
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp" % "2.3.2"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp" % "2.3.3"
 ```
 
 **spark-nlp-gpu:**
 
 ```sbtshell
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-gpu
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-gpu" % "2.3.2"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-gpu" % "2.3.3"
 ```
 
 Maven Central: [https://mvnrepository.com/artifact/com.johnsnowlabs.nlp](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp)
@@ -213,7 +212,7 @@ If you installed pyspark through pip/conda, you can install `spark-nlp` through 
 Pip:
 
 ```bash
-pip install spark-nlp==2.3.2
+pip install spark-nlp==2.3.3
 ```
 
 Conda:
@@ -240,7 +239,7 @@ spark = SparkSession.builder \
     .master("local[4]")\
     .config("spark.driver.memory","8G")\
     .config("spark.driver.maxResultSize", "2G") \
-    .config("spark.jars.packages", "JohnSnowLabs:spark-nlp:2.3.2")\
+    .config("spark.jars.packages", "JohnSnowLabs:spark-nlp:2.3.3")\
     .config("spark.kryoserializer.buffer.max", "500m")\
     .getOrCreate()
 ```
@@ -273,7 +272,7 @@ Use either one of the following options
 * Add the following Maven Coordinates to the interpreter's library list
 
 ```bash
-com.johnsnowlabs.nlp:spark-nlp_2.11:2.3.2
+com.johnsnowlabs.nlp:spark-nlp_2.11:2.3.3
 ```
 
 * Add path to pre-built jar from [here](#compiled-jars) in the interpreter's library list making sure the jar is available to driver path
@@ -283,7 +282,7 @@ com.johnsnowlabs.nlp:spark-nlp_2.11:2.3.2
 Apart from previous step, install python module through pip
 
 ```bash
-pip install spark-nlp==2.3.2
+pip install spark-nlp==2.3.3
 ```
 
 Or you can install `spark-nlp` from inside Zeppelin by using Conda:
@@ -308,7 +307,7 @@ export PYSPARK_PYTHON=python3
 export PYSPARK_DRIVER_PYTHON=jupyter
 export PYSPARK_DRIVER_PYTHON_OPTS=notebook
 
-pyspark --packages JohnSnowLabs:spark-nlp:2.3.2
+pyspark --packages JohnSnowLabs:spark-nlp:2.3.3
 ```
 
 Alternatively, you can mix in using `--jars` option for pyspark + `pip install spark-nlp`
@@ -334,7 +333,7 @@ os.environ["PATH"] = os.environ["JAVA_HOME"] + "/bin:" + os.environ["PATH"]
 ! pip install --ignore-installed pyspark==2.4.4
 
 # Install Spark NLP
-! pip install --ignore-installed spark-nlp==2.3.2
+! pip install --ignore-installed spark-nlp==2.3.3
 
 # Quick SparkSession start
 import sparknlp

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ if(is_gpu.equals("false")){
 
 organization:= "com.johnsnowlabs.nlp"
 
-version := "2.3.2"
+version := "2.3.3"
 
 scalaVersion in ThisBuild := scalaVer
 

--- a/docs/en/models.md
+++ b/docs/en/models.md
@@ -16,7 +16,7 @@ modify_date: "2019-10-23"
 |----------------------------------------|---------------|---------------|
 |LemmatizerModel (Lemmatizer)            |  `lemma_antbnc`      | [Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/public/models/lemma_antbnc_en_2.0.2_2.4_1556480454569.zip)
 |PerceptronModel (POS)                   |   `pos_anc`     | [Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/public/models/pos_anc_en_2.0.2_2.4_1556659930154.zip)
-|NerCRFModel (NER with GloVe)            |    `ner_crf`    | [Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/public/models/ner_crf_en_2.0.2_2.4_1556652790378.zip)
+|NerCrfModel (NER with GloVe)            |    `ner_crf`    | [Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/public/models/ner_crf_en_2.0.2_2.4_1556652790378.zip)
 |NerDLModel (NER with GloVe)             |    `ner_dl`    | [Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/public/models/ner_dl_en_2.0.2_2.4_1558802205173.zip)
 |NerDLModel (NER with GloVe)             |    `ner_dl_contrib`    | [Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/public/models/ner_dl_contrib_en_2.0.2_2.4_1556501490317.zip)
 |NerDLModel (NER with BERT)| `ner_dl_bert_base_cased`|[Download](https://s3.amazonaws.com/auxdata.johnsnowlabs.com/public/models/ner_dl_bert_base_cased_en_2.2.0_2.4_1567854461249.zip)

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -589,7 +589,7 @@ val regexTokenizer = new Tokenizer().
 We also include another special transformer, called **Finisher** to show
 tokens in a human language.
 
-***Pythond code***
+***Python code***
 
 ```python
 finisher = Finisher() \

--- a/python/setup.py
+++ b/python/setup.py
@@ -40,7 +40,7 @@ setup(
     # For a discussion on single-sourcing the version across setup.py and the
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='2.3.2',  # Required
+    version='2.3.3',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -4,7 +4,6 @@ from sparknlp import annotator
 from sparknlp.base import DocumentAssembler, Finisher, TokenAssembler, Chunk2Doc, Doc2Chunk
 
 sys.modules['com.johnsnowlabs.nlp.annotators'] = annotator
-sys.modules['com.johnsnowlabs.nlp.annotators.ocr'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.tokenizer'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.tokenizer.wordpiece'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.ner'] = annotator
@@ -21,7 +20,6 @@ sys.modules['com.johnsnowlabs.nlp.annotators.sda.pragmatic'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.sda.vivekn'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.spell'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.spell.norvig'] = annotator
-sys.modules['com.johnsnowlabs.nlp.annotators.spell.context'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.spell.symmetric'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.parser'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.parser.dep'] = annotator

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -36,10 +36,10 @@ def start():
         .master("local[*]") \
         .config("spark.driver.memory", "6G") \
         .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")\
-        .config("spark.jars.packages", "JohnSnowLabs:spark-nlp:2.3.2") \
+        .config("spark.jars.packages", "JohnSnowLabs:spark-nlp:2.3.3") \
 
     return builder.getOrCreate()
 
 
 def version():
-    print('2.3.2')
+    print('2.3.3')

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -40,5 +40,6 @@ def start():
 
     return builder.getOrCreate()
 
+
 def version():
     print('2.3.2')

--- a/python/sparknlp/annotation.py
+++ b/python/sparknlp/annotation.py
@@ -1,0 +1,39 @@
+from pyspark.sql.types import *
+
+
+class Annotation:
+
+    def __init__(self, annotator_type, begin, end, result, metadata, embeddings):
+        self.annotator_type = annotator_type
+        self.begin = begin
+        self.end = end
+        self.result = result
+        self.metadata = metadata
+        self.embeddings = embeddings
+
+    def __str__(self):
+        return "Annotation(%s, %i, %i, %s, %s)" % (
+            self.annotator_type,
+            self.begin,
+            self.end,
+            self.result,
+            str(self.metadata)
+        )
+
+    def __repr__(self):
+        return self.__str__()
+
+    @staticmethod
+    def dataType():
+        return StructType([
+            StructField('annotator_type', StringType(), False),
+            StructField('begin', IntegerType(), False),
+            StructField('end', IntegerType(), False),
+            StructField('result', StringType(), False),
+            StructField('metadata', MapType(StringType(), StringType()), False),
+            StructField('embeddings', ArrayType(FloatType()), False)
+        ])
+
+    @staticmethod
+    def arrayType():
+        return ArrayType(Annotation.dataType())

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1633,6 +1633,7 @@ class ChunkEmbeddings(AnnotatorModel):
         else:
             return self._set(poolingStrategy="AVERAGE")
 
+
 class NerOverwriter(AnnotatorModel):
 
     name = "NerOverwriter"
@@ -1641,7 +1642,6 @@ class NerOverwriter(AnnotatorModel):
     def __init__(self):
         super(NerOverwriter, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ner.NerOverwriter")
         self._setDefault(
-            stopWords=[],
             newResult="I-OVERWRITE"
         )
 

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1632,3 +1632,26 @@ class ChunkEmbeddings(AnnotatorModel):
             return self._set(poolingStrategy=strategy)
         else:
             return self._set(poolingStrategy="AVERAGE")
+
+class NerOverwriter(AnnotatorModel):
+
+    name = "NerOverwriter"
+
+    @keyword_only
+    def __init__(self):
+        super(NerOverwriter, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ner.NerOverwriter")
+        self._setDefault(
+            stopWords=[],
+            newResult="I-OVERWRITE"
+        )
+
+    stopWords = Param(Params._dummy(), "stopWords", "The words to be overwritten",
+                      typeConverter=TypeConverters.toListString)
+    newResult = Param(Params._dummy(), "newResult", "new NER class to apply to those stopwords",
+                      typeConverter=TypeConverters.toString)
+
+    def setStopWords(self, value):
+        return self._set(stopWords=value)
+
+    def setNewResult(self, value):
+        return self._set(newResult=value)

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -461,10 +461,16 @@ class TextMatcher(AnnotatorApproach):
                           "whether to match regardless of case. Defaults true",
                           typeConverter=TypeConverters.toBoolean)
 
+    mergeOverlapping = Param(Params._dummy(),
+                          "mergeOverlapping",
+                          "whether to merge overlapping matched chunks. Defaults false",
+                          typeConverter=TypeConverters.toBoolean)
+
     @keyword_only
     def __init__(self):
         super(TextMatcher, self).__init__(classname="com.johnsnowlabs.nlp.annotators.TextMatcher")
         self._setDefault(caseSensitive=True)
+        self._setDefault(mergeOverlapping=False)
 
     def _create_model(self, java_model):
         return TextMatcherModel(java_model=java_model)
@@ -475,6 +481,9 @@ class TextMatcher(AnnotatorApproach):
     def setCaseSensitive(self, b):
         return self._set(caseSensitive=b)
 
+    def setMergeOverlapping(self, b):
+        return self._set(mergeOverlapping=b)
+
 
 class TextMatcherModel(AnnotatorModel):
     name = "TextMatcherModel"
@@ -484,6 +493,11 @@ class TextMatcherModel(AnnotatorModel):
             classname=classname,
             java_model=java_model
         )
+
+    @staticmethod
+    def pretrained(name, lang="en", remote_loc=None):
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(TextMatcherModel, name, lang, remote_loc)
 
 
 class PerceptronApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -27,12 +27,10 @@ sda.pragmatic = sys.modules[__name__]
 sda.vivekn = sys.modules[__name__]
 spell = sys.modules[__name__]
 spell.norvig = sys.modules[__name__]
-spell.context = sys.modules[__name__]
 spell.symmetric = sys.modules[__name__]
 parser = sys.modules[__name__]
 parser.dep = sys.modules[__name__]
 parser.typdep = sys.modules[__name__]
-ocr = sys.modules[__name__]
 embeddings = sys.modules[__name__]
 
 

--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -67,17 +67,6 @@ class JavaRecursiveEstimator(JavaEstimator):
                              "but got %s." % type(params))
 
 
-class Annotation:
-    def __init__(self, annotator_type, begin, end, result, metadata, embeddings=[], sentence_embeddings=[]):
-        self.annotator_type = annotator_type
-        self.begin = begin
-        self.end = end
-        self.result = result
-        self.metadata = metadata
-        self.embeddings = embeddings
-        self.sentence_embeddings = sentence_embeddings
-
-
 class LightPipeline:
     def __init__(self, pipelineModel, parse_embeddings=False):
         self.pipeline_model = pipelineModel
@@ -85,15 +74,15 @@ class LightPipeline:
 
     @staticmethod
     def _annotation_from_java(java_annotations):
+        from sparknlp.annotation import Annotation
         annotations = []
         for annotation in java_annotations:
             annotations.append(Annotation(annotation.annotatorType(),
                                           annotation.begin(),
                                           annotation.end(),
                                           annotation.result(),
-                                          dict(annotation.metadata()),
-                                          annotation.embeddings,
-                                          annotation.sentence_embeddings
+                                          annotation.metadata(),
+                                          annotation.embeddings
                                           )
                                )
         return annotations

--- a/python/sparknlp/functions.py
+++ b/python/sparknlp/functions.py
@@ -1,0 +1,39 @@
+from pyspark.sql.functions import udf
+from pyspark.sql.types import *
+from pyspark.sql import DataFrame
+import sys
+import sparknlp
+
+
+def map_annotations(f, output_type: DataType):
+    sys.modules['sparknlp.annotation'] = sparknlp  # Makes Annotation() pickle serializable  in top-level
+    return udf(
+        lambda content: f(content),
+        output_type
+    )
+
+
+def map_annotations_strict(f):
+    from sparknlp.annotation import Annotation
+    sys.modules['sparknlp.annotation'] = sparknlp  # Makes Annotation() pickle serializable in top-level
+    return udf(
+        lambda content: f(content),
+        ArrayType(Annotation.dataType())
+    )
+
+
+def map_annotations_col(dataframe: DataFrame, f, column, output_column, output_type):
+    dataframe.withColumn(output_column, map_annotations(f, output_type)(column))
+
+
+def filter_by_annotations_col(dataframe, f, column):
+    this_udf = udf(
+        lambda content: f(content),
+        BooleanType()
+    )
+    return dataframe.filter(this_udf(column))
+
+
+def explode_annotations_col(dataframe: DataFrame, column, output_column):
+    from pyspark.sql.functions import explode
+    return dataframe.withColumn(output_column, explode(column))

--- a/python/sparknlp/internal.py
+++ b/python/sparknlp/internal.py
@@ -54,8 +54,8 @@ class _ConfigLoaderGetter(ExtendedJavaWrapper):
 
 
 class _DownloadModel(ExtendedJavaWrapper):
-    def __init__(self, reader, name, language, remote_loc):
-        super(_DownloadModel, self).__init__("com.johnsnowlabs.nlp.pretrained.PythonResourceDownloader.downloadModel", reader, name, language, remote_loc)
+    def __init__(self, reader, name, language, remote_loc, validator):
+        super(_DownloadModel, self).__init__("com.johnsnowlabs.nlp.pretrained."+validator+".downloadModel", reader, name, language, remote_loc)
 
 
 class _DownloadPipeline(ExtendedJavaWrapper):

--- a/python/sparknlp/pretrained.py
+++ b/python/sparknlp/pretrained.py
@@ -28,7 +28,7 @@ def printProgress(stop):
 class ResourceDownloader(object):
 
     @staticmethod
-    def downloadModel(reader, name, language, remote_loc=None):
+    def downloadModel(reader, name, language, remote_loc=None, j_dwn='PythonResourceDownloader'):
         print(name + " download started this may take some time.")
         file_size = _internal._GetResourceSize(name, language, remote_loc).apply()
         if file_size == "-1":
@@ -39,7 +39,7 @@ class ResourceDownloader(object):
             t1 = threading.Thread(target=printProgress, args=(lambda: stop_threads,))
             t1.start()
             try:
-                j_obj = _internal._DownloadModel(reader.name, name, language, remote_loc).apply()
+                j_obj = _internal._DownloadModel(reader.name, name, language, remote_loc, j_dwn).apply()
             finally:
                 stop_threads = True
                 t1.join()

--- a/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
@@ -153,8 +153,7 @@ object Annotation {
       annotations: Seq[Row] => annotations.map(r =>
         r.getString(0) match {
           case (AnnotatorType.WORD_EMBEDDINGS |
-               AnnotatorType.SENTENCE_EMBEDDINGS |
-               AnnotatorType.CHUNK_EMBEDDINGS) if (parseEmbeddings) => r.getSeq[Float](5).mkString(vSep)
+               AnnotatorType.SENTENCE_EMBEDDINGS) if (parseEmbeddings) => r.getSeq[Float](5).mkString(vSep)
           case _ => r.getString(3)
         }
       ).mkString(aSep)
@@ -167,8 +166,7 @@ object Annotation {
       annotations: Seq[Row] => annotations.map(r =>
         r.getString(0) match {
           case (AnnotatorType.WORD_EMBEDDINGS |
-               AnnotatorType.SENTENCE_EMBEDDINGS |
-               AnnotatorType.CHUNK_EMBEDDINGS) if (parseEmbeddings) =>
+               AnnotatorType.SENTENCE_EMBEDDINGS) if (parseEmbeddings) =>
             (r.getMap[String, String](4) ++
               Map(RESULT -> r.getString(3)) ++
               Map(EMBEDDINGS -> r.getSeq[Float](5).mkString(vSep))
@@ -186,8 +184,7 @@ object Annotation {
       annotations: Seq[Row] => annotations.map(r =>
         r.getString(0) match {
           case (AnnotatorType.WORD_EMBEDDINGS |
-               AnnotatorType.SENTENCE_EMBEDDINGS |
-               AnnotatorType.CHUNK_EMBEDDINGS) if (parseEmbeddings) => r.getSeq[Float](5).mkString(" ")
+               AnnotatorType.SENTENCE_EMBEDDINGS) if (parseEmbeddings) => r.getSeq[Float](5).mkString(" ")
           case _ => r.getString(3)
         }
       )

--- a/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
@@ -78,6 +78,7 @@ object Annotation {
     StructField("embeddings", ArrayType(FloatType, false), true)
   ))
 
+  val arrayType = new ArrayType(dataType, false)
 
   /**
     * This method converts a [[org.apache.spark.sql.Row]] into an [[Annotation]]

--- a/src/main/scala/com/johnsnowlabs/nlp/AnnotatorType.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/AnnotatorType.scala
@@ -6,7 +6,6 @@ object AnnotatorType {
   val WORDPIECE = "wordpiece"
   val WORD_EMBEDDINGS = "word_embeddings"
   val SENTENCE_EMBEDDINGS = "sentence_embeddings"
-  val CHUNK_EMBEDDINGS = "chunk_embeddings"
   val DATE = "date"
   val ENTITY = "entity"
   val SENTIMENT = "sentiment"

--- a/src/main/scala/com/johnsnowlabs/nlp/EmbeddingsFinisher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/EmbeddingsFinisher.scala
@@ -50,7 +50,6 @@ class EmbeddingsFinisher(override val uid: String)
 
     val embeddingsAnnotators = Seq(
       AnnotatorType.WORD_EMBEDDINGS,
-      AnnotatorType.CHUNK_EMBEDDINGS,
       AnnotatorType.SENTENCE_EMBEDDINGS
     )
 

--- a/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
@@ -59,8 +59,7 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddingsVectors: Bo
     fullAnnotate(target).mapValues(_.map(a => {
       a.annotatorType match {
         case (AnnotatorType.WORD_EMBEDDINGS |
-             AnnotatorType.SENTENCE_EMBEDDINGS |
-             AnnotatorType.CHUNK_EMBEDDINGS) if (parseEmbeddingsVectors) =>  a.embeddings.mkString(" ")
+             AnnotatorType.SENTENCE_EMBEDDINGS) if (parseEmbeddingsVectors) =>  a.embeddings.mkString(" ")
         case _ => a.result
       }
     }))

--- a/src/main/scala/com/johnsnowlabs/nlp/SparkNLP.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/SparkNLP.scala
@@ -4,7 +4,7 @@ import org.apache.spark.sql.SparkSession
 
 object SparkNLP {
 
-  val currentVersion = "2.3.2"
+  val currentVersion = "2.3.3"
 
   def start(): SparkSession = {
     val build = SparkSession.builder()
@@ -12,7 +12,7 @@ object SparkNLP {
       .master("local[*]")
       .config("spark.driver.memory", "6G")
       .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-      .config("spark.jars.packages", "JohnSnowLabs:spark-nlp:2.3.2")
+      .config("spark.jars.packages", "JohnSnowLabs:spark-nlp:2.3.3")
 
     build.getOrCreate()
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -1,6 +1,6 @@
 package com.johnsnowlabs.nlp
 
-import com.johnsnowlabs.nlp.annotators.{ReadablePretrainedTokenizer, ReadablePretrainedLemmatizer}
+import com.johnsnowlabs.nlp.annotators.{ReadablePretrainedLemmatizer, ReadablePretrainedTextMatcher, ReadablePretrainedTokenizer}
 import com.johnsnowlabs.nlp.annotators.ner.crf.ReadablePretrainedNerCrf
 import com.johnsnowlabs.nlp.annotators.ner.dl.{ReadablePretrainedNerDL, ReadsNERGraph, WithGraphResolver}
 import com.johnsnowlabs.nlp.annotators.parser.dep.ReadablePretrainedDependency
@@ -36,7 +36,7 @@ package object annotator {
   type TextMatcher = com.johnsnowlabs.nlp.annotators.TextMatcher
   object TextMatcher extends DefaultParamsReadable[TextMatcher]
   type TextMatcherModel = com.johnsnowlabs.nlp.annotators.TextMatcherModel
-  object TextMatcherModel extends ParamsAndFeaturesReadable[TextMatcherModel]
+  object TextMatcherModel extends ReadablePretrainedTextMatcher
 
   type RegexMatcher = com.johnsnowlabs.nlp.annotators.RegexMatcher
   object RegexMatcher extends DefaultParamsReadable[RegexMatcher]

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -127,4 +127,7 @@ package object annotator {
   type SentenceEmbeddings = com.johnsnowlabs.nlp.embeddings.SentenceEmbeddings
   object SentenceEmbeddings extends DefaultParamsReadable[SentenceEmbeddings]
 
+  type ChunkEmbeddings = com.johnsnowlabs.nlp.embeddings.ChunkEmbeddings
+  object ChunkEmbeddings extends DefaultParamsReadable[ChunkEmbeddings]
+
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -130,4 +130,7 @@ package object annotator {
   type ChunkEmbeddings = com.johnsnowlabs.nlp.embeddings.ChunkEmbeddings
   object ChunkEmbeddings extends DefaultParamsReadable[ChunkEmbeddings]
 
+  type NerOverwriter = com.johnsnowlabs.nlp.annotators.ner.NerOverwriter
+  object NerOverwriter extends DefaultParamsReadable[NerOverwriter]
+
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcher.scala
@@ -22,9 +22,11 @@ class TextMatcher(override val uid: String) extends AnnotatorApproach[TextMatche
 
   val entities = new ExternalResourceParam(this, "entities", "entities external resource.")
   val caseSensitive = new BooleanParam(this, "caseSensitive", "whether to match regardless of case. Defaults true")
+  val mergeOverlapping = new BooleanParam(this, "mergeOverlapping", "whether to merge overlapping matched chunks. Defaults false")
 
   setDefault(inputCols,Array(TOKEN))
   setDefault(caseSensitive, true)
+  setDefault(mergeOverlapping, false)
 
   def setEntities(value: ExternalResource): this.type =
     set(entities, value)
@@ -37,6 +39,10 @@ class TextMatcher(override val uid: String) extends AnnotatorApproach[TextMatche
 
   def getCaseSensitive: Boolean =
     $(caseSensitive)
+
+  def setMergeOverlapping(v: Boolean): this.type = set(mergeOverlapping, v)
+
+  def getMergeOverlapping: Boolean = $(mergeOverlapping)
 
   /**
     * Loads entities from a provided source.

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcherModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcherModel.scala
@@ -6,6 +6,7 @@ import org.apache.spark.ml.util.Identifiable
 import com.johnsnowlabs.nlp.AnnotatorType._
 import com.johnsnowlabs.nlp.serialization.ArrayFeature
 import org.apache.spark.ml.param.BooleanParam
+import annotation.{tailrec => tco}
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -22,8 +23,8 @@ class TextMatcherModel(override val uid: String) extends AnnotatorModel[TextMatc
   override val inputAnnotatorTypes: Array[AnnotatorType] = Array(DOCUMENT, TOKEN)
 
   val parsedEntities = new ArrayFeature[Array[String]](this, "parsedEntities")
-
   val caseSensitive = new BooleanParam(this, "caseSensitive", "whether to match regardless of case. Defaults true")
+  val mergeOverlapping = new BooleanParam(this, "mergeOverlapping", "whether to merge overlapping matched chunks. Defaults false")
 
   def setEntities(value: Array[Array[String]]): this.type = set(parsedEntities, value)
 
@@ -33,10 +34,23 @@ class TextMatcherModel(override val uid: String) extends AnnotatorModel[TextMatc
   def getCaseSensitive: Boolean =
     $(caseSensitive)
 
+  def setMergeOverlapping(v: Boolean): this.type = set(mergeOverlapping, v)
+
+  def getMergeOverlapping: Boolean = $(mergeOverlapping)
+
   lazy val searchTrie = SearchTrie.apply($$(parsedEntities), $(caseSensitive))
 
   /** internal constructor for writabale annotator */
   def this() = this(Identifiable.randomUID("ENTITY_EXTRACTOR"))
+
+  @tco final protected def collapse(rs: List[(Int,Int)], sep: List[(Int,Int)] = Nil): List[(Int,Int)] = rs match {
+    case x :: y :: rest =>
+      if (y._1 > x._2) collapse(y :: rest, x :: sep)
+      else collapse( (x._1, x._2 max y._2) :: rest, sep)
+    case _ =>
+      (rs ::: sep).reverse
+  }
+  protected def merge(rs: List[(Int,Int)]): List[(Int,Int)] = collapse(rs.sortBy(_._1))
 
   /**
     * Searches entities and stores them in the annotation
@@ -56,7 +70,11 @@ class TextMatcherModel(override val uid: String) extends AnnotatorModel[TextMatc
           token.begin >= sentence.begin &&
             token.end <= sentence.end)
 
-      for ((begin, end) <- searchTrie.search(tokens.map(_.result))) {
+      val foundTokens = searchTrie.search(tokens.map(_.result)).toList
+
+      val finalTokens = if($(mergeOverlapping)) merge(foundTokens) else foundTokens
+
+      for ((begin, end) <- finalTokens) {
 
         val firstTokenBegin = tokens(begin).begin
         val lastTokenEnd = tokens(end).end
@@ -81,4 +99,12 @@ class TextMatcherModel(override val uid: String) extends AnnotatorModel[TextMatc
 
 }
 
-object TextMatcherModel extends ParamsAndFeaturesReadable[TextMatcherModel]
+trait ReadablePretrainedTextMatcher extends ParamsAndFeaturesReadable[TextMatcherModel] with HasPretrained[TextMatcherModel] {
+  override val defaultModelName: String = "_"
+  override def pretrained(): TextMatcherModel = super.pretrained()
+  override def pretrained(name: String): TextMatcherModel = super.pretrained(name)
+  override def pretrained(name: String, lang: String): TextMatcherModel = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): TextMatcherModel = super.pretrained(name, lang, remoteLoc)
+}
+
+object TextMatcherModel extends ReadablePretrainedTextMatcher

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/EmbeddingsWithSentence.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/EmbeddingsWithSentence.scala
@@ -24,15 +24,15 @@ object EmbeddingsWithSentence extends Annotated[TokenizedSentence] {
         token.begin >= sentence.start & token.end <= sentence.end
       ).map(token => IndexedToken(token.result, token.begin, token.end))
       sentenceTokens
-    }).filter(_.nonEmpty).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}
+    }).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}.filter(_.indexedTokens.nonEmpty)
 
   }
 
   override def pack(sentences: Seq[TokenizedSentence]): Seq[Annotation] = {
-    sentences.zipWithIndex.flatMap{case (sentence, index) =>
+    sentences.flatMap{sentence =>
         sentence.indexedTokens.map{token =>
         Annotation(annotatorType, token.begin, token.end, token.token,
-          Map("sentence" -> index.toString))
+          Map("sentence" -> sentence.sentenceIndex.toString))
     }}
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceWithEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceWithEmbeddings.scala
@@ -71,15 +71,15 @@ object  WordpieceEmbeddingsSentence extends Annotated[WordpieceEmbeddingsSentenc
   }
 
   override def pack(sentences: Seq[WordpieceEmbeddingsSentence]): Seq[Annotation] = {
-    sentences.zipWithIndex.flatMap{case (sentence, sentenceIndex) =>
+    sentences.flatMap{sentence =>
       var isFirstToken = true
-      sentence.tokens.map{token =>
+      sentence.tokens.map{ token =>
         // Store embeddings for token
         val embeddings = token.embeddings
 
         isFirstToken = false
         Annotation(annotatorType, token.begin, token.end, token.token,
-          Map("sentence" -> sentenceIndex.toString,
+          Map("sentence" -> sentence.sentenceId.toString,
             "token" -> token.token,
             "pieceId" -> token.pieceId.toString,
             "isWordStart" -> token.isWordStart.toString,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
@@ -24,15 +24,14 @@ object TokenizedWithSentence extends Annotated[TokenizedSentence] {
         token.begin >= sentence.start & token.end <= sentence.end
       ).map(token => IndexedToken(token.result, token.begin, token.end))
       sentenceTokens
-    }).filter(_.nonEmpty).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}
-
+    }).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}.filter(_.indexedTokens.nonEmpty)
   }
 
   override def pack(sentences: Seq[TokenizedSentence]): Seq[Annotation] = {
-    sentences.zipWithIndex.flatMap{case (sentence, index) =>
+    sentences.flatMap{ sentence =>
         sentence.indexedTokens.map{token =>
         Annotation(annotatorType, token.begin, token.end, token.token,
-          Map("sentence" -> index.toString))
+          Map("sentence" -> sentence.sentenceIndex.toString))
     }}
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriter.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriter.scala
@@ -5,7 +5,7 @@ import com.johnsnowlabs.nlp.annotators.common.SentenceSplit
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, ParamsAndFeaturesReadable}
 import org.apache.spark.ml.feature.StopWordsRemover
 import org.apache.spark.ml.param.{BooleanParam, Param, ParamValidators, StringArrayParam}
-import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 
 
 class NerOverwriter(override val uid: String) extends AnnotatorModel[NerOverwriter] {
@@ -61,4 +61,4 @@ class NerOverwriter(override val uid: String) extends AnnotatorModel[NerOverwrit
 
 }
 
-object NerOverwriter extends ParamsAndFeaturesReadable[NerOverwriter]
+object NerOverwriter extends DefaultParamsReadable[NerOverwriter]

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriter.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriter.scala
@@ -28,9 +28,6 @@ class NerOverwriter(override val uid: String) extends AnnotatorModel[NerOverwrit
   def getNewResult: String = $(newResult)
 
   setDefault(
-    inputCols -> Array(NAMED_ENTITY),
-    outputCol -> "fixed_rer",
-    stopWords -> Array(),
     newResult -> "I-OVERWRITE"
   )
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriter.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriter.scala
@@ -1,0 +1,67 @@
+package com.johnsnowlabs.nlp.annotators.ner
+import java.util.Locale
+
+import com.johnsnowlabs.nlp.annotators.common.SentenceSplit
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, ParamsAndFeaturesReadable}
+import org.apache.spark.ml.feature.StopWordsRemover
+import org.apache.spark.ml.param.{BooleanParam, Param, ParamValidators, StringArrayParam}
+import org.apache.spark.ml.util.Identifiable
+
+
+class NerOverwriter(override val uid: String) extends AnnotatorModel[NerOverwriter] {
+
+  import com.johnsnowlabs.nlp.AnnotatorType.NAMED_ENTITY
+
+  override val outputAnnotatorType: AnnotatorType = NAMED_ENTITY
+
+  override val inputAnnotatorTypes: Array[AnnotatorType] = Array(NAMED_ENTITY)
+
+  def this() = this(Identifiable.randomUID("NER_OVERWRITER"))
+
+  val stopWords: StringArrayParam =
+    new StringArrayParam(this, "stopWords", "the words to be filtered out.")
+  def setStopWords(value: Array[String]): this.type = set(stopWords, value)
+  def getStopWords: Array[String] = $(stopWords)
+
+  val newResult: Param[String] = new Param(this, "newResult", "New NER class to overwrite")
+  def setNewResult(r: String): this.type = {set(newResult, r)}
+  def getNewResult: String = $(newResult)
+
+  setDefault(
+    inputCols -> Array(NAMED_ENTITY),
+    outputCol -> "fixed_rer",
+    stopWords -> Array(),
+    newResult -> "I-OVERWRITE"
+  )
+
+  override def annotate(annotations: Seq[Annotation]) : Seq[Annotation]= {
+
+    var annotationsOverwritten = annotations
+
+    annotationsOverwritten.map { tokenAnnotation =>
+      val stopWordsSet = $(stopWords).toSet
+      if (stopWordsSet.contains(tokenAnnotation.metadata("word"))) {
+        Annotation(
+          outputAnnotatorType,
+          tokenAnnotation.begin,
+          tokenAnnotation.end,
+          $(newResult),
+          tokenAnnotation.metadata
+        )
+      } else {
+        Annotation(
+          outputAnnotatorType,
+          tokenAnnotation.begin,
+          tokenAnnotation.end,
+          tokenAnnotation.result,
+          tokenAnnotation.metadata
+        )
+      }
+
+    }
+
+  }
+
+}
+
+object NerOverwriter extends ParamsAndFeaturesReadable[NerOverwriter]

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -129,12 +129,16 @@ class BertEmbeddings(override val uid: String) extends
     * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
     */
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
-    val sentences = SentenceSplit.unpack(annotations)
     val tokenizedSentences = TokenizedWithSentence.unpack(annotations)
-
-    val tokenized = tokenize(sentences)
-    val withEmbeddings = getModelIfNotSet.calculateEmbeddings(tokenized, tokenizedSentences, $(poolingLayer))
-    WordpieceEmbeddingsSentence.pack(withEmbeddings)
+    /*Return empty if the real tokens are empty*/
+    if(tokenizedSentences.nonEmpty) {
+      val sentences = SentenceSplit.unpack(annotations)
+      val tokenized = tokenize(sentences)
+      val withEmbeddings = getModelIfNotSet.calculateEmbeddings(tokenized, tokenizedSentences, $(poolingLayer))
+      WordpieceEmbeddingsSentence.pack(withEmbeddings)
+    }else {
+      Seq.empty[Annotation]
+    }
   }
 
   override def afterAnnotate(dataset: DataFrame): DataFrame = {

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
@@ -5,10 +5,12 @@ import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.ml.param.Param
 
+import scala.collection.Map
+
 class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmbeddings] {
 
   import com.johnsnowlabs.nlp.AnnotatorType._
-  override val outputAnnotatorType: AnnotatorType = CHUNK_EMBEDDINGS
+  override val outputAnnotatorType: AnnotatorType = WORD_EMBEDDINGS
 
   override val inputAnnotatorTypes: Array[AnnotatorType] = Array(CHUNK, WORD_EMBEDDINGS)
 
@@ -80,7 +82,11 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
           begin = chunk.begin,
           end = chunk.end,
           result = chunk.result,
-          metadata = chunk.metadata,
+          metadata = Map("sentence" -> idx.toString,
+            "token" -> chunk.result.toString,
+            "pieceId" -> "-1",
+            "isWordStart" -> "true"
+          ),
           embeddings = calculateChunkEmbeddings(allEmbeddings)
         )
 

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
@@ -72,12 +72,12 @@ class WordEmbeddingsModel(override val uid: String)
     */
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
     val sentences = TokenizedWithSentence.unpack(annotations)
-    val withEmbeddings = sentences.zipWithIndex.map{case (s, idx) =>
-      val tokens = s.indexedTokens.map {token =>
+    val withEmbeddings = sentences.map{ s =>
+      val tokens = s.indexedTokens.map { token =>
         val vectorOption = this.getEmbeddings.getEmbeddingsVector(token.token)
         TokenPieceEmbeddings(token.token, token.token, -1, true, vectorOption, this.getEmbeddings.zeroArray, token.begin, token.end)
       }
-      WordpieceEmbeddingsSentence(tokens, idx)
+      WordpieceEmbeddingsSentence(tokens, s.sentenceIndex)
     }
 
     WordpieceEmbeddingsSentence.pack(withEmbeddings)

--- a/src/main/scala/com/johnsnowlabs/util/Build.scala
+++ b/src/main/scala/com/johnsnowlabs/util/Build.scala
@@ -11,6 +11,6 @@ object Build {
     if (version != null && version.nonEmpty)
       version
     else
-      "2.3.2"
+      "2.3.3"
   }
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/FunctionsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/FunctionsTestSpec.scala
@@ -4,6 +4,7 @@ import com.johnsnowlabs.nlp.annotator.{PerceptronApproach, Tokenizer}
 import com.johnsnowlabs.nlp.training.POS
 import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
 import org.apache.spark.ml.Pipeline
+import org.apache.spark.sql.types.ArrayType
 import org.scalatest._
 
 class FunctionsTestSpec extends FlatSpec {
@@ -40,21 +41,33 @@ class FunctionsTestSpec extends FlatSpec {
 
     import functions._
 
-    val mapped = data.mapAnnotations("pos", "modpos", (annotations: Seq[Annotation]) => {
+    val mapped = data.mapAnnotationsCol("pos", "modpos", (annotations: Seq[Annotation]) => {
       annotations.filter(_.result == "JJ")
     })
 
-    val modified = data.mapAnnotations("pos", "modpos", (_: Seq[Annotation]) => {
+    val modified = data.mapAnnotationsCol("pos", "modpos", (_: Seq[Annotation]) => {
       "hello world"
     })
 
-    val filtered = data.filterByAnnotations("pos", (annotations: Seq[Annotation]) => {
+    val filtered = data.filterByAnnotationsCol("pos", (annotations: Seq[Annotation]) => {
       annotations.exists(_.result == "JJ")
     })
+
+    import org.apache.spark.sql.functions.col
+
+    val udfed = data.select(mapAnnotations((annotations: Seq[Annotation]) => {
+      annotations.filter(_.result == "JJ")
+    }, ArrayType(Annotation.dataType))(col("pos")))
+
+    val udfed2 = data.select(mapAnnotationsStrict((annotations: Seq[Annotation]) => {
+      annotations.filter(_.result == "JJ")
+    })(col("pos")))
 
     mapped.show(truncate = false)
     modified.show(truncate = false)
     filtered.show(truncate = false)
+    udfed.show(truncate = false)
+    udfed2.show(truncate = false)
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TextMatcherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TextMatcherTestSpec.scala
@@ -15,7 +15,7 @@ class TextMatcherTestSpec extends FlatSpec with TextMatcherBehaviors {
     assert(entityExtractor.outputAnnotatorType == CHUNK)
   }
 
-  "An TextMatcher" should "extract entities with and without sentences" in {
+  "A TextMatcher" should "extract entities with and without sentences" in {
     val dataset = DataBuilder.basicDataBuild("Hello dolore magna aliqua. Lorem ipsum dolor. sit in laborum")
     val result = AnnotatorBuilder.withFullTextMatcher(dataset)
     val resultNoSentence = AnnotatorBuilder.withFullTextMatcher(dataset, sbd = false)

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
@@ -1,6 +1,6 @@
 package com.johnsnowlabs.nlp.embeddings
 
-import com.johnsnowlabs.nlp.Finisher
+import com.johnsnowlabs.nlp.{EmbeddingsFinisher, Finisher}
 import com.johnsnowlabs.nlp.annotator.{Chunker, PerceptronModel}
 import com.johnsnowlabs.nlp.annotators.{NGramGenerator, Tokenizer}
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
@@ -46,12 +46,16 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
       .setOutputCol("chunk_embeddings")
       .setPoolingStrategy("AVERAGE")
 
-    val finisher = new Finisher()
+    val sentenceEmbeddingsChunk = new SentenceEmbeddings()
+      .setInputCols(Array("document", "chunk_embeddings"))
+      .setOutputCol("sentence_embeddings_chunks")
+      .setPoolingStrategy("AVERAGE")
+
+    val finisher = new EmbeddingsFinisher()
       .setInputCols("chunk_embeddings")
       .setOutputCols("finished_embeddings")
-      .setOutputAsArray(true)
+      .setOutputAsVector(true)
       .setCleanAnnotations(false)
-
 
     val pipeline = new RecursivePipeline()
       .setStages(Array(
@@ -62,6 +66,7 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
         chunker,
         embeddings,
         chunkEmbeddings,
+        sentenceEmbeddingsChunk,
         finisher
       ))
 
@@ -78,6 +83,9 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
     println("Chunk Embeddings")
     pipelineDF.select("chunk_embeddings.embeddings").show(2)
     pipelineDF.select(size(pipelineDF("chunk_embeddings.embeddings")).as("chunk_embeddings_size")).show
+
+    pipelineDF.select("sentence_embeddings_chunks.embeddings").show(2)
+    pipelineDF.select(size(pipelineDF("sentence_embeddings_chunks.embeddings")).as("chunk_embeddings_size")).show
 
     pipelineDF.select("finished_embeddings").show(2)
     pipelineDF.select(size(pipelineDF("finished_embeddings")).as("chunk_embeddings_size")).show

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
@@ -2,10 +2,12 @@ package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.nlp.{EmbeddingsFinisher, Finisher}
 import com.johnsnowlabs.nlp.annotator.{Chunker, PerceptronModel}
-import com.johnsnowlabs.nlp.annotators.{NGramGenerator, Tokenizer}
+import com.johnsnowlabs.nlp.annotators.{NGramGenerator, StopWordsCleaner, Tokenizer}
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.base.{DocumentAssembler, RecursivePipeline}
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.util.Benchmark
+import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.functions.size
 import org.scalatest._
 
@@ -159,6 +161,76 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
 
     pipelineDF.select("finished_embeddings").show(2)
     pipelineDF.select(size(pipelineDF("finished_embeddings")).as("chunk_embeddings_size")).show
+
+  }
+
+  "ChunkEmbeddings" should "correctly work with empty tokens" in {
+
+    val smallCorpus = ResourceHelper.spark.read.option("header","true").csv("src/test/resources/embeddings/sentence_embeddings.csv")
+
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentence = new SentenceDetector()
+      .setInputCols("document")
+      .setOutputCol("sentence")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("sentence"))
+      .setOutputCol("token")
+
+    val stopWordsCleaner = new StopWordsCleaner()
+      .setInputCols("token")
+      .setOutputCol("cleanTokens")
+      .setStopWords(Array("this", "is", "my", "document", "sentence", "second", "first", ",", "."))
+      .setCaseSensitive(false)
+
+    val posTagger = PerceptronModel.pretrained()
+      .setInputCols("sentence", "cleanTokens")
+      .setOutputCol("pos")
+
+    val chunker= new Chunker()
+      .setInputCols(Array("sentence", "pos"))
+      .setOutputCol("chunk")
+      .setRegexParsers(Array("<DT>?<JJ>*<NN>+"))
+
+    val embeddings = BertEmbeddings.pretrained()
+      .setInputCols("sentence", "cleanTokens")
+      .setOutputCol("embeddings")
+      .setCaseSensitive(true)
+      .setPoolingLayer(0)
+
+    val chunkEmbeddings = new ChunkEmbeddings()
+      .setInputCols(Array("chunk", "embeddings"))
+      .setOutputCol("chunk_embeddings")
+      .setPoolingStrategy("AVERAGE")
+
+    val embeddingsSentence = new SentenceEmbeddings()
+      .setInputCols(Array("sentence", "chunk_embeddings"))
+      .setOutputCol("sentence_embeddings")
+      .setPoolingStrategy("AVERAGE")
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        documentAssembler,
+        sentence,
+        tokenizer,
+        stopWordsCleaner,
+        posTagger,
+        chunker,
+        embeddings,
+        chunkEmbeddings,
+        embeddingsSentence
+      ))
+
+    val pipelineDF = pipeline.fit(smallCorpus).transform(smallCorpus)
+    println(pipelineDF.count())
+    pipelineDF.show()
+    pipelineDF.printSchema()
+    pipelineDF.select("chunk").show(1)
+    pipelineDF.select("embeddings").show(1)
+    pipelineDF.select("sentence_embeddings").show(1)
 
   }
 


### PR DESCRIPTION
Bugfixes
---------------
* Fix BertEmbeddings crashing on empty input
* Keep original index for the sentence-token columns pair
* Fixed typos in docs
* Fixed bad deprecated OCR and spell paths
---------------
Enhancement
---------------
* Make ChunkEmbeddings output to be compatible with SentenceEmbeddings

---------------
New Features
---------------
* NER overwriter annotator
* Add `map_annotations`, `map_annotations_strict`, `map_annotations_col`, `filter_by_annotations_col` and `explode_annotations_col` to python side. 
Renamed Scala's side functions to be the same.
