### PR TITLE
Introducing minLength and maxLength features in Tokenizer

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -90,6 +90,16 @@ class Tokenizer(AnnotatorApproach):
                        "character list used to separate from the inside of tokens",
                        typeConverter=TypeConverters.toListString)
 
+    minLength = Param(Params._dummy(),
+                      "minLength",
+                      "Set the minimum allowed legth for each token",
+                      typeConverter=TypeConverters.toInt)
+
+    maxLength = Param(Params._dummy(),
+                      "maxLength",
+                      "Set the maximum allowed legth for each token",
+                      typeConverter=TypeConverters.toInt)
+
     name = 'Tokenizer'
 
     @keyword_only
@@ -98,7 +108,9 @@ class Tokenizer(AnnotatorApproach):
         self._setDefault(
             targetPattern="\\S+",
             contextChars=[".", ",", ";", ":", "!", "?", "*", "-", "(", ")", "\"", "'"],
-            caseSensitiveExceptions=True
+            caseSensitiveExceptions=True,
+            minLength=0,
+            maxLength=99999
         )
 
     def getInfixPatterns(self):
@@ -177,6 +189,12 @@ class Tokenizer(AnnotatorApproach):
             split_chars = []
         split_chars.append(value)
         return self._set(splitChars=split_chars)
+
+    def setMinLength(self, value):
+        return self._set(minLength=value)
+
+    def setMaxLength(self, value):
+        return self._set(maxLength=value)
 
     def _create_model(self, java_model):
         return TokenizerModel(java_model=java_model)
@@ -462,9 +480,9 @@ class TextMatcher(AnnotatorApproach):
                           typeConverter=TypeConverters.toBoolean)
 
     mergeOverlapping = Param(Params._dummy(),
-                          "mergeOverlapping",
-                          "whether to merge overlapping matched chunks. Defaults false",
-                          typeConverter=TypeConverters.toBoolean)
+                             "mergeOverlapping",
+                             "whether to merge overlapping matched chunks. Defaults false",
+                             typeConverter=TypeConverters.toBoolean)
 
     @keyword_only
     def __init__(self):

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -99,7 +99,9 @@ class TokenizerTestSpec(unittest.TestCase):
         tokenizer = Tokenizer() \
             .setInputCols(["document"]) \
             .setOutputCol("token") \
-            .addInfixPattern("(\\p{L}+)(\\/)(\\p{L}+\\b)")
+            .addInfixPattern("(\\p{L}+)(\\/)(\\p{L}+\\b)") \
+            .setMinLength(3) \
+            .setMaxLength(6)
         finisher = Finisher() \
             .setInputCols(["token"]) \
             .setOutputCols(["token_out"]) \
@@ -108,7 +110,7 @@ class TokenizerTestSpec(unittest.TestCase):
         tokenized = tokenizer.fit(assembled).transform(assembled)
         finished = finisher.transform(tokenized)
         print(finished.first()['token_out'])
-        self.assertEqual(len(finished.first()['token_out']), 7)
+        self.assertEqual(len(finished.first()['token_out']), 4)
 
 
 class ChunkTokenizerTestSpec(unittest.TestCase):

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
@@ -8,7 +8,7 @@ import com.johnsnowlabs.nlp.annotators.param.ExternalResourceParam
 import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
 import com.johnsnowlabs.nlp.util.regex.{MatchStrategy, RuleFactory}
 import org.apache.spark.ml.PipelineModel
-import org.apache.spark.ml.param.{BooleanParam, Param, StringArrayParam}
+import org.apache.spark.ml.param.{BooleanParam, IntParam, Param, StringArrayParam}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.sql.Dataset
 
@@ -34,6 +34,8 @@ class Tokenizer(override val uid: String) extends AnnotatorApproach[TokenizerMod
   val infixPatterns: StringArrayParam = new StringArrayParam(this, "infixPatterns", "regex patterns that match tokens within a single target. groups identify different sub-tokens. multiple defaults")
   val prefixPattern: Param[String] = new Param[String](this, "prefixPattern", "regex with groups and begins with \\A to match target prefix. Overrides contextCharacters Param")
   val suffixPattern: Param[String] = new Param[String](this, "suffixPattern", "regex with groups and ends with \\z to match target suffix. Overrides contextCharacters Param")
+  val minLength = new IntParam(this, "minLength", "Set the minimum allowed legth for each token")
+  val maxLength = new IntParam(this, "maxLength", "Set the maximum allowed legth for each token")
 
   def setTargetPattern(value: String): this.type = set(targetPattern, value)
 
@@ -96,10 +98,26 @@ class Tokenizer(override val uid: String) extends AnnotatorApproach[TokenizerMod
     $(splitChars)
   }
 
+  def setMinLength(value: Int): this.type = {
+    require(value >= 0, "minLength must be greater equal than 0")
+    require(value.isValidInt, "minLength must be Int")
+    set(minLength, value)
+  }
+  def getMinLength(value: Int): Int = $(minLength)
+
+  def setMaxLength(value: Int): this.type = {
+    require(value >= ${minLength}, "maxLength must be greater equal than minLength")
+    require(value.isValidInt, "minLength must be Int")
+    set(maxLength, value)
+  }
+  def getMaxLength(value: Int): Int = $(maxLength)
+
   setDefault(
     targetPattern -> "\\S+",
     contextChars -> Array(".", ",", ";", ":", "!", "?", "*", "-", "(", ")", "\"", "'"),
-    caseSensitiveExceptions -> true
+    caseSensitiveExceptions -> true,
+    minLength -> 0,
+    maxLength -> 99999
   )
 
   def buildRuleFactory: RuleFactory = {
@@ -147,6 +165,8 @@ class Tokenizer(override val uid: String) extends AnnotatorApproach[TokenizerMod
       .setCaseSensitiveExceptions($(caseSensitiveExceptions))
       .setTargetPattern($(targetPattern))
       .setRules(ruleFactory)
+      .setMinLength($(minLength))
+      .setMaxLength($(maxLength))
 
     if (processedExceptions.nonEmpty)
       raw.setExceptions(processedExceptions)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -361,4 +361,19 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
     assert(result.equals(expected))
 
   }
+
+  "a Tokenizer" should "correctly filter out tokens based on setting minimum and maximum lengths" in {
+    val data = DataBuilder.basicDataBuild("Hello New York and Goodbye")
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token")
+      .setMinLength(4)
+      .setMaxLength(5)
+      .fit(data)
+
+    val result = getTokenizerOutput[String](tokenizer, data)
+    assert(
+      result.sameElements(Seq("Hello", "York")),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected1.mkString("|")}"
+    )
+  }
 }


### PR DESCRIPTION
This PR introduces two new params for Tokenizer. The `minLenght` and `maxLength` are very useful when dealing with broken sentences like Tweets, OCR results, etc. where the user wants to make sure the length of tokens going through the pipeline.

These features also ensure resources are being used over tokens within the target size only. When any token less than 3 characters won't matter to the user, there will be filtered out so they won't be used in the next annotators such as POS tagging, embeddings, NER, etc.

Example:

```scala
val tokenizer = new Tokenizer()
      .setInputCols("document")
      .setOutputCol("token")
      .setMinLength(4)
      .setMaxLength(10)
```

The results will be tokens larger equal than `4` characters and less than equal than `10` characters.