### PR TITLE
Adds python UDF ready functions to deal with annotations

### DIFF
--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -42,5 +42,6 @@ def start():
 
     return builder.getOrCreate()
 
+
 def version():
     print('2.3.2')

--- a/python/sparknlp/annotation.py
+++ b/python/sparknlp/annotation.py
@@ -1,0 +1,27 @@
+from pyspark.sql.types import *
+
+
+class Annotation:
+
+    def __init__(self, annotator_type, begin, end, result, metadata, embeddings):
+        self.annotator_type = annotator_type
+        self.begin = begin
+        self.end = end
+        self.result = result
+        self.metadata = metadata
+        self.embeddings = embeddings
+
+    @staticmethod
+    def dataType():
+        return StructType([
+            StructField('annotator_type', StringType(), False),
+            StructField('begin', IntegerType(), False),
+            StructField('end', IntegerType(), False),
+            StructField('result', StringType(), False),
+            StructField('metadata', MapType(StringType(), StringType()), False),
+            StructField('embeddings', ArrayType(FloatType()), False)
+        ])
+
+    @staticmethod
+    def arrayType():
+        return ArrayType(Annotation.dataType())

--- a/python/sparknlp/annotation.py
+++ b/python/sparknlp/annotation.py
@@ -11,6 +11,18 @@ class Annotation:
         self.metadata = metadata
         self.embeddings = embeddings
 
+    def __str__(self):
+        return "Annotation(%s, %i, %i, %s, %s)" % (
+            self.annotator_type,
+            self.begin,
+            self.end,
+            self.result,
+            str(self.metadata)
+        )
+
+    def __repr__(self):
+        return self.__str__()
+
     @staticmethod
     def dataType():
         return StructType([

--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -67,17 +67,6 @@ class JavaRecursiveEstimator(JavaEstimator):
                              "but got %s." % type(params))
 
 
-class Annotation:
-    def __init__(self, annotator_type, begin, end, result, metadata, embeddings=[], sentence_embeddings=[]):
-        self.annotator_type = annotator_type
-        self.begin = begin
-        self.end = end
-        self.result = result
-        self.metadata = metadata
-        self.embeddings = embeddings
-        self.sentence_embeddings = sentence_embeddings
-
-
 class LightPipeline:
     def __init__(self, pipelineModel, parse_embeddings=False):
         self.pipeline_model = pipelineModel
@@ -87,14 +76,13 @@ class LightPipeline:
     def _annotation_from_java(java_annotations):
         annotations = []
         for annotation in java_annotations:
-            annotations.append(Annotation(annotation.annotatorType(),
-                                          annotation.begin(),
-                                          annotation.end(),
-                                          annotation.result(),
-                                          dict(annotation.metadata()),
-                                          annotation.embeddings,
-                                          annotation.sentence_embeddings
-                                          )
+            annotations.append(annotation.Annotation(annotation.annotatorType(),
+                                                annotation.begin(),
+                                                annotation.end(),
+                                                annotation.result(),
+                                                dict(annotation.metadata()),
+                                                annotation.embeddings
+                                                )
                                )
         return annotations
 

--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -74,15 +74,16 @@ class LightPipeline:
 
     @staticmethod
     def _annotation_from_java(java_annotations):
+        from sparknlp.annotation import Annotation
         annotations = []
         for annotation in java_annotations:
-            annotations.append(annotation.Annotation(annotation.annotatorType(),
-                                                annotation.begin(),
-                                                annotation.end(),
-                                                annotation.result(),
-                                                dict(annotation.metadata()),
-                                                annotation.embeddings
-                                                )
+            annotations.append(Annotation(annotation.annotatorType(),
+                                          annotation.begin(),
+                                          annotation.end(),
+                                          annotation.result(),
+                                          annotation.metadata(),
+                                          annotation.embeddings
+                                          )
                                )
         return annotations
 

--- a/python/sparknlp/functions.py
+++ b/python/sparknlp/functions.py
@@ -5,7 +5,7 @@ import sys
 import sparknlp
 
 
-def map_annotations_udf(f, output_type: DataType):
+def map_annotations(f, output_type: DataType):
     sys.modules['sparknlp.annotation'] = sparknlp  # Makes Annotation() pickle serializable  in top-level
     return udf(
         lambda content: f(content),
@@ -13,7 +13,7 @@ def map_annotations_udf(f, output_type: DataType):
     )
 
 
-def map_annotations_to_annotations_udf(f, output_type: DataType):
+def map_annotations_strict(f):
     from sparknlp.annotation import Annotation
     sys.modules['sparknlp.annotation'] = sparknlp  # Makes Annotation() pickle serializable in top-level
     return udf(
@@ -22,11 +22,11 @@ def map_annotations_to_annotations_udf(f, output_type: DataType):
     )
 
 
-def map_annotations(dataframe: DataFrame, f, column, output_column, output_type):
-    dataframe.withColumn(output_column, map_annotations_udf(f, output_type)(column))
+def map_annotations_col(dataframe: DataFrame, f, column, output_column, output_type):
+    dataframe.withColumn(output_column, map_annotations(f, output_type)(column))
 
 
-def filter_by_annotations(dataframe, f, column):
+def filter_by_annotations_col(dataframe, f, column):
     this_udf = udf(
         lambda content: f(content),
         BooleanType()
@@ -34,6 +34,6 @@ def filter_by_annotations(dataframe, f, column):
     return dataframe.filter(this_udf(column))
 
 
-def explode_annotations(dataframe: DataFrame, column, output_column):
+def explode_annotations_col(dataframe: DataFrame, column, output_column):
     from pyspark.sql.functions import explode
     return dataframe.withColumn(output_column, explode(column))

--- a/python/sparknlp/functions.py
+++ b/python/sparknlp/functions.py
@@ -1,0 +1,39 @@
+from pyspark.sql.functions import udf
+from pyspark.sql.types import *
+from pyspark.sql import DataFrame
+import sys
+import sparknlp
+
+
+def map_annotations_udf(f, output_type: DataType):
+    sys.modules['sparknlp.annotation'] = sparknlp  # Makes Annotation() pickle serializable  in top-level
+    return udf(
+        lambda content: f(content),
+        output_type
+    )
+
+
+def map_annotations_to_annotations_udf(f, output_type: DataType):
+    from sparknlp.annotation import Annotation
+    sys.modules['sparknlp.annotation'] = sparknlp  # Makes Annotation() pickle serializable in top-level
+    return udf(
+        lambda content: f(content),
+        ArrayType(Annotation.dataType())
+    )
+
+
+def map_annotations(dataframe: DataFrame, f, column, output_column, output_type):
+    dataframe.withColumn(output_column, map_annotations_udf(f, output_type)(column))
+
+
+def filter_by_annotations(dataframe, f, column):
+    this_udf = udf(
+        lambda content: f(content),
+        BooleanType()
+    )
+    return dataframe.filter(this_udf(column))
+
+
+def explode_annotations(dataframe: DataFrame, column, output_column):
+    from pyspark.sql.functions import explode
+    return dataframe.withColumn(output_column, explode(column))

--- a/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
@@ -78,6 +78,7 @@ object Annotation {
     StructField("embeddings", ArrayType(FloatType, false), true)
   ))
 
+  val arrayType = new ArrayType(dataType, false)
 
   /**
     * This method converts a [[org.apache.spark.sql.Row]] into an [[Annotation]]

--- a/src/main/scala/com/johnsnowlabs/nlp/functions.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/functions.scala
@@ -10,7 +10,7 @@ import scala.reflect.runtime.universe._
 object functions {
 
   implicit class FilterAnnotations(dataset: DataFrame) {
-    def filterByAnnotations(column: String, function: Seq[Annotation] => Boolean): DataFrame = {
+    def filterByAnnotationsCol(column: String, function: Seq[Annotation] => Boolean): DataFrame = {
       val meta = dataset.schema(column).metadata
       val func = udf {
         annotatorProperties: Seq[Row] =>
@@ -20,18 +20,18 @@ object functions {
     }
   }
 
-  def mapAnnotationsUdf[T](function: Seq[Annotation] => T, outputType: DataType): UserDefinedFunction = udf ( {
+  def mapAnnotations[T](function: Seq[Annotation] => T, outputType: DataType): UserDefinedFunction = udf ( {
     annotatorProperties: Seq[Row] =>
       function(annotatorProperties.map(Annotation(_)))
   }, outputType)
 
-  def mapAnnotationsToAnnotationsUdf(function: Seq[Annotation] => Seq[Annotation]): UserDefinedFunction = udf {
+  def mapAnnotationsStrict(function: Seq[Annotation] => Seq[Annotation]): UserDefinedFunction = udf {
     annotatorProperties: Seq[Row] =>
       function(annotatorProperties.map(Annotation(_)))
   }
 
   implicit class MapAnnotations(dataset: DataFrame) {
-    def mapAnnotations[T: TypeTag](column: String, outputCol: String, function: Seq[Annotation] => T): DataFrame = {
+    def mapAnnotationsCol[T: TypeTag](column: String, outputCol: String, function: Seq[Annotation] => T): DataFrame = {
       val meta = dataset.schema(column).metadata
       val func = udf {
         annotatorProperties: Seq[Row] =>
@@ -45,13 +45,13 @@ object functions {
 
     import dataset.sparkSession.implicits._
 
-    def eachAnnotations[T: TypeTag](column: String, function: Seq[Annotation] => Unit): Unit = {
+    def eachAnnotationsCol[T: TypeTag](column: String, function: Seq[Annotation] => Unit): Unit = {
       dataset.select(column).as[Array[Annotation]].foreach(function(_))
     }
   }
 
   implicit class ExplodeAnnotations(dataset: DataFrame) {
-    def explodeAnnotations[T: TypeTag](column: String, outputCol: String): DataFrame = {
+    def explodeAnnotationsCol[T: TypeTag](column: String, outputCol: String): DataFrame = {
       val meta = dataset.schema(column).metadata
       dataset.
         withColumn(outputCol, explode(col(column))).

--- a/src/test/scala/com/johnsnowlabs/nlp/FunctionsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/FunctionsTestSpec.scala
@@ -4,6 +4,7 @@ import com.johnsnowlabs.nlp.annotator.{PerceptronApproach, Tokenizer}
 import com.johnsnowlabs.nlp.training.POS
 import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
 import org.apache.spark.ml.Pipeline
+import org.apache.spark.sql.types.ArrayType
 import org.scalatest._
 
 class FunctionsTestSpec extends FlatSpec {
@@ -52,9 +53,21 @@ class FunctionsTestSpec extends FlatSpec {
       annotations.exists(_.result == "JJ")
     })
 
+    import org.apache.spark.sql.functions.col
+
+    val udfed = data.select(mapAnnotationsUdf((annotations: Seq[Annotation]) => {
+      annotations.filter(_.result == "JJ")
+    }, ArrayType(Annotation.dataType))(col("pos")))
+
+    val udfed2 = data.select(mapAnnotationsToAnnotationsUdf((annotations: Seq[Annotation]) => {
+      annotations.filter(_.result == "JJ")
+    })(col("pos")))
+
     mapped.show(truncate = false)
     modified.show(truncate = false)
     filtered.show(truncate = false)
+    udfed.show(truncate = false)
+    udfed2.show(truncate = false)
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/FunctionsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/FunctionsTestSpec.scala
@@ -41,25 +41,25 @@ class FunctionsTestSpec extends FlatSpec {
 
     import functions._
 
-    val mapped = data.mapAnnotations("pos", "modpos", (annotations: Seq[Annotation]) => {
+    val mapped = data.mapAnnotationsCol("pos", "modpos", (annotations: Seq[Annotation]) => {
       annotations.filter(_.result == "JJ")
     })
 
-    val modified = data.mapAnnotations("pos", "modpos", (_: Seq[Annotation]) => {
+    val modified = data.mapAnnotationsCol("pos", "modpos", (_: Seq[Annotation]) => {
       "hello world"
     })
 
-    val filtered = data.filterByAnnotations("pos", (annotations: Seq[Annotation]) => {
+    val filtered = data.filterByAnnotationsCol("pos", (annotations: Seq[Annotation]) => {
       annotations.exists(_.result == "JJ")
     })
 
     import org.apache.spark.sql.functions.col
 
-    val udfed = data.select(mapAnnotationsUdf((annotations: Seq[Annotation]) => {
+    val udfed = data.select(mapAnnotations((annotations: Seq[Annotation]) => {
       annotations.filter(_.result == "JJ")
     }, ArrayType(Annotation.dataType))(col("pos")))
 
-    val udfed2 = data.select(mapAnnotationsToAnnotationsUdf((annotations: Seq[Annotation]) => {
+    val udfed2 = data.select(mapAnnotationsStrict((annotations: Seq[Annotation]) => {
       annotations.filter(_.result == "JJ")
     })(col("pos")))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds `map_annotations`, `map_annotations_strict`, `map_annotations_col`, `filter_by_annotations_col` and `explode_annotations_col` to python side. Renamed Scala side functions to be the same.