### PR TITLE
Add pretrained support to StopWordsCleaner annotator

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1863,6 +1863,11 @@ class StopWordsCleaner(AnnotatorModel):
         stopWordsObj = _jvm().org.apache.spark.ml.feature.StopWordsRemover
         return list(stopWordsObj.loadDefaultStopWords(language))
 
+    @staticmethod
+    def pretrained(name="stopwords_en", lang="en", remote_loc=None):
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(StopWordsCleaner, name, lang, remote_loc)
+
 
 class NGramGenerator(AnnotatorModel):
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -3,7 +3,7 @@ package com.johnsnowlabs.nlp
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.ReadSentencePieceModel
 import com.johnsnowlabs.nlp.annotators.btm.ReadablePretrainedBigTextMatcher
 import com.johnsnowlabs.nlp.annotators.classifier.dl.{ReadClassifierDLTensorflowModel, ReadSentimentDLTensorflowModel, ReadablePretrainedClassifierDL, ReadablePretrainedSentimentDL}
-import com.johnsnowlabs.nlp.annotators.{ReadablePretrainedLemmatizer, ReadablePretrainedTextMatcher, ReadablePretrainedTokenizer}
+import com.johnsnowlabs.nlp.annotators.{ReadablePretrainedLemmatizer, ReadablePretrainedStopWordsCleanerModel, ReadablePretrainedTextMatcher, ReadablePretrainedTokenizer}
 import com.johnsnowlabs.nlp.annotators.ner.crf.ReadablePretrainedNerCrf
 import com.johnsnowlabs.nlp.annotators.ner.dl.{ReadablePretrainedNerDL, ReadsNERGraph, WithGraphResolver}
 import com.johnsnowlabs.nlp.annotators.parser.dep.ReadablePretrainedDependency
@@ -69,7 +69,7 @@ package object annotator {
   object LemmatizerModel extends ReadablePretrainedLemmatizer
 
   type StopWordsCleaner = com.johnsnowlabs.nlp.annotators.StopWordsCleaner
-  object StopWordsCleaner extends DefaultParamsReadable[StopWordsCleaner]
+  object StopWordsCleaner extends DefaultParamsReadable[StopWordsCleaner] with ReadablePretrainedStopWordsCleanerModel
 
   type NGramGenerator = com.johnsnowlabs.nlp.annotators.NGramGenerator
   object NGramGenerator extends DefaultParamsReadable[NGramGenerator]

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/StopWordsCleaner.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/StopWordsCleaner.scala
@@ -2,10 +2,11 @@ package com.johnsnowlabs.nlp.annotators
 
 import java.util.Locale
 
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, ParamsAndFeaturesReadable}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasPretrained, ParamsAndFeaturesReadable}
 import org.apache.spark.ml.feature.StopWordsRemover
 import org.apache.spark.ml.param.{BooleanParam, Param, ParamValidators, StringArrayParam}
 import org.apache.spark.ml.util.Identifiable
+import com.johnsnowlabs.nlp.AnnotatorType._
 
 /** This annotator excludes from a sequence of strings (e.g. the output of a Tokenizer, Normalizer, Lemmatizer, and Stemmer) and drops all the stop words from the input sequences.
   *
@@ -26,9 +27,6 @@ import org.apache.spark.ml.util.Identifiable
   * @groupdesc Parameters A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
   **/
 class StopWordsCleaner(override val uid: String) extends AnnotatorModel[StopWordsCleaner] {
-
-  import com.johnsnowlabs.nlp.AnnotatorType._
-
 
   /** Output annotator type: TOKEN
     *
@@ -151,4 +149,17 @@ class StopWordsCleaner(override val uid: String) extends AnnotatorModel[StopWord
 
 }
 
-object StopWordsCleaner extends ParamsAndFeaturesReadable[StopWordsCleaner]
+trait ReadablePretrainedStopWordsCleanerModel
+  extends ParamsAndFeaturesReadable[StopWordsCleaner]
+    with HasPretrained[StopWordsCleaner] {
+  override val defaultModelName: Some[String] = Some("stopwords_en")
+
+  /** Java compliant-overrides */
+  override def pretrained(): StopWordsCleaner = super.pretrained()
+  override def pretrained(name: String): StopWordsCleaner = super.pretrained(name)
+  override def pretrained(name: String, lang: String): StopWordsCleaner = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String, remoteLoc: String): StopWordsCleaner =
+    super.pretrained(name, lang, remoteLoc)
+}
+
+object StopWordsCleaner extends ParamsAndFeaturesReadable[StopWordsCleaner] with ReadablePretrainedStopWordsCleanerModel

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -454,7 +454,8 @@ object PythonResourceDownloader {
     "AlbertEmbeddings" -> AlbertEmbeddings,
     "XlnetEmbeddings" -> XlnetEmbeddings,
     "SentimentDLModel" -> SentimentDLModel,
-    "LanguageDetectorDL" -> LanguageDetectorDL
+    "LanguageDetectorDL" -> LanguageDetectorDL,
+    "StopWordsCleaner" -> StopWordsCleaner
   )
 
   def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces `pretrained()` function to `StopWordsCleaner` annotator. This allows users to downloads pre-trained models for all languages and other custom stop words lists.

## Motivation and Context
Deliver stop words lists as pre-trained models

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
