### PR TITLE
Fixing functions utilities making udf untyped

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/functions.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/functions.scala
@@ -20,15 +20,11 @@ object functions {
     }
   }
 
-  def mapAnnotations[T](function: Seq[Annotation] => T, outputType: DataType): UserDefinedFunction = udf ( {
-    annotatorProperties: Seq[Row] =>
-      function(annotatorProperties.map(Annotation(_)))
-  }, outputType)
+  def mapAnnotations(function: Seq[Annotation] => Seq[Annotation]): UserDefinedFunction =
+    udf { annotatorProperties: Seq[Row] => function(annotatorProperties.map(Annotation(_))) }
 
-  def mapAnnotationsStrict(function: Seq[Annotation] => Seq[Annotation]): UserDefinedFunction = udf {
-    annotatorProperties: Seq[Row] =>
-      function(annotatorProperties.map(Annotation(_)))
-  }
+  def mapAnnotationsStrict(function: Seq[Annotation] => Seq[Annotation]): UserDefinedFunction =
+    udf { annotatorProperties: Seq[Row] => function(annotatorProperties.map(Annotation(_))) }
 
   implicit class MapAnnotations(dataset: DataFrame) {
     def mapAnnotationsCol[T: TypeTag](column: String, outputCol: String, function: Seq[Annotation] => T): DataFrame = {

--- a/src/test/scala/com/johnsnowlabs/nlp/FunctionsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/FunctionsTestSpec.scala
@@ -58,7 +58,7 @@ class FunctionsTestSpec extends FlatSpec {
 
     val udfed = data.select(mapAnnotations((annotations: Seq[Annotation]) => {
       annotations.filter(_.result == "JJ")
-    }, ArrayType(Annotation.dataType))(col("pos")))
+    })(col("pos")))
 
     val udfed2 = data.select(mapAnnotationsStrict((annotations: Seq[Annotation]) => {
       annotations.filter(_.result == "JJ")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
FIx to compile and execute functions utilities in Spark 3 TF 2 branch

## Description
<!--- Describe your changes in detail -->
Untyped UDF is no more allowed in new Scala version so we have to fix functions utilities methods signature to be compliant.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Making UDF untyped fixes the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Full non-regression tests are green for both Scala 2.11 and 2.12 .

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
