### PR TITLE
splitPattern alternative for Tokenizers

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
@@ -30,6 +30,7 @@ class Tokenizer(override val uid: String) extends AnnotatorApproach[TokenizerMod
   val caseSensitiveExceptions: BooleanParam = new BooleanParam(this, "caseSensitiveExceptions", "Whether to care for case sensitiveness in exceptions")
   val contextChars: StringArrayParam = new StringArrayParam(this, "contextChars", "character list used to separate from token boundaries")
   val splitChars: StringArrayParam = new StringArrayParam(this, "splitChars", "character list used to separate from the inside of tokens")
+  val splitPattern: Param[String] = new Param(this, "splitPattern", "pattern to separate from the inside of tokens. takes priority over splitChars.")
   val targetPattern: Param[String] = new Param(this, "targetPattern", "pattern to grab from text as token candidates. Defaults \\S+")
   val infixPatterns: StringArrayParam = new StringArrayParam(this, "infixPatterns", "regex patterns that match tokens within a single target. groups identify different sub-tokens. multiple defaults")
   val prefixPattern: Param[String] = new Param[String](this, "prefixPattern", "regex with groups and begins with \\A to match target prefix. Overrides contextCharacters Param")
@@ -38,6 +39,8 @@ class Tokenizer(override val uid: String) extends AnnotatorApproach[TokenizerMod
   val maxLength = new IntParam(this, "maxLength", "Set the maximum allowed legth for each token")
 
   def setTargetPattern(value: String): this.type = set(targetPattern, value)
+
+  def setSplitPattern(value: String): this.type = set(splitPattern, value)
 
   def setInfixPatterns(value: Array[String]): this.type = set(infixPatterns, value)
 
@@ -69,6 +72,8 @@ class Tokenizer(override val uid: String) extends AnnotatorApproach[TokenizerMod
   def getSuffixPattern: String = $(suffixPattern)
 
   def getTargetPattern: String = $(targetPattern)
+
+  def getSplitPattern: String = $(splitPattern)
 
   def setContextChars(v: Array[String]): this.type = {
     require(v.forall(_.length == 1), "All elements in context chars must have length == 1")
@@ -166,9 +171,9 @@ class Tokenizer(override val uid: String) extends AnnotatorApproach[TokenizerMod
     if (processedExceptions.nonEmpty)
       raw.setExceptions(processedExceptions)
 
-    if (isSet(splitChars)) {
-      raw.setSplitChars($(splitChars))
-    }
+    if (isSet(splitPattern)) raw.setSplitPattern($(splitPattern))
+
+    if (isSet(splitChars)) raw.setSplitChars($(splitChars))
 
     raw
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -403,4 +403,32 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
         s"\nresult was \n${result.mkString("\n")} \nexpected is: \n${expected.mkString("\n")}"
     )
   }
+
+  "a Tokenizer" should "work correctly with a split pattern" in {
+    val data = DataBuilder.basicDataBuild("Hello big-city-of-lights welcome to the ground###earth.")
+    val tokenizer = new Tokenizer()
+      .setInputCols("document")
+      .setOutputCol("token")
+      .setSplitPattern("-|#")
+      .fit(data)
+    val expected = Seq(
+      Annotation("token", 0, 4, "Hello", Map("sentence" -> "0")),
+      Annotation("token", 6, 8, "big", Map("sentence" -> "0")),
+      Annotation("token", 10, 13, "city", Map("sentence" -> "0")),
+      Annotation("token", 15, 16, "of", Map("sentence" -> "0")),
+      Annotation("token", 18, 23, "lights", Map("sentence" -> "0")),
+      Annotation("token", 25, 31, "welcome", Map("sentence" -> "0")),
+      Annotation("token", 33, 34, "to", Map("sentence" -> "0")),
+      Annotation("token", 36, 38, "the", Map("sentence" -> "0")),
+      Annotation("token", 40, 45, "ground", Map("sentence" -> "0")),
+      Annotation("token", 49, 53, "earth", Map("sentence" -> "0")),
+      Annotation("token", 54, 54, ".", Map("sentence" -> "0"))
+    )
+    val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
+    assert(
+      result.sameElements(expected),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("\n")} \nexpected is: \n${expected.mkString("\n")}"
+    )
+  }
 }


### PR DESCRIPTION
In the current `splitChars` implementation, the requirement defined below is problematic when splitting on characters which are regex meta characters.
```
def setSplitChars(v: Array[String]): this.type = {
    require(v.forall(_.length == 1), "All elements in context chars must have length == 1")
    set(splitChars, v)
  }
```
For example, attempting to split on the `|` character as implemented will behave improperly.
```
scala> test
res4: String = he,ll@o(mike)||t
scala> test.split("|")
res5: Array[String] = Array(h, e, ,, l, l, @, o, (, m, i, k, e, ), |, |, t) // BAD!
scala> test.split("\\|")
res6: Array[String] = Array(he,ll@o(mike), "", t) // GOOD, but rejected by require.
```

## Description
Implements a `splitPattern` param where users can directly provide the splitting regex. `splitPattern` takes priority over `splitChars`.


## Motivation and Context
See above.

## How Has This Been Tested?

The implemented test case validates the functionality.
```sbt testOnly **.TokenizerTestSpec```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ X] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
