### PR TITLE
Fix java.io.UTFDataFormatException in cluster-mode and some Databricks runtime versions

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/serialization/Feature.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/serialization/Feature.scala
@@ -5,7 +5,6 @@ import com.github.liblevenshtein.serialization.PlainTextSerializer
 import com.github.liblevenshtein.transducer.{Candidate, ITransducer, Transducer}
 import com.johnsnowlabs.nlp.HasFeatures
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.util.ConfigLoader
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.{Encoder, Encoders, SparkSession}
@@ -15,11 +14,12 @@ import scala.reflect.ClassTag
 abstract class Feature[Serializable1, Serializable2, TComplete: ClassTag](model: HasFeatures, val name: String) extends Serializable {
   model.features.append(this)
 
-  private val config = ConfigLoader.retrieve
+  // private val config = ConfigLoader.retrieve
   private val spark = ResourceHelper.spark
 
-  val serializationMode: String = config.getString("sparknlp.settings.annotatorSerializationFormat")
-  val useBroadcast: Boolean = config.getBoolean("sparknlp.settings.useBroadcastForFeatures")
+  val serializationMode: String = "object"
+  //config.getString("sparknlp.settings.annotatorSerializationFormat")
+  val useBroadcast: Boolean = true //config.getBoolean("sparknlp.settings.useBroadcastForFeatures")
 
   final protected var broadcastValue: Option[Broadcast[TComplete]] = None
 

--- a/src/main/scala/com/johnsnowlabs/nlp/serialization/Feature.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/serialization/Feature.scala
@@ -5,6 +5,7 @@ import com.github.liblevenshtein.serialization.PlainTextSerializer
 import com.github.liblevenshtein.transducer.{Candidate, ITransducer, Transducer}
 import com.johnsnowlabs.nlp.HasFeatures
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.util.ConfigHelper
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.{Encoder, Encoders, SparkSession}
@@ -14,13 +15,11 @@ import scala.reflect.ClassTag
 abstract class Feature[Serializable1, Serializable2, TComplete: ClassTag](model: HasFeatures, val name: String) extends Serializable {
   model.features.append(this)
 
-  // private val config = ConfigLoader.retrieve
+
   private val spark = ResourceHelper.spark
 
-  val serializationMode: String = "object"
-  //config.getString("sparknlp.settings.annotatorSerializationFormat")
-  val useBroadcast: Boolean = true //config.getBoolean("sparknlp.settings.useBroadcastForFeatures")
-
+  val serializationMode: String = ConfigHelper.serializationMode
+  val useBroadcast: Boolean = ConfigHelper.useBroadcast
   final protected var broadcastValue: Option[Broadcast[TComplete]] = None
 
   final protected var rawValue: Option[TComplete] = None

--- a/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
@@ -36,9 +36,9 @@ object ConfigHelper {
   val awsCredentials = "sparknlp.settings.pretrained.credentials"
 
 
-  val accessKeyId = awsCredentials + ".access_key_id"
-  val secretAccessKey = awsCredentials + ".secret_access_key"
-  val awsProfileName = awsCredentials + ".aws_profile_name"
+  val accessKeyId: String = awsCredentials + ".access_key_id"
+  val secretAccessKey: String = awsCredentials + ".secret_access_key"
+  val awsProfileName: String = awsCredentials + ".aws_profile_name"
 
   val s3SocketTimeout = "sparknlp.settings.pretrained.s3_socket_timeout"
 

--- a/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
@@ -44,4 +44,8 @@ object ConfigHelper {
 
   val storageTmpDir = "sparknlp.settings.storage.cluster_tmp_dir"
 
+  val serializationMode: String = getConfigValueOrElse("sparknlp.settings.annotatorSerializationFormat", "object")
+  val useBroadcast: Boolean = getConfigValueOrElse("sparknlp.settings.useBroadcastForFeatures", "true").toBoolean
+
+
 }


### PR DESCRIPTION
Fix ConfigLoader.retrieve not to use the config or fallback config as String and also cleaned up unrequired settings from Feature.scala.

Detailed tests: https://github.com/JohnSnowLabs/spark-nlp/issues/832