### PR TITLE
#1174: aws-java-sdk upgraded from 1.11.603 to 1.11.904

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,12 +129,12 @@ lazy val utilDependencies = Seq(
     exclude("commons-configuration","commons-configuration")
     exclude("com.amazonaws","aws-java-sdk-bundle")
     exclude("org.apache.hadoop" ,"hadoop-common"),
-  "com.amazonaws" % "aws-java-sdk-core" % "1.11.603"
+  "com.amazonaws" % "aws-java-sdk-core" % "1.11.904"
     exclude("com.fasterxml.jackson.core", "jackson-annotations")
     exclude("com.fasterxml.jackson.core", "jackson-databind")
     exclude("com.fasterxml.jackson.core", "jackson-core")
     exclude("commons-configuration","commons-configuration"),
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.603",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.904",
   "com.github.universal-automata" % "liblevenshtein" % "3.0.0"
     exclude("com.google.guava", "guava")
     exclude("org.apache.commons", "commons-lang3"),


### PR DESCRIPTION
Suggested fix for #1174. The project is buildable and tests run successfully with aws-java-sdk v1.11.904.