### PR TITLE
Shading Hadoop AWS and AWS Java SDK for better EMR intgration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,9 @@ resolvers in ThisBuild += "Maven Central" at "https://central.maven.org/maven2/"
 resolvers in ThisBuild += "Spring Plugins" at "http://repo.spring.io/plugins-release/"
 
 assemblyShadeRules in assembly := Seq(
-  ShadeRule.rename("org.apache.http.**" -> "org.apache.httpShaded@1").inAll
+  ShadeRule.rename("org.apache.http.**" -> "org.apache.httpShaded@1").inAll,
+  ShadeRule.rename("com.amazonaws.**" -> "com.amazonawsShaded@1").inAll
+  
 )
 
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(
@@ -129,14 +131,6 @@ lazy val testDependencies = Seq(
 lazy val utilDependencies = Seq(
   "com.typesafe" % "config" % "1.3.0",
   "org.rocksdb" % "rocksdbjni" % "6.5.3",
-  "org.apache.hadoop" % "hadoop-aws" %  "2.7.3"
-    exclude("com.fasterxml.jackson.core", "jackson-annotations")
-    exclude("com.fasterxml.jackson.core", "jackson-databind")
-    exclude("com.fasterxml.jackson.core", "jackson-core")
-    exclude("commons-configuration","commons-configuration")
-    exclude("com.amazonaws","aws-java-sdk-bundle")
-    exclude("com.amazonaws","aws-java-sdk")
-    exclude("org.apache.hadoop" ,"hadoop-common"),
   "com.amazonaws" % "aws-java-sdk" % "1.7.4"
     exclude("com.fasterxml.jackson.core", "jackson-annotations")
     exclude("com.fasterxml.jackson.core", "jackson-databind")


### PR DESCRIPTION
This PR will shade `hadoop-aws` and `aws-java-sdk` for outside of Spark NLP. Since Hadoop AWS and AWS Java SDK are presented in the classpath in EMR, we don't need to provide them. We only use these two within Spark NLP from now on.