### PR TITLE
Fix max sequence length issue in AlbertEmbeddings and BertEmbeddings

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowAlbert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowAlbert.scala
@@ -139,7 +139,9 @@ class TensorflowAlbert(val tensorflow: TensorflowWrapper,
 
       val tokensPiece = tokenize(batch, maxSentenceLength, caseSensitive)
       val tokenIds = tokensPiece.map { sentence =>
-        val tokens = sentence.flatMap(x => x.tokens.map(x => x.pieceId))
+        // SentencePiece generates multiple tokenIDs
+        // We need to be sure the maxSenetnceLength is respecetd
+        val tokens = sentence.flatMap(x => x.tokens.map(x => x.pieceId)).take(maxSentenceLength - 3)
         sentenceStartTokenId ++ tokens ++ sentenceEndTokenId
       }
       val vectors = tag(tokenIds)
@@ -173,7 +175,7 @@ class TensorflowAlbert(val tensorflow: TensorflowWrapper,
   Seq[Array[WordpieceTokenizedSentence]] = {
 
     val sentecneTokenPieces = sentences.map { s =>
-      val shrinkedSentence = s.indexedTokens.take(maxSeqLength - 1)
+      val shrinkedSentence = s.indexedTokens.take(maxSeqLength - 3)
       shrinkedSentence.map{
         case(token) =>
           val tokenContent = if (caseSensitive) token.token else token.token.toLowerCase()

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlnet.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlnet.scala
@@ -174,7 +174,7 @@ class TensorflowXlnet(val tensorflow: TensorflowWrapper,
 
     val sentecneTokenPieces = sentences.map { s =>
       // Account for one [SEP] & one [CLS]
-      val shrinkedSentence = s.indexedTokens.take(maxSeqLength - 3)
+      val shrinkedSentence = s.indexedTokens.take(maxSeqLength)
       shrinkedSentence.map{
         case(token) =>
           val tokenContent = if (caseSensitive) token.token else token.token.toLowerCase()

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/AlbertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/AlbertEmbeddings.scala
@@ -86,6 +86,8 @@ class AlbertEmbeddings(override val uid: String) extends
   }
 
   def setMaxSentenceLength(value: Int): this.type = {
+    require(value <= 512, "ALBERT models do not support sequences longer than 512 because of trainable positional embeddings")
+
     if(get(maxSentenceLength).isEmpty)
       set(maxSentenceLength, value)
     this

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -151,6 +151,8 @@ class BertEmbeddings(override val uid: String) extends
     * @group setParam
     **/
   def setMaxSentenceLength(value: Int): this.type = {
+    require(value <= 512, "BERT models do not support sequences longer than 512 because of trainable positional embeddings")
+
     if (get(maxSentenceLength).isEmpty)
       set(maxSentenceLength, value)
     this

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlnetEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlnetEmbeddings.scala
@@ -119,6 +119,8 @@ class XlnetEmbeddings(override val uid: String) extends
     * @group setParam
     **/
   def setMaxSentenceLength(value: Int): this.type = {
+    require(value <= 512, "XLNet model does not support sequences longer than 512 because of trainable positional embeddings")
+
     if (get(maxSentenceLength).isEmpty)
       set(maxSentenceLength, value)
     this


### PR DESCRIPTION
This PR fixes the following issues:

- BertEmbeddings and AlbertEmbeddings do not support sequences longer than 512 because of trainable positional embeddings. A condition was added to `maxSentenceLength` to ensure it is less than equal 512.
- In AlbertEmbeddings even with `maxSentenceLength` less than 512 it is possible to generate more SentencePiece IDs, so we have to ensure that the max sequence length after generating SentencePiece. (we cut the sentence by maxSentenceLength before generating SentencePiece to save extra computations over tokens which won't be part of the output anyway)

Note: The issue of `maxSentenceLength` being larger than 512 has been hidden since the best practice is to feed `sentence` into AlbertEmbeddings, BertEmbeddings, XlnetEmbeddings, and ElmoEmbeddings. Even with 512 as maxSentenceLength, it is not that usual to have a sentence longer than 512. Feeding `SentenceDetector` into Transformers in Spark NLP has a few benefits:
- The shorter the sequence the more accurate the contextualize vectors.
- Transformers are faster on shorter sequences.
- The limit of 512 will not be enough for some documents. Breaking them into sentences may likely result into covering all the sentences with even a much shorter max length.
- When there is more than 1 sentence in the document, all will be transformed as a batch so the speed for multiple sentences with 128 limit is higher than a document with 256 lengths.

That is why it is a good idea to use SentenceDetector and feed it into Tokenizer and these embeddings.