### PR TITLE
Fix to restore the regex tokenizer tag algorithm

### DIFF
--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/RegexTokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/RegexTokenizerTestSpec.scala
@@ -23,19 +23,19 @@ class RegexTokenizerTestSpec extends FlatSpec {
       Annotation(TOKEN, 8, 9, "my", Map("sentence" -> "0")),
       Annotation(TOKEN, 11, 15, "first", Map("sentence" -> "0")),
       Annotation(TOKEN, 17, 25, "sentence.", Map("sentence" -> "0")),
-      Annotation(TOKEN, 0, 3, "this", Map("sentence" -> "1")),
-      Annotation(TOKEN, 5, 6, "is", Map("sentence" -> "1")),
-      Annotation(TOKEN, 8, 9, "my", Map("sentence" -> "1")),
-      Annotation(TOKEN, 11, 17, "second.", Map("sentence" -> "1")),
+      Annotation(TOKEN, 27, 30, "this", Map("sentence" -> "1")),
+      Annotation(TOKEN, 32, 33, "is", Map("sentence" -> "1")),
+      Annotation(TOKEN, 35, 36, "my", Map("sentence" -> "1")),
+      Annotation(TOKEN, 38, 44, "second.", Map("sentence" -> "1")),
       Annotation(TOKEN, 0, 3, "this", Map("sentence" -> "0")),
       Annotation(TOKEN, 5, 6, "is", Map("sentence" -> "0")),
       Annotation(TOKEN, 8, 9, "my", Map("sentence" -> "0")),
       Annotation(TOKEN, 11, 15, "third", Map("sentence" -> "0")),
       Annotation(TOKEN, 17, 25, "sentence.", Map("sentence" -> "0")),
-      Annotation(TOKEN, 0, 3, "this", Map("sentence" -> "1")),
-      Annotation(TOKEN, 5, 6, "is", Map("sentence" -> "1")),
-      Annotation(TOKEN, 8, 9, "my", Map("sentence" -> "1")),
-      Annotation(TOKEN, 11, 16, "forth.", Map("sentence" -> "1"))
+      Annotation(TOKEN, 27, 30, "this", Map("sentence" -> "1")),
+      Annotation(TOKEN, 32, 33, "is", Map("sentence" -> "1")),
+      Annotation(TOKEN, 35, 36, "my", Map("sentence" -> "1")),
+      Annotation(TOKEN, 38, 43, "forth.", Map("sentence" -> "1"))
     )
 
     val documentAssembler = new DocumentAssembler()
@@ -143,16 +143,9 @@ class RegexTokenizerTestSpec extends FlatSpec {
       .setPattern(pattern)
       .setPositionalMask(true)
 
-    //#.setSplitPattern("\s+|(?=[^a-zA-Z0-9_/])|(?<=[^a-zA-Z0-9_/])")
-    //#.setSplitPattern("\s+|(?=[-.:;*+,$&%\[\]])|(?<=[-.:;*+,$&%\[\]])")
-
     val pipeline = new Pipeline().setStages(Array(documentAssembler, sentenceDetect, tokenizer))
 
     val pipelineDF = pipeline.fit(data).transform(data)
-
-    //    pipelineDF.select("token").collect().foreach {
-    //      row => println(row.getSeq[Row](0).map(Annotation(_)).mkString("\n"))
-    //    }
 
     val expectedTokens = Seq(
       Annotation(TOKEN, 0, 0, "1", Map("sentence" -> "0")),


### PR DESCRIPTION
## Description
Fix to restore the actual regex tokenizer tag algorithm which is used by default.

## Motivation and Context
Fix is necessary to restore the existent tagging algorithm behavior.

## How Has This Been Tested?
Locally restoring the RegexTokenizer suite in regression tests.
Adding the new test for the new algorithm.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
