### PR TITLE
Delimiter param for NGramGenerator

### DIFF
--- a/docs/en/annotators.md
+++ b/docs/en/annotators.md
@@ -364,6 +364,7 @@ val chunker = new Chunker()
 
 - setN: number elements per n-gram (>=1)
 - setEnableCumulative: whether to calculate just the actual n-grams or all n-grams from 1 through n
+- setDelimiter: Glue character used to join the tokens
 
 **Example:**
 
@@ -375,6 +376,7 @@ ngrams_cum = NGramGenerator() \
             .setOutputCol("ngrams") \
             .setN(2) \
             .setEnableCumulative(True)
+            .setDelimiter("_")
 ```
 
 ```scala
@@ -383,6 +385,7 @@ val nGrams = new NGramGenerator()
       .setOutputCol("ngrams")
       .setN(2)
       .setEnableCumulative(true)
+      .setDelimiter("_")
 ```
 
 ### DateMatcher

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1609,6 +1609,8 @@ class NGramGenerator(AnnotatorModel):
     enableCumulative = Param(Params._dummy(), "enableCumulative", "whether to calculate just the actual n-grams " +
                              "or all n-grams from 1 through n", typeConverter=TypeConverters.toBoolean)
 
+    delimiter = Param(Params._dummy(), "delimiter", "String to use to join the tokens ", typeConverter=TypeConverters.toString)
+
     def setN(self, value):
         """
         Sets the value of :py:attr:`n`.
@@ -1620,6 +1622,14 @@ class NGramGenerator(AnnotatorModel):
         Sets the value of :py:attr:`enableCumulative`.
         """
         return self._set(enableCumulative=value)
+
+    def setDelimiter(self, value):
+        """
+        Sets the value of :py:attr:`delimiter`.
+        """
+        if len(value) > 1:
+            raise Exception("Delimiter should have length == 1")
+        return self._set(delimiter=value)
 
 
 class ChunkEmbeddings(AnnotatorModel):

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/NGramGenerator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/NGramGenerator.scala
@@ -1,7 +1,7 @@
 package com.johnsnowlabs.nlp.annotators
 
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, ParamsAndFeaturesReadable}
-import org.apache.spark.ml.param.{IntParam, BooleanParam, ParamValidators}
+import org.apache.spark.ml.param.{BooleanParam, IntParam, Param, ParamValidators}
 import org.apache.spark.ml.util.Identifiable
 
 /**
@@ -37,16 +37,22 @@ class NGramGenerator (override val uid: String) extends AnnotatorModel[NGramGene
   val enableCumulative: BooleanParam = new BooleanParam(this, "enableCumulative",
     "whether to calculate just the actual n-grams or all n-grams from 1 through n")
 
+  val delimiter: Param[String] = new Param[String](this, "delimiter",
+    "String to use to join the tokens")
+
   def setN(value: Int): this.type = set(n, value)
   def setEnableCumulative(value: Boolean): this.type = set(enableCumulative, value)
+  def setDelimiter(value: String): this.type = set(delimiter, value)
 
   /** @group getParam */
-  def getN: Int = $(n)
+  def getN: Int = $(n)v
   def getEnableCumulative: Boolean = $(enableCumulative)
+  def getDelimiter: String = $(delimiter)
 
   setDefault(
     n -> 2,
-    enableCumulative -> false
+    enableCumulative -> false,
+    delimiter -> " "
   )
 
   private def generateNGrams(documents: Seq[(Int, Seq[Annotation])]): Seq[Annotation] = {
@@ -61,7 +67,7 @@ class NGramGenerator (override val uid: String) extends AnnotatorModel[NGramGene
             outputAnnotatorType,
             tokens.head.begin,
             tokens.last.end,
-            tokens.map(_.result).mkString(" "),
+            tokens.map(_.result).mkString($(delimiter)),
             tokens.head.metadata
           )
         }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/NGramGenerator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/NGramGenerator.scala
@@ -38,14 +38,17 @@ class NGramGenerator (override val uid: String) extends AnnotatorModel[NGramGene
     "whether to calculate just the actual n-grams or all n-grams from 1 through n")
 
   val delimiter: Param[String] = new Param[String](this, "delimiter",
-    "String to use to join the tokens")
+    "Glue character used to join the tokens")
 
   def setN(value: Int): this.type = set(n, value)
   def setEnableCumulative(value: Boolean): this.type = set(enableCumulative, value)
-  def setDelimiter(value: String): this.type = set(delimiter, value)
+  def setDelimiter(value: String): this.type = {
+    require(value.length==1, "Delimiter should have length == 1")
+    set(delimiter, value)
+  }
 
   /** @group getParam */
-  def getN: Int = $(n)v
+  def getN: Int = $(n)
   def getEnableCumulative: Boolean = $(enableCumulative)
   def getDelimiter: String = $(delimiter)
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/NGramGeneratorTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/NGramGeneratorTestSpec.scala
@@ -10,6 +10,18 @@ import org.scalatest.FlatSpec
 
 class NGramGeneratorTestSpec extends FlatSpec {
 
+  val documentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+  val sentence = new SentenceDetector()
+    .setInputCols("document")
+    .setOutputCol("sentence")
+
+  val tokenizer = new Tokenizer()
+    .setInputCols(Array("sentence"))
+    .setOutputCol("token")
+
   "NGramGenerator" should "correctly generate n-grams from tokenizer's results" in {
 
     val testData = ResourceHelper.spark.createDataFrame(Seq(
@@ -37,18 +49,6 @@ class NGramGeneratorTestSpec extends FlatSpec {
       Annotation(CHUNK, 35, 43, "my fourth", Map("sentence" -> "1")),
       Annotation(CHUNK, 38, 44, "fourth .", Map("sentence" -> "1"))
     )
-
-    val documentAssembler = new DocumentAssembler()
-      .setInputCol("text")
-      .setOutputCol("document")
-
-    val sentence = new SentenceDetector()
-      .setInputCols("document")
-      .setOutputCol("sentence")
-
-    val tokenizer = new Tokenizer()
-      .setInputCols(Array("sentence"))
-      .setOutputCol("token")
 
     val nGrams = new NGramGenerator()
       .setInputCols("token")
@@ -123,18 +123,6 @@ class NGramGeneratorTestSpec extends FlatSpec {
       Annotation(CHUNK, 38, 44, "fourth .", Map("sentence" -> "1"))
     )
 
-    val documentAssembler = new DocumentAssembler()
-      .setInputCol("text")
-      .setOutputCol("document")
-
-    val sentence = new SentenceDetector()
-      .setInputCols("document")
-      .setOutputCol("sentence")
-
-    val tokenizer = new Tokenizer()
-      .setInputCols(Array("sentence"))
-      .setOutputCol("token")
-
     val nGrams = new NGramGenerator()
       .setInputCols("token")
       .setOutputCol("ngrams")
@@ -155,6 +143,83 @@ class NGramGeneratorTestSpec extends FlatSpec {
 
     val nGramGeneratorResults = Annotation.collect(pipelineDF, "ngrams").flatten.toSeq
 
+    assert(nGrams.getEnableCumulative == true)
+    assert(nGramGeneratorResults == expectedNGrams)
+
+  }
+
+  "NGramGenerator" should "correctly generate n-grams with specified delimiter" in {
+    val delimiter = "_"
+
+    val testData = ResourceHelper.spark.createDataFrame(Seq(
+      (1, "This is my first sentence. This is my second."),
+      (2, "This is my third sentence. This is my fourth.")
+    )).toDF("id", "text")
+
+    val expectedNGrams = Seq(
+      Annotation(CHUNK, 0, 3, "This", Map("sentence" -> "0")),
+      Annotation(CHUNK, 5, 6, "is", Map("sentence" -> "0")),
+      Annotation(CHUNK, 8, 9, "my", Map("sentence" -> "0")),
+      Annotation(CHUNK, 11, 15, "first", Map("sentence" -> "0")),
+      Annotation(CHUNK, 17, 24, "sentence", Map("sentence" -> "0")),
+      Annotation(CHUNK, 25, 25, ".", Map("sentence" -> "0")),
+      Annotation(CHUNK, 0, 6, "This_is", Map("sentence" -> "0")),
+      Annotation(CHUNK, 5, 9, "is_my", Map("sentence" -> "0")),
+      Annotation(CHUNK, 8, 15, "my_first", Map("sentence" -> "0")),
+      Annotation(CHUNK, 11, 24, "first_sentence", Map("sentence" -> "0")),
+      Annotation(CHUNK, 17, 25, "sentence_.", Map("sentence" -> "0")),
+      Annotation(CHUNK, 27, 30, "This", Map("sentence" -> "1")),
+      Annotation(CHUNK, 32, 33, "is", Map("sentence" -> "1")),
+      Annotation(CHUNK, 35, 36, "my", Map("sentence" -> "1")),
+      Annotation(CHUNK, 38, 43, "second", Map("sentence" -> "1")),
+      Annotation(CHUNK, 44, 44, ".", Map("sentence" -> "1")),
+      Annotation(CHUNK, 27, 33, "This_is", Map("sentence" -> "1")),
+      Annotation(CHUNK, 32, 36, "is_my", Map("sentence" -> "1")),
+      Annotation(CHUNK, 35, 43, "my_second", Map("sentence" -> "1")),
+      Annotation(CHUNK, 38, 44, "second_.", Map("sentence" -> "1")),
+      Annotation(CHUNK, 0, 3, "This", Map("sentence" -> "0")),
+      Annotation(CHUNK, 5, 6, "is", Map("sentence" -> "0")),
+      Annotation(CHUNK, 8, 9, "my", Map("sentence" -> "0")),
+      Annotation(CHUNK, 11, 15, "third", Map("sentence" -> "0")),
+      Annotation(CHUNK, 17, 24, "sentence", Map("sentence" -> "0")),
+      Annotation(CHUNK, 25, 25, ".", Map("sentence" -> "0")),
+      Annotation(CHUNK, 0, 6, "This_is", Map("sentence" -> "0")),
+      Annotation(CHUNK, 5, 9, "is_my", Map("sentence" -> "0")),
+      Annotation(CHUNK, 8, 15, "my_third", Map("sentence" -> "0")),
+      Annotation(CHUNK, 11, 24, "third_sentence", Map("sentence" -> "0")),
+      Annotation(CHUNK, 17, 25, "sentence_.", Map("sentence" -> "0")),
+      Annotation(CHUNK, 27, 30, "This", Map("sentence" -> "1")),
+      Annotation(CHUNK, 32, 33, "is", Map("sentence" -> "1")),
+      Annotation(CHUNK, 35, 36, "my", Map("sentence" -> "1")),
+      Annotation(CHUNK, 38, 43, "fourth", Map("sentence" -> "1")),
+      Annotation(CHUNK, 44, 44, ".", Map("sentence" -> "1")),
+      Annotation(CHUNK, 27, 33, "This_is", Map("sentence" -> "1")),
+      Annotation(CHUNK, 32, 36, "is_my", Map("sentence" -> "1")),
+      Annotation(CHUNK, 35, 43, "my_fourth", Map("sentence" -> "1")),
+      Annotation(CHUNK, 38, 44, "fourth_.", Map("sentence" -> "1"))
+    )
+
+    val nGrams = new NGramGenerator()
+      .setInputCols("token")
+      .setOutputCol("ngrams")
+      .setN(2)
+      .setEnableCumulative(true)
+      .setDelimiter(delimiter)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        documentAssembler,
+        sentence,
+        tokenizer,
+        nGrams
+      ))
+
+    val pipelineDF = pipeline.fit(testData).transform(testData)
+    pipelineDF.select("token").show(false)
+    pipelineDF.select("ngrams").show(false)
+
+    val nGramGeneratorResults = Annotation.collect(pipelineDF, "ngrams").flatten.toSeq
+    assert(nGrams.getDelimiter == delimiter)
     assert(nGramGeneratorResults == expectedNGrams)
 
   }


### PR DESCRIPTION
Include a parameter in NGramGenerator to allow for a separator/delimiter string.By default it will use " " (space) to join the tokens.

## Description
Include the parameter
Implement its consumption inside the mkstring function


## Motivation and Context
It allows the user to flexibly meet the token format of the previously stored embeddings (delimiter for composed tokens)


## How Has This Been Tested?
Specific test for the setDelimiter and getDelimiter functionality
Test for expected results

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ X] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
