### PR TITLE
Move import to top level to avoid import fail

### DIFF
--- a/python/sparknlp/functions.py
+++ b/python/sparknlp/functions.py
@@ -1,6 +1,7 @@
 from pyspark.sql.functions import udf
 from pyspark.sql.types import *
 from pyspark.sql import DataFrame
+from sparknlp.annotation import Annotation
 import sys
 import sparknlp
 
@@ -14,7 +15,6 @@ def map_annotations(f, output_type: DataType):
 
 
 def map_annotations_strict(f):
-    from sparknlp.annotation import Annotation
     sys.modules['sparknlp.annotation'] = sparknlp  # Makes Annotation() pickle serializable in top-level
     return udf(
         lambda content: f(content),

--- a/python/sparknlp/functions.py
+++ b/python/sparknlp/functions.py
@@ -7,7 +7,6 @@ import sparknlp
 
 
 def map_annotations(f, output_type: DataType):
-    sys.modules['sparknlp.annotation'] = sparknlp  # Makes Annotation() pickle serializable  in top-level
     return udf(
         lambda content: f(content),
         output_type
@@ -15,7 +14,6 @@ def map_annotations(f, output_type: DataType):
 
 
 def map_annotations_strict(f):
-    sys.modules['sparknlp.annotation'] = sparknlp  # Makes Annotation() pickle serializable in top-level
     return udf(
         lambda content: f(content),
         ArrayType(Annotation.dataType())

--- a/python/sparknlp/functions.py
+++ b/python/sparknlp/functions.py
@@ -2,8 +2,6 @@ from pyspark.sql.functions import udf
 from pyspark.sql.types import *
 from pyspark.sql import DataFrame
 from sparknlp.annotation import Annotation
-import sys
-import sparknlp
 
 
 def map_annotations(f, output_type: DataType):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Because of a sys.modules hack to workaround serialization issues, importing of `Annotation` will fail after calling map functions the second time.

This alleviates the issue by moving the import to top level, however, Importing manually `Annotation` after a function is called will still fail.