### PR TITLE
Fix SentenceDetectorDL Unsupported Model error

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -34,6 +34,7 @@ unittest.TextTestRunner().run(ChunkEmbeddingsTestSpec())
 unittest.TextTestRunner().run(EmbeddingsFinisherTestSpec())
 unittest.TextTestRunner().run(NerDLModelTestSpec())
 unittest.TextTestRunner().run(YakeModelTestSpec())
+unittest.TextTestRunner().run(SentenceDetectorDLTestSpec())
 # Should be locally tested
 # unittest.TextTestRunner().run(ElmoEmbeddingsTestSpec())
 # unittest.TextTestRunner().run(AlbertEmbeddingsTestSpec())

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -2948,7 +2948,7 @@ class SentenceDetectorDLModel(AnnotatorModel):
         )
 
     @staticmethod
-    def pretrained(name, lang="en", remote_loc=None):
+    def pretrained(name="sentence_detector_dl", lang="en", remote_loc=None):
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(SentenceDetectorDLModel, name, lang, remote_loc)
 

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -1264,3 +1264,26 @@ class YakeModelTestSpec(unittest.TestCase):
 
         result = pipeline.fit(self.data).transform(self.data)
         result.select("keywords").show(truncate=False)
+
+
+class SentenceDetectorDLTestSpec(unittest.TestCase):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+    def runTest(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        sentence_detector = SentenceDetectorDLModel.pretrained() \
+            .setInputCols(["document"]) \
+            .setOutputCol("sentence")
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            sentence_detector
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -15,6 +15,7 @@ import com.johnsnowlabs.nlp.annotators.pos.perceptron.PerceptronModel
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.annotators.sda.pragmatic.SentimentDetectorModel
 import com.johnsnowlabs.nlp.annotators.sda.vivekn.ViveknSentimentModel
+import com.johnsnowlabs.nlp.annotators.sentence_detector_dl.SentenceDetectorDLModel
 import com.johnsnowlabs.nlp.annotators.spell.context.ContextSpellCheckerModel
 import com.johnsnowlabs.nlp.annotators.spell.norvig.NorvigSweetingModel
 import com.johnsnowlabs.nlp.annotators.spell.symmetric.SymmetricDeleteModel
@@ -458,7 +459,8 @@ object PythonResourceDownloader {
     "LanguageDetectorDL" -> LanguageDetectorDL,
     "StopWordsCleaner" -> StopWordsCleaner,
     "BertSentenceEmbeddings" -> BertSentenceEmbeddings,
-    "MultiClassifierDLModel" -> MultiClassifierDLModel
+    "MultiClassifierDLModel" -> MultiClassifierDLModel,
+    "SentenceDetectorDLModel" -> SentenceDetectorDLModel
   )
 
   def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLSpec.scala
@@ -96,4 +96,38 @@ class SentenceDetectorDLSpec  extends FlatSpec {
     })
   }
 
+  "Sentence Detector DL" should "download and run pretrained model" in {
+
+    val text = Source.fromFile(testSampleFreeText).getLines().mkString("\n")
+
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentenceDetectorDL = SentenceDetectorDLModel.pretrained()
+      .setInputCols(Array("document"))
+      .setOutputCol("sentences")
+
+    val pipeline = new Pipeline()
+      .setStages(Array(documentAssembler, sentenceDetectorDL))
+
+    case class textOnly(text: String)
+
+    import spark.implicits._
+
+    val emptyDataset = spark.emptyDataset[String]
+
+    val lightModel = new LightPipeline(pipeline.fit(emptyDataset))
+
+    lightModel.fullAnnotate(text).foreach(anno => {
+      if (anno._1 == "sentences"){
+        anno._2.foreach(s => {
+          println(s.result)
+          println("\n")
+        })
+      }
+
+    })
+  }
+
 }


### PR DESCRIPTION
This PR fixes the` Unsupported Model` error in SentenceDetectorDLModel when it is used with `.pretrained()`, adds unit tests for Scala and Python using the pretrained model, and sets a default pretrained model's name for Python side.