### PR TITLE
Config prefix update to avoid -D option conflicts in Spark.

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,9 +395,11 @@ ConfigLoader.setConfigPath("/somewhere/to/put/application.conf")
 And then we need to put in such application.conf the following content
 
 ```bash
-sparknlp {
-  settings {
-    cluster_tmp_dir = "somewhere in s3n:// path to some folder"
+jsl {
+  sparknlp {
+    settings {
+      cluster_tmp_dir = "somewhere in s3n:// path to some folder"
+    }
   }
 }
 ```

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -162,11 +162,13 @@ ConfigLoader.setConfigPath("/somewhere/to/put/application.conf")
 And then we need to put in such application.conf the following content
 
 ```json
-sparknlp {
-    settings {
-        cluster_tmp_dir = "somewhere in s3n:// path to some folder"
+    jsl {
+        sparknlp {
+            settings {
+                cluster_tmp_dir = "somewhere in s3n:// path to some folder"
+            }
+        }
     }
-}
 ```
 
 For further alternatives and documentation check out our README page in [GitHub](https://github.com/JohnSnowLabs/spark-nlp).

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,29 +1,25 @@
-sparknlp {
-
-  settings {
-
-    overrideConfigPath = "./application.conf"
-    annotatorSerializationFormat = "object"
-    useBroadcastForFeatures = true
-
-    storage {
-      // Override with cluster location. Default is non set. Leads to fs.defaultFS scheme. e.g. hdfs:// in YARN.
-      // and hadoop.tmp.dir. Highly dependant on defaultFS. Override in non hadoop, e.g. S3 storage based clusters.
-      // cluster_tmp_dir = "s3://"
+jsl {
+  sparknlp {
+    settings {
+      overrideConfigPath = "./application.conf"
+      annotatorSerializationFormat = "object"
+      useBroadcastForFeatures = true
+      storage {
+        // Override with cluster location. Default is non set. Leads to fs.defaultFS scheme. e.g. hdfs:// in YARN.
+        // and hadoop.tmp.dir. Highly dependant on defaultFS. Override in non hadoop, e.g. S3 storage based clusters.
+        // cluster_tmp_dir = "s3://"
+      }
+      pretrained {
+        s3_bucket = "auxdata.johnsnowlabs.com"
+        s3_path = ""
+        s3_socket_timeout = 3600000
+        // Override as required. Defaults to home/cache_pretrained folder.
+        // cache_folder = "/home/robert/models"
+        credentials {}
+      }
+      annotator {
+        // log_folder = "/home/robert/logs"
+      }
     }
-
-    pretrained {
-      s3_bucket = "auxdata.johnsnowlabs.com"
-      s3_path = ""
-      s3_socket_timeout = 3600000
-      // Override as required. Defaults to home/cache_pretrained folder.
-      // cache_folder = "/home/robert/models"
-      credentials {}
-    }
-
-    annotator {
-      // log_folder = "/home/robert/logs"
-    }
-
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/serialization/Feature.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/serialization/Feature.scala
@@ -18,8 +18,8 @@ abstract class Feature[Serializable1, Serializable2, TComplete: ClassTag](model:
   private val config = ConfigLoader.retrieve
   private val spark = ResourceHelper.spark
 
-  val serializationMode: String = config.getString("sparknlp.settings.annotatorSerializationFormat")
-  val useBroadcast: Boolean = config.getBoolean("sparknlp.settings.useBroadcastForFeatures")
+  val serializationMode: String = config.getString("jsl.sparknlp.settings.annotatorSerializationFormat")
+  val useBroadcast: Boolean = config.getBoolean("jsl.sparknlp.settings.useBroadcastForFeatures")
 
   final protected var broadcastValue: Option[Broadcast[TComplete]] = None
 

--- a/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
@@ -20,28 +20,30 @@ object ConfigHelper {
     getConfigValue(path).getOrElse(defaultValue)
   }
 
+  val configPrefix = "jsl.sparknlp"
+
   // Configures s3 bucket where pretrained models are stored
-  val pretrainedS3BucketKey = "sparknlp.settings.pretrained.s3_bucket"
+  val pretrainedS3BucketKey = configPrefix + ".settings.pretrained.s3_bucket"
 
   // Configures s3 path where pretrained models are stored
-  val pretrainedS3PathKey = "sparknlp.settings.pretrained.s3_path"
+  val pretrainedS3PathKey = configPrefix + ".settings.pretrained.s3_path"
 
   // Configures cache folder where to cache pretrained models
-  val pretrainedCacheFolder = "sparknlp.settings.pretrained.cache_folder"
+  val pretrainedCacheFolder = configPrefix + ".settings.pretrained.cache_folder"
 
   // Configures cache folder where to cache pretrained models
-  val annotatorLogFolder = "sparknlp.settings.annotator.log_folder"
+  val annotatorLogFolder = configPrefix + "settings.annotator.log_folder"
 
   // Stores credentials for AWS S3 private models
-  val awsCredentials = "sparknlp.settings.pretrained.credentials"
+  val awsCredentials = configPrefix + ".settings.pretrained.credentials"
 
 
   val accessKeyId = awsCredentials + ".access_key_id"
   val secretAccessKey = awsCredentials + ".secret_access_key"
   val awsProfileName = awsCredentials + ".aws_profile_name"
 
-  val s3SocketTimeout = "sparknlp.settings.pretrained.s3_socket_timeout"
+  val s3SocketTimeout = configPrefix + ".settings.pretrained.s3_socket_timeout"
 
-  val storageTmpDir = "sparknlp.settings.storage.cluster_tmp_dir"
+  val storageTmpDir = configPrefix + ".settings.storage.cluster_tmp_dir"
 
 }

--- a/src/main/scala/com/johnsnowlabs/util/ConfigLoader.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigLoader.scala
@@ -13,7 +13,7 @@ object ConfigLoader {
     if (System.getenv().containsKey("SPARKNLP_CONFIG_PATH"))
       System.getenv("SPARKNLP_CONFIG_PATH")
     else
-      defaultConfig.getString("sparknlp.settings.overrideConfigPath")
+      defaultConfig.getString("jsl.sparknlp.settings.overrideConfigPath")
   }
 
   def getConfigPath: String = overrideConfigPath

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,6 +1,8 @@
-sparknlp {
-  settings {
-    annotatorSerializationFormat = "object"
-    useBroadcastForFeatures = true
+jsl {
+  sparknlp {
+    settings {
+      annotatorSerializationFormat = "object"
+      useBroadcastForFeatures = true
+    }
   }
 }


### PR DESCRIPTION
## Description
Prefixes the Spark NLP settings with `jsl.`.


## Motivation and Context
The current settings implementation of `sparknlp.settings. ...` leads to an exception being thrown by Spark's `validateSettings` when the Spark NLP configuration is provided as a `-D` option in either `spark.driver.extraJavaOptions` or `spark.executor.extraJavaOptions`, as shown here: 

https://github.com/apache/spark/blob/d8613571bc1847775dd5c1945757279234cb388c/core/src/main/scala/org/apache/spark/SparkConf.scala#L529

```
    getOption(executorOptsKey).foreach { javaOpts =>
      if (javaOpts.contains("-Dspark")) {
        val msg = s"$executorOptsKey is not allowed to set Spark options (was '$javaOpts'). " +
          "Set them directly on a SparkConf or in a properties file when using ./bin/spark-submit."
        throw new Exception(msg)
      }
      if (javaOpts.contains("-Xmx")) {
        val msg = s"$executorOptsKey is not allowed to specify max heap memory settings " +
          s"(was '$javaOpts'). Use spark.executor.memory instead."
        throw new Exception(msg)
      }
    }
```

Spark simply looks for any strings which contain `-Dspark` (which `-Dsparknlp` does) and errors out.

## How Has This Been Tested?
Against both a GCP Dataproc Cluster and a Zepplin notebook running on top of Dataproc. Example settings config shown below:

```
-Djsl.sparknlp.settings.license="LICENSE_KEY" -Djsl.sparknlp.settings.pretrained.credentials.access_key_id="ACCESS_KEY" -Djsl.sparknlp.settings.pretrained.credentials.secret_access_key="SECRET_ACCESS_KEY" -Djsl.sparknlp.settings.pretrained.s3_bucket=auxdata.johnsnowlabs.com -Djsl.sparknlp.settings.pretrained.s3_socket_timeout=3600000
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional Info:

**IMPORTANT** The  `sparknlp.settings.license` references are not public. I believe these reside in the spark-nlp-license project and will need to be updated there.

