### PR TITLE
Fix bug in bert sentence embeddings resulting in multiple annotations per sentence

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
@@ -268,15 +268,17 @@ class TensorflowBert(val tensorflow: TensorflowWrapper,
                                  ): Seq[Annotation] = {
 
     /*Run embeddings calculation by batches*/
-    tokens.zipWithIndex.grouped(batchSize).flatMap{batch =>
-      val encoded = encode(batch, maxSentenceLength)
+    tokens.zip(sentences).zipWithIndex.grouped(batchSize).flatMap{batch =>
+      val tokensBatch = batch.map(x => (x._1._1, x._2))
+      val sentencesBatch = batch.map(x => x._1._2)
+      val encoded = encode(tokensBatch, maxSentenceLength)
       val embeddings = if (isLong) {
         tagSentenceSBert(encoded)
       } else {
         tagSentence(encoded)
       }
 
-      sentences.zip(embeddings).map { case (sentence, vectors) =>
+      sentencesBatch.zip(embeddings).map { case (sentence, vectors) =>
         Annotation(
           annotatorType = AnnotatorType.SENTENCE_EMBEDDINGS,
           begin = sentence.start,


### PR DESCRIPTION
Fix bug in producing multiple annotations per sentence when the number of sentences in a row exceeds the batch size

The problem was that TensorflowBert.calculateSentenceEmbeddings was grouping the data into batches and then using the ungrouped sentence collection to get the sentence details

TensorflowBert.calculateSentenceEmbeddings updated

## Motivation and Context
There were multiple records for the same sentence when there were more than batchSize sentences per row. The bug affected the sentence string (i.e. result) and other details (begin, end, metadata), but not the embeddings itself.

## How Has This Been Tested?
I've tested it manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
