### PR TITLE
Removing unused param in NerDLModel

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1409,7 +1409,7 @@ class NerDLModel(AnnotatorModel, HasStorageRef):
 
 
 class NerConverter(AnnotatorModel):
-    name = 'Tokenizer'
+    name = 'NerConverter'
 
     whiteList = Param(
         Params._dummy(),

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
@@ -28,21 +28,20 @@ class NerDLModel(override val uid: String)
   override val outputAnnotatorType = NAMED_ENTITY
 
   val minProba = new FloatParam(this, "minProbe", "Minimum probability. Used only if there is no CRF on top of LSTM layer.")
-  val batchSize = new IntParam(this, "batchSize", "Size of every batch.")
   val datasetParams = new StructFeature[DatasetEncoderParams](this, "datasetParams")
   val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
   val includeConfidence = new BooleanParam(this, "includeConfidence", "whether to include confidence scores in annotation metadata")
 
-  setDefault(includeConfidence, false)
+  setDefault(
+    includeConfidence-> false
+  )
 
   def setMinProbability(minProba: Float) = set(this.minProba, minProba)
-  def setBatchSize(size: Int) = set(this.batchSize, size)
   def setDatasetParams(params: DatasetEncoderParams) = set(this.datasetParams, params)
   def setConfigProtoBytes(bytes: Array[Int]) = set(this.configProtoBytes, bytes)
   def setIncludeConfidence(value: Boolean) = set(this.includeConfidence, value)
 
   def getMinProba: Float = $(this.minProba)
-  def getBatchSize: Int = $(this.batchSize)
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
   def getModelIfNotSet: TensorflowNer = _model.get.value
   def getIncludeConfidence: Boolean = $(includeConfidence)


### PR DESCRIPTION
The batchSize is not used inside NerDLModel and it is not presented in Python. I removed the param as it has no advantage.