### PR TITLE
Token assembler should preserve the new lines from DocumentAssembler

### DIFF
--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -177,6 +177,7 @@ class DocumentAssembler(AnnotatorTransformer):
 class TokenAssembler(AnnotatorTransformer, AnnotatorProperties):
 
     name = "TokenAssembler"
+    preservePosition = Param(Params._dummy(), "preservePosition", "whether to preserve the actual position of the tokens or reduce them to one space", typeConverter=TypeConverters.toBoolean)
 
     @keyword_only
     def __init__(self):
@@ -186,6 +187,9 @@ class TokenAssembler(AnnotatorTransformer, AnnotatorProperties):
     def setParams(self):
         kwargs = self._input_kwargs
         return self._set(**kwargs)
+
+    def setPreservePosition(self, value):
+        return self._set(preservePosition=value)
 
 
 class Doc2Chunk(AnnotatorTransformer, AnnotatorProperties):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed TokenAssembler to be able to process the formating of the sentences. Used `setPreservePosition` parameter and added it to the Python. Format of annotator changed - input columns should be `Array(initial_sentence, tokens)`

## Motivation and Context
Previously TokenAssembler couldn't process special characters and returned new text without any formating.

## How Has This Been Tested?
Created tests for 3 use cases - plain text, text with special characters, and text with stop words removal.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
