### PR TITLE
added parameter to enable/disable list detection in SentenceDetector

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -49,9 +49,9 @@ docs-en:
         url:  /docs/en/developers
       - title: Release Notes
         url: /docs/en/release_notes
-  - title: Licensed Content
+  - title: Healthcare NLP
     children:
-      - title:  Installation
+      - title:  Getting started
         url:    /docs/en/licensed_install
       - title:  Annotators
         url:    /docs/en/licensed_annotators
@@ -65,7 +65,7 @@ docs-en:
         url: /docs/en/licensed_release_notes
   - title: Spark OCR
     children:
-      - title:  General Concepts
+      - title:  Getting started
         url:    /docs/en/ocr
       - title:  Installation
         url:    /docs/en/ocr_install

--- a/docs/en/examples.md
+++ b/docs/en/examples.md
@@ -10,7 +10,8 @@ Showcasing notebooks and codes of how to use Spark NLP in Python and Scala.
 
 ## Docker setup
 
-If you want to experience Spark NLP and run Jupyter exmaples without installing anything, you can simply use our [Docker image](https://hub.docker.com/r/johnsnowlabs/spark-nlp-workshop):
+
+If you want to experience Spark NLP and run Jupyter examples without installing anything, you can simply use our [Docker image](https://hub.docker.com/r/johnsnowlabs/spark-nlp-workshop):
 
 1- Get the docker image for spark-nlp-workshop:
 
@@ -27,8 +28,13 @@ docker pull johnsnowlabs/spark-nlp-workshop
 3- Open Jupyter notebooks inside your browser by using the token printed on the console.
 
 ```bash
-http://localhost:8888/?token=LOOK_INSIDE_YOUR_CONSOLE
+http://localhost:8888/
 ```
+
+* The password to Jupyter notebook is `sparknlp`
+* The size of the image grows everytime you download a pretrained model or a pretrained pipeline. You can cleanup `~/cache_pretrained` if you don't need them.
+* This docker image is only meant for testing/learning purposes and should not be used in production environments. Please install Spark NLP natively.
+* There are lots of notebooks for Google Colab. If you intend to use those inside the Docker you should skip the Java intallation part
 
 ## Notebooks
 

--- a/docs/en/licensed_annotators.md
+++ b/docs/en/licensed_annotators.md
@@ -1,13 +1,12 @@
 ---
 layout: article
-title: Licensed Annotators
+title: Spark NLP for Healthcare Annotators
 permalink: /docs/en/licensed_annotators
 key: docs-licensed-annotators
 modify_date: "2020-08-10"
 use_language_switcher: "Python-Scala"
 ---
 
-## Spark-NLP Licensed
 
 The following annotators are available by buying a John Snow Labs Spark NLP license.
 They are mostly meant for healthcare applications but other applications have been made with these NLP features.

--- a/docs/en/licensed_annotators.md
+++ b/docs/en/licensed_annotators.md
@@ -222,11 +222,38 @@ patients and remove them by replacing with semantic tags.
 
 **Input types:** "sentence", "token", "ner_chunk"
 
-**Output type:** "deidentified"
+**Output type:** "sentence"
 
-**Functions:**
-
-- setRegexPatternsDictionary(path, read_as, options)
+```python
+deid = DeIdentificationApproach() \
+      .setInputCols("sentence", "token", "ner_chunk") \
+      .setOutputCol("deid_sentence") \
+      .setRegexPatternsDictionary("src/test/resources/de-identification/dic_regex_patterns_main_categories.txt") \
+      .setMode("mask") \
+      .setDateTag("DATE") \
+      .setObfuscateDate(False) \
+      .setDays(5) \
+      .setDateToYear(False) \
+      .setMinYear(1900) \
+      .setDateFormats(["MM-dd-yyyy","MM-dd-yy"]) \
+      .setConsistentObfuscation(True) \
+      .setSameEntityThreshold(0.9)
+```
+```scala
+val deid = new DeIdentificationApproach()
+      .setInputCols("sentence", "token", "ner_chunk")
+      .setOutputCol("deid_sentence")
+      .setRegexPatternsDictionary("src/test/resources/de-identification/dic_regex_patterns_main_categories.txt") \
+      .setMode("mask")
+      .setDateTag("DATE")
+      .setObfuscateDate(false)
+      .setDays(5)
+      .setDateToYear(false)
+      .setMinYear(1900)
+      .setDateFormats(Seq("MM-dd-yyyy","MM-dd-yy"))
+      .setConsistentObfuscation(true)
+      .setSameEntityThreshold(0.9)
+```
 
 ### Contextual Parser
 

--- a/docs/en/licensed_install.md
+++ b/docs/en/licensed_install.md
@@ -1,12 +1,12 @@
 ---
 layout: article
-title: Licensed Installation
+title: Spark NLP for Healthcare (licensed)
 permalink: /docs/en/licensed_install
 key: docs-licensed-install
 modify_date: "2020-10-11"
 ---
 
-### Install Licensed Spark NLP
+### Installation
 
 You can also install the licensed package with extra functionalities and
 pretrained models by using:

--- a/docs/en/licensed_release_notes.md
+++ b/docs/en/licensed_release_notes.md
@@ -1,6 +1,6 @@
 ---
 layout: article
-title: Licensed Release Notes
+title: Spark NLP for Healthcare Release Notes
 permalink: /docs/en/licensed_release_notes
 key: docs-licensed-release-notes
 modify_date: "2020-04-22"
@@ -10,7 +10,7 @@ modify_date: "2020-04-22"
 
 #### Overview
 
-We are very happy to release Spark NLP Enterprise 2.5.5 with a new state-of-the-art RelationExtraction annotator to identify relationships between entities coming from our pretrained NER models.
+We are very happy to release Spark NLP for Healthcare 2.5.5 with a new state-of-the-art RelationExtraction annotator to identify relationships between entities coming from our pretrained NER models.
 This is also the first release to support Relation Extraction with the following two (2) models: `re_clinical` and `re_posology` in the `clinical/models` repository.
 We also include multiple bug fixes as usual.
 
@@ -46,7 +46,7 @@ Models
 
 #### Overview
 
-We are pleased to announce the release of Spark NLP Enterprise 2.5.3.
+We are pleased to announce the release of Spark NLP for Healthcare 2.5.3.
 This time we include four (4) new Annotators: FeatureAssembler, GenericClassifier, Yake Keyword Extractor and NerConverterInternal.
 We also include helper classes to read datasets from CodiEsp and Cantemist Spanish NER Challenges.
 This is also the first release to support the following models: `ner_diag_proc` (spanish), `ner_neoplasms` (spanish), `ner_deid_enriched` (english).
@@ -78,7 +78,7 @@ We have also included Bugifxes and Enhancements for AnnotationToolJsonReader and
 
 #### Overview
 
-We are really happy to bring you Spark NLP Enterprise 2.5.2, with a couple new features and several enhancements in our existing annotators.
+We are really happy to bring you Spark NLP for Healthcare 2.5.2, with a couple new features and several enhancements in our existing annotators.
 This release was mainly dedicated to generate adoption in our AnnotationToolJsonReader, a connector that provide out-of-the-box support for out Annotation Tool and our practices.
 Also the ChunkMerge annotator has ben provided with extra functionality to remove entire entity types and to modify some chunk's entity type
 We also dedicated some time in finalizing some refactorization in DeIdentification annotator, mainly improving type consistency and case insensitive entity dictionary for obfuscation.
@@ -115,7 +115,7 @@ Thanks to the community for all the feedback and suggestions, it's really comfor
 
 #### Overview
 
-We are happy to bring you Spark NLP Enterprise 2.5.0 with new Annotators, Models and Data Readers.
+We are happy to bring you Spark NLP for Healthcare 2.5.0 with new Annotators, Models and Data Readers.
 Model composition and iteration is now faster with readers and annotators designed for real world tasks.
 We introduce ChunkMerge annotator to combine all CHUNKS extracted by different Entity Extraction Annotators.
 We also introduce an Annotation Reader for JSL AI Platform's Annotation Tool.
@@ -149,7 +149,7 @@ And of course we have fixed some bugs.
 
 #### Overview
 
-We release Spark NLP Enterprise 2.4.6 to fix some minor bugs.
+We release Spark NLP for Healthcare 2.4.6 to fix some minor bugs.
 
 
 #### Bugfixes
@@ -166,7 +166,7 @@ We release Spark NLP Enterprise 2.4.6 to fix some minor bugs.
 #### Overview
 
 
-We are glad to announce Spark NLP Enterprise 2.4.5. As a new feature we are happy to introduce our new EnsembleEntityResolver which allows our Entity Resolution architecture to scale up in multiple orders of magnitude and handle datasets of millions of records on a sub-log computation increase
+We are glad to announce Spark NLP for Healthcare 2.4.5. As a new feature we are happy to introduce our new EnsembleEntityResolver which allows our Entity Resolution architecture to scale up in multiple orders of magnitude and handle datasets of millions of records on a sub-log computation increase
 We also enhanced our ChunkEntityResolverModel with 5 new distance calculations with weighting-array and aggregation-strategy params that results in more levers to finetune its performance against a given dataset.
 
 
@@ -206,7 +206,7 @@ before it would calculate them over the neighbours and return them all in the me
 
 #### Overview
 
-We are glad to announce Spark NLP Enterprise 2.4.2. As a new feature we are happy to introduce our new Disambiguation Annotator,
+We are glad to announce Spark NLP for Healthcare 2.4.2. As a new feature we are happy to introduce our new Disambiguation Annotator,
 which will let the users resolve different kind of entities based on Knowledge bases provided in the form of Records in a RocksDB database.
 We also enhanced / fixed DocumentLogRegClassifier, ChunkEntityResolverModel and ChunkEntityResolverSelector Annotators.
 
@@ -233,7 +233,7 @@ returns DISAMBIGUATION annotator type. This output annotation type includes all 
 
 #### Overview
 
-Introducing Spark NLP Enterprise 2.4.1 after all the feedback we received in the form of issues and suggestions on our different communication channels.
+Introducing Spark NLP for Healthcare 2.4.1 after all the feedback we received in the form of issues and suggestions on our different communication channels.
 Even though 2.4.0 was very stable, version 2.4.1 is here to address minor bug fixes that we summarize in the following lines.
 
 
@@ -246,7 +246,7 @@ Even though 2.4.0 was very stable, version 2.4.1 is here to address minor bug fi
 
 #### Overview
 
-We are glad to announce Spark NLP Enterprise 2.4.0. This is an important release because of several refactorizations achieved in the core library, plus the introduction of several state of the art algorithms, new features and enhancements.
+We are glad to announce Spark NLP for Healthcare 2.4.0. This is an important release because of several refactorizations achieved in the core library, plus the introduction of several state of the art algorithms, new features and enhancements.
 We have included several architecture and performance improvements, that aim towards making the library more robust in terms of storage handling for Big Data.
 In the NLP aspect, we have introduced a ContextualParser, DocumentLogRegClassifier and a ChunkEntityResolverSelector.
 These last two Annotators also target performance time and memory consumption by lowering the order of computation and data loaded to memory in each step when designed following a hierarchical pattern.

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -912,11 +912,20 @@ class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
 
     name = 'SentenceDetector'
 
+    # this one is exclusive to this detector
+    detectLists = Param(Params._dummy(),
+                             "detectLists",
+                             "whether detect lists during sentence detection",
+                             typeConverter=TypeConverters.toBoolean)
+
     def setCustomBounds(self, value):
         return self._set(customBounds=value)
 
     def setUseAbbreviations(self, value):
         return self._set(useAbbreviations=value)
+
+    def setDetectLists(self, value):
+        return self._set(detectLists=value)
 
     def setUseCustomBoundsOnly(self, value):
         return self._set(useCustomBoundsOnly=value)
@@ -939,6 +948,7 @@ class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
             classname="com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector")
         self._setDefault(
             useAbbreviations=True,
+            detectLists=True,
             useCustomBoundsOnly=False,
             customBounds=[],
             explodeSentences=False,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/SentenceDetectorParams.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/SentenceDetectorParams.scala
@@ -9,6 +9,8 @@ trait SentenceDetectorParams extends Params {
 
   /** whether to apply abbreviations at sentence detection */
   val useAbbrevations = new BooleanParam(this, "useAbbreviations", "whether to apply abbreviations at sentence detection")
+  /** whether take lists into consideration at sentence detection */
+  val detectLists = new BooleanParam(this, "detectLists", "whether take lists into consideration at sentence detection")
   /** whether to only utilize custom bounds for sentence detection */
   val useCustomBoundsOnly = new BooleanParam(this, "useCustomBoundsOnly", "whether to only utilize custom bounds for sentence detection")
   /** whether to explode each sentence into a different row, for better parallelization. Defaults to false. */
@@ -24,6 +26,7 @@ trait SentenceDetectorParams extends Params {
 
   setDefault(
     useAbbrevations -> true,
+    detectLists -> true,
     useCustomBoundsOnly -> false,
     explodeSentences -> false,
     customBounds -> Array.empty[String],
@@ -47,6 +50,12 @@ trait SentenceDetectorParams extends Params {
 
   /** Whether to consider abbreviation strategies for better accuracy but slower performance. Defaults to true. */
   def getUseAbbreviations: Boolean = $(useAbbrevations)
+
+  /** Whether to take lists into consideration at sentence detection. Defaults to true. */
+  def setDetectLists(value: Boolean): this.type = set(detectLists, value)
+
+  /** Whether to take lists into consideration at sentence detection. Defaults to true. */
+  def getDetectLists: Boolean = $(detectLists)
 
   /** Whether to split sentences into different Dataset rows. Useful for higher parallelism in fat rows. Defaults to false. */
   def setExplodeSentences(value: Boolean): this.type = set(explodeSentences, value)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticContentFormatter.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticContentFormatter.scala
@@ -38,9 +38,9 @@ class PragmaticContentFormatter(text: String) {
     * prepend separation symbol
     * @return
     */
-  def formatLists: this.type = {
-
-    wip = formatListsFactory.transformWithSymbolicRules(wip)
+  def formatLists(useLists:Boolean): this.type = {
+    if(useLists)
+      wip = formatListsFactory.transformWithSymbolicRules(wip)
 
     this
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticMethod.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticMethod.scala
@@ -32,7 +32,8 @@ class CustomPragmaticMethod(customBounds: Array[String]) extends PragmaticMethod
   }
 }
 
-class DefaultPragmaticMethod(useAbbreviations: Boolean = false) extends PragmaticMethod with Serializable {
+class DefaultPragmaticMethod(useAbbreviations: Boolean = false, detectLists: Boolean = true)
+  extends PragmaticMethod with Serializable {
   /** this is a hardcoded order of operations
     * considered to go from those most specific non-ambiguous cases
     * down to those that are more general and can easily be ambiguous
@@ -40,7 +41,7 @@ class DefaultPragmaticMethod(useAbbreviations: Boolean = false) extends Pragmati
   def extractBounds(content: String): Array[Sentence] = {
     val symbolyzedData =
       new PragmaticContentFormatter(content)
-        .formatLists
+        .formatLists(detectLists)
         .formatNumbers
         .formatAbbreviations(useAbbreviations)
         .formatPunctuations
@@ -56,7 +57,8 @@ class DefaultPragmaticMethod(useAbbreviations: Boolean = false) extends Pragmati
   }
 }
 
-class MixedPragmaticMethod(useAbbreviations: Boolean = false, customBounds: Array[String]) extends PragmaticMethod with Serializable {
+class MixedPragmaticMethod(useAbbreviations: Boolean = false, detectLists: Boolean = true,
+                           customBounds: Array[String]) extends PragmaticMethod with Serializable {
   val customBoundsFactory = new RuleFactory(MATCH_ALL, REPLACE_ALL_WITH_SYMBOL)
   customBounds.foreach(bound => customBoundsFactory.addRule(bound.r, s"split bound: $bound"))
   /** this is a hardcoded order of operations
@@ -67,7 +69,7 @@ class MixedPragmaticMethod(useAbbreviations: Boolean = false, customBounds: Arra
     val symbolyzedData =
       new PragmaticContentFormatter(content)
         .formatCustomBounds(customBoundsFactory)
-        .formatLists
+        .formatLists(detectLists)
         .formatAbbreviations(useAbbreviations)
         .formatNumbers
         .formatPunctuations

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetector.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetector.scala
@@ -48,9 +48,9 @@ class SentenceDetector(override val uid: String) extends AnnotatorModel[Sentence
     if ($(customBounds).nonEmpty && $(useCustomBoundsOnly))
       new CustomPragmaticMethod($(customBounds))
     else if ($(customBounds).nonEmpty)
-      new MixedPragmaticMethod($(useAbbrevations), $(customBounds))
+      new MixedPragmaticMethod($(useAbbrevations), $(detectLists), $(customBounds))
     else
-      new DefaultPragmaticMethod($(useAbbrevations))
+      new DefaultPragmaticMethod($(useAbbrevations), $(detectLists))
 
   def tag(document: String): Array[Sentence] = {
     model.extractBounds(

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticDetectionBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticDetectionBehaviors.scala
@@ -33,7 +33,7 @@ trait PragmaticDetectionBehaviors { this: FlatSpec =>
   def isolatedPDReadAndMatchResult(input: String, correctAnswer: Array[String], customBounds: Array[String] = Array.empty[String]): Unit = {
     s"pragmatic boundaries detector with ${input.take(10)}...:" should
       s"successfully identify sentences as ${correctAnswer.take(1).take(10).mkString}..." in {
-      val pragmaticApproach = new MixedPragmaticMethod(true, customBounds)
+      val pragmaticApproach = new MixedPragmaticMethod(true, true, customBounds)
       val result = pragmaticApproach.extractBounds(input)
       val diffInResult = result.map(_.content).diff(correctAnswer)
       val diffInCorrect = correctAnswer.diff(result.map(_.content))
@@ -67,7 +67,7 @@ trait PragmaticDetectionBehaviors { this: FlatSpec =>
 
   def isolatedPDReadScore(input: String, correctAnswer: Array[String], customBounds: Array[String] = Array.empty[String]): Unit = {
     s"boundaries prediction" should s"have an F1 score higher than 95%" in {
-      val pragmaticApproach = new MixedPragmaticMethod(true, customBounds)
+      val pragmaticApproach = new MixedPragmaticMethod(true, true, customBounds)
       val result = pragmaticApproach.extractBounds(input).map(_.content)
       val f1 = f1Score(result, correctAnswer)
       val unmatched = result.zip(correctAnswer).toMap.mapValues("\n"+_)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetectorBoundsSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetectorBoundsSpec.scala
@@ -8,6 +8,18 @@ import org.scalatest.FlatSpec
 
 class SentenceDetectorBoundsSpec extends FlatSpec {
 
+  "SentenceDetector" should "support disable list detection" in {
+    val model = new DefaultPragmaticMethod(false, false)
+    val text = "His age is 34. He is visiting hospital."
+    val bounds = model.extractBounds(text)
+
+    assert(bounds.length == 2)
+    assert(bounds(0) == Sentence("His age is 34.", 0, 13, 0))
+    assert(bounds(1) == Sentence("He is visiting hospital.", 15, 38, 1))
+
+    checkBounds(text, bounds)
+  }
+
   "SentenceDetector" should "return correct sentence bounds" in {
     val model = new DefaultPragmaticMethod(false)
     val text = "Hello World!! New Sentence"
@@ -34,7 +46,7 @@ class SentenceDetectorBoundsSpec extends FlatSpec {
   }
 
   "SentenceDetector" should "correct process custom delimiters" in {
-    val model = new MixedPragmaticMethod(false, Array("\n\n"))
+    val model = new MixedPragmaticMethod(false, true, Array("\n\n"))
     val text = " Hello World.\n\nNew Sentence\n\nThird"
     val bounds = model.extractBounds(" Hello World.\n\nNew Sentence\n\nThird")
 
@@ -47,7 +59,7 @@ class SentenceDetectorBoundsSpec extends FlatSpec {
   }
 
   "SentenceDetector" should "correct process custom delimiters in with dots" in {
-    val model = new MixedPragmaticMethod(false, Array("\n\n"))
+    val model = new MixedPragmaticMethod(false, true, Array("\n\n"))
     val bounds = model.extractBounds(ContentProvider.conllEightSentences)
 
     assert(bounds.length == 8)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a parameter, detectLists, to SentenceDetector so the split of sentences in a list of items can be disabled.



## Motivation and Context
This behavior was necessary to deal with numbers around sentence boundaries.

## How Has This Been Tested?
All test suits cases Scala/Python.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
