### PR TITLE
Fix NorvigSweetingModel missing sentence ID in its metadata

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/NGramGenerator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/NGramGenerator.scala
@@ -85,7 +85,7 @@ class NGramGenerator (override val uid: String) extends AnnotatorModel[NGramGene
 
     val documentsWithTokens = annotations
       .filter(token => token.annotatorType == TOKEN)
-      .groupBy(_.metadata.head._2.toInt)
+      .groupBy(_.metadata("sentence").head.toInt)
       .toSeq
       .sortBy(_._1)
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/NGramGenerator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/NGramGenerator.scala
@@ -85,7 +85,7 @@ class NGramGenerator (override val uid: String) extends AnnotatorModel[NGramGene
 
     val documentsWithTokens = annotations
       .filter(token => token.annotatorType == TOKEN)
-      .groupBy(_.metadata("sentence").head.toInt)
+      .groupBy(_.metadata.getOrElse[String]("sentence", "0").toInt)
       .toSeq
       .sortBy(_._1)
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingModel.scala
@@ -41,14 +41,17 @@ class NorvigSweetingModel(override val uid: String) extends AnnotatorModel[Norvi
 
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
     annotations.map { token =>
-        val verifiedWord = checkSpellWord(token.result)
-        Annotation(
-          outputAnnotatorType,
-          token.begin,
-          token.end,
-          verifiedWord._1,
-          Map("confidence"->verifiedWord._2.toString)
+      val verifiedWord = checkSpellWord(token.result)
+      Annotation(
+        outputAnnotatorType,
+        token.begin,
+        token.end,
+        verifiedWord._1,
+        Map(
+          "confidence"->verifiedWord._2.toString,
+          "sentence"->token.metadata("sentence")
         )
+      )
     }
   }
 
@@ -199,7 +202,7 @@ class NorvigSweetingModel(override val uid: String) extends AnnotatorModel[Norvi
       word._2 == bestFrequencyValue && word._3 == bestHammingValue)
     if (bestRecommendations.nonEmpty) {
       val result = (Utilities.getRandomValueFromList(bestRecommendations),
-                    Utilities.computeConfidenceValue(bestRecommendations))
+        Utilities.computeConfidenceValue(bestRecommendations))
       (Some(result._1.get._1), result._2)
     } else {
       if ($(frequencyPriority)) {


### PR DESCRIPTION
NorvigSweetingModel doesn't add `sentence` to its metadata which has the id of each sentence. This causes problems in further annotators such as NGramsGenerator where the sentence ID is needed.
https://github.com/JohnSnowLabs/spark-nlp/issues/780

