### PR TITLE
Tokenizer split chars review

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -222,6 +222,11 @@ class TokenizerModel(AnnotatorModel):
                   "Rules structure factory containing pre processed regex rules",
                   typeConverter=TypeConverters.identity)
 
+    splitChars = Param(Params._dummy(),
+                       "splitChars",
+                       "character list used to separate from the inside of tokens",
+                       typeConverter=TypeConverters.toListString)
+
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.TokenizerModel", java_model=None):
         super(TokenizerModel, self).__init__(
             classname=classname,
@@ -231,6 +236,17 @@ class TokenizerModel(AnnotatorModel):
             targetPattern="\\S+",
             caseSensitiveExceptions=True
         )
+
+    def setSplitChars(self, value):
+        return self._set(splitChars=value)
+
+    def addSplitChars(self, value):
+        try:
+            split_chars = self.getSplitChars()
+        except KeyError:
+            split_chars = []
+        split_chars.append(value)
+        return self._set(splitChars=split_chars)
 
     @staticmethod
     def pretrained(name="token_rules", lang="en", remote_loc=None):

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -45,7 +45,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
   val expected1b = Array(
     "Hello", ",", "I", "won't", "be", "from", "New York", "in", "the", "U.S.A", ".", "(", "and", "you", "know", "it",
     "héroe", ").", "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "',", "I'll",
-    "defeat", "markus", "-", "crassus", ".", "You", "understand", ".", "Goodbye", "George", "E", ".", "Bush", ".", "www.google.com", "."
+    "defeat", "markus", "crassus", ".", "You", "understand", ".", "Goodbye", "George", "E", ".", "Bush", ".", "www.google.com", "."
   )
 
   "a Tokenizer" should "correctly tokenize target text on its defaults parameters with composite" in {
@@ -374,6 +374,33 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
       result.sameElements(Seq("Hello", "York")),
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected1.mkString("|")}"
+    )
+  }
+
+  "a Tokenizer" should "work correctly with multiple split chars" in {
+    val data = DataBuilder.basicDataBuild("Hello big-city-of-lights welcome to the ground#earth.")
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token")
+      .setSplitChars(Array("-", "#"))
+      .fit(data)
+
+    val expected = Seq(
+      Annotation("token", 0, 4, "Hello", Map("sentence" -> "0")),
+      Annotation("token", 6, 8, "big", Map("sentence" -> "0")),
+      Annotation("token", 10, 13, "city", Map("sentence" -> "0")),
+      Annotation("token", 15, 16, "of", Map("sentence" -> "0")),
+      Annotation("token", 18, 23, "lights", Map("sentence" -> "0")),
+      Annotation("token", 25, 31, "welcome", Map("sentence" -> "0")),
+      Annotation("token", 33, 34, "to", Map("sentence" -> "0")),
+      Annotation("token", 36, 38, "the", Map("sentence" -> "0")),
+      Annotation("token", 40, 45, "ground", Map("sentence" -> "0")),
+      Annotation("token", 47, 51, "earth", Map("sentence" -> "0")),
+      Annotation("token", 52, 52, ".", Map("sentence" -> "0"))
+    )
+    val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
+    assert(
+      result.sameElements(expected),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("\n")} \nexpected is: \n${expected.mkString("\n")}"
     )
   }
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -378,7 +378,7 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
   }
 
   "a Tokenizer" should "work correctly with multiple split chars" in {
-    val data = DataBuilder.basicDataBuild("Hello big-city-of-lights welcome to the ground#earth.")
+    val data = DataBuilder.basicDataBuild("Hello big-city-of-lights welcome to the ground###earth.")
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token")
       .setSplitChars(Array("-", "#"))
       .fit(data)
@@ -393,8 +393,8 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
       Annotation("token", 33, 34, "to", Map("sentence" -> "0")),
       Annotation("token", 36, 38, "the", Map("sentence" -> "0")),
       Annotation("token", 40, 45, "ground", Map("sentence" -> "0")),
-      Annotation("token", 47, 51, "earth", Map("sentence" -> "0")),
-      Annotation("token", 52, 52, ".", Map("sentence" -> "0"))
+      Annotation("token", 49, 53, "earth", Map("sentence" -> "0")),
+      Annotation("token", 54, 54, ".", Map("sentence" -> "0"))
     )
     val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
     assert(


### PR DESCRIPTION
Tokenizer split chars review for multiple occurences, deleted the split char from retrieved tokens

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
TokenizerModel's splitChars was not working correctly when there were multiple splitChars in the same token. This fixes that behavior, and also removes the split char itself from the output tokens.