### PR TITLE
Better error handling in SentimentDLApproach

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLApproach.scala
@@ -100,9 +100,9 @@ class SentimentDLApproach(override val uid: String)
     val labels = train.select($(labelColumn)).distinct.collect.map(x => x(0).toString)
 
     require(
-      labels.length >= 2 && labels.length <= 3,
-      s"The total unique number of classes must be maximum 3. Currently is ${labels.length}. Please use ClassifierDL" +
-        s" if you have more than 3 classes/labels"
+      labels.length == 2,
+      s"The total unique number of classes must be 2. Currently is ${labels.length}. Please use ClassifierDLApproach" +
+        s" if you have more than 2 classes/labels."
     )
 
     val tf = loadSavedModel()


### PR DESCRIPTION
SentimentDL model only accepts 2 labels, but we check for up to 3. This results in other errors related to TF where those layers for 3 labels don't exist.

This PR fixes this issue by communicating with users more clearly when they have more or less than 2 labels/classes during the training.