### PR TITLE
Get the chunk metadata by its name rather than by its index

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
@@ -75,7 +75,7 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
 
     val documentsWithChunks = annotations
       .filter(token => token.annotatorType == CHUNK)
-      .groupBy(_.metadata.head._2.toInt)
+      .groupBy(_.metadata.getOrElse[String]("chunk", "0").toInt)
       .toSeq
       .sortBy(_._1)
 


### PR DESCRIPTION
## Description
ChunkEmbeddings was getting the chunk id by using head in the metadata (first key)
This PR changes it to get the explicit "chunk" key


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
ChunkEmbeddings was failing on NER because the first index in an NER chunk is the actual entity

## How Has This Been Tested?
This is not a new feature
All tests passed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
