### PR TITLE
Introducing new outputLogsPath for NerDLApproach and ClassifierDLApproach

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -2087,7 +2087,7 @@ class ClassifierDLApproach(AnnotatorApproach):
                              TypeConverters.toBoolean)
 
     outputLogsPath = Param(Params._dummy(), "outputLogsPath", "Folder path to save training logs", TypeConverters.toString)
-    
+
     labelColumn = Param(Params._dummy(),
                         "labelColumn",
                         "Column with label per each token",

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1417,6 +1417,8 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
                              "Whether to use stdout in addition to Spark logs.",
                              TypeConverters.toBoolean)
 
+    outputLogsPath = Param(Params._dummy(), "outputLogsPath", "Folder path to save training logs", TypeConverters.toString)
+
     def setConfigProtoBytes(self, b):
         return self._set(configProtoBytes=b)
 
@@ -1463,6 +1465,9 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
 
     def setEnableOutputLogs(self, value):
         return self._set(enableOutputLogs=value)
+
+    def setOutputLogsPath(self, p):
+        return self._set(outputLogsPath=p)
 
     @keyword_only
     def __init__(self):
@@ -2081,6 +2086,8 @@ class ClassifierDLApproach(AnnotatorApproach):
                              "Whether to use stdout in addition to Spark logs.",
                              TypeConverters.toBoolean)
 
+    outputLogsPath = Param(Params._dummy(), "outputLogsPath", "Folder path to save training logs", TypeConverters.toString)
+    
     labelColumn = Param(Params._dummy(),
                         "labelColumn",
                         "Column with label per each token",
@@ -2125,6 +2132,9 @@ class ClassifierDLApproach(AnnotatorApproach):
 
     def setEnableOutputLogs(self, value):
         return self._set(enableOutputLogs=value)
+
+    def setOutputLogsPath(self, p):
+        return self._set(outputLogsPath=p)
 
     @keyword_only
     def __init__(self):

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/Logging.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/Logging.scala
@@ -17,9 +17,9 @@ trait Logging {
       logger.info(value)
     }
   }
-  protected def outputLog(value: => String, uuid: String, shouldLog: Boolean): Unit = {
+  protected def outputLog(value: => String, uuid: String, shouldLog: Boolean, outputLogsPath: String): Unit = {
     if (shouldLog) {
-      OutputHelper.writeAppend(uuid, value)
+      OutputHelper.writeAppend(uuid, value, outputLogsPath)
     }
   }
 }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowClassifier.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowClassifier.scala
@@ -38,6 +38,7 @@ class TensorflowClassifier(
              configProtoBytes: Option[Array[Byte]] = None,
              validationSplit: Float = 0.0f,
              enableOutputLogs: Boolean = false,
+             outputLogsPath: String,
              uuid: String = Identifiable.randomUID("classifierdl")
            ): Unit = {
 
@@ -62,7 +63,7 @@ class TensorflowClassifier(
 
     println(s"Training started - total epochs: $endEpoch - learning rate: $lr - batch size: $batchSize - training examples: ${trainDatasetSeq.length}")
     outputLog(s"Training started - total epochs: $endEpoch - learning rate: $lr - batch size: $batchSize - training examples: ${trainDatasetSeq.length}",
-      uuid, enableOutputLogs)
+      uuid, enableOutputLogs, outputLogsPath)
 
     for (epoch <- startEpoch until endEpoch) {
 
@@ -108,11 +109,11 @@ class TensorflowClassifier(
         val validationAccuracy = measure(validateDatasetSample, (s: String) => log(s, Verbose.Epochs))
         val endTime = (System.nanoTime() - time)/1e9
         println(f"Epoch ${epoch+1}/$endEpoch - $endTime%.2fs - loss: $loss - accuracy: $acc - validation: $validationAccuracy - batches: $batches")
-        outputLog(s"Epoch $epoch/$endEpoch - $endTime%.2fs - loss: $loss - accuracy: $acc - validation: $validationAccuracy - batches: $batches", uuid, enableOutputLogs)
+        outputLog(s"Epoch $epoch/$endEpoch - $endTime%.2fs - loss: $loss - accuracy: $acc - validation: $validationAccuracy - batches: $batches", uuid, enableOutputLogs, outputLogsPath)
       }else{
         val endTime = (System.nanoTime() - time)/1e9
         println(f"Epoch ${epoch+1}/$endEpoch - $endTime%.2fs - loss: $loss - accuracy: $acc - batches: $batches")
-        outputLog(s"Epoch $epoch/$endEpoch - $endTime%.2fs - loss: $loss - accuracy: $acc - batches: $batches", uuid, enableOutputLogs)
+        outputLog(s"Epoch $epoch/$endEpoch - $endTime%.2fs - loss: $loss - accuracy: $acc - batches: $batches", uuid, enableOutputLogs, outputLogsPath)
       }
 
     }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLApproach.scala
@@ -31,6 +31,7 @@ class ClassifierDLApproach(override val uid: String)
   val dropout = new FloatParam(this, "dropout", "Dropout coefficient")
   val maxEpochs = new IntParam(this, "maxEpochs", "Maximum number of epochs to train")
   val enableOutputLogs = new BooleanParam(this, "enableOutputLogs", "Whether to output to annotators log folder")
+  val outputLogsPath = new Param[String](this, "outputLogsPath", "Folder path to save training logs")
   val validationSplit = new FloatParam(this, "validationSplit", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.")
   val verbose = new IntParam(this, "verbose", "Level of verbosity during training")
   val configProtoBytes = new IntArrayParam(
@@ -46,6 +47,7 @@ class ClassifierDLApproach(override val uid: String)
   def setMaxEpochs(epochs: Int): ClassifierDLApproach.this.type = set(maxEpochs, epochs)
   def setConfigProtoBytes(bytes: Array[Int]): ClassifierDLApproach.this.type = set(this.configProtoBytes, bytes)
   def setEnableOutputLogs(enableOutputLogs: Boolean): ClassifierDLApproach.this.type = set(this.enableOutputLogs, enableOutputLogs)
+  def setOutputLogsPath(path: String):ClassifierDLApproach.this.type = set(this.outputLogsPath, path)
   def setValidationSplit(validationSplit: Float):ClassifierDLApproach.this.type = set(this.validationSplit, validationSplit)
   def setVerbose(verbose: Int): ClassifierDLApproach.this.type = set(this.verbose, verbose)
   def setVerbose(verbose: Verbose.Level): ClassifierDLApproach.this.type = set(this.verbose, verbose.id)
@@ -55,6 +57,7 @@ class ClassifierDLApproach(override val uid: String)
   def getBatchSize: Int = $(this.batchSize)
   def getDropout: Float = $(this.dropout)
   def getEnableOutputLogs: Boolean = $(enableOutputLogs)
+  def getOutputLogsPath: String = $(outputLogsPath)
   def getValidationSplit: Float = $(this.validationSplit)
   def getMaxEpochs: Int = $(maxEpochs)
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
@@ -66,7 +69,8 @@ class ClassifierDLApproach(override val uid: String)
     batchSize -> 64,
     enableOutputLogs -> false,
     verbose -> Verbose.Silent.id,
-    validationSplit -> 0.0f
+    validationSplit -> 0.0f,
+    outputLogsPath -> ""
   )
 
   override def beforeTraining(spark: SparkSession): Unit = {}
@@ -126,6 +130,7 @@ class ClassifierDLApproach(override val uid: String)
         configProtoBytes = getConfigProtoBytes,
         validationSplit = $(validationSplit),
         enableOutputLogs=$(enableOutputLogs),
+        outputLogsPath=$(outputLogsPath),
         uuid = this.uid
       )
       model

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -31,8 +31,8 @@ class NerDLApproach(override val uid: String)
 
   override def getLogName: String = "NerDL"
   override val description = "Trains Tensorflow based Char-CNN-BLSTM model"
-  override val inputAnnotatorTypes = Array(DOCUMENT, TOKEN, WORD_EMBEDDINGS)
-  override val outputAnnotatorType:String = NAMED_ENTITY
+  override val inputAnnotatorTypes: Array[String] = Array(DOCUMENT, TOKEN, WORD_EMBEDDINGS)
+  override val outputAnnotatorType: String = NAMED_ENTITY
 
   val lr = new FloatParam(this, "lr", "Learning Rate")
   val po = new FloatParam(this, "po", "Learning rate decay coefficient. Real Learning Rage = lr / (1 + po * epoch)")
@@ -44,6 +44,7 @@ class NerDLApproach(override val uid: String)
   val validationSplit = new FloatParam(this, "validationSplit", "Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.")
   val evaluationLogExtended = new BooleanParam(this, "evaluationLogExtended", "Whether logs for validation to be extended: it displays time and evaluation of each label. Default is false.")
   val enableOutputLogs = new BooleanParam(this, "enableOutputLogs", "Whether to output to annotators log folder")
+  val outputLogsPath = new Param[String](this, "outputLogsPath", "Folder path to save training logs")
   val testDataset = new ExternalResourceParam(this, "testDataset", "Path to test dataset. " +
     "If set used to calculate statistic on it during training.")
   val includeConfidence = new BooleanParam(this, "includeConfidence", "whether to include confidence scores in annotation metadata")
@@ -57,6 +58,7 @@ class NerDLApproach(override val uid: String)
   def getValidationSplit: Float = $(this.validationSplit)
   def getIncludeConfidence: Boolean = $(includeConfidence)
   def getEnableOutputLogs: Boolean = $(enableOutputLogs)
+  def getOutputLogsPath: String = $(outputLogsPath)
 
   def setLr(lr: Float):NerDLApproach.this.type = set(this.lr, lr)
   def setPo(po: Float):NerDLApproach.this.type = set(this.po, po)
@@ -69,6 +71,8 @@ class NerDLApproach(override val uid: String)
 
   def setEvaluationLogExtended(evaluationLogExtended: Boolean):NerDLApproach.this.type = set(this.evaluationLogExtended, evaluationLogExtended)
   def setEnableOutputLogs(enableOutputLogs: Boolean):NerDLApproach.this.type = set(this.enableOutputLogs, enableOutputLogs)
+  def setOutputLogsPath(path: String):NerDLApproach.this.type = set(this.outputLogsPath, path)
+
   def setTestDataset(path: String,
                      readAs: ReadAs.Format = ReadAs.SPARK,
                      options: Map[String, String] = Map("format" -> "parquet")): this.type =
@@ -89,7 +93,8 @@ class NerDLApproach(override val uid: String)
     validationSplit -> 0.0f,
     evaluationLogExtended -> false,
     includeConfidence -> false,
-    enableOutputLogs -> false
+    enableOutputLogs -> false,
+    outputLogsPath -> ""
   )
 
   override val verboseLevel: Verbose.Level = Verbose($(verbose))
@@ -163,6 +168,7 @@ class NerDLApproach(override val uid: String)
         evaluationLogExtended=$(evaluationLogExtended),
         includeConfidence=$(includeConfidence),
         enableOutputLogs=$(enableOutputLogs),
+        outputLogsPath=$(outputLogsPath),
         uuid=this.uid
       )
       model

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/OutputHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/OutputHelper.scala
@@ -13,9 +13,16 @@ object OutputHelper {
 
   private lazy val logsFolderExists = fs.exists(new Path(logsFolder))
 
-  def writeAppend(uuid: String, content: String): Unit = {
-    if (!logsFolderExists) fs.mkdirs(new Path(logsFolder))
-    val targetPath = new Path(logsFolder, uuid+".log")
+  def writeAppend(uuid: String, content: String, outputLogsPath: String): Unit = {
+
+    val targetPath = if(outputLogsPath.isEmpty){
+      if (!logsFolderExists) fs.mkdirs(new Path(logsFolder))
+       new Path(logsFolder, uuid+".log")
+    }else{
+      if (!fs.exists(new Path(outputLogsPath))) fs.mkdirs(new Path(outputLogsPath))
+      new Path(outputLogsPath, uuid+".log")
+    }
+
     if (fs.getScheme != "file") {
       val fo = fs.append(targetPath)
       val writer = new PrintWriter(fo, true)

--- a/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
+++ b/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
@@ -63,16 +63,16 @@ object NerDLCoNLL2003 extends App {
   val ner = try {
     val model = new TensorflowNer(tf, encoder, 32, Verbose.All)
     for (epoch <- 0 until 150) {
-      model.train(trainDataset, 1e-3f, 0.005f, 32, 0.5f, epoch, epoch + 1)
+      model.train(trainDataset, 1e-3f, 0.005f, 32, 0.5f, epoch, epoch + 1, outputLogsPath = "")
 
       System.out.println("\n\nQuality on train data")
-      model.measure(trainDataset, (s: String) => System.out.println(s), extended = true)
+      model.measure(trainDataset, extended = true, outputLogsPath = "")
 
       System.out.println("\n\nQuality on test A data")
-      model.measure(testDatasetA, (s: String) => System.out.println(s), extended = true)
+      model.measure(testDatasetA, extended = true, outputLogsPath = "")
 
       System.out.println("\n\nQuality on test B data")
-      model.measure(testDatasetB, (s: String) => System.out.println(s), extended = true)
+      model.measure(testDatasetB, extended = true, outputLogsPath = "")
     }
     model
   }

--- a/src/test/scala/com/johnsnowlabs/benchmarks/spark/NerDLCoNLL2003.scala
+++ b/src/test/scala/com/johnsnowlabs/benchmarks/spark/NerDLCoNLL2003.scala
@@ -84,7 +84,7 @@ object NerDLPipeline extends App {
 
     val labeled = NerTagged.collectTrainingInstances(transformed, Seq("sentence", "token", "glove"), "label")
 
-    ner.measure(labeled, (s: String) => System.out.println(s), extended, errorsToPrint)
+    ner.measure(labeled, extended, errorsToPrint, outputLogsPath = "")
   }
 
   val spark = SparkAccessor.benchmarkSpark


### PR DESCRIPTION
It is now possible to use `setOutputLogsPath` param in `NerDLApproach` and `ClassifierDLApproach` when `setEnableOutputLogs` is set to `true` to set the output folder to save the logs during training. 

- [x] Scala param
- [x] Python param
- [x] Test locally
- [x] Test in DBFS (failing in 2.4.x release)
- [x] Test in HDFS 