### PR TITLE
Fixed race condition in LruMap

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/util/LruMap.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/LruMap.scala
@@ -28,7 +28,7 @@ class LruMap[TKey, TValue](maxCacheSize: Int) {
 
   def foreach: (((TKey, TValue)) => Any) => Unit = cache.foreach
 
-  def update(key: TKey, value: => TValue): TValue = {
+  def update(key: TKey, value: => TValue): TValue = synchronized {
     val isNewKey = !cache.contains(key)
     if (isNewKey && getSize >= maxCacheSize)
       deleteOne()


### PR DESCRIPTION
Fixes a race condition in Lru that can cause NullPointerException during a LightPipeline operations with embeddings.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When using a LightPipeline on a large collection with a pipeline containing embeddings (for example explain_document_dl), a race condition triggers and quite often can trigger a NullPointerException in `LruMap:61`. This clause addresses this problem, with no significant performance impact.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves a NullPointerException in LruMap

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests, manual testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
