### PR TITLE
253 text matcher from tokens

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -614,6 +614,12 @@ class TextMatcher(AnnotatorApproach):
                              "value for the entity metadata field",
                              typeConverter=TypeConverters.toString)
 
+
+    buildFromTokens = Param(Params._dummy(),
+                            "buildFromTokens",
+                            "whether the TextMatcher should take the CHUNK from TOKEN or not",
+                            typeConverter=TypeConverters.toBoolean)
+
     @keyword_only
     def __init__(self):
         super(TextMatcher, self).__init__(classname="com.johnsnowlabs.nlp.annotators.TextMatcher")
@@ -635,6 +641,9 @@ class TextMatcher(AnnotatorApproach):
     def setEntityValue(self, b):
         return self._set(entityValue=b)
 
+    def setBuildFromTokens(self, b):
+        return self._set(buildFromTokens=b)
+
 
 class TextMatcherModel(AnnotatorModel):
     name = "TextMatcherModel"
@@ -654,6 +663,12 @@ class TextMatcherModel(AnnotatorModel):
                         "value for the entity metadata field",
                         typeConverter=TypeConverters.toString)
 
+
+    buildFromTokens = Param(Params._dummy(),
+                            "buildFromTokens",
+                            "whether the TextMatcher should take the CHUNK from TOKEN or not",
+                            typeConverter=TypeConverters.toBoolean)
+
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.TextMatcherModel", java_model=None):
         super(TextMatcherModel, self).__init__(
             classname=classname,
@@ -665,6 +680,9 @@ class TextMatcherModel(AnnotatorModel):
 
     def setEntityValue(self, b):
         return self._set(entityValue=b)
+
+    def setBuildFromTokens(self, b):
+        return self._set(buildFromTokens=b)
 
     @staticmethod
     def pretrained(name, lang="en", remote_loc=None):

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcher.scala
@@ -68,6 +68,11 @@ class TextMatcher(override val uid: String) extends AnnotatorApproach[TextMatche
     * @group param
     **/
   val entityValue = new Param[String](this, "entityValue", "Value for the entity metadata field")
+  /** Whether the TextMatcher should take the CHUNK from TOKEN or not
+    *
+    * @group param
+    **/
+  val buildFromTokens = new BooleanParam(this, "buildFromTokens", "Whether the TextMatcher should take the CHUNK from TOKEN or not")
   /** Tokenizer
     *
     * @group param
@@ -78,6 +83,7 @@ class TextMatcher(override val uid: String) extends AnnotatorApproach[TextMatche
   setDefault(caseSensitive, true)
   setDefault(mergeOverlapping, false)
   setDefault(entityValue, "entity")
+  setDefault(buildFromTokens, false)
 
 
   /** Provides a file with phrases to match. Default: Looks up path in configuration.
@@ -142,6 +148,18 @@ class TextMatcher(override val uid: String) extends AnnotatorApproach[TextMatche
     **/
   def getEntityValue: String = $(entityValue)
 
+  /** Setter for buildFromTokens param
+    *
+    * @group setParam
+    **/
+  def setBuildFromTokens(v: Boolean): this.type = set(buildFromTokens, v)
+
+  /** Getter for buildFromTokens param
+    *
+    * @group getParam
+    **/
+  def getBuildFromTokens: Boolean = $(buildFromTokens)
+
   /**
     * Loads entities from a provided source.
     */
@@ -170,6 +188,7 @@ class TextMatcher(override val uid: String) extends AnnotatorApproach[TextMatche
     new TextMatcherModel()
       .setSearchTrie(SearchTrie.apply(loadEntities(dataset), $(caseSensitive)))
       .setMergeOverlapping($(mergeOverlapping))
+      .setBuildFromTokens($(buildFromTokens))
   }
 
 }

--- a/src/test/resources/entity-extractor/test-phrases-par.txt
+++ b/src/test/resources/entity-extractor/test-phrases-par.txt
@@ -1,0 +1,1 @@
+core blah biopsies

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TextMatcherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TextMatcherTestSpec.scala
@@ -106,6 +106,7 @@ class TextMatcherTestSpec extends FlatSpec with TextMatcherBehaviors {
     val tokenizer = new Tokenizer()
       .setInputCols(Array("sentence"))
       .setOutputCol("token")
+      .setContextChars(Array(".", ",", ";", ":", "!", "?", "*", "-", "\"", "'","(",")","+","-"))
       .setSplitChars(Array("'","\"",",", "/"," ",".","|","@","#","%","&","\\$","\\[","\\]","\\(","\\)","-",";"))
 
     val entityExtractor = new TextMatcher()
@@ -113,7 +114,7 @@ class TextMatcherTestSpec extends FlatSpec with TextMatcherBehaviors {
       .setEntities("src/test/resources/entity-extractor/test-phrases-par.txt", ReadAs.TEXT)
       .setOutputCol("entity")
       .setCaseSensitive(false)
-      .setBuildFromTokens(true)
+      .setBuildFromTokens(true) // Remove this line if you want to reproduce the bug
 
     val finisher = new Finisher()
       .setInputCols("entity")

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TextMatcherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TextMatcherTestSpec.scala
@@ -92,6 +92,48 @@ class TextMatcherTestSpec extends FlatSpec with TextMatcherBehaviors {
     assert(recursivePipeline.fit(data).transform(data).filter("finished_entity == ''").count > 0)
   }
 
+  "A Recursive Pipeline TextMatcher" should "extract entities from dataset without context chars" in {
+    val data = SparkAccessor.spark.createDataFrame(Seq(("LEFT PROSTATE (CORE blah BIOPSIES) jeje",""))).toDF("text","none")
+
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentenceDetector = new SentenceDetector()
+      .setInputCols(Array("document"))
+      .setOutputCol("sentence")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("sentence"))
+      .setOutputCol("token")
+      .setSplitChars(Array("'","\"",",", "/"," ",".","|","@","#","%","&","\\$","\\[","\\]","\\(","\\)","-",";"))
+
+    val entityExtractor = new TextMatcher()
+      .setInputCols("sentence", "token")
+      .setEntities("src/test/resources/entity-extractor/test-phrases-par.txt", ReadAs.TEXT)
+      .setOutputCol("entity")
+      .setCaseSensitive(false)
+      .setBuildFromTokens(true)
+
+    val finisher = new Finisher()
+      .setInputCols("entity")
+      .setOutputAsArray(false)
+      .setAnnotationSplitSymbol("@")
+      .setValueSplitSymbol("#")
+
+    val recursivePipeline = new RecursivePipeline()
+      .setStages(Array(
+        documentAssembler,
+        sentenceDetector,
+        tokenizer,
+        entityExtractor,
+        finisher
+      ))
+
+    recursivePipeline.fit(data).transform(data).show(false)
+    assert(recursivePipeline.fit(data).transform(data).filter("finished_entity == 'CORE blah BIOPSIES'").count > 0)
+  }
+
   val latinBodyData: Dataset[Row] = DataBuilder.basicDataBuild(ContentProvider.latinBody)
 
   "A full Normalizer pipeline with latin content" should behave like fullTextMatcher(latinBodyData)


### PR DESCRIPTION
Currently the TextMatcher  builds the chunk from the raw sentence

I included a param to generate the chunk from the tokens, not to lose any preprocessing done on them.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
