### PR TITLE
bug fix for setOutputAsArray(false), add default parameters

### DIFF
--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -267,7 +267,9 @@ class Finisher(AnnotatorTransformer):
             cleanAnnotations=True,
             includeMetadata=False,
             outputAsArray=True,
-            parseEmbeddingsVectors=False
+            parseEmbeddingsVectors=False,
+            valueSplitSymbol="#",
+            annotationSplitSymbol="@"
         )
 
     @keyword_only

--- a/src/main/scala/com/johnsnowlabs/nlp/Finisher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Finisher.scala
@@ -49,7 +49,9 @@ class Finisher(override val uid: String)
     cleanAnnotations -> true,
     includeMetadata -> false,
     outputAsArray -> true,
-    parseEmbeddingsVectors -> false
+    parseEmbeddingsVectors -> false,
+    valueSplitSymbol -> "#",
+    annotationSplitSymbol -> "@"
   )
 
   def this() = this(Identifiable.randomUID("finisher"))

--- a/src/test/scala/com/johnsnowlabs/nlp/FinisherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/FinisherTestSpec.scala
@@ -49,6 +49,27 @@ class FinisherTestSpec extends FlatSpec {
     result.select("finished_token").as[String].collect.foreach(s => assert(s.contains("@"), "because @ separator string was not found"))
   }
 
+  "A Finisher with default settings without split parameters" should "return clean results" taggedAs FastTest in {
+
+    val finisher = new Finisher()
+      .setInputCols("token", "embeddings")
+      .setOutputAsArray(false)
+      .setIncludeMetadata(false)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        documentAssembler,
+        tokenizer,
+        embeddings,
+        finisher
+      ))
+
+    val result = pipeline.fit(data).transform(data)
+
+    assert(result.columns.length == 5, "because finisher did not clean annotations or did not return proper columns")
+    result.select("finished_token").as[String].collect.foreach(s => assert(s.contains("@"), "because @ separator string was not found"))
+  }
+
   "A Finisher with custom settings" should "behave accordingly" taggedAs FastTest in {
 
     val finisher = new Finisher()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add default parameters for the splitters in finisher (output as array)


## Motivation and Context
https://github.com/JohnSnowLabs/spark-nlp/issues/808

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
