### PR TITLE
Introducing minLength and maxLength features in SentenceDetector

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -571,10 +571,20 @@ class SentenceDetectorParams:
                              "whether to explode each sentence into a different row, for better parallelization. Defaults to false.",
                              typeConverter=TypeConverters.toBoolean)
 
-    maxLength = Param(Params._dummy(),
-                      "maxLength",
-                      "length at which sentences will be forcibly split. Defaults to 240",
+    splitLength = Param(Params._dummy(),
+                      "splitLength",
+                      "length at which sentences will be forcibly split.",
                       typeConverter=TypeConverters.toInt)
+
+    minLength = Param(Params._dummy(),
+                        "minLength",
+                        "Set the minimum allowed length for each sentence.",
+                        typeConverter=TypeConverters.toInt)
+
+    maxLength = Param(Params._dummy(),
+                        "maxLength",
+                        "Set the maximum allowed length for each sentence",
+                        typeConverter=TypeConverters.toInt)
 
 
 class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
@@ -593,6 +603,12 @@ class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
     def setExplodeSentences(self, value):
         return self._set(explodeSentences=value)
 
+    def setSplitLength(self, value):
+        return self._set(splitLength=value)
+
+    def setMinLength(self, value):
+        return self._set(minLength=value)
+
     def setMaxLength(self, value):
         return self._set(maxLength=value)
 
@@ -600,8 +616,14 @@ class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
     def __init__(self):
         super(SentenceDetector, self).__init__(
             classname="com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector")
-        self._setDefault(useAbbreviations=True, useCustomBoundsOnly=False, customBounds=[],
-                         explodeSentences=False)
+        self._setDefault(
+            useAbbreviations=True,
+            useCustomBoundsOnly=False,
+            customBounds=[],
+            explodeSentences=False,
+            minLength=0,
+            maxLength=99999
+        )
 
 
 class DeepSentenceDetector(AnnotatorModel, SentenceDetectorParams):
@@ -636,8 +658,8 @@ class DeepSentenceDetector(AnnotatorModel, SentenceDetectorParams):
     def setUseCustomBoundsOnly(self, value):
         return self._set(useCustomBoundsOnly=value)
 
-    def setMaxLength(self, value):
-        return self._set(maxLength=value)
+    def setSplitLength(self, value):
+        return self._set(splitLength=value)
 
     @keyword_only
     def __init__(self):

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -283,7 +283,10 @@ class PragmaticSBDTestSpec(unittest.TestCase):
             .setInputCols(["document"]) \
             .setOutputCol("sentence") \
             .setCustomBounds(["%%"]) \
-            .setMaxLength(235)
+            .setSplitLength(235) \
+            .setMinLength(4) \
+            .setMaxLength(50)
+
         assembled = document_assembler.transform(self.data)
         sentence_detector.transform(assembled).show()
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/SentenceDetectorParams.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/SentenceDetectorParams.scala
@@ -19,8 +19,8 @@ trait SentenceDetectorParams extends Params {
   )
 
   val splitLength: IntParam = new IntParam(this, "splitLength", "length at which sentences will be forcibly split.")
-  val minLength = new IntParam(this, "minLength", "Set the minimum allowed legth for each sentence")
-  val maxLength = new IntParam(this, "maxLength", "Set the maximum allowed legth for each sentence")
+  val minLength = new IntParam(this, "minLength", "Set the minimum allowed length for each sentence")
+  val maxLength = new IntParam(this, "maxLength", "Set the maximum allowed length for each sentence")
 
   setDefault(
     useAbbrevations -> true,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/SentenceDetectorParams.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/SentenceDetectorParams.scala
@@ -18,13 +18,17 @@ trait SentenceDetectorParams extends Params {
     "characters used to explicitly mark sentence bounds"
   )
 
-  val maxLength: IntParam = new IntParam(this, "maxLength", "length at which sentences will be forcibly split. Defaults to 240")
+  val splitLength: IntParam = new IntParam(this, "splitLength", "length at which sentences will be forcibly split.")
+  val minLength = new IntParam(this, "minLength", "Set the minimum allowed legth for each sentence")
+  val maxLength = new IntParam(this, "maxLength", "Set the maximum allowed legth for each sentence")
 
   setDefault(
     useAbbrevations -> true,
     useCustomBoundsOnly -> false,
     explodeSentences -> false,
-    customBounds -> Array.empty[String]
+    customBounds -> Array.empty[String],
+    minLength -> 0,
+    maxLength -> 99999
   )
 
   def setCustomBounds(value: Array[String]): this.type = set(customBounds, value)
@@ -43,9 +47,24 @@ trait SentenceDetectorParams extends Params {
 
   def getExplodeSentences: Boolean = $(explodeSentences)
 
-  def setMaxLength(value: Int): this.type = set(maxLength, value)
+  def setSplitLength(value: Int): this.type = set(splitLength, value)
 
-  def getMaxLength: Int = $(maxLength)
+  def getSplitLength: Int = $(splitLength)
+
+  def setMinLength(value: Int): this.type = {
+    require(value >= 0, "minLength must be greater equal than 0")
+    require(value.isValidInt, "minLength must be Int")
+    set(minLength, value)
+  }
+  def getMinLength(value: Int): Int = $(minLength)
+
+  def setMaxLength(value: Int): this.type = {
+    require(value >= ${minLength}, "maxLength must be greater equal than minLength")
+    require(value.isValidInt, "minLength must be Int")
+    set(maxLength, value)
+  }
+  def getMaxLength(value: Int): Int = $(maxLength)
+
 
   def truncateSentence(sentence: String, maxLength: Int): Array[String] = {
     var currentLength = 0

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/deep/DeepSentenceDetector.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/deep/DeepSentenceDetector.scala
@@ -47,7 +47,7 @@ class DeepSentenceDetector(override val uid: String) extends AnnotatorModel[Deep
         .setUseAbbreviations($(useAbbrevations))
         .setUseCustomBoundsOnly($(useCustomBoundsOnly))
         .setCustomBounds($(customBounds))
-      if (get(maxLength).isDefined) pragmaticSentenceDetector.setMaxLength($(maxLength))
+      if (get(splitLength).isDefined) pragmaticSentenceDetector.setSplitLength($(splitLength))
       val pragmaticSegmentedSentences = pragmaticSentenceDetector.annotate(document)
       val unpunctuatedSentences = getUnpunctuatedSentences(pragmaticSegmentedSentences)
 
@@ -148,8 +148,8 @@ class DeepSentenceDetector(override val uid: String) extends AnnotatorModel[Deep
         }
       }
       var currentStart = segmentedSentence.start
-      val annotatedSentenceWithLimit = get(maxLength)
-        .map(maxLength => truncateSentence(segmentedSentence.content, maxLength))
+      val annotatedSentenceWithLimit = get(splitLength)
+        .map(splitLength => truncateSentence(segmentedSentence.content, splitLength))
         .getOrElse(Array(segmentedSentence.content))
         .map{truncatedSentence => {
           val currentEnd = currentStart + truncatedSentence.length - 1

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetector.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetector.scala
@@ -34,13 +34,13 @@ class SentenceDetector(override val uid: String) extends AnnotatorModel[Sentence
       document
     ).flatMap(sentence => {
       var currentStart = sentence.start
-      get(maxLength).map(maxLength => truncateSentence(sentence.content, maxLength)).getOrElse(Array(sentence.content))
+      get(splitLength).map(splitLength => truncateSentence(sentence.content, splitLength)).getOrElse(Array(sentence.content))
         .zipWithIndex.map{ case (truncatedSentence, index) =>
-          val currentEnd = currentStart + truncatedSentence.length - 1
-          val result = Sentence(truncatedSentence, currentStart, currentEnd, index)
-          /** +1 because of shifting to the next token begin. +1 because of a whitespace jump to next token. */
-          currentStart = currentEnd + 2
-          result
+        val currentEnd = currentStart + truncatedSentence.length - 1
+        val result = Sentence(truncatedSentence, currentStart, currentEnd, index)
+        /** +1 because of shifting to the next token begin. +1 because of a whitespace jump to next token. */
+        currentStart = currentEnd + 2
+        result
       }
     })
   }
@@ -59,7 +59,10 @@ class SentenceDetector(override val uid: String) extends AnnotatorModel[Sentence
     */
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
     val docs = annotations.map(_.result)
-    val sentences = docs.flatMap(doc => tag(doc)).filter(_.content.nonEmpty)
+    val sentences = docs.flatMap(doc => tag(doc))
+      .filter(_.content.nonEmpty)
+      .filter(t => t.content.length >= ${minLength})
+      .filter(t => t.content.length <= ${maxLength})
     SentenceSplit.pack(sentences)
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/sbd/deep/DeepSentenceDetectorTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/sbd/deep/DeepSentenceDetectorTestSpec.scala
@@ -249,7 +249,7 @@ class DeepSentenceDetectorTestSpec extends FlatSpec with DeepSentenceDetectorBeh
     val dsd = new DeepSentenceDetector()
       .setInputCols(Array("document", "token", "ner_con"))
       .setOutputCol("sentence")
-      .setMaxLength(12)
+      .setSplitLength(12)
 
     val nerTagger = getNerTagger("src/test/resources/ner-corpus/sentence-detector/hello_training_right.txt")
     val purePipeline = new RecursivePipeline().setStages(

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticApproachTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticApproachTestSpec.scala
@@ -379,7 +379,7 @@ class PragmaticApproachTestSpec extends FlatSpec with PragmaticDetectionBehavior
   val veryLong = "This is a so long sentence that it will end up being cut off in different pieces because otherwise I don't " +
     "know how to end a sentence really I need some help getting this sentence to continue for some really really REALLY long " +
     "time although we should be almost there this part should become the second sentence, thanks."
-  "an isolated pragmatic detector" should behave like isolatedPDReadAndMatchResultTag(veryLong, veryLongAns, maxLength = Some(240))
+  "an isolated pragmatic detector" should behave like isolatedPDReadAndMatchResultTag(veryLong, veryLongAns, splitLength = Some(240))
 
   /*
   //List with bullet

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticDetectionBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticDetectionBehaviors.scala
@@ -48,12 +48,12 @@ trait PragmaticDetectionBehaviors { this: FlatSpec =>
     }
   }
 
-  def isolatedPDReadAndMatchResultTag(input: String, correctAnswer: Array[String], customBounds: Array[String] = Array.empty[String], maxLength: Option[Int] = None): Unit = {
+  def isolatedPDReadAndMatchResultTag(input: String, correctAnswer: Array[String], customBounds: Array[String] = Array.empty[String], splitLength: Option[Int] = None): Unit = {
     s"pragmatic boundaries detector with ${input.take(10)}...:" should
       s"successfully identify sentences as ${correctAnswer.take(1).take(10).mkString}..." in {
       val sentenceDetector = new SentenceDetector()
-      if (maxLength.isDefined)
-        sentenceDetector.setMaxLength(maxLength.get)
+      if (splitLength.isDefined)
+        sentenceDetector.setSplitLength(splitLength.get)
       val result = sentenceDetector.tag(input).map(_.content)
       val diffInResult = result.diff(correctAnswer)
       val diffInCorrect = correctAnswer.diff(result)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetectorBoundsSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetectorBoundsSpec.scala
@@ -87,7 +87,7 @@ class SentenceDetectorBoundsSpec extends FlatSpec {
     assert(sentenced(1) == Annotation(AnnotatorType.DOCUMENT, 13, 21, "this is a", Map("sentence" -> "1"), Array.emptyFloatArray))
     assert(sentenced(2) == Annotation(AnnotatorType.DOCUMENT, 23, 26, "long", Map("sentence" -> "2"), Array.emptyFloatArray))
     assert(sentenced(3) == Annotation(AnnotatorType.DOCUMENT, 28, 35, "sentence", Map("sentence" -> "3"), Array.emptyFloatArray))
-    assert(sentenced(4) == Annotation(AnnotatorType.DOCUMENT, 37, 55, "longerThanMaxLength", Map("sentence" -> "4"), Array.emptyFloatArray))
+    assert(sentenced(4) == Annotation(AnnotatorType.DOCUMENT, 37, 57, "longerThanSplitLength", Map("sentence" -> "4"), Array.emptyFloatArray))
 
   }
 


### PR DESCRIPTION
This PR introduces two new params for SentenceDetector. The **minLenght** and **maxLength** are very useful to filter out sentences based on min and max sentence's length.

**BREAKING CHANGES:** The old `maxLength` which was intended to truncate the sentence and split it into multiple sentences based on the target length now is renamed to `splitLength` in SentenceDetector and DeepSentenceDetector.

Example:

```scala
val sentence = new SentenceDetector()
      .setInputCols(Array("document"))
      .setOutputCol("sentence")
      .setMinLength(16)
      .setMaxLength(26)
```

The results are, sentences larger equal than 16 characters and less than equal than 26 characters.
