### PR TITLE
Make Spark NLP on Apache Spark 3.0 a default package

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,10 +35,10 @@ jobs:
           brew install sbt
           sbt clean
           sbt compile
-          sbt -mem 4096 assemblyAndCopy
+          sbt -mem 4096 -Dis_spark24=true assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 2.4.x
         run: |
-          sbt -mem 4096 test
+          sbt -mem 4096 -Dis_spark24=true test
       - name: Test Spark NLP in Python - Apache Spark 2.4.x
         run: |
           cd python
@@ -101,12 +101,12 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.0.1
         run: |
           brew install sbt
-          sbt -Dis_spark30=true clean
-          sbt -Dis_spark30=true compile
-          sbt -mem 4096 -Dis_spark30=true assemblyAndCopy
+          sbt clean
+          sbt compile
+          sbt -mem 4096 assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.0.1
         run: |
-          sbt -mem 4096 -Dis_spark30=true test
+          sbt -mem 4096 test
       - name: Test Spark NLP in Python - Apache Spark 3.0.1
         run: |
           cd python

--- a/.gitignore
+++ b/.gitignore
@@ -323,3 +323,4 @@ tst_shortcut_sd/
 src/*/resources/*.classes
 /word_segmenter_metrics/
 /special_class.ser
+.bsp/sbt.json

--- a/build.sbt
+++ b/build.sbt
@@ -5,26 +5,25 @@ val spark23Ver = "2.3.4"
 val spark24Ver = "2.4.7"
 val spark30Ver = "3.0.1"
 
-val is_gpu = System.getProperty("is_gpu","false")
-val is_opt = System.getProperty("is_opt","false")
-val is_spark23 = System.getProperty("is_spark23","false")
-//TODO breaking with older spark Why???
-val is_spark30 = System.getProperty("is_spark30","false")
+val is_gpu = System.getProperty("is_gpu", "false")
+val is_opt = System.getProperty("is_opt", "false")
+val is_spark23 = System.getProperty("is_spark23", "false")
+val is_spark24 = System.getProperty("is_spark24", "false")
 
-def getSparkVersion(is_spark23: String, is_spark30: String): String = {
-  if(is_spark30 == "true") spark30Ver
+def getSparkVersion(is_spark23: String, is_spark24: String): String = {
+  if(is_spark24 == "true") spark24Ver
   else
-    if(is_spark23=="false") spark24Ver
-    else spark23Ver
+    if(is_spark23=="true") spark23Ver
+    else spark30Ver
 }
 
-val sparkVer = getSparkVersion(is_spark23, is_spark30)
+val sparkVer = getSparkVersion(is_spark23, is_spark24)
 /** ------- Spark version end ------- */
 
 /** ------- Scala version start ------- */
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.10"
-lazy val scalaVer = if(is_spark30 =="true") scala212 else scala211
+lazy val scalaVer = if(is_spark23 == "true" | is_spark24 == "true") scala211 else scala212
 
 lazy val supportedScalaVersions = List(scala212, scala211)
 
@@ -34,23 +33,23 @@ val scalaTestVersion = "3.0.0"
 
 /** Package attributes */
 
-def getPackageName(is_spark23: String, is_spark30: String, is_gpu: String): String = {
+def getPackageName(is_spark23: String, is_spark24: String, is_gpu: String): String = {
   if (is_gpu.equals("true") && is_spark23.equals("true")){
     "spark-nlp-gpu-spark23"
-  }else if (is_gpu.equals("true") && is_spark30.equals("true")){
-    "spark-nlp-gpu-spark30"
-  }else if (is_gpu.equals("true") && is_spark30.equals("false")){
+  }else if (is_gpu.equals("true") && is_spark24.equals("true")){
+    "spark-nlp-gpu-spark24"
+  }else if (is_gpu.equals("true") && is_spark24.equals("false")){
     "spark-nlp-gpu"
   }else if (is_gpu.equals("false") && is_spark23.equals("true")){
     "spark-nlp-spark23"
-  }else if (is_gpu.equals("false") && is_spark30.equals("true")){
-    "spark-nlp-spark30"
+  }else if (is_gpu.equals("false") && is_spark24.equals("true")){
+    "spark-nlp-spark24"
   }else{
     "spark-nlp"
   }
 }
 
-name:= getPackageName(is_spark23, is_spark30, is_gpu)
+name:= getPackageName(is_spark23, is_spark24, is_gpu)
 
 organization:= "com.johnsnowlabs.nlp"
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,6 @@ val scalaTestVersion = "3.0.0"
 
 
 /** Package attributes */
-
 def getPackageName(is_spark23: String, is_spark24: String, is_gpu: String): String = {
   if (is_gpu.equals("true") && is_spark23.equals("true")){
     "spark-nlp-gpu-spark23"
@@ -57,24 +56,26 @@ version := "3.0.0-rc1"
 
 scalaVersion in ThisBuild := scalaVer
 
-sparkVersion in ThisBuild := sparkVer
-
 scalacOptions in ThisBuild += "-target:jvm-1.8"
 
+/** DEPRECATED **/
 /** Spark-Package attributes */
+/*
+sparkVersion in ThisBuild := sparkVer
 spName in ThisBuild := "JohnSnowLabs/spark-nlp"
-
 sparkComponents in ThisBuild ++= Seq("mllib")
+spIncludeMaven in ThisBuild:= false
+spAppendScalaVersion := false
+ivyScala := ivyScala.value map {
+  _.copy(overrideScalaVersion = true)
+}
+*/
 
 licenses  += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")
 
-spIncludeMaven in ThisBuild:= false
-
-spAppendScalaVersion := false
-
 resolvers in ThisBuild += "Maven Central" at "https://central.maven.org/maven2/"
 
-resolvers in ThisBuild += "Spring Plugins" at "http://repo.spring.io/plugins-release/"
+resolvers in ThisBuild += "Spring Plugins" at "https://repo.spring.io/plugins-release/"
 
 resolvers in ThisBuild += "Another Maven" at "https://mvnrepository.com/artifact/"
 
@@ -87,10 +88,6 @@ assemblyOption in assembly := (assemblyOption in assembly).value.copy(
 )
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".sbtcredentials")
-
-ivyScala := ivyScala.value map {
-  _.copy(overrideScalaVersion = true)
-}
 
 /** Bintray settings */
 bintrayPackageLabels := Seq("nlp", "nlu",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.4.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,12 @@
-val scoverageVersion = "1.6.0"
+val scoverageVersion = "1.6.1"
 
 resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
 
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.6")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")
 
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 /** scoverage */
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % scoverageVersion)

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -37,31 +37,41 @@ sys.modules['com.johnsnowlabs.nlp.annotators.ws'] = annotator
 annotators = annotator
 embeddings = annotator
 
-def start(gpu=False, spark23=False):
+
+def start(gpu=False, spark23=False, spark24=False, memory="16G"):
     current_version = "3.0.0-rc1"
 
-    maven_spark24 = "com.johnsnowlabs.nlp:spark-nlp_2.11:{}".format(current_version)
-    maven_gpu_spark24 = "com.johnsnowlabs.nlp:spark-nlp-gpu_2.11:{}".format(current_version)
+    # Spark NLP on Apache Spark 3.0.x
+    maven_spark = "com.johnsnowlabs.nlp:spark-nlp_2.12:{}".format(current_version)
+    maven_gpu_spark = "com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:{}".format(current_version)
+    # Spark NLP on Apache Spark 2.4.x
+    maven_spark24 = "com.johnsnowlabs.nlp:spark-nlp-spark24_2.11:{}".format(current_version)
+    maven_gpu_spark24 = "com.johnsnowlabs.nlp:spark-nlp-gpu-spark24_2.11:{}".format(current_version)
+    # Spark NLP on Apache Spark 2.3.x
     maven_spark23 = "com.johnsnowlabs.nlp:spark-nlp-spark23_2.11:{}".format(current_version)
     maven_gpu_spark23 = "com.johnsnowlabs.nlp:spark-nlp-gpu-spark23_2.11:{}".format(current_version)
 
     builder = SparkSession.builder \
         .appName("Spark NLP") \
         .master("local[*]") \
-        .config("spark.driver.memory", "16G") \
+        .config("spark.driver.memory", memory) \
         .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer") \
-        .config("spark.kryoserializer.buffer.max", "1000M") \
+        .config("spark.kryoserializer.buffer.max", "2000M") \
         .config("spark.driver.maxResultSize", "0")
 
     if gpu and spark23:
         builder.config("spark.jars.packages", maven_gpu_spark23)
+    elif gpu and spark24:
+        builder.config("spark.jars.packages", maven_gpu_spark24)
     elif spark23:
         builder.config("spark.jars.packages", maven_spark23)
-    elif gpu:
-        builder.config("spark.jars.packages", maven_gpu_spark24)
-    else:
+    elif spark24:
         builder.config("spark.jars.packages", maven_spark24)
-        
+    elif gpu:
+        builder.config("spark.jars.packages", maven_gpu_spark)
+    else:
+        builder.config("spark.jars.packages", maven_spark)
+
     return builder.getOrCreate()
 
 

--- a/src/main/scala/com/johnsnowlabs/nlp/SparkNLP.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/SparkNLP.scala
@@ -13,7 +13,7 @@ object SparkNLP {
   val MavenGpuSpark23 = s"com.johnsnowlabs.nlp:spark-nlp-gpu-spark23_2.11:$currentVersion"
 
   /**
-    *
+    * Start SparkSession with Spark NLP
     * @param gpu start Spark NLP with GPU
     * @param spark23 start Spark NLP on Apache Spark 2.3.x
     * @param spark24 start Spark NLP on Apache Spark 2.4.x

--- a/src/main/scala/com/johnsnowlabs/nlp/SparkNLP.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/SparkNLP.scala
@@ -5,28 +5,42 @@ import org.apache.spark.sql.SparkSession
 object SparkNLP {
 
   val currentVersion = "3.0.0-rc1"
-  val MavenSpark24 = s"com.johnsnowlabs.nlp:spark-nlp_2.11:$currentVersion"
-  val MavenGpuSpark24 = s"com.johnsnowlabs.nlp:spark-nlp-gpu_2.11:$currentVersion"
+  val MavenSpark30 = s"com.johnsnowlabs.nlp:spark-nlp_2.12:$currentVersion"
+  val MavenGpuSpark30 = s"com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:$currentVersion"
+  val MavenSpark24 = s"com.johnsnowlabs.nlp:spark-nlp-spark24_2.11:$currentVersion"
+  val MavenGpuSpark24 = s"com.johnsnowlabs.nlp:spark-nlp-gpu-spark24_2.11:$currentVersion"
   val MavenSpark23 = s"com.johnsnowlabs.nlp:spark-nlp-spark23_2.11:$currentVersion"
   val MavenGpuSpark23 = s"com.johnsnowlabs.nlp:spark-nlp-gpu-spark23_2.11:$currentVersion"
 
-  def start(gpu:Boolean = false, spark23:Boolean = false): SparkSession = {
+  /**
+    *
+    * @param gpu start Spark NLP with GPU
+    * @param spark23 start Spark NLP on Apache Spark 2.3.x
+    * @param spark24 start Spark NLP on Apache Spark 2.4.x
+    * @param memory set driver memory for SparkSession
+    * @return SparkSession
+    */
+  def start(gpu: Boolean = false, spark23: Boolean = false, spark24: Boolean = false, memory: String = "16G"): SparkSession = {
     val build = SparkSession.builder()
       .appName("Spark NLP")
       .master("local[*]")
-      .config("spark.driver.memory", "16G")
+      .config("spark.driver.memory", memory)
       .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-      .config("spark.kryoserializer.buffer.max", "1000M")
+      .config("spark.kryoserializer.buffer.max", "2000M")
       .config("spark.driver.maxResultSize", "0")
 
     if(gpu & spark23){
       build.config("spark.jars.packages", MavenGpuSpark23)
+    } else if(gpu & spark24){
+      build.config("spark.jars.packages", MavenGpuSpark24)
     } else if(spark23){
       build.config("spark.jars.packages", MavenSpark23)
-    } else if(gpu){
-      build.config("spark.jars.packages", MavenGpuSpark24)
-    } else {
+    } else if(spark24){
       build.config("spark.jars.packages", MavenSpark24)
+    } else if(gpu){
+      build.config("spark.jars.packages", MavenGpuSpark30)
+    } else {
+      build.config("spark.jars.packages", MavenSpark30)
     }
 
     build.getOrCreate()

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserModelTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserModelTestSpec.scala
@@ -4,9 +4,11 @@ import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotator.PerceptronModel
 import com.johnsnowlabs.nlp.annotators.Tokenizer
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.SlowTest
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.ml.util.MLWriter
-import org.apache.spark.sql.{Dataset, Row, SparkSession}
+import org.apache.spark.sql.{Dataset, Row}
 import org.scalatest.FlatSpec
 
 import java.nio.file.{Files, Paths}
@@ -14,14 +16,7 @@ import scala.language.reflectiveCalls
 
 class DependencyParserModelTestSpec extends FlatSpec with DependencyParserBehaviors {
 
-  private val spark = SparkSession.builder()
-    .appName("benchmark")
-    .master("local[*]")
-    .config("spark.driver.memory", "4G")
-    .config("spark.kryoserializer.buffer.max", "200M")
-    .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
-    .getOrCreate()
-
+  private val spark = ResourceHelper.spark
   import spark.implicits._
 
   private val emptyDataSet = spark.createDataset(Seq.empty[String]).toDF("text")
@@ -72,8 +67,8 @@ class DependencyParserModelTestSpec extends FlatSpec with DependencyParserBehavi
 
   def getPerceptronModel: PerceptronModel = {
     val perceptronTagger = PerceptronModel.pretrained()
-          .setInputCols(Array("token", "sentence"))
-          .setOutputCol("pos")
+      .setInputCols(Array("token", "sentence"))
+      .setOutputCol("pos")
     perceptronTagger
   }
 
@@ -89,70 +84,62 @@ class DependencyParserModelTestSpec extends FlatSpec with DependencyParserBehavi
     }
   }
 
-  "A Dependency Parser (trained through TreeBank format file)" should behave like {
+  "DependencyParser" should "A Dependency Parser (trained through TreeBank format file)" taggedAs SlowTest in {
     val testDataSet: Dataset[Row] =
       AnnotatorBuilder.withTreeBankDependencyParser(DataBuilder.basicDataBuild(ContentProvider.depSentence))
     initialAnnotations(testDataSet)
   }
 
-  "A dependency parser (trained through TreeBank format file) with an input text of one sentence" should behave like {
+  "DependencyParser" should "A dependency parser (trained through TreeBank format file) with an input text of one sentence" taggedAs SlowTest in {
     val testDataSet = Seq("I saw a girl with a telescope").toDS.toDF("text")
 
     relationshipsBetweenWordsPredictor(testDataSet, pipelineTreeBank)
   }
 
-  "A dependency parser (trained through TreeBank format file) with input text of two sentences" should
+  "DependencyParser" should "A dependency parser (trained through TreeBank format file) with input text of two sentences" taggedAs SlowTest in {
     behave like {
-    val text = "I solved the problem with statistics. I saw a girl with a telescope"
-    val testDataSet = Seq(text).toDS.toDF("text")
-    relationshipsBetweenWordsPredictor(testDataSet, pipelineTreeBank)
+      val text = "I solved the problem with statistics. I saw a girl with a telescope"
+      val testDataSet = Seq(text).toDS.toDF("text")
+      relationshipsBetweenWordsPredictor(testDataSet, pipelineTreeBank)
+    }
+
+    "DependencyParser" should "A dependency parser (trained through TreeBank format file) with an input text of several rows" taggedAs SlowTest in {
+      val text = Seq(
+        "The most troublesome report may be the August merchandise trade deficit due out tomorrow",
+        "Meanwhile, September housing starts, due Wednesday, are thought to have inched upward",
+        "Book me the morning flight",
+        "I solved the problem with statistics")
+      val testDataSet = text.toDS.toDF("text")
+      relationshipsBetweenWordsPredictor(testDataSet, pipelineTreeBank)
+    }
+
+    "DependencyParser" should "A dependency parser (trained through Universal Dependencies format file) with an input text of one sentence" taggedAs SlowTest in {
+      val testDataSet = Seq(
+        "So what happened?",
+        "It should continue to be defanged.",
+        "That too was stopped."
+      ).toDS.toDF("text")
+      relationshipsBetweenWordsPredictor(testDataSet, pipelineConllU)
+    }
+
+    "DependencyParser" should "A dependency parser (trained through Universal Dependencies format file) with input text of two sentences" taggedAs SlowTest in {
+      val text = "I solved the problem with statistics. I saw a girl with a telescope"
+      val testDataSet = Seq(text).toDS.toDF("text")
+
+      relationshipsBetweenWordsPredictor(testDataSet, pipelineConllU)
+    }
+
+    "DependencyParser" should "A dependency parser (trained through Universal Dependencies format file) with an input text of several rows" taggedAs SlowTest in {
+      val text = Seq(
+        "The most troublesome report may be the August merchandise trade deficit due out tomorrow",
+        "Meanwhile, September housing starts, due Wednesday, are thought to have inched upward",
+        "Book me the morning flight",
+        "I solved the problem with statistics")
+      val testDataSet = text.toDS.toDF("text")
+
+      relationshipsBetweenWordsPredictor(testDataSet, pipelineConllU)
+    }
+
   }
-
-  "A dependency parser (trained through TreeBank format file) with an input text of several rows" should
-   behave like {
-
-    val text = Seq(
-      "The most troublesome report may be the August merchandise trade deficit due out tomorrow",
-      "Meanwhile, September housing starts, due Wednesday, are thought to have inched upward",
-      "Book me the morning flight",
-      "I solved the problem with statistics")
-    val testDataSet = text.toDS.toDF("text")
-    relationshipsBetweenWordsPredictor(testDataSet, pipelineTreeBank)
-  }
-
-  "A dependency parser (trained through Universal Dependencies format file) with an input text of one sentence" should
-    behave like {
-
-    val testDataSet = Seq(
-      "So what happened?",
-      "It should continue to be defanged.",
-      "That too was stopped."
-    ).toDS.toDF("text")
-    relationshipsBetweenWordsPredictor(testDataSet, pipelineConllU)
-  }
-
-  "A dependency parser (trained through Universal Dependencies format file) with input text of two sentences" should
-    behave like {
-
-    val text = "I solved the problem with statistics. I saw a girl with a telescope"
-    val testDataSet = Seq(text).toDS.toDF("text")
-
-    relationshipsBetweenWordsPredictor(testDataSet, pipelineConllU)
-
-  }
-
-  "A dependency parser (trained through Universal Dependencies format file) with an input text of several rows" should
-    behave like {
-
-    val text = Seq(
-      "The most troublesome report may be the August merchandise trade deficit due out tomorrow",
-      "Meanwhile, September housing starts, due Wednesday, are thought to have inched upward",
-      "Book me the morning flight",
-      "I solved the problem with statistics")
-    val testDataSet = text.toDS.toDF("text")
-
-    relationshipsBetweenWordsPredictor(testDataSet, pipelineConllU)
-  }
-
 
 }


### PR DESCRIPTION
Starting the Spark NLP 3.0.0 release the default Spark NLP packages will be based on Apache Spark 3.0.x and Scala 2.12. This means the following packages will be by default Apache Spark 3.0.x/Scala 2.12:

- `spark-nlp`
- `spark-nlp-gpu`

For Apache Spark 2.3.x and Apache Spark 2.4.x:

- `spark-nlp-spark23`
- `spark-nlp-spark24`
- `spark-nlp-gpu-spark23`
- `spark-nlp-gpu-spark24`

Spark NLP start functions in Python and Scala are also updated for these changes.
