### PR TITLE
Storage annotators can now explicitly save their storage

### DIFF
--- a/python/sparknlp/common.py
+++ b/python/sparknlp/common.py
@@ -119,6 +119,10 @@ class HasStorageModel(HasStorageRef, HasCaseSensitiveProperties):
 
     databases = None
 
+    def saveStorage(self, path, spark):
+        self._transfer_params_to_java()
+        self._java_obj.saveStorage(path, spark._jsparkSession, False)
+
     @staticmethod
     def loadStorage(path, spark, storage_ref):
         if not HasStorageModel.databases:

--- a/src/main/scala/com/johnsnowlabs/storage/HasStorageModel.scala
+++ b/src/main/scala/com/johnsnowlabs/storage/HasStorageModel.scala
@@ -8,9 +8,13 @@ trait HasStorageModel extends HasStorageReader with HasExcludableStorage {
 
   def serializeStorage(path: String, spark: SparkSession): Unit = {
     if ($(includeStorage))
-      databases.foreach(database => {
-        StorageHelper.save(path, getReader(database).getConnection, spark)
-      })
+      saveStorage(path, spark, withinStorage = true)
+  }
+
+  def saveStorage(path: String, spark: SparkSession, withinStorage: Boolean = false): Unit = {
+    databases.foreach(database => {
+      StorageHelper.save(path, getReader(database).getConnection, spark, withinStorage)
+    })
   }
 
   override protected def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/storage/StorageHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/storage/StorageHelper.scala
@@ -28,16 +28,12 @@ object StorageHelper {
     RocksDBConnection.getOrCreate(locator.clusterFileName)
   }
 
-  def save(path: String, connection: RocksDBConnection, spark: SparkSession): Unit = {
-    StorageHelper.save(path, spark, connection)
-  }
-
-  private def save(path: String, spark: SparkSession, connection: RocksDBConnection): Unit = {
+  def save(path: String, connection: RocksDBConnection, spark: SparkSession, withinStorage: Boolean): Unit = {
     val index = new Path("file://"+connection.findLocalIndex)
 
     val uri = new java.net.URI(path.replaceAllLiterally("\\", "/"))
     val fs = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
-    val dst = new Path(path+"/storage/")
+    val dst = new Path(path+{if (withinStorage) "/storage/" else ""})
 
     save(fs, index, dst)
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Annotators with `HasStorageModel` can now call `saveStorage(path, sparkSession)` to save their indexed storage. This allows them to be loaded later through `loadStorage(path, sparkSession, ref)`