### PR TITLE
Add minLength and maxLength params to Normalizer

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -6,6 +6,7 @@ from test.base import *
 unittest.TextTestRunner().run(BasicAnnotatorsTestSpec())
 unittest.TextTestRunner().run(RegexMatcherTestSpec())
 unittest.TextTestRunner().run(TokenizerTestSpec())
+unittest.TextTestRunner().run(NormalizerTestSpec())
 unittest.TextTestRunner().run(ChunkTokenizerTestSpec())
 unittest.TextTestRunner().run(LemmatizerTestSpec())
 unittest.TextTestRunner().run(LemmatizerWithTrainingDataSetTestSpec())

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -531,13 +531,24 @@ class Normalizer(AnnotatorApproach):
                             "slang dictionary is a delimited text. needs 'delimiter' in options",
                             typeConverter=TypeConverters.identity)
 
+    minLength = Param(Params._dummy(),
+                      "minLength",
+                      "Set the minimum allowed legth for each token",
+                      typeConverter=TypeConverters.toInt)
+
+    maxLength = Param(Params._dummy(),
+                      "maxLength",
+                      "Set the maximum allowed legth for each token",
+                      typeConverter=TypeConverters.toInt)
+
     @keyword_only
     def __init__(self):
         super(Normalizer, self).__init__(classname="com.johnsnowlabs.nlp.annotators.Normalizer")
         self._setDefault(
             cleanupPatterns=["[^\\pL+]"],
             lowercase=False,
-            slangMatchCase=False
+            slangMatchCase=False,
+            minLength=0
         )
 
     def setCleanupPatterns(self, value):
@@ -551,6 +562,12 @@ class Normalizer(AnnotatorApproach):
         if "delimiter" not in opts:
             opts["delimiter"] = delimiter
         return self._set(slangDictionary=ExternalResource(path, read_as, opts))
+
+    def setMinLength(self, value):
+        return self._set(minLength=value)
+
+    def setMaxLength(self, value):
+        return self._set(maxLength=value)
 
     def _create_model(self, java_model):
         return NormalizerModel(java_model=java_model)
@@ -3198,10 +3215,10 @@ class WordSegmenterApproach(AnnotatorApproach):
 
     def getNIterations(self):
         return self.getOrDefault(self.nIterations)
-    
+
     def getFrequencyThreshold(self):
         return self.getOrDefault(self.frequencyThreshold)
-    
+
     def getAmbiguityThreshold(self):
         return self.getOrDefault(self.ambiguityThreshold)
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/NormalizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/NormalizerModel.scala
@@ -2,8 +2,8 @@ package com.johnsnowlabs.nlp.annotators
 
 import com.johnsnowlabs.nlp.AnnotatorType.TOKEN
 import com.johnsnowlabs.nlp.serialization.MapFeature
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, ParamsAndFeaturesReadable, HasSimpleAnnotate}
-import org.apache.spark.ml.param.{BooleanParam, StringArrayParam}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasSimpleAnnotate, ParamsAndFeaturesReadable}
+import org.apache.spark.ml.param.{BooleanParam, IntParam, StringArrayParam}
 import org.apache.spark.ml.util.Identifiable
 
 /**
@@ -33,12 +33,12 @@ class NormalizerModel(override val uid: String) extends AnnotatorModel[Normalize
   /** Output annotator type : TOKEN
     *
     * @group anno
-    **/
+    */
   override val outputAnnotatorType: AnnotatorType = TOKEN
   /** Input annotator type : TOKEN
     *
     * @group anno
-    **/
+    */
   override val inputAnnotatorTypes: Array[AnnotatorType] = Array(TOKEN)
 
   case class TokenizerAndNormalizerMap(beginTokenizer: Int, endTokenizer: Int, token: String,
@@ -47,66 +47,117 @@ class NormalizerModel(override val uid: String) extends AnnotatorModel[Normalize
   /** normalization regex patterns which match will be removed from token
     *
     * @group param
-    **/
+    */
   val cleanupPatterns = new StringArrayParam(this, "cleanupPatterns", "normalization regex patterns which match will be removed from token")
+
+  /**
+    * @group setParam
+    */
+  def setCleanupPatterns(value: Array[String]): this.type = set(cleanupPatterns, value)
+
+  /**
+    * @group setParam
+    */
+  def getCleanupPatterns: Array[String] = $(cleanupPatterns)
+
   /** whether to convert strings to lowercase
     *
     * @group param
-    **/
+    */
   val lowercase = new BooleanParam(this, "lowercase", "whether to convert strings to lowercase")
+
+  /**
+    *
+    * @group setParam
+    */
+  def setLowercase(value: Boolean): this.type = set(lowercase, value)
+
+  /**
+    *
+    * @group setParam
+    */
+  def getLowercase: Boolean = $(lowercase)
+
   /** slangDict
     *
     * @group param
-    **/
+    */
   protected val slangDict: MapFeature[String, String] = new MapFeature(this, "slangDict")
+
   /** whether or not to be case sensitive to match slangs. Defaults to false.
     *
     * @group param
-    **/
+    */
   val slangMatchCase = new BooleanParam(this, "slangMatchCase", "whether or not to be case sensitive to match slangs. Defaults to false.")
+
+  /**
+    *
+    * @group setParam
+    */
+  def setSlangMatchCase(value: Boolean): this.type = set(slangMatchCase, value)
+
+  /**
+    *
+    * @group getParam
+    */
+  def getSlangMatchCase: Boolean = $(slangMatchCase)
 
   def this() = this(Identifiable.randomUID("NORMALIZER"))
 
-  /** Regular expressions list for normalization, defaults [^A-Za-z]
-    * @group setParam
-    **/
-  def setCleanupPatterns(value: Array[String]): this.type = set(cleanupPatterns, value)
 
-  /** Regular expressions list for normalization, defaults [^A-Za-z]
-    * @group setParam
-    **/
-  def getCleanupPatterns: Array[String] = $(cleanupPatterns)
-
-  /** Lowercase tokens, default true
+  /**
     *
     * @group setParam
-    **/
-  def setLowercase(value: Boolean): this.type = set(lowercase, value)
-
-  /** Lowercase tokens, default true
-    *
-    * @group setParam
-    **/
-  def getLowercase: Boolean = $(lowercase)
-
-
-  /** Txt file with delimited words to be transformed into something else
-    *
-    * @group setParam
-    **/
+    */
   def setSlangDict(value: Map[String, String]): this.type = set(slangDict, value)
 
-  /** Whether to convert string to lowercase or not while checking
+
+  /** Set the minimum allowed length for each token
+    *
+    * @group Parameters
+    */
+  val minLength = new IntParam(this, "minLength", "Set the minimum allowed length for each token")
+
+  /**
     *
     * @group setParam
-    **/
-  def setSlangMatchCase(value: Boolean): this.type = set(slangMatchCase, value)
+    */
+  def setMinLength(value: Int): this.type = {
+    require(value >= 0, "minLength must be greater equal than 0")
+    require(value.isValidInt, "minLength must be Int")
+    set(minLength, value)
+  }
 
-  /** Whether to convert string to lowercase or not while checking
+  /**
     *
     * @group getParam
-    **/
-  def getSlangMatchCase: Boolean = $(slangMatchCase)
+    */
+  def getMinLength: Int = $(minLength)
+
+
+  /** Set the maximum allowed length for each token
+    *
+    * @group Parameters
+    */
+  val maxLength = new IntParam(this, "maxLength", "Set the maximum allowed length for each token")
+
+  /**
+    *
+    * @group setParam
+    */
+  def setMaxLength(value: Int): this.type = {
+    require(value >= ${
+      minLength
+    }, "maxLength must be greater equal than minLength")
+    require(value.isValidInt, "minLength must be Int")
+    set(maxLength, value)
+  }
+
+  /**
+    *
+    * @group getParam
+    */
+  def getMaxLength: Int = $(maxLength)
 
   def applyRegexPatterns(word: String): String = {
 
@@ -121,7 +172,7 @@ class NormalizerModel(override val uid: String) extends AnnotatorModel[Normalize
   /** Txt file with delimited words to be transformed into something else
     *
     * @group getParam
-    **/
+    */
   protected def getSlangDict: Map[String, String] = $$(slangDict)
 
   /** ToDo: Review implementation, Current implementation generates spaces between non-words, potentially breaking tokens */

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/NormalizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/NormalizerModel.scala
@@ -196,7 +196,7 @@ class NormalizerModel(override val uid: String) extends AnnotatorModel[Normalize
 
       val cased = if ($(lowercase)) cleaned.map(_.toLowerCase) else cleaned
 
-      cased.filter(_.nonEmpty).map { finalToken => {
+      cased.filter(t => t.nonEmpty && t.length >= $(minLength) && get(maxLength).forall(m => t.length <= m)).map { finalToken => {
         Annotation(
           outputAnnotatorType,
           originalToken.begin,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
@@ -107,16 +107,52 @@ class Tokenizer(override val uid: String) extends AnnotatorApproach[TokenizerMod
     * @group Parameters
     **/
   val suffixPattern: Param[String] = new Param[String](this, "suffixPattern", "Regex with groups and ends with \\z to match target suffix. Overrides contextCharacters Param")
+
   /** Set the minimum allowed length for each token
     *
     * @group Parameters
     **/
   val minLength = new IntParam(this, "minLength", "Set the minimum allowed length for each token")
+
+  /**
+    *
+    * @group setParam
+    **/
+  def setMinLength(value: Int): this.type = {
+    require(value >= 0, "minLength must be greater equal than 0")
+    require(value.isValidInt, "minLength must be Int")
+    set(minLength, value)
+  }
+
+  /**
+    *
+    * @group getParam
+    **/
+  def getMinLength(value: Int): Int = $(minLength)
+
   /** Set the maximum allowed length for each token
     *
     * @group Parameters
     **/
   val maxLength = new IntParam(this, "maxLength", "Set the maximum allowed length for each token")
+
+  /**
+    *
+    * @group setParam
+    **/
+  def setMaxLength(value: Int): this.type = {
+    require(value >= ${
+      minLength
+    }, "maxLength must be greater equal than minLength")
+    require(value.isValidInt, "minLength must be Int")
+    set(maxLength, value)
+  }
+
+  /**
+    *
+    * @group getParam
+    **/
+  def getMaxLength(value: Int): Int = $(maxLength)
 
 
   /**
@@ -335,40 +371,6 @@ class Tokenizer(override val uid: String) extends AnnotatorApproach[TokenizerMod
   def getSplitChars: Array[String] = {
     $(splitChars)
   }
-
-  /** Set the minimum allowed legth for each token
-    *
-    * @group setParam
-    **/
-  def setMinLength(value: Int): this.type = {
-    require(value >= 0, "minLength must be greater equal than 0")
-    require(value.isValidInt, "minLength must be Int")
-    set(minLength, value)
-  }
-
-  /** Get the minimum allowed legth for each token
-    *
-    * @group getParam
-    **/
-  def getMinLength(value: Int): Int = $(minLength)
-
-  /** Set the maximum allowed legth for each token
-    *
-    * @group setParam
-    **/
-  def setMaxLength(value: Int): this.type = {
-    require(value >= ${
-      minLength
-    }, "maxLength must be greater equal than minLength")
-    require(value.isValidInt, "minLength must be Int")
-    set(maxLength, value)
-  }
-
-  /** Get the maximum allowed legth for each token
-    *
-    * @group getParam
-    **/
-  def getMaxLength(value: Int): Int = $(maxLength)
 
   setDefault(
     inputCols -> Array(DOCUMENT),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Tokenizer has the ability to filter tokens by min and max lengths. However, Normalizer can break those tokens into other tokens which require to have independent min and max length params to control it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
