### PR TITLE
fixed databricks setGraph Path issue.

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -1,10 +1,5 @@
 package com.johnsnowlabs.nlp.util.io
 
-import java.io._
-import java.net.{URL, URLDecoder}
-import java.nio.file.{Files, Paths}
-import java.util.jar.JarFile
-
 import com.johnsnowlabs.nlp.annotators.Tokenizer
 import com.johnsnowlabs.nlp.annotators.common.{TaggedSentence, TaggedWord}
 import com.johnsnowlabs.nlp.util.io.ReadAs._
@@ -402,7 +397,7 @@ object ResourceHelper {
           throw new FileNotFoundException("Word count dictionary for spell checker does not exist or is empty")
         wordCount
       case SPARK =>
-        import spark.implicits._
+
         val dataset = spark.read.options(externalResource.options).format(externalResource.options("format"))
           .load(externalResource.path)
         val transformation = {
@@ -446,6 +441,13 @@ object ResourceHelper {
   }
 
   def listLocalFiles(path: String): List[File] = {
+    val fs = FileSystem.get(spark.sparkContext.hadoopConfiguration)
+    if (fs.getScheme == "dbfs") {
+      //return fs.listStatus(new Path(path)).map(_.getPath().toString).map(new File(_)).toList
+      val filesPath = Option(new File(path.replace("file:", "")).listFiles())
+      val files = filesPath.getOrElse(throw new FileNotFoundException(s"folder: $path not found"))
+      return files.toList
+    }
     val filesPath = Option(new File(path).listFiles())
     val files = filesPath.getOrElse(throw new FileNotFoundException(s"folder: $path not found"))
     files.toList

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -7,7 +7,10 @@ import com.johnsnowlabs.nlp.{DocumentAssembler, Finisher}
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
-
+import java.io._
+import java.net.{URL, URLDecoder}
+import java.nio.file.{Files, Paths}
+import java.util.jar.JarFile
 import scala.collection.mutable.{ArrayBuffer, Map => MMap}
 import scala.io.BufferedSource
 
@@ -397,7 +400,7 @@ object ResourceHelper {
           throw new FileNotFoundException("Word count dictionary for spell checker does not exist or is empty")
         wordCount
       case SPARK =>
-
+        import spark.implicits._
         val dataset = spark.read.options(externalResource.options).format(externalResource.options("format"))
           .load(externalResource.path)
         val transformation = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed code to handle dbfs file system separately to fix setGraph Path issue in nerDL.
The following file system are now supported
1) HDFS
2) normal File based systems
3) DBFS

S3 is still not supported though

To use dbfs file system path 

use file:/dbfs/<mounted dbfs folder> (mounted path are shown at [https://docs.databricks.com/data/databricks-file-system.html](dbfs)
or file:/<driver folder path>

for example
file:/dbfs/FileStore/tables/ -- if you uploaded the graph file directly using file upload interface of dbfs 
file:/databricks/driver/ -- if you downloaded the graph files from internet.

Note: for faster lookup make sure you copy the graph files into a specific folder and give that folder path. directly.

## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
