### PR TITLE
fix shadding package

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ resolvers in ThisBuild += "Spring Plugins" at "http://repo.spring.io/plugins-rel
 
 assemblyShadeRules in assembly := Seq(
   ShadeRule.rename("org.apache.http.**" -> "org.apache.httpShaded@1").inAll,
-  ShadeRule.rename("com.amazonaws.**" -> "com.amazonawsShaded@1").inAll
+  ShadeRule.rename("com.amazonaws.**" -> "com.amazonaws.shaded.Shaded@1").inAll
   
 )
 


### PR DESCRIPTION
I shade the com.amazonaws. llibrary because in the spark-nlp-internal was a compilation error because that libary was a conflict.
## Description
I create a new rule in build sbt to shade in a proper way the com.amazonaws. 


## Motivation and Context
The new version of spark-nlp library doesnt work in spark-nlp-jsl because the are a conflict in the com.amazonaws libary y fix that using a new shade rule.

## How Has This Been Tested?
This change was tested manually on spark-nlp-jsl using the jar with the new change.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
