### PR TITLE
2.7.0 py api bug fixes T5, WordSegmenter

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -3176,7 +3176,7 @@ class WordSegmenterModel(AnnotatorModel):
         )
 
     @staticmethod
-    def pretrained(name="word_segmenter", lang="en", remote_loc=None):
+    def pretrained(name="word_segmenter", lang="zh", remote_loc=None):
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(WordSegmenterModel, name, lang, remote_loc)
 
@@ -3217,7 +3217,7 @@ class T5Transformer(AnnotatorModel):
         return T5Transformer(java_model=jModel)
 
     @staticmethod
-    def pretrained(name="t5_small", lang="xx", remote_loc=None):
+    def pretrained(name="t5_small", lang="en", remote_loc=None):
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(T5Transformer, name, lang, remote_loc)
 

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -3176,7 +3176,7 @@ class WordSegmenterModel(AnnotatorModel):
         )
 
     @staticmethod
-    def pretrained(name="word_segmenter", lang="zh", remote_loc=None):
+    def pretrained(name="wordseg_weibo", lang="zh", remote_loc=None):
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(WordSegmenterModel, name, lang, remote_loc)
 

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowT5.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowT5.scala
@@ -17,7 +17,7 @@ class TensorflowT5(val tensorflow: TensorflowWrapper,
                        configProtoBytes: Option[Array[Byte]] = None
                       ) extends Serializable {
 
-  // keys representing the input and output tensors of the ALBERT model
+  // keys representing the input and output tensors of the T5 model
 
   private val encoderInputIdsKey = "encoder/encoder_input_ids:0"
   private val encoderAttentionMaskKey = "encoder/encoder_attention_mask:0"

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -20,6 +20,7 @@ import com.johnsnowlabs.nlp.annotators.seq2seq.{MarianTransformer, T5Transformer
 import com.johnsnowlabs.nlp.annotators.spell.context.ContextSpellCheckerModel
 import com.johnsnowlabs.nlp.annotators.spell.norvig.NorvigSweetingModel
 import com.johnsnowlabs.nlp.annotators.spell.symmetric.SymmetricDeleteModel
+import com.johnsnowlabs.nlp.annotators.ws.WordSegmenterModel
 import com.johnsnowlabs.nlp.embeddings.{AlbertEmbeddings, BertEmbeddings, BertSentenceEmbeddings, ElmoEmbeddings, UniversalSentenceEncoder, WordEmbeddingsModel, XlnetEmbeddings}
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader.{listPretrainedResources, publicLoc, showString}
 import com.johnsnowlabs.nlp.pretrained.ResourceType.ResourceType
@@ -463,7 +464,8 @@ object PythonResourceDownloader {
     "MultiClassifierDLModel" -> MultiClassifierDLModel,
     "SentenceDetectorDLModel" -> SentenceDetectorDLModel,
     "T5Transformer" -> T5Transformer,
-    "MarianTransformer" -> MarianTransformer
+    "MarianTransformer" -> MarianTransformer,
+    "WordSegmenterModel" -> WordSegmenterModel
   )
 
   def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
I noticed the following bugs in the Python API

- Bad default values for pretrained T5 and Wordsegmenter ( fixed)
- Missing reference for PythonRessource Downloaded (fixed)
- WordSegmenter not loadable (fixed)


## Motivation and Context
- T5.pretrained() and WordSegmenter.pretrained() threw errors'model not found' because of bad pretrained values
- WordSegmenter  model not creatable, throwing JavaErrors when creating it in Python 

## How Has This Been Tested?
- Created FatJar and loaded it  in spark-nlp 2.7.0 python Enviroment. This fixed all issues marked as fixed


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [] All new and existing tests passed. Did not run the tests
