### PR TITLE
prevent default init of resource downloader

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/HasPretrained.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasPretrained.scala
@@ -13,7 +13,7 @@ trait HasPretrained[M <: PipelineStage] {
 
   val defaultLang: String = "en"
 
-  val defaultLoc: String = ResourceDownloader.publicLoc
+  def defaultLoc: String = ResourceDownloader.publicLoc
 
   implicit private val companion = this.asInstanceOf[DefaultParamsReadable[M]]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sometimes when we load models from disk we still get problems from S3ResourceDownloader because it initialization is triggered even when you are not pulling models from S3.
With this change we make initialization lazy.



## Motivation and Context
We were experiencing the following problem whe loading models from disk,
```
    sentenceDetectordl = SentenceDetectorDLModel.load("./pretrained_models/sentence_detector_dl_healthcare_en_2.6.0_2.4_1600001082565/")
  File "/home/iquartic/.local/lib/python3.7/site-packages/pyspark/ml/util.py", line 362, in load
    return cls.read().load(path)
  File "/usr/local/lib/python3.7/site-packages/sparknlp/internal.py", line 51, in read
    return AnnotatorJavaMLReader(cls())
  File "/home/iquartic/.local/lib/python3.7/site-packages/pyspark/ml/util.py", line 294, in __init__
    self._jread = self._load_java_obj(clazz).read()
  File "/home/iquartic/.local/lib/python3.7/site-packages/py4j/java_gateway.py", line 1257, in __call__
    answer, self.gateway_client, self.target_id, self.name)
  File "/home/iquartic/.local/lib/python3.7/site-packages/pyspark/sql/utils.py", line 63, in deco
    return f(*a, **kw)
  File "/home/iquartic/.local/lib/python3.7/site-packages/py4j/protocol.py", line 328, in get_return_value
    format(target_id, ".", name), value)
py4j.protocol.Py4JJavaError: An error occurred while calling z:com.johnsnowlabs.nlp.annotators.sentence_detector_dl.SentenceDetectorDLModel.read.
: java.lang.NoClassDefFoundError: com/typesafe/config/ConfigMergeable
    at com.johnsnowlabs.util.ConfigHelper$.getConfigValue(ConfigHelper.scala:13)
    at com.johnsnowlabs.util.ConfigHelper$.getConfigValueOrElse(ConfigHelper.scala:20)
    at com.johnsnowlabs.util.ConfigHelper$.<init>(ConfigHelper.scala:47)
    at com.johnsnowlabs.util.ConfigHelper$.<clinit>(ConfigHelper.scala)
    at com.johnsnowlabs.nlp.pretrained.ResourceDownloader$.cacheFolder(ResourceDownloader.scala:66)
    at com.johnsnowlabs.nlp.pretrained.ResourceDownloader$$anonfun$3.apply(ResourceDownloader.scala:127)
    at com.johnsnowlabs.nlp.pretrained.ResourceDownloader$$anonfun$3.apply(ResourceDownloader.scala:127)
    at com.johnsnowlabs.nlp.pretrained.S3ResourceDownloader.<init>(S3ResourceDownloader.scala:30)
    at com.johnsnowlabs.nlp.pretrained.ResourceDownloader$.<init>(ResourceDownloader.scala:127)
    at com.johnsnowlabs.nlp.pretrained.ResourceDownloader$.<clinit>(ResourceDownloader.scala)
    at com.johnsnowlabs.nlp.HasPretrained$class.$init$(HasPretrained.scala:16)
    at com.johnsnowlabs.nlp.annotators.sentence_detector_dl.SentenceDetectorDLModel$.<init>(SentenceDetectorDLModel.scala:332)
    at com.johnsnowlabs.nlp.annotators.sentence_detector_dl.SentenceDetectorDLModel$.<clinit>(SentenceDetectorDLModel.scala)
    at com.johnsnowlabs.nlp.annotators.sentence_detector_dl.SentenceDetectorDLModel.read(SentenceDetectorDLModel.scala)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
    at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
    at py4j.Gateway.invoke(Gateway.java:282)
    at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
    at py4j.commands.CallCommand.execute(CallCommand.java:79)
    at py4j.GatewayConnection.run(GatewayConnection.java:238)
    at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: com.typesafe.config.ConfigMergeable
    at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
    ... 25 more
    
```    
  
  



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
