### PR TITLE
Fix ModuleNotFoundError in LanguageDetectorDL pipelines

### DIFF
--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -28,7 +28,8 @@ sys.modules['com.johnsnowlabs.nlp.embeddings'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.classifier'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.classifier.dl'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.spell.context'] = annotator
-sys.modules['com.johnsnowlabs.nlp.annotators.ld.dl.LanguageDetectorDL'] = annotator
+sys.modules['com.johnsnowlabs.nlp.annotators.ld'] = annotator
+sys.modules['com.johnsnowlabs.nlp.annotators.ld.dl'] = annotator
 
 annotators = annotator
 embeddings = annotator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes the error in `LanguageDetectorDL` pipeline: 

```
ModuleNotFoundError: No module named 'com.johnsnowlabs.nlp.annotators.ld'; 'com.johnsnowlabs.nlp.annotators' is not a package
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
