### PR TITLE
Splitpattern and splitchars patch

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -85,6 +85,11 @@ class Tokenizer(AnnotatorApproach):
                          "character list used to separate from token boundaries",
                          typeConverter=TypeConverters.toListString)
 
+    splitPattern = Param(Params._dummy(),
+                         "splitPattern",
+                         "character list used to separate from the inside of tokens",
+                         typeConverter=TypeConverters.toString)
+
     splitChars = Param(Params._dummy(),
                        "splitChars",
                        "character list used to separate from the inside of tokens",
@@ -179,6 +184,9 @@ class Tokenizer(AnnotatorApproach):
         context_chars.append(value)
         return self._set(contextChars=context_chars)
 
+    def setSplitPattern(self, value):
+        return self._set(splitPattern=value)
+
     def setSplitChars(self, value):
         return self._set(splitChars=value)
 
@@ -223,6 +231,11 @@ class TokenizerModel(AnnotatorModel):
                   "Rules structure factory containing pre processed regex rules",
                   typeConverter=TypeConverters.identity)
 
+    splitPattern = Param(Params._dummy(),
+                         "splitPattern",
+                         "character list used to separate from the inside of tokens",
+                         typeConverter=TypeConverters.toString)
+
     splitChars = Param(Params._dummy(),
                        "splitChars",
                        "character list used to separate from the inside of tokens",
@@ -237,6 +250,9 @@ class TokenizerModel(AnnotatorModel):
             targetPattern="\\S+",
             caseSensitiveExceptions=True
         )
+
+    def setSplitPattern(self, value):
+        return self._set(splitPattern=value)
 
     def setSplitChars(self, value):
         return self._set(splitChars=value)

--- a/python/sparknlp/functions.py
+++ b/python/sparknlp/functions.py
@@ -19,7 +19,7 @@ def map_annotations_strict(f):
 
 
 def map_annotations_col(dataframe: DataFrame, f, column, output_column, output_type):
-    dataframe.withColumn(output_column, map_annotations(f, output_type)(column))
+    return dataframe.withColumn(output_column, map_annotations(f, output_type)(column))
 
 
 def filter_by_annotations_col(dataframe, f, column):

--- a/python/tensorflow/ner/create_models.py
+++ b/python/tensorflow/ner/create_models.py
@@ -9,7 +9,7 @@ def create_graph(output_path, number_of_tags, embeddings_dimension, number_of_ch
     if sys.version_info[0] != 3 or sys.version_info[1] >= 7:
         raise Exception('Python 3.7 or above not supported by TensorFlow')
     if tf.__version__ != '1.15.0':
-        raise Exception('Spark NLP is compiled with TensorFlow 1.15.0. Please use such version.')
+        raise Exception(f'Spark NLP is compiled with TensorFlow 1.15.0. Please use such version and not {tf.__version__}.')
     tf.reset_default_graph()
     name_prefix = 'blstm'
     model_name = name_prefix+'_{}_{}_{}_{}'.format(number_of_tags, embeddings_dimension, lstm_size, number_of_chars)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
@@ -85,12 +85,12 @@ class Tokenizer(override val uid: String) extends AnnotatorApproach[TokenizerMod
   }
 
   def setSplitChars(v: Array[String]): this.type = {
-    require(v.forall(_.length == 1), "All elements in context chars must have length == 1")
+    require(v.forall(x=>x.length == 1 || (x.length==2 && x.substring(0,1)=="\\")), "All elements in context chars must have length == 1")
     set(splitChars, v)
   }
 
   def addSplitChars(v: String): this.type = {
-    require(v.length == 1, "Context char must have length == 1")
+    require(v.length == 1 || (v.length==2 && v.substring(0,1)=="\\"), "Context char must have length == 1")
     set(splitChars, get(splitChars).getOrElse(Array.empty[String]) :+ v)
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/TokenizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/TokenizerModel.scala
@@ -54,12 +54,12 @@ class TokenizerModel(override val uid: String) extends AnnotatorModel[TokenizerM
   def getMaxLength(value: Int): Int = $(maxLength)
 
   def setSplitChars(v: Array[String]): this.type = {
-    require(v.forall(_.length == 1), "All elements in context chars must have length == 1")
+    require(v.forall(x=>x.length == 1 || (x.length==2 && x.substring(0,1)=="\\")), "All elements in context chars must have length == 1")
     set(splitChars, v)
   }
 
   def addSplitChars(v: String): this.type = {
-    require(v.length == 1, "Context char must have length == 1")
+    require(v.length == 1 || (v.length==2 && v.substring(0,1)=="\\"), "Context char must have length == 1")
     set(splitChars, get(splitChars).getOrElse(Array.empty[String]) :+ v)
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/TokenizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/TokenizerModel.scala
@@ -84,6 +84,7 @@ class TokenizerModel(override val uid: String) extends AnnotatorModel[TokenizerM
       $(exceptions).exists(e => ("(?i)"+e).r.findFirstIn(candidateMatched).isDefined)
 
   def tag(sentences: Seq[Sentence]): Seq[TokenizedSentence] = {
+    lazy val splitCharsExists = $(splitChars).map(_.last.toString)
     sentences.map{text =>
       /** Step 1, define breaks from non breaks */
       val protectedText = {
@@ -113,7 +114,7 @@ class TokenizerModel(override val uid: String) extends AnnotatorModel[TokenizerM
               .flatMap (i => {
                 val target = m.content.group(i)
                 val applyPattern = isSet(splitPattern) && (target.split($(splitPattern)).size > 1)
-                val applyChars =  isSet(splitChars) && $(splitChars).map(_.last.toString).exists(target.contains)
+                val applyChars =  isSet(splitChars) && splitCharsExists.exists(target.contains)
                 if (target.nonEmpty && (applyPattern || applyChars)){
                   try {
                     val strs = if (applyPattern) target.split($(splitPattern))

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/TokenizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/TokenizerModel.scala
@@ -113,7 +113,7 @@ class TokenizerModel(override val uid: String) extends AnnotatorModel[TokenizerM
               .flatMap (i => {
                 val target = m.content.group(i)
                 val applyPattern = isSet(splitPattern) && (target.split($(splitPattern)).size > 1)
-                val applyChars =  isSet(splitChars) && $(splitChars).exists(target.contains)
+                val applyChars =  isSet(splitChars) && $(splitChars).map(_.last.toString).exists(target.contains)
                 if (target.nonEmpty && (applyPattern || applyChars)){
                   try {
                     val strs = if (applyPattern) target.split($(splitPattern))

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -404,6 +404,33 @@ class TokenizerTestSpec extends FlatSpec with TokenizerBehaviors {
     )
   }
 
+  "a Tokenizer" should "work correctly with multiple split chars including stars '*'" in {
+    val data = DataBuilder.basicDataBuild("Hello big-city-of-lights welcome to*the ground###earth.")
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token")
+      .setSplitChars(Array("-", "#", "\\*"))
+      .fit(data)
+
+    val expected = Seq(
+      Annotation("token", 0, 4, "Hello", Map("sentence" -> "0")),
+      Annotation("token", 6, 8, "big", Map("sentence" -> "0")),
+      Annotation("token", 10, 13, "city", Map("sentence" -> "0")),
+      Annotation("token", 15, 16, "of", Map("sentence" -> "0")),
+      Annotation("token", 18, 23, "lights", Map("sentence" -> "0")),
+      Annotation("token", 25, 31, "welcome", Map("sentence" -> "0")),
+      Annotation("token", 33, 34, "to", Map("sentence" -> "0")),
+      Annotation("token", 36, 38, "the", Map("sentence" -> "0")),
+      Annotation("token", 40, 45, "ground", Map("sentence" -> "0")),
+      Annotation("token", 49, 53, "earth", Map("sentence" -> "0")),
+      Annotation("token", 54, 54, ".", Map("sentence" -> "0"))
+    )
+    val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
+    assert(
+      result.sameElements(expected),
+      s"because result tokens differ: " +
+        s"\nresult was \n${result.mkString("\n")} \nexpected is: \n${expected.mkString("\n")}"
+    )
+  }
+
   "a Tokenizer" should "work correctly with a split pattern" in {
     val data = DataBuilder.basicDataBuild("Hello big-city-of-lights welcome to the ground###earth.")
     val tokenizer = new Tokenizer()


### PR DESCRIPTION
In the current `splitChars` implementation, the requirement defined below is problematic when splitting on characters which are regex meta characters.
```
def setSplitChars(v: Array[String]): this.type = {
    require(v.forall(_.length == 1), "All elements in context chars must have length == 1")
    set(splitChars, v)
  }
```
For example, attempting to split on the `|` character as implemented will behave improperly.
```
scala> test
res4: String = he,ll@o(mike)||t
scala> test.split("|")
res5: Array[String] = Array(h, e, ,, l, l, @, o, (, m, i, k, e, ), |, |, t) // BAD!
scala> test.split("\\|")
res6: Array[String] = Array(he,ll@o(mike), "", t) // GOOD, but rejected by require.
```

## Description
Implements a `splitPattern` param where users can directly provide the splitting regex. `splitPattern` takes priority over `splitChars`.


## Motivation and Context
See above.

## How Has This Been Tested?

The implemented test case validates the functionality.
```sbt testOnly **.TokenizerTestSpec```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ X] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
