### PR TITLE
WIP: Inherit sentence from the document in Word Embeddings Model

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/IndexedToken.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/IndexedToken.scala
@@ -1,3 +1,3 @@
 package com.johnsnowlabs.nlp.annotators.common
 
-case class IndexedToken(token: String, begin: Int = 0, end: Int = 0)
+case class IndexedToken(token: String, begin: Int = 0, end: Int = 0, sentenceIndex: Int = 0)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceSplit.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceSplit.scala
@@ -27,7 +27,7 @@ object SentenceSplit extends Annotated[Sentence] {
   override def unpack(annotations: Seq[Annotation]): Seq[Sentence] = {
     annotations.filter(_.annotatorType == annotatorType)
       .zipWithIndex.map { case (annotation, index) =>
-      Sentence(annotation.result, annotation.begin, annotation.end, index)
+      Sentence(annotation.result, annotation.begin, annotation.end, annotation.metadata.getOrElse("sentence", index.toString).toInt)
     }
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
@@ -19,12 +19,12 @@ object TokenizedWithSentence extends Annotated[TokenizedSentence] {
       "Inconsistencies found in pipeline. Tokens in sentences does not match with sentence count")
       */
 
-    sentences.map(sentence => {
+    sentences.flatMap(sentence => {
       val sentenceTokens = tokens.filter(token =>
         token.begin >= sentence.start & token.end <= sentence.end
-      ).map(token => IndexedToken(token.result, token.begin, token.end))
+      ).map(token => IndexedToken(token.result, token.begin, token.end, sentence.index))
       sentenceTokens
-    }).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}.filter(_.indexedTokens.nonEmpty)
+    }).groupBy(_.sentenceIndex).map{case (sentenceIndex, indexedTokens) => TokenizedSentence(indexedTokens.toArray, sentenceIndex)}.filter(_.indexedTokens.nonEmpty).toSeq.sortBy(_.sentenceIndex)
   }
 
   override def pack(sentences: Seq[TokenizedSentence]): Seq[Annotation] = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
@@ -12,30 +12,19 @@ object TokenizedWithSentence extends Annotated[TokenizedSentence] {
       .filter(_.annotatorType == annotatorType)
       .toArray
 
-    val hasMeta = annotations.find(_.metadata.get("sentence").nonEmpty).nonEmpty
     val sentences = SentenceSplit.unpack(annotations)
 
     /** // Evaluate whether to enable this validation to check proper usage of DOCUMENT and SENTENCE within entire pipelines
       * require(tokens.map(_.metadata.getOrElse("sentence", "0").toInt).distinct.length == sentences.length,
       * "Inconsistencies found in pipeline. Tokens in sentences does not match with sentence count")
       */
-    val retAnns = if (!hasMeta) {
-      sentences.map(sentence => filterTokensFromSentence(sentence, tokens))
-        .zipWithIndex.map { case (indexedTokens, index) => TokenizedSentence(indexedTokens.toArray, index) }.filter(_.indexedTokens.nonEmpty)
-    } else {
-      sentences.flatMap(sentence => filterTokensFromSentence(sentence, tokens))
-        .groupBy(_.sentenceIndex).map { case (sentenceIndex, indexedTokens) => TokenizedSentence(indexedTokens.toArray, sentenceIndex) }
-        .filter(_.indexedTokens.nonEmpty).toSeq.sortBy(_.sentenceIndex)
-    }
 
-    retAnns
-  }
-
-  def filterTokensFromSentence(sentence:Sentence, tokens: Seq[Annotation]): Seq[IndexedToken] = {
-    val sentenceTokens = tokens.filter(token =>
-      token.begin >= sentence.start & token.end <= sentence.end
-    ).map(token => IndexedToken(token.result, token.begin, token.end, sentence.index))
-    sentenceTokens
+    sentences.map(sentence => {
+      val sentenceTokens = tokens.filter(token =>
+        token.begin >= sentence.start & token.end <= sentence.end
+      ).map(token => IndexedToken(token.result, token.begin, token.end, token.metadata.getOrElse[String]("sentence", sentence.index.toString).toInt))
+      sentenceTokens
+    }).zipWithIndex.map{case (indexedTokens, index) => TokenizedSentence(indexedTokens, index)}.filter(_.indexedTokens.nonEmpty)
   }
 
   override def pack(sentences: Seq[TokenizedSentence]): Seq[Annotation] = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TokenizedWithSentence.scala
@@ -12,26 +12,37 @@ object TokenizedWithSentence extends Annotated[TokenizedSentence] {
       .filter(_.annotatorType == annotatorType)
       .toArray
 
+    val hasMeta = annotations.find(_.metadata.get("sentence").nonEmpty).nonEmpty
     val sentences = SentenceSplit.unpack(annotations)
 
     /** // Evaluate whether to enable this validation to check proper usage of DOCUMENT and SENTENCE within entire pipelines
-    require(tokens.map(_.metadata.getOrElse("sentence", "0").toInt).distinct.length == sentences.length,
-      "Inconsistencies found in pipeline. Tokens in sentences does not match with sentence count")
+      * require(tokens.map(_.metadata.getOrElse("sentence", "0").toInt).distinct.length == sentences.length,
+      * "Inconsistencies found in pipeline. Tokens in sentences does not match with sentence count")
       */
+    val retAnns = if (!hasMeta) {
+      sentences.map(sentence => filterTokensFromSentence(sentence, tokens))
+        .zipWithIndex.map { case (indexedTokens, index) => TokenizedSentence(indexedTokens.toArray, index) }.filter(_.indexedTokens.nonEmpty)
+    } else {
+      sentences.flatMap(sentence => filterTokensFromSentence(sentence, tokens))
+        .groupBy(_.sentenceIndex).map { case (sentenceIndex, indexedTokens) => TokenizedSentence(indexedTokens.toArray, sentenceIndex) }
+        .filter(_.indexedTokens.nonEmpty).toSeq.sortBy(_.sentenceIndex)
+    }
 
-    sentences.flatMap(sentence => {
-      val sentenceTokens = tokens.filter(token =>
-        token.begin >= sentence.start & token.end <= sentence.end
-      ).map(token => IndexedToken(token.result, token.begin, token.end, sentence.index))
-      sentenceTokens
-    }).groupBy(_.sentenceIndex).map{case (sentenceIndex, indexedTokens) => TokenizedSentence(indexedTokens.toArray, sentenceIndex)}.filter(_.indexedTokens.nonEmpty).toSeq.sortBy(_.sentenceIndex)
+    retAnns
+  }
+
+  def filterTokensFromSentence(sentence:Sentence, tokens: Seq[Annotation]): Seq[IndexedToken] = {
+    val sentenceTokens = tokens.filter(token =>
+      token.begin >= sentence.start & token.end <= sentence.end
+    ).map(token => IndexedToken(token.result, token.begin, token.end, sentence.index))
+    sentenceTokens
   }
 
   override def pack(sentences: Seq[TokenizedSentence]): Seq[Annotation] = {
     sentences.flatMap{ sentence =>
-        sentence.indexedTokens.map{token =>
+      sentence.indexedTokens.map{token =>
         Annotation(annotatorType, token.begin, token.end, token.token,
           Map("sentence" -> sentence.sentenceIndex.toString))
-    }}
+      }}
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronModel.scala
@@ -66,7 +66,7 @@ class PerceptronModel(override val uid: String) extends AnnotatorModel[Perceptro
     var prev2 = START(1)
     tokenizedSentences.map(sentence => {
       val context: Array[String] = START ++: sentence.tokens.map(normalized) ++: END
-      sentence.indexedTokens.zipWithIndex.map { case (IndexedToken(word, begin, end), i) =>
+      sentence.indexedTokens.zipWithIndex.map { case (IndexedToken(word, begin, end, _), i) =>
         val tag = $$(model).getTaggedBook.getOrElse(word.toLowerCase,
           {
             val features = getFeatures(i, word, context, prev, prev2)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
@@ -150,12 +150,12 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
       val sentenceIdx = chunk.metadata.getOrElse("sentence", "0").toInt
       val chunkIdx = chunk.metadata.getOrElse("chunk", "0").toInt
 
-      if (sentenceIdx < embeddingsSentences.length) {
 
-        val tokensWithEmbeddings = embeddingsSentences(sentenceIdx).tokens.filter(
+      val embeddingsSentence = embeddingsSentences.find(_.sentenceId==sentenceIdx)
+      if (embeddingsSentence.nonEmpty) {
+        val tokensWithEmbeddings = embeddingsSentence.get.tokens.filter(
           token => token.begin >= chunk.begin && token.end <= chunk.end
         )
-
         val allEmbeddings = tokensWithEmbeddings.flatMap(tokenEmbedding =>
           if (!tokenEmbedding.isOOV || !$(skipOOV))
             Some(tokenEmbedding.embeddings)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
@@ -83,7 +83,7 @@ class WordEmbeddingsModel(override val uid: String)
           token.end
         )
       }
-      WordpieceEmbeddingsSentence(tokens, s.sentenceIndex)
+      WordpieceEmbeddingsSentence(tokens, s.indexedTokens.head.sentenceIndex)
     }
 
     WordpieceEmbeddingsSentence.pack(withEmbeddings)

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
@@ -233,7 +233,7 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
 
   }
 
-  "ChunkEmbeddings new" should "correctly work with empty tokens" in {
+  "ChunkEmbeddings" should "correctly work with multiple chunks per sentence" in {
     val rows = Array(
           Tuple1("""In short, the patient is a 55-year-old entleman with a broken leg. The guy also has long-standing morbid obesity, resistant to nonsurgical methods
       of weight loss with of 69.7 with comorbidities of hypertension, atrial fibrillation,

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
@@ -233,39 +233,4 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
 
   }
 
-  "ChunkEmbeddings" should "correctly work with multiple chunks per sentence" in {
-    val rows = Array(
-          Tuple1("""In short, the patient is a 55-year-old entleman with a broken leg. The guy also has long-standing morbid obesity, resistant to nonsurgical methods
-      of weight loss with of 69.7 with comorbidities of hypertension, atrial fibrillation,
-      hyperlipidemia, possible sleep apnea, and also osteoarthritis of the lower extremities.
-      He is also an ex-smoker. Does not have diabetes at all. He is currently smoking SMOKER and he is planning to quit and
-      at least he should do this six to eight days before for multiple reasons including decreasing the DVT,
-      pulmonary embolism rates and marginal ulcer problems after surgery, which will be discussed later on.""")
-    )
-    val df = ResourceHelper.spark.createDataFrame(rows).toDF("text")
-    val dac = new DocumentAssembler().setInputCol("text").setOutputCol("doc")
-    val sd = SentenceDetectorDLModel.pretrained("sentence_detector_dl","en")
-      .setInputCols("doc").setOutputCol("sentence")
-    val tk = new Tokenizer().setInputCols("sentence").setOutputCol("token")
-    val emb = WordEmbeddingsModel.pretrained("glove_100d").setOutputCol("embs")
-    val ner = NerDLModel.pretrained("ner_dl").setInputCols("sentence","token","embs").setOutputCol("ner")
-    val conv = new NerConverter().setInputCols("sentence","token","ner").setOutputCol("ner_chunk")
-    val c2d = new Chunk2Doc().setInputCols("ner_chunk").setOutputCol("chunk_doc")
-    val ctk = new ChunkTokenizer().setInputCols("ner_chunk").setOutputCol("chunk_tk") //Optional
-    val cembs = WordEmbeddingsModel.pretrained("glove_6B_300", "xx")
-      .setInputCols("chunk_doc","chunk_tk").setOutputCol("chunk_tk_embs")
-    val aggembs = new ChunkEmbeddings().setInputCols("ner_chunk","chunk_tk_embs").setOutputCol("chunk_embs")
-      .setPoolingStrategy("AVERAGE").setSkipOOV(false)
-    val embs_pl = new Pipeline().setStages(Array(dac, sd, tk, emb, ner, conv, c2d, ctk, cembs, aggembs)).fit(df)
-    val out_df = embs_pl.transform(df)
-    out_df.selectExpr("explode(arrays_zip(ner_chunk.result, chunk_embs.embeddings)) as a").show(100, truncate=50)
-
-    val textSent = out_df.selectExpr("explode(arrays_zip(chunk_tk.result,chunk_tk.metadata,chunk_tk_embs.result,chunk_tk_embs.metadata)) as a")
-    .selectExpr("(a['0'],a['1'].sentence) as chunk",
-      "(a['2'],a['3'].sentence) as embs")
-    textSent.show(100,false)
-     val assertion = textSent.collect().forall(r=>r(0)==r(1))
-    assert(assertion)
-  }
-
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
@@ -235,8 +235,8 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
 
   "ChunkEmbeddings new" should "correctly work with empty tokens" in {
     val rows = Array(
-          Tuple1("""In short, the patient is a 55-year-old entleman with a broken leg. The guy also has long-standing morbid obesity, resistant to nonsurgical
-      methods of weight loss with of 69.7 with comorbidities of hypertension, atrial fibrillation,
+          Tuple1("""In short, the patient is a 55-year-old entleman with a broken leg. The guy also has long-standing morbid obesity, resistant to nonsurgical methods
+      of weight loss with of 69.7 with comorbidities of hypertension, atrial fibrillation,
       hyperlipidemia, possible sleep apnea, and also osteoarthritis of the lower extremities.
       He is also an ex-smoker. Does not have diabetes at all. He is currently smoking SMOKER and he is planning to quit and
       at least he should do this six to eight days before for multiple reasons including decreasing the DVT,
@@ -259,7 +259,11 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
     val embs_pl = new Pipeline().setStages(Array(dac, sd, tk, emb, ner, conv, c2d, ctk, cembs, aggembs)).fit(df)
     val out_df = embs_pl.transform(df)
     out_df.selectExpr("explode(arrays_zip(ner_chunk.result, chunk_embs.embeddings)) as a").show(100, truncate=50)
-    //TODO:
+
+    val textSent = out_df.selectExpr("explode(arrays_zip(chunk_tk.result,chunk_tk.metadata,chunk_tk_embs.result,chunk_tk_embs.metadata)) as a")
+    .selectExpr("(a['0'],a['1'].sentence) as chunk",
+      "(a['2'],a['3'].sentence) as embs").collect().forall(r=>r(0)==r(1))
+    assert(textSent)
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
@@ -1,11 +1,11 @@
 package com.johnsnowlabs.nlp.embeddings
 
-import com.johnsnowlabs.nlp.annotator.{Chunker, PerceptronModel}
+import com.johnsnowlabs.nlp.annotator.{ChunkTokenizer, Chunker, NerConverter, NerDLModel, PerceptronModel, SentenceDetectorDLModel}
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.annotators.{NGramGenerator, StopWordsCleaner, Tokenizer}
 import com.johnsnowlabs.nlp.base.{DocumentAssembler, RecursivePipeline}
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.nlp.{AnnotatorBuilder, EmbeddingsFinisher, Finisher}
+import com.johnsnowlabs.nlp.{AnnotatorBuilder, Chunk2Doc, EmbeddingsFinisher, Finisher}
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.functions.size
 import org.scalatest._
@@ -231,6 +231,35 @@ class ChunkEmbeddingsTestSpec extends FlatSpec {
     pipelineDF.select("embeddings").show(1)
     pipelineDF.select("sentence_embeddings").show(1)
 
+  }
+
+  "ChunkEmbeddings new" should "correctly work with empty tokens" in {
+    val rows = Array(
+          Tuple1("""In short, the patient is a 55-year-old entleman with a broken leg. The guy also has long-standing morbid obesity, resistant to nonsurgical
+      methods of weight loss with of 69.7 with comorbidities of hypertension, atrial fibrillation,
+      hyperlipidemia, possible sleep apnea, and also osteoarthritis of the lower extremities.
+      He is also an ex-smoker. Does not have diabetes at all. He is currently smoking SMOKER and he is planning to quit and
+      at least he should do this six to eight days before for multiple reasons including decreasing the DVT,
+      pulmonary embolism rates and marginal ulcer problems after surgery, which will be discussed later on.""")
+    )
+    val df = ResourceHelper.spark.createDataFrame(rows).toDF("text")
+    val dac = new DocumentAssembler().setInputCol("text").setOutputCol("doc")
+    val sd = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare","en","clinical/models")
+      .setInputCols("doc").setOutputCol("sentence")
+    val tk = new Tokenizer().setInputCols("sentence").setOutputCol("token")
+    val emb = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models").setOutputCol("embs")
+    val ner = NerDLModel.pretrained("ner_clinical","en","clinical/models").setInputCols("sentence","token","embs").setOutputCol("ner")
+    val conv = new NerConverter().setInputCols("sentence","token","ner").setOutputCol("ner_chunk")
+    val c2d = new Chunk2Doc().setInputCols("ner_chunk").setOutputCol("chunk_doc")
+    val ctk = new ChunkTokenizer().setInputCols("ner_chunk").setOutputCol("chunk_tk") //Optional
+    val cembs = WordEmbeddingsModel.pretrained("embeddings_healthcare_100d","en","clinical/models")
+      .setInputCols("chunk_doc","chunk_tk").setOutputCol("chunk_tk_embs")
+    val aggembs = new ChunkEmbeddings().setInputCols("ner_chunk","chunk_tk_embs").setOutputCol("chunk_embs")
+      .setPoolingStrategy("AVERAGE").setSkipOOV(false)
+    val embs_pl = new Pipeline().setStages(Array(dac, sd, tk, emb, ner, conv, c2d, ctk, cembs, aggembs)).fit(df)
+    val out_df = embs_pl.transform(df)
+    out_df.selectExpr("explode(arrays_zip(ner_chunk.result, chunk_embs.embeddings)) as a").show(100, truncate=50)
+    //TODO:
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsTestSpec.scala
@@ -1,5 +1,7 @@
 package com.johnsnowlabs.nlp.embeddings
 
+import com.johnsnowlabs.nlp.Chunk2Doc
+import com.johnsnowlabs.nlp.annotator.{ChunkTokenizer, NerConverter, NerDLModel, SentenceDetectorDLModel}
 import com.johnsnowlabs.nlp.annotators.Tokenizer
 import com.johnsnowlabs.nlp.base.{DocumentAssembler, RecursivePipeline}
 import com.johnsnowlabs.nlp.util.io.{ReadAs, ResourceHelper}
@@ -97,4 +99,38 @@ class WordEmbeddingsTestSpec extends FlatSpec {
     loadedPipeline2.transform(data).show(1)
   }
 
+  "WordEmbeddingsModel" should "not reset sentence indexes of the documents it processes" in {
+    val rows = Array(
+      Tuple1("""In short, the patient is a 55-year-old entleman with a broken leg. The guy also has long-standing morbid obesity, resistant to nonsurgical methods
+      of weight loss with of 69.7 with comorbidities of hypertension, atrial fibrillation,
+      hyperlipidemia, possible sleep apnea, and also osteoarthritis of the lower extremities.
+      He is also an ex-smoker. Does not have diabetes at all. He is currently smoking SMOKER and he is planning to quit and
+      at least he should do this six to eight days before for multiple reasons including decreasing the DVT,
+      pulmonary embolism rates and marginal ulcer problems after surgery, which will be discussed later on.""")
+    )
+    val df = ResourceHelper.spark.createDataFrame(rows).toDF("text")
+    val dac = new DocumentAssembler().setInputCol("text").setOutputCol("doc")
+    val sd = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare","en","clinical/models")
+      .setInputCols("doc").setOutputCol("sentence")
+    val tk = new Tokenizer().setInputCols("sentence").setOutputCol("token")
+    val emb = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models").setOutputCol("embs")
+    val ner = NerDLModel.pretrained("ner_clinical","en","clinical/models").setInputCols("sentence","token","embs").setOutputCol("ner")
+    val conv = new NerConverter().setInputCols("sentence","token","ner").setOutputCol("ner_chunk")
+    val c2d = new Chunk2Doc().setInputCols("ner_chunk").setOutputCol("chunk_doc")
+    val ctk = new ChunkTokenizer().setInputCols("ner_chunk").setOutputCol("chunk_tk") //Optional
+
+
+    val cembs = WordEmbeddingsModel.pretrained("embeddings_healthcare_100d","en","clinical/models")
+      .setInputCols("chunk_doc","chunk_tk").setOutputCol("chunk_tk_embs")
+    val aggembs = new ChunkEmbeddings().setInputCols("ner_chunk","chunk_tk_embs").setOutputCol("chunk_embs")
+      .setPoolingStrategy("AVERAGE").setSkipOOV(false)
+    val embs_pl = new Pipeline().setStages(Array(dac, sd, tk, emb, ner, conv, c2d, ctk, cembs, aggembs)).fit(df)
+    val out_df = embs_pl.transform(df)
+    out_df.selectExpr("explode(arrays_zip(ner_chunk.result, chunk_embs.embeddings)) as a").show(100, truncate=50)
+
+    val textSent = out_df.selectExpr("explode(arrays_zip(chunk_tk.result,chunk_tk.metadata,chunk_tk_embs.result,chunk_tk_embs.metadata)) as a")
+      .selectExpr("(a['0'],a['1'].sentence) as chunk",
+        "(a['2'],a['3'].sentence) as embs").collect().forall(r=>r(0)==r(1))
+    assert(textSent)
+  }
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsTestSpec.scala
@@ -110,27 +110,23 @@ class WordEmbeddingsTestSpec extends FlatSpec {
     )
     val df = ResourceHelper.spark.createDataFrame(rows).toDF("text")
     val dac = new DocumentAssembler().setInputCol("text").setOutputCol("doc")
-    val sd = SentenceDetectorDLModel.pretrained("sentence_detector_dl_healthcare","en","clinical/models")
+    val sd = SentenceDetectorDLModel.pretrained("sentence_detector_dl","en")
       .setInputCols("doc").setOutputCol("sentence")
     val tk = new Tokenizer().setInputCols("sentence").setOutputCol("token")
-    val emb = WordEmbeddingsModel.pretrained("embeddings_clinical","en","clinical/models").setOutputCol("embs")
-    val ner = NerDLModel.pretrained("ner_clinical","en","clinical/models").setInputCols("sentence","token","embs").setOutputCol("ner")
+    val emb = WordEmbeddingsModel.pretrained("glove_100d").setOutputCol("embs")
+    val ner = NerDLModel.pretrained("ner_dl").setInputCols("sentence","token","embs").setOutputCol("ner")
     val conv = new NerConverter().setInputCols("sentence","token","ner").setOutputCol("ner_chunk")
     val c2d = new Chunk2Doc().setInputCols("ner_chunk").setOutputCol("chunk_doc")
     val ctk = new ChunkTokenizer().setInputCols("ner_chunk").setOutputCol("chunk_tk") //Optional
-
-
-    val cembs = WordEmbeddingsModel.pretrained("embeddings_healthcare_100d","en","clinical/models")
+    val cembs = WordEmbeddingsModel.pretrained("glove_6B_300", "xx")
       .setInputCols("chunk_doc","chunk_tk").setOutputCol("chunk_tk_embs")
-    val aggembs = new ChunkEmbeddings().setInputCols("ner_chunk","chunk_tk_embs").setOutputCol("chunk_embs")
-      .setPoolingStrategy("AVERAGE").setSkipOOV(false)
-    val embs_pl = new Pipeline().setStages(Array(dac, sd, tk, emb, ner, conv, c2d, ctk, cembs, aggembs)).fit(df)
+    val embs_pl = new Pipeline().setStages(Array(dac, sd, tk, emb, ner, conv, c2d, ctk, cembs)).fit(df)
     val out_df = embs_pl.transform(df)
-    out_df.selectExpr("explode(arrays_zip(ner_chunk.result, chunk_embs.embeddings)) as a").show(100, truncate=50)
-
     val textSent = out_df.selectExpr("explode(arrays_zip(chunk_tk.result,chunk_tk.metadata,chunk_tk_embs.result,chunk_tk_embs.metadata)) as a")
       .selectExpr("(a['0'],a['1'].sentence) as chunk",
-        "(a['2'],a['3'].sentence) as embs").collect().forall(r=>r(0)==r(1))
-    assert(textSent)
+        "(a['2'],a['3'].sentence) as embs")
+    textSent.show(100,false)
+    val assertion = textSent.collect().forall(r=>r(0)==r(1))
+    assert(assertion)
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Word embeddings does not pay attention when the sentence indexes are already calculated and are not just the positions in the array. For example when docs are generated using Chunk2Doc annotator.


## Motivation and Context
In order to embed chunks -> docs and use ChunkEmbeddings to aggregate before a classifier or any downstream annotator.

## How Has This Been Tested?
- [X] All existing tests pass
- [x] Specific test for the feature is included

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
