### PR TITLE
[WIP][BREAKING] All embeddings have mandatory ref, ref as a flexible trait

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1452,7 +1452,7 @@ class WordEmbeddingsModel(AnnotatorModel, HasWordEmbeddings):
         return ResourceDownloader.downloadModel(WordEmbeddingsModel, name, lang, remote_loc)
 
 
-class BertEmbeddings(AnnotatorModel, HasEmbeddings):
+class BertEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasEmbeddingsRef):
 
     name = "BertEmbeddings"
 

--- a/python/sparknlp/common.py
+++ b/python/sparknlp/common.py
@@ -81,7 +81,7 @@ class AnnotatorModel(JavaModel, AnnotatorJavaMLReadable, JavaMLWritable, Annotat
             self._transfer_params_from_java()
 
 
-class HasEmbeddings(Params):
+class HasEmbeddingsProperties(Params):
     dimension = Param(Params._dummy(),
                       "dimension",
                       "Number of embedding dimensions",
@@ -99,16 +99,11 @@ class HasEmbeddings(Params):
         return self._set(caseSensitive=value)
 
 
-class HasWordEmbeddings(HasEmbeddings):
+class HasEmbeddingsRef(Params):
     embeddingsRef = Param(Params._dummy(),
                           "embeddingsRef",
-                          "if sourceEmbeddingsPath was provided, name them with this ref. Otherwise, use embeddings by this ref",
+                          "unique reference name for identification",
                           typeConverter=TypeConverters.toString)
-
-    includeEmbeddings = Param(Params._dummy(),
-                           "includeEmbeddings",
-                           "whether or not to save indexed embeddings along this annotator",
-                           typeConverter=TypeConverters.toBoolean)
 
     def setEmbeddingsRef(self, value):
         from sparknlp.annotator import WordEmbeddingsModel
@@ -118,6 +113,14 @@ class HasWordEmbeddings(HasEmbeddings):
 
     def getEmbeddingsRef(self):
         return self.getOrDefault('embeddingsRef')
+
+
+class HasWordEmbeddings(HasEmbeddingsProperties, HasEmbeddingsRef):
+
+    includeEmbeddings = Param(Params._dummy(),
+                           "includeEmbeddings",
+                           "whether or not to save indexed embeddings along this annotator",
+                           typeConverter=TypeConverters.toBoolean)
 
     def setIncludeEmbeddings(self, value):
         return self._set(includeEmbeddings=value)

--- a/src/main/scala/com/johnsnowlabs/nlp/HasEmbeddingsRef.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasEmbeddingsRef.scala
@@ -19,7 +19,8 @@ trait HasEmbeddingsRef extends Params {
   def validateEmbeddingsRef(dataset: Dataset[_], inputCols: Array[String]): Unit = {
     val embeddings_col = dataset.schema.fields
       .find(f => inputCols.contains(f.name) && f.metadata.getString("annotatorType") == AnnotatorType.WORD_EMBEDDINGS)
-      .getOrElse(throw new Exception("Could not find a valid embeddings column")).name
+      .getOrElse(throw new Exception(s"Could not find a valid embeddings column, make sure the embeddings are loaded " +
+        s"and have the following ref: ${$(embeddingsRef)}")).name
 
     val embeddings_meta = dataset.select(embeddings_col).schema.fields.head.metadata
 

--- a/src/main/scala/com/johnsnowlabs/nlp/HasEmbeddingsRef.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasEmbeddingsRef.scala
@@ -2,18 +2,32 @@ package com.johnsnowlabs.nlp
 
 import com.johnsnowlabs.nlp.embeddings.WordEmbeddingsModel
 import org.apache.spark.ml.param.{Param, Params}
+import org.apache.spark.sql.Dataset
 
 trait HasEmbeddingsRef extends Params {
 
   val embeddingsRef = new Param[String](this, "embeddingsRef", "unique reference name for identification")
 
-  setDefault(embeddingsRef, this.uid)
-
   def setEmbeddingsRef(value: String): this.type = {
     if (this.isInstanceOf[WordEmbeddingsModel] && get(embeddingsRef).nonEmpty)
-      throw new UnsupportedOperationException(s"Cannot override embeddings ref on a WordEmbeddingsModel. Please re-use current ref: $getEmbeddingsRef")
+      throw new UnsupportedOperationException(s"Cannot override embeddings ref on a WordEmbeddingsModel. " +
+        s"Please re-use current ref: $getEmbeddingsRef")
     set(this.embeddingsRef, value)
   }
   def getEmbeddingsRef: String = $(embeddingsRef)
+
+  def validateEmbeddingsRef(dataset: Dataset[_], inputCols: Array[String]): Unit = {
+    val embeddings_col = dataset.schema.fields
+      .find(f => inputCols.contains(f.name) && f.metadata.getString("annotatorType") == AnnotatorType.WORD_EMBEDDINGS)
+      .getOrElse(throw new Exception("Could not find a valid embeddings column")).name
+
+    val embeddings_meta = dataset.select(embeddings_col).schema.fields.head.metadata
+
+    require(embeddings_meta.contains("ref"), "Cannot find embeddings ref in column schema metadata")
+
+    require(embeddings_meta.getString("ref") == $(embeddingsRef),
+      s"Found embeddings column, but embeddings ref does not match to the embeddings this model was trained with. " +
+        s"Make sure you are using the right embeddings in your pipeline, with ref: ${$(embeddingsRef)}")
+  }
 
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/HasEmbeddingsRef.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasEmbeddingsRef.scala
@@ -1,0 +1,19 @@
+package com.johnsnowlabs.nlp
+
+import com.johnsnowlabs.nlp.embeddings.WordEmbeddingsModel
+import org.apache.spark.ml.param.{Param, Params}
+
+trait HasEmbeddingsRef extends Params {
+
+  val embeddingsRef = new Param[String](this, "embeddingsRef", "unique reference name for identification")
+
+  setDefault(embeddingsRef, this.uid)
+
+  def setEmbeddingsRef(value: String): this.type = {
+    if (this.isInstanceOf[WordEmbeddingsModel] && get(embeddingsRef).nonEmpty)
+      throw new UnsupportedOperationException(s"Cannot override embeddings ref on a WordEmbeddingsModel. Please re-use current ref: $getEmbeddingsRef")
+    set(this.embeddingsRef, value)
+  }
+  def getEmbeddingsRef: String = $(embeddingsRef)
+
+}

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfModel.scala
@@ -5,16 +5,17 @@ import com.johnsnowlabs.nlp.AnnotatorType._
 import com.johnsnowlabs.nlp.annotators.common.Annotated.{NerTaggedSentence, PosTaggedSentence}
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.serialization.{MapFeature, StructFeature}
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasPretrained, ParamsAndFeaturesReadable}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasEmbeddingsRef, HasPretrained, ParamsAndFeaturesReadable}
 import org.apache.spark.ml.param.{BooleanParam, StringArrayParam}
 import org.apache.spark.ml.util._
+import org.apache.spark.sql.Dataset
 
 
 /*
   Named Entity Recognition model
  */
 
-class NerCrfModel(override val uid: String) extends AnnotatorModel[NerCrfModel] {
+class NerCrfModel(override val uid: String) extends AnnotatorModel[NerCrfModel] with HasEmbeddingsRef {
 
   def this() = this(Identifiable.randomUID("NER"))
 
@@ -32,6 +33,11 @@ class NerCrfModel(override val uid: String) extends AnnotatorModel[NerCrfModel] 
 
   setDefault(dictionaryFeatures, () => Map.empty[String, String])
   setDefault(includeConfidence, false)
+
+  override def beforeAnnotate(dataset: Dataset[_]): Dataset[_] = {
+    validateEmbeddingsRef(dataset, $(inputCols))
+    dataset
+  }
 
   /**
   Predicts Named Entities in input sentences

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
@@ -13,13 +13,14 @@ import org.apache.commons.lang.SystemUtils
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.param.{BooleanParam, FloatParam, IntArrayParam, IntParam}
 import org.apache.spark.ml.util.Identifiable
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{Dataset, SparkSession}
 
 
 class NerDLModel(override val uid: String)
   extends AnnotatorModel[NerDLModel]
     with WriteTensorflowModel
-    with ParamsAndFeaturesWritable {
+    with ParamsAndFeaturesWritable
+    with HasEmbeddingsRef {
 
   def this() = this(Identifiable.randomUID("NerDLModel"))
 
@@ -67,6 +68,11 @@ class NerDLModel(override val uid: String)
 
       new TaggedSentence(tokens)
     }.toArray
+  }
+
+  override def beforeAnnotate(dataset: Dataset[_]): Dataset[_] = {
+    validateEmbeddingsRef(dataset, $(inputCols))
+    dataset
   }
 
   def setModelIfNotSet(spark: SparkSession, tf: TensorflowWrapper): this.type = {

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -18,7 +18,8 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 class BertEmbeddings(override val uid: String) extends
   AnnotatorModel[BertEmbeddings]
   with WriteTensorflowModel
-  with HasEmbeddings
+  with EmbeddingsProperties
+  with HasEmbeddingsRef
 {
 
   def this() = this(Identifiable.randomUID("BERT_EMBEDDINGS"))
@@ -142,7 +143,7 @@ class BertEmbeddings(override val uid: String) extends
   }
 
   override def afterAnnotate(dataset: DataFrame): DataFrame = {
-    dataset.withColumn(getOutputCol, wrapEmbeddingsMetadata(dataset.col(getOutputCol), $(dimension)))
+    dataset.withColumn(getOutputCol, wrapEmbeddingsMetadata(dataset.col(getOutputCol), $(dimension), $(embeddingsRef)))
   }
 
   /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 class BertEmbeddings(override val uid: String) extends
   AnnotatorModel[BertEmbeddings]
   with WriteTensorflowModel
-  with EmbeddingsProperties
+  with HasEmbeddingsProperties
   with HasEmbeddingsRef
 {
 

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/EmbeddingsProperties.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/EmbeddingsProperties.scala
@@ -5,7 +5,7 @@ import org.apache.spark.ml.param.{BooleanParam, IntParam, Params}
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.types.MetadataBuilder
 
-trait HasEmbeddings extends Params {
+trait EmbeddingsProperties extends Params {
 
   val dimension = new IntParam(this, "dimension", "Number of embedding dimensions")
   val caseSensitive = new BooleanParam(this, "caseSensitive", "whether to ignore case in tokens for embeddings matching")
@@ -18,11 +18,11 @@ trait HasEmbeddings extends Params {
   def getDimension: Int = $(dimension)
   def getCaseSensitive: Boolean = $(caseSensitive)
 
-  protected def wrapEmbeddingsMetadata(col: Column, embeddingsDim: Int, embeddingsRef: Option[String] = None): Column = {
+  protected def wrapEmbeddingsMetadata(col: Column, embeddingsDim: Int, embeddingsRef: String): Column = {
     val metadataBuilder: MetadataBuilder = new MetadataBuilder()
     metadataBuilder.putString("annotatorType", AnnotatorType.WORD_EMBEDDINGS)
     metadataBuilder.putLong("dimension", embeddingsDim.toLong)
-    embeddingsRef.foreach(ref => metadataBuilder.putString("ref", ref))
+    metadataBuilder.putString("ref", embeddingsRef)
     col.as(col.toString, metadataBuilder.build)
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasEmbeddingsProperties.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasEmbeddingsProperties.scala
@@ -5,7 +5,7 @@ import org.apache.spark.ml.param.{BooleanParam, IntParam, Params}
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.types.MetadataBuilder
 
-trait EmbeddingsProperties extends Params {
+trait HasEmbeddingsProperties extends Params {
 
   val dimension = new IntParam(this, "dimension", "Number of embedding dimensions")
   val caseSensitive = new BooleanParam(this, "caseSensitive", "whether to ignore case in tokens for embeddings matching")

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasWordEmbeddings.scala
@@ -3,7 +3,7 @@ package com.johnsnowlabs.nlp.embeddings
 import com.johnsnowlabs.nlp.HasEmbeddingsRef
 import org.apache.spark.ml.param.BooleanParam
 
-trait HasWordEmbeddings extends EmbeddingsProperties with HasEmbeddingsRef {
+trait HasWordEmbeddings extends HasEmbeddingsProperties with HasEmbeddingsRef {
 
   val includeEmbeddings = new BooleanParam(this, "includeEmbeddings", "whether or not to save indexed embeddings along this annotator")
 

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasWordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasWordEmbeddings.scala
@@ -1,22 +1,13 @@
 package com.johnsnowlabs.nlp.embeddings
 
-import org.apache.spark.ml.param.{BooleanParam, Param}
+import com.johnsnowlabs.nlp.HasEmbeddingsRef
+import org.apache.spark.ml.param.BooleanParam
 
-trait HasWordEmbeddings extends HasEmbeddings {
-
-  val embeddingsRef = new Param[String](this, "embeddingsRef", "if sourceEmbeddingsPath was provided, name them with this ref. Otherwise, use embeddings by this ref")
+trait HasWordEmbeddings extends EmbeddingsProperties with HasEmbeddingsRef {
 
   val includeEmbeddings = new BooleanParam(this, "includeEmbeddings", "whether or not to save indexed embeddings along this annotator")
 
-  setDefault(embeddingsRef, this.uid)
   setDefault(includeEmbeddings, true)
-
-  def setEmbeddingsRef(value: String): this.type = {
-    if (this.isInstanceOf[WordEmbeddingsModel] && get(embeddingsRef).nonEmpty)
-      throw new UnsupportedOperationException(s"Cannot override embeddings ref on a WordEmbeddingsModel. Please re-use current ref: $getEmbeddingsRef")
-    set(this.embeddingsRef, value)
-  }
-  def getEmbeddingsRef: String = $(embeddingsRef)
 
   def setIncludeEmbeddings(value: Boolean): this.type = set(includeEmbeddings, value)
   def getIncludeEmbeddings: Boolean = $(includeEmbeddings)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
@@ -86,7 +86,7 @@ class WordEmbeddingsModel(override val uid: String)
   override protected def afterAnnotate(dataset: DataFrame): DataFrame = {
     getClusterEmbeddings.getLocalRetriever.close()
 
-    dataset.withColumn(getOutputCol, wrapEmbeddingsMetadata(dataset.col(getOutputCol), $(dimension), Some(getEmbeddingsRef)))
+    dataset.withColumn(getOutputCol, wrapEmbeddingsMetadata(dataset.col(getOutputCol), $(dimension), $(embeddingsRef)))
   }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Annotators that use Embeddings will now have a mandatory `embeddingsRef` so they only work with the embeddings they have been trained with.