### PR TITLE
Fix BERT loadSavedModel

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
@@ -86,7 +86,7 @@ class TensorflowBert(val tensorflow: TensorflowWrapper,
     maskBuffers.flip()
     segmentBuffers.flip()
 
-    val runner = tensorflow.getTFHubSession(configProtoBytes = configProtoBytes).runner
+    val runner = tensorflow.getTFHubSession(configProtoBytes = configProtoBytes, initAllTables = false).runner
 
     val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
     val maskTensors = tensorsMasks.createIntBufferTensor(shape, maskBuffers)
@@ -145,7 +145,7 @@ class TensorflowBert(val tensorflow: TensorflowWrapper,
     maskBuffers.flip()
     segmentBuffers.flip()
 
-    val runner = tensorflow.getTFHubSession(configProtoBytes = configProtoBytes).runner
+    val runner = tensorflow.getTFHubSession(configProtoBytes = configProtoBytes, initAllTables = false).runner
 
     val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
     val maskTensors = tensorsMasks.createIntBufferTensor(shape, maskBuffers)

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowWrapper.scala
@@ -72,7 +72,7 @@ class TensorflowWrapper(
     msession
   }
 
-  def getTFHubSession(configProtoBytes: Option[Array[Byte]] = None): Session = {
+  def getTFHubSession(configProtoBytes: Option[Array[Byte]] = None, initAllTables: Boolean = true): Session = {
 
     if (msession == null){
       logger.debug("Restoring TF Hub session from bytes")
@@ -98,11 +98,18 @@ class TensorflowWrapper(
       // create the session and load the variables
       val session = new Session(g, config)
       val variablesPath = Paths.get(folder, "variables").toAbsolutePath.toString
-      session.runner
-        .addTarget("save/restore_all")
-        .addTarget("init_all_tables")
-        .feed("save/Const", t.createTensor(variablesPath))
-        .run()
+      if(initAllTables) {
+        session.runner
+          .addTarget("save/restore_all")
+          .addTarget("init_all_tables")
+          .feed("save/Const", t.createTensor(variablesPath))
+          .run()
+      }else{
+        session.runner
+          .addTarget("save/restore_all")
+          .feed("save/Const", t.createTensor(variablesPath))
+          .run()
+      }
 
       //delete variable files
       Files.delete(varData)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -263,7 +263,7 @@ trait ReadBertTensorflowModel extends ReadTensorflowModel {
 
   def readTensorflow(instance: BertEmbeddings, path: String, spark: SparkSession): Unit = {
 
-    val tf = readTensorflowModel(path, spark, "_bert_tf", initAllTables = true)
+    val tf = readTensorflowModel(path, spark, "_bert_tf", initAllTables = false)
     instance.setModelIfNotSet(spark, tf)
   }
 
@@ -288,7 +288,7 @@ trait ReadBertTensorflowModel extends ReadTensorflowModel {
     val vocabResource = new ExternalResource(vocab.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
     val words = ResourceHelper.parseLines(vocabResource).zipWithIndex.toMap
 
-    val wrapper = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"), initAllTables = true)
+    val wrapper = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"), initAllTables = false)
 
     new BertEmbeddings()
       .setVocabulary(words)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings.scala
@@ -255,7 +255,7 @@ trait ReadBertSentenceTensorflowModel extends ReadTensorflowModel {
 
   def readTensorflow(instance: BertSentenceEmbeddings, path: String, spark: SparkSession): Unit = {
 
-    val tf = readTensorflowModel(path, spark, "_bert_sentence_tf", initAllTables = true)
+    val tf = readTensorflowModel(path, spark, "_bert_sentence_tf", initAllTables = false)
     instance.setModelIfNotSet(spark, tf)
   }
 
@@ -280,7 +280,7 @@ trait ReadBertSentenceTensorflowModel extends ReadTensorflowModel {
     val vocabResource = new ExternalResource(vocab.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
     val words = ResourceHelper.parseLines(vocabResource).zipWithIndex.toMap
 
-    val wrapper = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"), initAllTables = true)
+    val wrapper = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"), initAllTables = false)
 
     new BertSentenceEmbeddings()
       .setVocabulary(words)


### PR DESCRIPTION
This PR fixes the issue when the exported BERT models don't require `init_all_tables` in the graph. This only improves the quality of the BERT models exported from checkpoints and doesn't change the models from TF Hub module.