### PR TITLE
skipOOV handling OOV chunks WIP

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -488,6 +488,9 @@ class TextMatcher(AnnotatorApproach):
 class TextMatcherModel(AnnotatorModel):
     name = "TextMatcherModel"
 
+    def setCaseSensitive(self, b):
+        return self._set(caseSensitive=b)
+
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.TextMatcherModel", java_model=None):
         super(TextMatcherModel, self).__init__(
             classname=classname,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcherModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcherModel.scala
@@ -28,11 +28,9 @@ class TextMatcherModel(override val uid: String) extends AnnotatorModel[TextMatc
 
   def setEntities(value: Array[Array[String]]): this.type = set(parsedEntities, value)
 
-  def setCaseSensitive(v: Boolean): this.type =
-    set(caseSensitive, v)
+  def setCaseSensitive(v: Boolean): this.type = set(caseSensitive, v)
 
-  def getCaseSensitive: Boolean =
-    $(caseSensitive)
+  def getCaseSensitive: Boolean = $(caseSensitive)
 
   def setMergeOverlapping(v: Boolean): this.type = set(mergeOverlapping, v)
 


### PR DESCRIPTION
When a chunk is fully composed by OOV words, and the parameter skipOOV is set to true, there might be a chance of an empty bag of vectors. When that happens this the result should just be the aggregation of whatever OOV vectors arrived.

## Description
Mainly a line selecting which vectors to make part of the pooling calculation.


## Motivation and Context
Sometimes we want to discard the OOV vectors from downstream tasks.

## How Has This Been Tested?
Unit test for the feature

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
