### PR TITLE
Add anchorDate params to DateMatcher and MultiDateMatcher

### DIFF
--- a/docs/en/annotators.md
+++ b/docs/en/annotators.md
@@ -4,7 +4,7 @@ header: true
 title: Annotators
 permalink: /docs/en/annotators
 key: docs-annotators
-modify_date: "2021-01-23"
+modify_date: "2021-02-01"
 use_language_switcher: "Python-Scala"
 ---
 
@@ -72,6 +72,7 @@ The types are:
 |Chunker|Matches a pattern of part-of-speech tags in order to return meaningful phrases from document|Opensource|
 |NGramGenerator|integrates Spark ML NGram function into Spark ML with a new cumulative feature to also generate range ngrams like the scikit-learn library|Opensource|
 |DateMatcher|Reads from different forms of date and time expressions and converts them to a provided date format|Opensource|
+|MultiDateMatcher|Reads from multiple different forms of date and time expressions and converts them to a provided date format|Opensource|
 |SentenceDetector|Finds sentence bounds in raw text. Applies rules from Pragmatic Segmenter|Opensource|
 |POSTagger|Sets a Part-Of-Speech tag to each word within a sentence. |Opensource|
 |ViveknSentimentDetector|Scores a sentence for a sentiment|Opensource|
@@ -549,6 +550,9 @@ Reads from different forms of date and time expressions and converts them to a p
 **Functions:**
 
 - setDateFormat(format): SimpleDateFormat standard date *output* formatting. Defaults to yyyy/MM/dd
+- setAnchorDateYear: Add an anchor year for the relative dates such as a day after tomorrow. If not set it will use the current year. Example: 2021
+- setAnchorDateMonth: Add an anchor month for the relative dates such as a day after tomorrow. If not set it will use the current month. Example: 1 which means January
+- setAnchorDateDay: Add an anchor day of the day for the relative dates such as a day after tomorrow. If not set it will use the current day. Example: 11
 
 **Example:**
 
@@ -560,14 +564,81 @@ Refer to the [DateMatcher](https://nlp.johnsnowlabs.com/api/index#com.johnsnowla
 
 ```python
 date_matcher = DateMatcher() \
-    .setInputCols('document')
+    .setInputCols('document')\
     .setOutputCol("date") \
     .setDateFormat("yyyy/MM/dd")
 ```
 
 ```scala
 val dateMatcher = new DateMatcher()
-    .setInputCols('document')
+    .setInputCols("document")
+    .setOutputCol("date")
+    .setFormat("yyyyMM")
+```
+
+## MultiDateMatcher
+
+Reads from multiple different forms of date and time expressions and converts them to a provided date format. Extracts multiple dates per sentence.
+**Output type:** Date  
+**Input types:** Document  
+**Reference:** [MultiDateMatcher](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/MultiDateMatcher.scala)  
+**Reads the following kind of dates:**
+
+- 1978-01-28
+- 1984/04/02
+- 1/02/1980
+- 2/28/79
+- The 31st of April in the year 2008
+- Fri, 21 Nov 1997
+- Jan 21, '97
+- Sun, Nov 21
+- jan 1st
+- next thursday
+- last wednesday
+- today
+- tomorrow
+- yesterday
+- next week
+- next month
+- next year
+- day after
+- the day before
+- 0600h
+- 06:00 hours
+- 6pm
+- 5:30 a.m.
+- at 5
+- 12:59
+- 23:59
+- 1988/11/23 6pm
+- next week at 7.30
+- 5 am tomorrow
+  
+**Functions:**
+
+- setDateFormat(format): SimpleDateFormat standard date *output* formatting. Defaults to yyyy/MM/dd
+- setAnchorDateYear: Add an anchor year for the relative dates such as a day after tomorrow. If not set it will use the current year. Example: 2021
+- setAnchorDateMonth: Add an anchor month for the relative dates such as a day after tomorrow. If not set it will use the current month. Example: 1 which means January
+- setAnchorDateDay: Add an anchor day of the day for the relative dates such as a day after tomorrow. If not set it will use the current day. Example: 11
+
+**Example:**
+
+Refer to the [MultiDateMatcher](https://nlp.johnsnowlabs.com/api/index#com.johnsnowlabs.nlp.annotators.MultiDateMatcher) Scala docs for more details on the API.
+
+<div class="tabs-box" markdown="1">
+
+{% include programmingLanguageSelectScalaPython.html %}
+
+```python
+date_matcher = MultiDateMatcher() \
+    .setInputCols('document')\
+    .setOutputCol("date") \
+    .setDateFormat("yyyy/MM/dd")
+```
+
+```scala
+val dateMatcher = new MultiDateMatcher()
+    .setInputCols("document")
     .setOutputCol("date")
     .setFormat("yyyyMM")
 ```
@@ -575,7 +646,6 @@ val dateMatcher = new DateMatcher()
 </div></div><div class="h3-box" markdown="1">
 
 ## SentenceDetector
-
 
 Finds sentence bounds in raw text. Applies rules from Pragmatic Segmenter.  
 **Output type:** Sentence

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -678,6 +678,27 @@ class DateMatcherUtils(Params):
                                   typeConverter=TypeConverters.toInt
                                   )
 
+    anchorDateYear = Param(Params._dummy(),
+                           "anchorDateYear",
+                           "Add an anchor year for the relative dates such as a day after tomorrow. If not set it "
+                           "will use the current year. Example: 2021",
+                           typeConverter=TypeConverters.toInt
+                           )
+
+    anchorDateMonth = Param(Params._dummy(),
+                            "anchorDateMonth",
+                            "Add an anchor month for the relative dates such as a day after tomorrow. If not set it "
+                            "will use the current month. Example: 1 which means January",
+                            typeConverter=TypeConverters.toInt
+                            )
+
+    anchorDateDay = Param(Params._dummy(),
+                          "anchorDateDay",
+                          "Add an anchor day of the day for the relative dates such as a day after tomorrow. If not "
+                          "set it will use the current day. Example: 11",
+                          typeConverter=TypeConverters.toInt
+                          )
+
     def setFormat(self, value):
         return self._set(dateFormat=value)
 
@@ -686,6 +707,15 @@ class DateMatcherUtils(Params):
 
     def setDefaultDayWhenMissing(self, value):
         return self._set(defaultDayWhenMissing=value)
+
+    def setAnchorDateYear(self, value):
+        return self._set(anchorDateYear=value)
+
+    def setAnchorDateMonth(self, value):
+        return self._set(anchorDateMonth=value)
+
+    def setAnchorDateDay(self, value):
+        return self._set(anchorDateDay=value)
 
 
 class DateMatcher(AnnotatorModel, DateMatcherUtils):
@@ -698,7 +728,10 @@ class DateMatcher(AnnotatorModel, DateMatcherUtils):
         self._setDefault(
             dateFormat="yyyy/MM/dd",
             readMonthFirst=True,
-            defaultDayWhenMissing=1
+            defaultDayWhenMissing=1,
+            anchorDateYear=-1,
+            anchorDateMonth=-1,
+            anchorDateDay=-1
         )
 
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
@@ -61,7 +61,7 @@ trait DateMatcherUtils extends Params {
     * Default: -1
     * @group param
     **/
-  val anchorDateYear: Param[Int] = new Param(
+  val anchorDateYear: Param[Int] = new IntParam(
     this,
     "anchorDateYear",
     "Add an anchor year for the relative dates such as a day after tomorrow. If not set it will use the current year. Example: 2021"
@@ -83,7 +83,7 @@ trait DateMatcherUtils extends Params {
     * Default: -1
     * @group param
     **/
-  val anchorDateMonth: Param[Int] = new Param(
+  val anchorDateMonth: Param[Int] = new IntParam(
     this,
     "anchorDateMonth",
     "Add an anchor month for the relative dates such as a day after tomorrow. If not set it will use the current month. Example: 1 which means January"
@@ -107,7 +107,7 @@ trait DateMatcherUtils extends Params {
     * Default: -1
     * @group param
     **/
-  val anchorDateDay: Param[Int] = new Param(
+  val anchorDateDay: Param[Int] = new IntParam(
     this,
     "anchorDateDay",
     "Add an anchor day of the day for the relative dates such as a day after tomorrow. If not set it will use the current day. Example: 11"

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
@@ -2,7 +2,6 @@ package com.johnsnowlabs.nlp.annotators
 
 import java.util.Calendar
 
-import com.johnsnowlabs.nlp.AnnotatorType.DOCUMENT
 import com.johnsnowlabs.nlp.util.regex.{MatchStrategy, RuleFactory}
 import org.apache.spark.ml.param.{BooleanParam, IntParam, Param, Params}
 
@@ -42,10 +41,10 @@ trait DateMatcherUtils extends Params {
   private val altTime = new Regex("([0-2]?[0-9])\\.([0-5][0-9])\\.?([0-5][0-9])?", "hour", "minutes", "seconds")
   private val coordTIme = new Regex("([0-2]?[0-9])([0-5][0-9])?\\.?([0-5][0-9])?\\s*(?:h|a\\.?m|p\\.?m)", "hour", "minutes", "seconds")
   private val refTime = new Regex("at\\s+([0-9])\\s*([0-5][0-9])*\\s*([0-5][0-9])*")
-  protected val amDefinition = "(?i)(a\\.?m)".r
+  protected val amDefinition: Regex = "(?i)(a\\.?m)".r
 
   protected val defaultMonthWhenMissing = 0
-  protected val defaultYearWhenMissing = Calendar.getInstance.get(Calendar.YEAR)
+  protected val defaultYearWhenMissing: Int = Calendar.getInstance.get(Calendar.YEAR)
 
   /** Annotator param containing expected output format of parsed date*/
   val dateFormat: Param[String] = new Param(this, "dateFormat", "SimpleDateFormat standard criteria")
@@ -53,6 +52,75 @@ trait DateMatcherUtils extends Params {
   def getFormat: String = $(dateFormat)
 
   def setFormat(value: String): this.type = set(dateFormat, value)
+
+  /**
+    * Add an anchor year for the relative dates such as a day after tomorrow.
+    * If not set it will use the current year.
+    * Example: 2021
+    * By default it will use the current year
+    * Default: -1
+    * @group param
+    **/
+  val anchorDateYear: Param[Int] = new Param(
+    this,
+    "anchorDateYear",
+    "Add an anchor year for the relative dates such as a day after tomorrow. If not set it will use the current year. Example: 2021"
+  )
+
+  /** @group setParam **/
+  def setAnchorDateYear(value: Int): this.type = {
+    require(value <= 9999 || value >= 999 , "The year must be between 999 and 9999")
+    set(anchorDateYear, value)
+  }
+
+  /** @group getParam **/
+  def getAnchorDateYear: Int = $(anchorDateYear)
+
+  /**
+    * Add an anchor month for the relative dates such as a day after tomorrow.
+    * Month value is 1-based. e.g., 1 for January.
+    * By default it will use the current month
+    * Default: -1
+    * @group param
+    **/
+  val anchorDateMonth: Param[Int] = new Param(
+    this,
+    "anchorDateMonth",
+    "Add an anchor month for the relative dates such as a day after tomorrow. If not set it will use the current month. Example: 1 which means January"
+  )
+
+  /** @group setParam **/
+  def setAnchorDateMonth(value: Int): this.type = {
+    val normalizedMonth = value - 1
+    require(normalizedMonth <= 11 || normalizedMonth >= 0 , "The month value is 1-based. e.g., 1 for January. The value must be between 1 and 12")
+    set(anchorDateMonth, normalizedMonth)
+  }
+
+  /** @group getParam **/
+  def getAnchorDateMonth: Int = $(anchorDateMonth)
+
+  /**
+    * Add an anchor year for the relative dates such as a day after tomorrow.
+    * The first day of the month has value 1
+    * Example: 11
+    * By default it will use the current day
+    * Default: -1
+    * @group param
+    **/
+  val anchorDateDay: Param[Int] = new Param(
+    this,
+    "anchorDateDay",
+    "Add an anchor day of the day for the relative dates such as a day after tomorrow. If not set it will use the current day. Example: 11"
+  )
+
+  /** @group setParam **/
+  def setAnchorDateDay(value: Int): this.type = {
+    require(value <= 31 || value >= 1 , "The day value starts from 1. The value must be between 1 and 31")
+    set(anchorDateDay, value)
+  }
+
+  /** @group getParam **/
+  def getAnchorDateDay: Int = $(anchorDateDay)
 
   val readMonthFirst: BooleanParam = new BooleanParam(this, "readMonthFirst", "Whether to parse july 07/05/2015 or as 05/07/2015")
 
@@ -68,6 +136,9 @@ trait DateMatcherUtils extends Params {
 
   setDefault(
     dateFormat -> "yyyy/MM/dd",
+    anchorDateYear -> -1,
+    anchorDateMonth -> -1,
+    anchorDateDay -> -1,
     readMonthFirst -> true,
     defaultDayWhenMissing -> 1
   )
@@ -97,7 +168,7 @@ trait DateMatcherUtils extends Params {
     * Strategy used is to match first only. any other matches discarded
     * Auto completes short versions of months. Any two digit year is considered to be XX century
     */
-  protected val relaxedFactory = new RuleFactory(MatchStrategy.MATCH_FIRST)
+  protected val relaxedFactory: RuleFactory = new RuleFactory(MatchStrategy.MATCH_FIRST)
     .addRule(relaxedDayNumbered, "relaxed days")
     .addRule(relaxedMonths.r, "relaxed months exclusive")
     .addRule(relaxedYear, "relaxed year")
@@ -107,15 +178,15 @@ trait DateMatcherUtils extends Params {
     * Will always assume relative day from current time at processing
     * ToDo: Support relative dates from input date
     */
-  protected val relativeFactory = new RuleFactory(MatchStrategy.MATCH_FIRST)
+  protected val relativeFactory: RuleFactory = new RuleFactory(MatchStrategy.MATCH_FIRST)
     .addRule(relativeDate, "relative dates")
 
   /** Searches for relative informal dates such as today or the day after tomorrow */
-  protected val tyFactory = new RuleFactory(MatchStrategy.MATCH_FIRST)
+  protected val tyFactory: RuleFactory = new RuleFactory(MatchStrategy.MATCH_FIRST)
     .addRule(relativeDay, "relative days")
 
   /** Searches for exactly provided days of the week. Always relative from current time at processing */
-  protected val relativeExactFactory = new RuleFactory(MatchStrategy.MATCH_FIRST)
+  protected val relativeExactFactory: RuleFactory = new RuleFactory(MatchStrategy.MATCH_FIRST)
     .addRule(relativeExactDay, "relative precise dates")
 
   /**
@@ -124,11 +195,22 @@ trait DateMatcherUtils extends Params {
     * text target document
     * @return a final possible date if any found
     */
-  protected val timeFactory = new RuleFactory(MatchStrategy.MATCH_FIRST)
+  protected val timeFactory: RuleFactory = new RuleFactory(MatchStrategy.MATCH_FIRST)
     .addRule(clockTime, "standard time extraction")
     .addRule(altTime, "alternative time format")
     .addRule(coordTIme, "coordinate like time")
     .addRule(refTime, "referred time")
+
+  protected def calculateAnchorCalendar(): Calendar = {
+    val calendar = Calendar.getInstance()
+
+    val anchorYear = if ($(anchorDateYear) != -1) $(anchorDateYear) else calendar.get(Calendar.YEAR)
+    val anchorMonth = if ($(anchorDateMonth) != -1) $(anchorDateMonth) else calendar.get(Calendar.MONTH)
+    val anchorDay = if ($(anchorDateDay) != -1) $(anchorDateDay) else calendar.get(Calendar.DAY_OF_MONTH)
+
+    calendar.set(anchorYear, anchorMonth, anchorDay)
+    calendar
+  }
 
   protected def formalDateContentParse(date: RuleFactory.RuleMatch): MatchedDateTime = {
     val formalDate = date.content
@@ -164,36 +246,29 @@ trait DateMatcherUtils extends Params {
 
   def tomorrowYesterdayContentParse(date: RuleFactory.RuleMatch): MatchedDateTime = {
     val tyDate = date.content
+    val calendar = calculateAnchorCalendar()
     tyDate.matched.toLowerCase match {
       case "today" =>
-        val calendar = Calendar.getInstance()
         MatchedDateTime(calendar, tyDate.start, tyDate.end)
       case "tomorrow" =>
-        val calendar = Calendar.getInstance()
         calendar.add(Calendar.DAY_OF_MONTH, 1)
         MatchedDateTime(calendar, tyDate.start, tyDate.end)
       case "past tomorrow" =>
-        val calendar = Calendar.getInstance()
         calendar.add(Calendar.DAY_OF_MONTH, 2)
         MatchedDateTime(calendar, tyDate.start, tyDate.end)
       case "yesterday" =>
-        val calendar = Calendar.getInstance()
         calendar.add(Calendar.DAY_OF_MONTH, -1)
         MatchedDateTime(calendar, tyDate.start, tyDate.end)
       case "day after" =>
-        val calendar = Calendar.getInstance()
         calendar.add(Calendar.DAY_OF_MONTH, 1)
         MatchedDateTime(calendar, tyDate.start, tyDate.end)
       case "day before" =>
-        val calendar = Calendar.getInstance()
         calendar.add(Calendar.DAY_OF_MONTH, -1)
         MatchedDateTime(calendar, tyDate.start, tyDate.end)
       case "day after tomorrow" =>
-        val calendar = Calendar.getInstance()
         calendar.add(Calendar.DAY_OF_MONTH, 2)
         MatchedDateTime(calendar, tyDate.start, tyDate.end)
       case "day before yesterday" =>
-        val calendar = Calendar.getInstance()
         calendar.add(Calendar.DAY_OF_MONTH, -2)
         MatchedDateTime(calendar, tyDate.start, tyDate.end)
     }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
@@ -234,7 +234,7 @@ trait DateMatcherUtils extends Params {
 
   protected def relativeDateContentParse(date: RuleFactory.RuleMatch): MatchedDateTime = {
     val relativeDate = date.content
-    val calendar = Calendar.getInstance()
+    val calendar = calculateAnchorCalendar()
     val amount = if (relativeDate.group(1) == "next") 1 else -1
     relativeDate.group(2) match {
       case "week" => calendar.add(Calendar.WEEK_OF_MONTH, amount)
@@ -276,7 +276,7 @@ trait DateMatcherUtils extends Params {
 
   def relativeExactContentParse(possibleDate: RuleFactory.RuleMatch): MatchedDateTime = {
     val relativeDate = possibleDate.content
-    val calendar = Calendar.getInstance()
+    val calendar = calculateAnchorCalendar()
     val amount = if (relativeDate.group(1) == "next") 1 else -1
     calendar.add(Calendar.DAY_OF_MONTH, amount)
     relativeDate.group(2) match {

--- a/src/main/scala/com/johnsnowlabs/nlp/util/regex/RuleFactory.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/regex/RuleFactory.scala
@@ -5,10 +5,6 @@ import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.RuleSymbols
 import scala.util.matching.Regex
 
 /**
-  * Created by Saif Addin on 5/8/2017.
-  */
-
-/**
   * Regular Expressions rule manager. Applies rules based on Matching and Replacement strategies
   * @param matchStrategy How to decide on regex search
   * @param transformStrategy How to decide when replacing or transforming content with Regex

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/DateMatcherBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/DateMatcherBehaviors.scala
@@ -11,8 +11,8 @@ import scala.language.reflectiveCalls
 
 trait DateMatcherBehaviors extends FlatSpec {
   def fixture(dataset: Dataset[Row]) = new {
-    val df = AnnotatorBuilder.withDateMatcher(dataset)
-    val dateAnnotations = df.select("date")
+    val df: Dataset[Row] = AnnotatorBuilder.withDateMatcher(dataset)
+    val dateAnnotations: Array[Annotation] = df.select("date")
       .collect
       .flatMap { _.getSeq[Row](0) }
       .map { Annotation(_) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This commit adds `anchorDateYear`, `anchorDateMonth`, and `anchorDateDay` params to `DateMatcher` to set a base Date to relative dates. For instance, `tomorrow` can be a day after those dates or if they are not set it will be a day after the current date.

- [x] Add Scala APIs  to DateMatcher
- [x] Add Python APIs to DateMatcher
- [x] Add Scala APIs  to MultiDateMatcher
- [x] Add Python APIs to MultiDateMatcher
- [ ] Update documentation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
