### PR TITLE
Fix ElmoEmbeddings.Pretrained() in Python

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -31,6 +31,7 @@ unittest.TextTestRunner().run(StopWordsCleanerTestSpec())
 unittest.TextTestRunner().run(NGramGeneratorTestSpec())
 unittest.TextTestRunner().run(ChunkEmbeddingsTestSpec())
 unittest.TextTestRunner().run(EmbeddingsFinisherTestSpec())
+unittest.TextTestRunner().run(ElmoEmbeddingsTestSpec())
 
 # unittest.TextTestRunner().run(RecursiveTestSpec())
 

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1898,7 +1898,7 @@ class ElmoEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasCaseSensitivePr
 
     poolingLayer = Param(Params._dummy(),
                          "poolingLayer", "Set ELMO pooling layer to: word_emb, lstm_outputs1, lstm_outputs2, or elmo",
-                         typeConverter=TypeConverters.toInt)
+                         typeConverter=TypeConverters.toString)
 
     def setConfigProtoBytes(self, b):
         return self._set(configProtoBytes=b)
@@ -1939,4 +1939,4 @@ class ElmoEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasCaseSensitivePr
     @staticmethod
     def pretrained(name="elmo", lang="en", remote_loc=None):
         from sparknlp.pretrained import ResourceDownloader
-        return ResourceDownloader.downloadModel(BertEmbeddings, name, lang, remote_loc)
+        return ResourceDownloader.downloadModel(ElmoEmbeddings, name, lang, remote_loc)

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -963,3 +963,34 @@ class EmbeddingsFinisherTestSpec(unittest.TestCase):
         model = pipeline.fit(self.data)
         model.transform(self.data).show()
 
+
+class ElmoEmbeddingsTestSpec(unittest.TestCase):
+
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+    def runTest(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+        sentence_detector = SentenceDetector() \
+            .setInputCols(["document"]) \
+            .setOutputCol("sentence")
+        tokenizer = Tokenizer() \
+            .setInputCols(["sentence"]) \
+            .setOutputCol("token")
+        elmo = ElmoEmbeddings.pretrained() \
+            .setInputCols(["sentence", "token"]) \
+            .setOutputCol("embeddings")\
+            .setPoolingLayer("word_emb")
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            sentence_detector,
+            tokenizer,
+            elmo
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -15,7 +15,7 @@ import com.johnsnowlabs.nlp.annotators.sda.pragmatic.SentimentDetectorModel
 import com.johnsnowlabs.nlp.annotators.sda.vivekn.ViveknSentimentModel
 import com.johnsnowlabs.nlp.annotators.spell.norvig.NorvigSweetingModel
 import com.johnsnowlabs.nlp.annotators.spell.symmetric.SymmetricDeleteModel
-import com.johnsnowlabs.nlp.embeddings.{BertEmbeddings, WordEmbeddingsModel}
+import com.johnsnowlabs.nlp.embeddings.{BertEmbeddings, ElmoEmbeddings, UniversalSentenceEncoder, WordEmbeddingsModel}
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader.{listPretrainedResources, publicLoc, showString}
 import com.johnsnowlabs.nlp.pretrained.ResourceType.ResourceType
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
@@ -443,7 +443,9 @@ object PythonResourceDownloader {
     "WordEmbeddingsModel" -> WordEmbeddingsModel,
     "BertEmbeddings" -> BertEmbeddings,
     "DependencyParserModel" -> DependencyParserModel,
-    "TypedDependencyParserModel" -> TypedDependencyParserModel
+    "TypedDependencyParserModel" -> TypedDependencyParserModel,
+    "UniversalSentenceEncoder" -> UniversalSentenceEncoder,
+    "ElmoEmbeddings" -> ElmoEmbeddings
   )
 
   def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {


### PR DESCRIPTION
Due to the wrong type in `downloadModel` it wasn't possible to download and load the ElmoEmbedings model in `pretrained()`. 
Also, `poolingLayer` is supposed to be a `string`, not `int`. 