### PR TITLE
Added Spark cross version exception handler in Norvig Approach

### DIFF
--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingBehaviors.scala
@@ -144,7 +144,7 @@ trait NorvigSweetingBehaviors { this: FlatSpec =>
         spell.fit(trainDataSet)
       }
 
-      val expectedErrorMessage = caught match{
+      val expectedErrorMessage = caught match {
         case ex: AnalysisException => "need an array field but got string" // Spark 3.x
         case ex: IllegalArgumentException => "Train dataset must have an array annotation type column" // Spark 2.x
         case _ => new Exception("Unknown exception. Please check Spark version for correct handling.")

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingBehaviors.scala
@@ -135,14 +135,19 @@ trait NorvigSweetingBehaviors { this: FlatSpec =>
   def raiseErrorWhenWrongColumnIsSent(): Unit = {
     "" should "raise an error when dataset without array annotation is used"  in {
       val trainDataSet = AnnotatorBuilder.getTrainingDataSet("src/test/resources/spell/sherlockholmes.txt")
-      val expectedErrorMessage = "need an array field but got string"
       val spell = new NorvigSweetingApproach()
         .setInputCols(Array("text"))
         .setOutputCol("spell")
         .setDictionary("src/test/resources/spell/words.txt")
 
-      val caught = intercept[AnalysisException] {
+      val caught = intercept[Exception] {
         spell.fit(trainDataSet)
+      }
+
+      val expectedErrorMessage = caught match{
+        case ex: AnalysisException => "need an array field but got string" // Spark 3.x
+        case ex: IllegalArgumentException => "Train dataset must have an array annotation type column" // Spark 2.x
+        case _ => new Exception("Unknown exception. Please check Spark version for correct handling.")
       }
 
       assert(caught.getMessage == expectedErrorMessage)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Norvig Sweeter Approach test spec handle the exception differently when a dataset without array annotation is provided across Spark 2.x and 3.1.x versions.

## Description
<!--- Describe your changes in detail -->
Added a flow to handle both Spark 2.x and 3.x versions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Spark 3.1.x moved this exception handler to catalyst level.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Non regression locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
