### PR TITLE
Date matcher fix flexible dates

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcher.scala
@@ -320,7 +320,7 @@ class DateMatcher(override val uid: String) extends AnnotatorModel[DateMatcher] 
         matchedDate.start,
         matchedDate.end - 1,
         simpleDateFormat.format(matchedDate.calendar.getTime),
-        Map("sentence" -> annotation.metadata.getOrElse("sentence", "0"))
+        annotation.metadata
       ))
     )
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcher.scala
@@ -320,7 +320,7 @@ class DateMatcher(override val uid: String) extends AnnotatorModel[DateMatcher] 
         matchedDate.start,
         matchedDate.end - 1,
         simpleDateFormat.format(matchedDate.calendar.getTime),
-        Map.empty[String, String]
+        Map("sentence" -> annotation.metadata.getOrElse("sentence", "0"))
       ))
     )
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/DateMatcherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/DateMatcherTestSpec.scala
@@ -59,60 +59,84 @@ class DateMatcherTestSpec extends FlatSpec with DateMatcherBehaviors {
     calendarBuild.build
   }
 
-  val dateSentences = Array(
-    ("1978-01-28", new Calendar.Builder().setDate(1978, 1-1, 28).build),
-    ("1984/04/02", new Calendar.Builder().setDate(1984, 4-1, 2).build),
-    ("1/02/1980", new Calendar.Builder().setDate(1980, 1-1, 2).build),
-    ("2/28/79", new Calendar.Builder().setDate(1979, 2-1, 28).build),
-    ("The 31st of April in the year 2008", new Calendar.Builder().setDate(2008, 4-1, 31).build),
-    ("Fri, 21 Nov 1997", new Calendar.Builder().setDate(1997, 11-1, 21).build),
-    ("Jan 21, '97", new Calendar.Builder().setDate(1997, 1-1, 21).build),
-    ("Sun, Nov 21", new Calendar.Builder().setDate(currentYear, 11-1, 21).build),
-    ("jan 1st", new Calendar.Builder().setDate(currentYear, 1-1, 1).build),
+  val dateSentences: Array[(String, Option[Calendar])] = Array(
+//    ("1978-01-28", Some(new Calendar.Builder().setDate(1978, 1-1, 28).build)),
+//    ("1984/04/02", Some(new Calendar.Builder().setDate(1984, 4-1, 2).build)),
+//    ("1/02/1980", Some(new Calendar.Builder().setDate(1980, 1-1, 2).build)),
+//    ("2/28/79", Some(new Calendar.Builder().setDate(1979, 2-1, 28).build)),
+//    ("The 31st of April in the year 2008", Some(new Calendar.Builder().setDate(2008, 4-1, 31).build)),
+//    ("Fri, 21 Nov 1997", Some(new Calendar.Builder().setDate(1997, 11-1, 21).build)),
+//    ("Jan 21, '97", Some(new Calendar.Builder().setDate(1997, 1-1, 21).build)),
+    ("Sun, Nov 21", Some(new Calendar.Builder().setDate(currentYear, 11-1, 21).build)),
+    ("jan 1st", Some(new Calendar.Builder().setDate(currentYear, 1-1, 1).build)),
     //NS: "february twenty-eighth",
-    ("next thursday", nextThursdayCalendar),
-    ("last wednesday", lastWednesdayCalendar),
-    ("today", Calendar.getInstance),
-    ("tomorrow", tomorrowCalendar),
-    ("yesterday", yesterdayCalendar),
-    ("next week", nextCalendar(Calendar.WEEK_OF_MONTH)),
-    ("next month", nextCalendar(Calendar.MONTH)),
-    ("next year", nextCalendar(Calendar.YEAR)),
+    ("next thursday", Some(nextThursdayCalendar)),
+    ("last wednesday", Some(lastWednesdayCalendar)),
+    ("today", Some(Calendar.getInstance)),
+    ("tomorrow", Some(tomorrowCalendar)),
+    ("yesterday", Some(yesterdayCalendar)),
+    ("next week", Some(nextCalendar(Calendar.WEEK_OF_MONTH))),
+    ("next month", Some(nextCalendar(Calendar.MONTH))),
+    ("next year", Some(nextCalendar(Calendar.YEAR))),
     //NS: "3 days from now",
     //NS: "three weeks ago",
-    ("day after", tomorrowCalendar),
-    ("the day before", yesterdayCalendar),
+    ("day after", Some(tomorrowCalendar)),
+    ("the day before", Some(yesterdayCalendar)),
     //"the monday after",
     //"the monday before"
     //NS: "2 fridays before",
     //NS: "4 tuesdays after"
-    ("0600h", setTimeTo(Calendar.getInstance, 6,0,0)),
-    ("06:00 hours", setTimeTo(Calendar.getInstance, 6,0,0)),
-    ("6pm", setTimeTo(Calendar.getInstance, 18,0,0)),
-    ("5:30 a.m.", setTimeTo(Calendar.getInstance, 5,30,0)),
-    ("at 5", setTimeTo(Calendar.getInstance, 17,0,0)),
-    ("12:59", setTimeTo(Calendar.getInstance, 12,59,0)),
-    ("23:59", setTimeTo(Calendar.getInstance, 23,59,0)),
-    ("1988/11/23 6pm", setTimeTo(new Calendar.Builder().setDate(1988, 11-1, 23).build, 18, 0, 0)),
-    ("next week at 7.30", setTimeTo(nextCalendar(Calendar.WEEK_OF_MONTH), 19, 0, 0)),
-    ("5 am tomorrow", setTimeTo(tomorrowCalendar, 5, 0, 0)),
-    ("Let's meet on 20th of February.", new Calendar.Builder().setDate(currentYear, 2-1, 20).build),
-    ("Today is March 14th 2019.", new Calendar.Builder().setDate(2019, 3-1, 14).build),
-    ("10-02-19", new Calendar.Builder().setDate(2019, 10-1, 2).build)
-
+    ("0600h", Some(setTimeTo(Calendar.getInstance, 6,0,0))),
+    ("06:00 hours", Some(setTimeTo(Calendar.getInstance, 6,0,0))),
+    ("6pm", Some(setTimeTo(Calendar.getInstance, 18,0,0))),
+    ("5:30 a.m.", Some(setTimeTo(Calendar.getInstance, 5,30,0))),
+    ("at 5", Some(setTimeTo(Calendar.getInstance, 17,0,0))),
+    ("12:59", Some(setTimeTo(Calendar.getInstance, 12,59,0))),
+    ("23:59", Some(setTimeTo(Calendar.getInstance, 23,59,0))),
+    ("1988/11/23 6pm", Some(setTimeTo(new Calendar.Builder().setDate(1988, 11-1, 23).build, 18, 0, 0))),
+    ("next week at 7.30", Some(setTimeTo(nextCalendar(Calendar.WEEK_OF_MONTH), 19, 0, 0))),
+    ("5 am tomorrow", Some(setTimeTo(tomorrowCalendar, 5, 0, 0))),
+    ("Let's meet on 20th of February.", Some(new Calendar.Builder().setDate(currentYear, 2-1, 20).build)),
+    ("Today is March 14th 2019.", Some(new Calendar.Builder().setDate(2019, 3-1, 14).build)),
+    ("10-02-19", Some(new Calendar.Builder().setDate(2019, 10-1, 2).build)),
+    // Breaking use cases
+    ("June 2015", Some(new Calendar.Builder().setDate(2015, 6-1, 1).build)),
+    ("August 2016", Some(new Calendar.Builder().setDate(2016, 8-1, 1).build)),
+    ("4", None),
+    ("L-2", None),
+    ("Tarceva", None),
+    ("2", None),
+    ("3", None),
+    ("Xgeva", None),
+    ("today 4", Some(Calendar.getInstance)),
+    ("1 month", None)
   )
 
   dateSentences.map(date => dateMatcher.extractDate(date._1)).zip(dateSentences).foreach(dateAnswer => {
-    "a DateMatcher" should s"successfully parse ${dateAnswer._2._1}" in {
-      val result = dateAnswer._1.getOrElse(fail(s"because we could not parse ${dateAnswer._2._1}"))
-      assert(
-        result.calendar.get(Calendar.YEAR) == dateAnswer._2._2.get(Calendar.YEAR) &&
-          result.calendar.get(Calendar.MONTH) == dateAnswer._2._2.get(Calendar.MONTH) &&
-          result.calendar.get(Calendar.DAY_OF_MONTH) == dateAnswer._2._2.get(Calendar.DAY_OF_MONTH) &&
-          result.calendar.get(Calendar.DAY_OF_WEEK) == dateAnswer._2._2.get(Calendar.DAY_OF_WEEK),
-        s"because result ${result.calendar.getTime} is not expected ${dateAnswer._2._2.getTime} for string ${dateAnswer._2._1}")
+    "a DateMatcher" should s"successfully parse ${dateAnswer._2._1} as ${dateAnswer._2._2.map(_.getTime)}" in {
+      if (dateAnswer._1.isEmpty && dateAnswer._2._2.isEmpty)
+        succeed
+      else if (dateAnswer._1.nonEmpty && dateAnswer._2._2.isEmpty) {
+        fail(s"because date matcher found ${dateAnswer._1.get.calendar.getTime} within ${dateAnswer._2._1} where None was expected")
+      }
+      else if (dateAnswer._1.isEmpty && dateAnswer._2._2.nonEmpty) {
+        fail(s"because date matcher could not find anything within ${dateAnswer._2._1}")
+      }
+      else {
+        val result = dateAnswer._1.getOrElse(fail(s"because we could not parse ${dateAnswer._2._1}"))
+        assert(
+          result.calendar.get(Calendar.YEAR) == dateAnswer._2._2.get.get(Calendar.YEAR) &&
+            result.calendar.get(Calendar.MONTH) == dateAnswer._2._2.get.get(Calendar.MONTH) &&
+            result.calendar.get(Calendar.DAY_OF_MONTH) == dateAnswer._2._2.get.get(Calendar.DAY_OF_MONTH) &&
+            result.calendar.get(Calendar.DAY_OF_WEEK) == dateAnswer._2._2.get.get(Calendar.DAY_OF_WEEK),
+          s"because result ${result.calendar.getTime} is not expected ${dateAnswer._2._2.get.getTime} for string ${dateAnswer._2._1}")
+      }
     }
   })
+
+  "a DateMatcher" should "ignore chunks of text with nothing relevant" in {
+    val data: Dataset[Row] = DataBuilder.multipleDataBuild(Array("2014/01/23", "day after tomorrow"))
+  }
 
   "a DateMatcher" should "be writable and readable" in {
     val dateMatcher = new DateMatcher().setFormat("YYYY")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Flexible dates in DateMatcher returned `java.lang.NumberFormatException: For input string: ""` 
This fixes the error and also adds missing metadata of its annotations.