### PR TITLE
Upgrade to the latest Apache Spark 2.4.x release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val is_gpu = System.getProperty("is_gpu","false")
 val is_spark23 = System.getProperty("is_spark23","false")
 
 val spark23Ver = "2.3.4"
-val spark24Ver = "2.4.4"
+val spark24Ver = "2.4.7"
 val sparkVer = if(is_spark23=="false") spark24Ver else spark23Ver
 val scalaVer = "2.11.12"
 val scalaTestVersion = "3.0.0"


### PR DESCRIPTION
This PR makes the default Apache Spark of Spark NLP the `2.4.7`. 