### PR TITLE
Added error message handler at catalyst level in NorvigSweetingApproach

### DIFF
--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingBehaviors.scala
@@ -6,7 +6,7 @@ import com.johnsnowlabs.nlp.annotators.{Normalizer, Tokenizer}
 import com.johnsnowlabs.tags.FastTest
 import com.johnsnowlabs.util.PipelineModels
 import org.apache.spark.ml.Pipeline
-import org.apache.spark.sql.{Dataset, Row}
+import org.apache.spark.sql.{AnalysisException, Dataset, Row}
 import org.scalatest._
 
 trait NorvigSweetingBehaviors { this: FlatSpec =>
@@ -135,13 +135,13 @@ trait NorvigSweetingBehaviors { this: FlatSpec =>
   def raiseErrorWhenWrongColumnIsSent(): Unit = {
     "" should "raise an error when dataset without array annotation is used"  in {
       val trainDataSet = AnnotatorBuilder.getTrainingDataSet("src/test/resources/spell/sherlockholmes.txt")
-      val expectedErrorMessage = "Train dataset must have an array annotation type column"
+      val expectedErrorMessage = "need an array field but got string"
       val spell = new NorvigSweetingApproach()
         .setInputCols(Array("text"))
         .setOutputCol("spell")
         .setDictionary("src/test/resources/spell/words.txt")
 
-      val caught = intercept[IllegalArgumentException] {
+      val caught = intercept[AnalysisException] {
         spell.fit(trainDataSet)
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Error handler for NorvigSweetingApproach chaged in new Spark 3.1.1 version

## Description
<!--- Describe your changes in detail -->
The returned exception is now at catalyst level (AnalysisException).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Exception handling changed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All non-reg tests run successfully locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
