### PR TITLE
Fixing action default value in DocumentNormalizer Python wrapper

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -484,7 +484,7 @@ class DocumentNormalizer(AnnotatorModel):
     def __init__(self):
         super(DocumentNormalizer, self).__init__(classname="com.johnsnowlabs.nlp.annotators.DocumentNormalizer")
         self._setDefault(
-            action="clean_up",
+            action="clean",
             patterns=["<[^>]*>"],
             replacement=" ",
             lowercase=False,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Bugfix to change the default value for action parameter in Python wrapper for DocumentNormalizer annotator.

## Description
<!--- Describe your changes in detail -->
The DocumentNormalizer annotator Python wrapper has a default value for parameter action set to "clean_up" instead of "clean" so the bugfix is needed to let the default value work.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
User notification of the error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Scala code has been tested with unit tests, Python code has been tested with unit tests but both cases force explicit parameters not covering faulty default values.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
