### PR TITLE
SkipOOV parameter for ChunkEmbeddings

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1638,6 +1638,7 @@ class ChunkEmbeddings(AnnotatorModel):
                             "Choose how you would like to aggregate Word Embeddings to Chunk Embeddings:" +
                             "AVERAGE or SUM",
                             typeConverter=TypeConverters.toString)
+    skipOOV = Param(Params._dummy(), "skipOOV", "Whether to discard default vectors for OOV words from the aggregation / pooling ", typeConverter=TypeConverters.toBoolean)
 
     def setPoolingStrategy(self, strategy):
         """
@@ -1649,6 +1650,12 @@ class ChunkEmbeddings(AnnotatorModel):
             return self._set(poolingStrategy=strategy)
         else:
             return self._set(poolingStrategy="AVERAGE")
+
+    def setSkipOOV(self, value):
+        """
+        Sets the value of :py:attr:`skipOOV`.
+        """
+        return self._set(skipOOV=value)
 
 
 class NerOverwriter(AnnotatorModel):

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
@@ -96,6 +96,8 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
               None
         )
 
+        val finalEmbeddings = if(allEmbeddings.length > 0) allEmbeddings else tokensWithEmbeddings.map(_.embeddings)
+
         Annotation(
           annotatorType = outputAnnotatorType,
           begin = chunk.begin,
@@ -106,7 +108,7 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
             "pieceId" -> "-1",
             "isWordStart" -> "true"
           ),
-          embeddings = calculateChunkEmbeddings(allEmbeddings)
+          embeddings = calculateChunkEmbeddings(finalEmbeddings)
         )
 
       }


### PR DESCRIPTION
When a chunk is fully composed by OOV words, and the parameter skipOOV is set to true, there might be a chance of an empty bag of vectors. When that happens this the result should just be the aggregation of whatever OOV vectors arrived.

## Description
Mainly a line selecting which vectors to make part of the pooling calculation.


## Motivation and Context
Sometimes we want to discard the OOV vectors from downstream tasks.

## How Has This Been Tested?
Unit test for the feature

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.
