### PR TITLE
Fix BERT max sequence length calculation

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
@@ -36,28 +36,27 @@ class TensorflowBert(val tensorflow: TensorflowWrapper,
 
   def encode(sentences: Seq[(WordpieceTokenizedSentence, Int)], maxSequenceLength: Int): Seq[Array[Int]] = {
 
-    //    val tokens = sentence.tokens.map(t => t.pieceId)
-
-    val sentenceLength = sentences.map(x => x._1.tokens.length).toArray
-    val maxSentenceLength = sentenceLength.max
+    val sentencesLength = sentences.map(x => x._1.tokens.length).toArray
+    val maxSentenceLength = sentencesLength.max
 
     sentences.map { sentence =>
 
       val tokenPieceId = sentence._1.tokens.map(t => t.pieceId)
-      val diff = maxSentenceLength - tokenPieceId.length
+      val tokenPieceLength = tokenPieceId.length
 
-      if(maxSentenceLength >= maxSequenceLength){
+      if(tokenPieceLength > maxSequenceLength){
         Array(sentenceStartTokenId) ++
           tokenPieceId.take(maxSequenceLength - 2) ++
           Array(sentenceEndTokenId)
-      }else if(tokenPieceId.length < maxSentenceLength){
+      }else if(tokenPieceLength < maxSentenceLength){
+        val diff = if(maxSentenceLength <= maxSequenceLength) maxSentenceLength - tokenPieceLength else maxSequenceLength - tokenPieceLength
         Array(sentenceStartTokenId) ++
           tokenPieceId ++
           Array(sentenceEndTokenId) ++
-          Array.fill(diff)(0)
+          Array.fill(diff - 2)(0)
       }else{
         Array(sentenceStartTokenId) ++
-          tokenPieceId ++
+          tokenPieceId.take(maxSequenceLength - 2) ++
           Array(sentenceEndTokenId)
       }
     }
@@ -69,10 +68,11 @@ class TensorflowBert(val tensorflow: TensorflowWrapper,
     val tensorsSegments = new TensorResources()
 
     val maxSentenceLength = batch.map(x => x.length).max
+    val batchLength = batch.length
 
-    val tokenBuffers = tensors.createIntBuffer(batch.length*maxSentenceLength)
-    val maskBuffers = tensorsMasks.createIntBuffer(batch.length*maxSentenceLength)
-    val segmentBuffers = tensorsSegments.createIntBuffer(batch.length*maxSentenceLength)
+    val tokenBuffers = tensors.createIntBuffer(batchLength*maxSentenceLength)
+    val maskBuffers = tensorsMasks.createIntBuffer(batchLength*maxSentenceLength)
+    val segmentBuffers = tensorsSegments.createIntBuffer(batchLength*maxSentenceLength)
 
     val shape = Array(batch.length.toLong, maxSentenceLength)
 


### PR DESCRIPTION
This PR fixes the issue when the sentence is longer than 512 tokens as the new calculation released in 2.6.0 with dynamic shape fails with a correct calculation/trimming.