### PR TITLE
Fix reading, loading and saving TF SavedModel

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
@@ -72,10 +72,9 @@ class TensorflowBert(val tensorflow: TensorflowWrapper,
 
     val dim = embeddings.length / (batch.length * maxSentenceLength)
     val shrinkedEmbeddings: Array[Array[Array[Float]]] = embeddings.grouped(dim).toArray.grouped(maxSentenceLength).toArray
-    //
+
     val emptyVector = Array.fill(dim)(0f)
 
-    Seq(Array(emptyVector))
     batch.zip(shrinkedEmbeddings).map { case (ids, embeddings) =>
       if (ids.length > embeddings.length) {
         embeddings.take(embeddings.length - 1) ++

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowSerializeModel.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowSerializeModel.scala
@@ -41,11 +41,11 @@ trait WriteTensorflowModel {
   }
 
   def writeTensorflowHub(
-                            path: String,
-                            tfPath: String,
-                            spark: SparkSession,
-                            suffix: String = "_use"
-                          ): Unit = {
+                          path: String,
+                          tfPath: String,
+                          spark: SparkSession,
+                          suffix: String = "_use"
+                        ): Unit = {
 
     val uri = new java.net.URI(path.replaceAllLiterally("\\", "/"))
     val fs = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
@@ -77,7 +77,8 @@ trait ReadTensorflowModel {
                            suffix: String,
                            zipped:Boolean = true,
                            useBundle:Boolean = false,
-                           tags:Array[String]=Array.empty
+                           tags:Array[String]=Array.empty,
+                           initAllTables: Boolean = false
                          ): TensorflowWrapper = {
 
     LoadsContrib.loadContribToCluster(spark)
@@ -94,7 +95,7 @@ trait ReadTensorflowModel {
 
     // 3. Read Tensorflow state
     val tf = TensorflowWrapper.read(new Path(tmpFolder, tfFile).toString,
-      zipped, tags = tags, useBundle = useBundle)
+      zipped, tags = tags, useBundle = useBundle, initAllTables = initAllTables)
 
     // 4. Remove tmp folder
     FileHelper.delete(tmpFolder)
@@ -103,13 +104,13 @@ trait ReadTensorflowModel {
   }
 
   def readTensorflowHub(
-                           path: String,
-                           spark: SparkSession,
-                           suffix: String,
-                           zipped:Boolean = true,
-                           useBundle:Boolean = false,
-                           tags:Array[String]=Array.empty
-                         ): TensorflowWrapper = {
+                         path: String,
+                         spark: SparkSession,
+                         suffix: String,
+                         zipped:Boolean = true,
+                         useBundle:Boolean = false,
+                         tags:Array[String]=Array.empty
+                       ): TensorflowWrapper = {
 
 
     val uri = new java.net.URI(path.replaceAllLiterally("\\", "/"))

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowWrapper.scala
@@ -248,7 +248,9 @@ object TensorflowWrapper {
       val session = new Session(graph, tfSessionConfig)
       val varPath = Paths.get(folder, "variables.data-00000-of-00001")
       val idxPath = Paths.get(folder, "variables.index")
-      session.runner.addTarget("save/restore_all")
+      session.runner
+        .addTarget("save/restore_all")
+        .addTarget("init_all_tables")
         .feed("save/Const", t.createTensor(Paths.get(folder, "variables").toString))
         .run()
       (graph, session, varPath, idxPath)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -185,7 +185,7 @@ trait ReadBertTensorflowModel extends ReadTensorflowModel {
 
   def readTensorflow(instance: BertEmbeddings, path: String, spark: SparkSession): Unit = {
 
-    val tf = readTensorflowModel(path, spark, "_bert_tf")
+    val tf = readTensorflowModel(path, spark, "_bert_tf", initAllTables = true)
     instance.setModelIfNotSet(spark, tf)
   }
 
@@ -210,7 +210,7 @@ trait ReadBertTensorflowModel extends ReadTensorflowModel {
     val vocabResource = new ExternalResource(vocab.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
     val words = ResourceHelper.parseLines(vocabResource).zipWithIndex.toMap
 
-    val wrapper = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"))
+    val wrapper = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"), initAllTables = true)
 
     val Bert = new BertEmbeddings()
       .setVocabulary(words)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ElmoEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ElmoEmbeddings.scala
@@ -148,7 +148,7 @@ trait ReadElmoTensorflowModel extends ReadTensorflowModel {
   override val tfFile: String = "elmo_tensorflow"
 
   def readTensorflow(instance: ElmoEmbeddings, path: String, spark: SparkSession): Unit = {
-    val tf = readTensorflowModel(path, spark, "_elmo_tf")
+    val tf = readTensorflowModel(path, spark, "_elmo_tf", initAllTables = true)
     instance.setModelIfNotSet(spark, tf)
   }
 
@@ -165,7 +165,7 @@ trait ReadElmoTensorflowModel extends ReadTensorflowModel {
       s"savedModel file saved_model.pb not found in folder $folder"
     )
 
-    val wrapper = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"))
+    val wrapper = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"), initAllTables = true)
 
     val Elmo = new ElmoEmbeddings()
       .setModelIfNotSet(spark, wrapper)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder.scala
@@ -7,7 +7,6 @@ import com.johnsnowlabs.nlp.AnnotatorType.{DOCUMENT, SENTENCE_EMBEDDINGS}
 import com.johnsnowlabs.nlp.annotators.common.SentenceSplit
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasPretrained, ParamsAndFeaturesReadable}
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.ml.PipelineModel
 import org.apache.spark.ml.param.IntArrayParam
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.SparkSession
@@ -72,7 +71,8 @@ class UniversalSentenceEncoder(override val uid: String)
 
   override def onWrite(path: String, spark: SparkSession): Unit = {
     super.onWrite(path, spark)
-    writeTensorflowHub(path, tfPath = getTFhubPath, spark)
+    //    writeTensorflowHub(path, tfPath = getTFhubPath, spark)
+    writeTensorflowModel(path, spark, getModelIfNotSet.tensorflow, "_use", UniversalSentenceEncoder.tfFile, configProtoBytes = getConfigProtoBytes)
   }
 
 }
@@ -84,11 +84,8 @@ trait ReadablePretrainedUSEModel
 
   /** Java compliant-overrides */
   override def pretrained(): UniversalSentenceEncoder = super.pretrained()
-
   override def pretrained(name: String): UniversalSentenceEncoder = super.pretrained(name)
-
   override def pretrained(name: String, lang: String): UniversalSentenceEncoder = super.pretrained(name, lang)
-
   override def pretrained(name: String, lang: String, remoteLoc: String): UniversalSentenceEncoder = super.pretrained(name, lang, remoteLoc)
 }
 
@@ -96,43 +93,37 @@ trait ReadUSETensorflowModel extends ReadTensorflowModel {
   this: ParamsAndFeaturesReadable[UniversalSentenceEncoder] =>
 
   /*Needs to point to an actual folder rather than a .pb file*/
-  override val tfFile: String = ""
+  override val tfFile: String = "use_tensorflow"
 
-  def readTensorflow(instance: UniversalSentenceEncoder,
-                     path: String,
-                     spark: SparkSession): Unit = {
-    val tf = readTensorflowHub(
-      path,
-      spark,
-      "_use_tf",
-      zipped = false,
-      useBundle = true,
-      tags = Array("serve")
-    )
+  def readTensorflow(instance: UniversalSentenceEncoder, path: String, spark: SparkSession): Unit = {
+
+    val tf = readTensorflowModel(path, spark, "_use_tf")
     instance.setModelIfNotSet(spark, tf)
   }
 
   addReader(readTensorflow)
 
-  def loadSavedModel(tfHubPath: String,
+  def loadSavedModel(folder: String,
                      spark: SparkSession): UniversalSentenceEncoder = {
-    val f = new File(tfHubPath)
-    val savedModel = new File(tfHubPath, "saved_model.pb")
+    val f = new File(folder)
+    val savedModel = new File(folder, "saved_model.pb")
 
-    require(f.exists, s"Folder $tfHubPath not found")
-    require(f.isDirectory, s"File $tfHubPath is not folder")
+    require(f.exists, s"Folder $folder not found")
+    require(f.isDirectory, s"File $folder is not folder")
     require(
       savedModel.exists(),
-      s"savedModel file saved_model.pb not found in folder $tfHubPath"
+      s"savedModel file saved_model.pb not found in folder $folder"
     )
 
+    val wrapper = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"))
+
     val USE = new UniversalSentenceEncoder()
-    USE.setTFhubPath(tfHubPath)
+      .setModelIfNotSet(spark, wrapper)
+
+    USE.setTFhubPath(folder)
 
     USE
   }
 }
 
-object UniversalSentenceEncoder
-  extends ReadablePretrainedUSEModel
-    with ReadUSETensorflowModel
+object UniversalSentenceEncoder extends ReadablePretrainedUSEModel with ReadUSETensorflowModel

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder.scala
@@ -97,7 +97,7 @@ trait ReadUSETensorflowModel extends ReadTensorflowModel {
 
   def readTensorflow(instance: UniversalSentenceEncoder, path: String, spark: SparkSession): Unit = {
 
-    val tf = readTensorflowModel(path, spark, "_use_tf")
+    val tf = readTensorflowModel(path, spark, "_use_tf", initAllTables = true)
     instance.setModelIfNotSet(spark, tf)
   }
 
@@ -115,7 +115,7 @@ trait ReadUSETensorflowModel extends ReadTensorflowModel {
       s"savedModel file saved_model.pb not found in folder $folder"
     )
 
-    val wrapper = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"))
+    val wrapper = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"), initAllTables = true)
 
     val USE = new UniversalSentenceEncoder()
       .setModelIfNotSet(spark, wrapper)


### PR DESCRIPTION
Currently, the BertEmbeddings and UnviersalSentenceEncoder annotators cannot be saved individually or inside a pipeline. This PR fixes this issue.