### PR TITLE
Fix a bug in RegexTokenizer on Python side

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -335,7 +335,7 @@ class RegexTokenizer(AnnotatorModel):
     def __init__(self):
         super(RegexTokenizer, self).__init__(classname="com.johnsnowlabs.nlp.annotators.RegexTokenizer")
         self._setDefault(
-            inputCols="document",
+            inputCols=["document"],
             outputCol="regexToken",
             toLowercase=False,
             minLength=1,


### PR DESCRIPTION
Due to a bad default value in Python RegexTokenizer crashes. This PR will fix that.