### PR TITLE
Introducing ClassifierDL annotator for training multi-class text classification

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -31,7 +31,9 @@ unittest.TextTestRunner().run(StopWordsCleanerTestSpec())
 unittest.TextTestRunner().run(NGramGeneratorTestSpec())
 unittest.TextTestRunner().run(ChunkEmbeddingsTestSpec())
 unittest.TextTestRunner().run(EmbeddingsFinisherTestSpec())
+unittest.TextTestRunner().run(UniversalSentenceEncoderTestSpec())
 unittest.TextTestRunner().run(ElmoEmbeddingsTestSpec())
+unittest.TextTestRunner().run(ClassifierDLTestSpec())
 
 # unittest.TextTestRunner().run(RecursiveTestSpec())
 

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1943,13 +1943,15 @@ class ElmoEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasCaseSensitivePr
         return ResourceDownloader.downloadModel(ElmoEmbeddings, name, lang, remote_loc)
 
 
-class ClassifierDLApproach(AnnotatorApproach, ClassifierDLApproach):
+class ClassifierDLApproach(AnnotatorApproach):
 
     lr = Param(Params._dummy(), "lr", "Learning Rate", TypeConverters.toFloat)
 
     batchSize = Param(Params._dummy(), "batchSize", "Batch size", TypeConverters.toInt)
 
     dropout = Param(Params._dummy(), "dropout", "Dropout coefficient", TypeConverters.toFloat)
+
+    maxEpochs = Param(Params._dummy(), "maxEpochs", "Maximum number of epochs to train", TypeConverters.toInt)
 
     configProtoBytes = Param(Params._dummy(), "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()", TypeConverters.toListString)
 
@@ -1962,6 +1964,14 @@ class ClassifierDLApproach(AnnotatorApproach, ClassifierDLApproach):
     enableOutputLogs = Param(Params._dummy(), "enableOutputLogs",
                              "Whether to use stdout in addition to Spark logs.",
                              TypeConverters.toBoolean)
+
+    labelColumn = Param(Params._dummy(),
+                        "labelColumn",
+                        "Column with label per each token",
+                        typeConverter=TypeConverters.toString)
+
+    def setLabelColumn(self, value):
+        return self._set(labelColumn=value)
 
     def setConfigProtoBytes(self, b):
         return self._set(configProtoBytes=b)
@@ -1977,6 +1987,9 @@ class ClassifierDLApproach(AnnotatorApproach, ClassifierDLApproach):
     def setDropout(self, v):
         self._set(dropout=v)
         return self
+
+    def setMaxEpochs(self, epochs):
+        return self._set(maxEpochs=epochs)
 
     def _create_model(self, java_model):
         return NerDLModel(java_model=java_model)

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1958,9 +1958,6 @@ class ClassifierDLApproach(AnnotatorApproach):
     validationSplit = Param(Params._dummy(), "validationSplit", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
                             TypeConverters.toFloat)
 
-    evaluationLogExtended = Param(Params._dummy(), "evaluationLogExtended", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.",
-                                  TypeConverters.toBoolean)
-
     enableOutputLogs = Param(Params._dummy(), "enableOutputLogs",
                              "Whether to use stdout in addition to Spark logs.",
                              TypeConverters.toBoolean)
@@ -1969,6 +1966,15 @@ class ClassifierDLApproach(AnnotatorApproach):
                         "labelColumn",
                         "Column with label per each token",
                         typeConverter=TypeConverters.toString)
+
+    verbose = Param(Params._dummy(), "verbose", "Level of verbosity during training", TypeConverters.toInt)
+    randomSeed = Param(Params._dummy(), "randomSeed", "Random seed", TypeConverters.toInt)
+
+    def setVerbose(self, value):
+        return self._set(verbose=value)
+
+    def setRandomSeed(self, seed):
+        return self._set(randomSeed=seed)
 
     def setLabelColumn(self, value):
         return self._set(labelColumn=value)
@@ -1992,14 +1998,10 @@ class ClassifierDLApproach(AnnotatorApproach):
         return self._set(maxEpochs=epochs)
 
     def _create_model(self, java_model):
-        return NerDLModel(java_model=java_model)
+        return ClassifierDLModel(java_model=java_model)
 
     def setValidationSplit(self, v):
         self._set(validationSplit=v)
-        return self
-
-    def setEvaluationLogExtended(self, v):
-        self._set(evaluationLogExtended=v)
         return self
 
     def setEnableOutputLogs(self, value):

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowClassifier.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowClassifier.scala
@@ -36,7 +36,6 @@ class TensorflowClassifier(
              endEpoch: Int = 30,
              configProtoBytes: Option[Array[Byte]] = None,
              validationSplit: Float = 0.0f,
-             evaluationLogExtended: Boolean = false,
              enableOutputLogs: Boolean = false,
              uuid: String = Identifiable.randomUID("classifierdl")
            ): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLApproach.scala
@@ -97,7 +97,6 @@ class ClassifierDLApproach(override val uid: String)
       settings
     )
 
-
     val trainDataset = encoder.collectTrainingInstances(train, getLabelColumn)
     val inputEmbeddings = encoder.extractSentenceEmbeddings(trainDataset)
     val inputLabels = encoder.extractLabels(trainDataset)
@@ -121,7 +120,6 @@ class ClassifierDLApproach(override val uid: String)
         endEpoch = $(maxEpochs),
         configProtoBytes = getConfigProtoBytes,
         validationSplit = $(validationSplit),
-        evaluationLogExtended = true,
         enableOutputLogs=$(enableOutputLogs),
         uuid = this.uid
       )

--- a/src/test/resources/classifier/sentiment.csv
+++ b/src/test/resources/classifier/sentiment.csv
@@ -1,0 +1,3 @@
+text,label
+This movie is the best movie I have wached ever! In my opinion this movie can win an award.,0
+This was a terrible movie! The acting was bad really bad!,1


### PR DESCRIPTION
- [x] TF model for multi-class text classification up to 50 classes
- [x] Export TF save_model compatible with Spark NLP
- [x] Add hasStorage to SentenceEmbeddings
- [x] Add hasStorage to UniversalSentenceEncoder
- [ ] Automatically extract storageRef from embeddings in SentenceEmbeddings
- [x] Accept both StringType or IntegerType in label column
- [x] Accept both document or sentence in training (explode sentences with the same label inside)
- [x] Parameters for LR, DP, Epochs, batchSize
- [x] Dynamic input by padding (train, prediction)
- [x] Metrics during training
- [x] validationSplit during training with F-scores
- [x] Python interface
- [ ] Unit test in Scala
- [x] Unit test in Python
