### PR TITLE
added proper conversions for Scala 2.11/2.12

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/parser/SpecialTokensParser.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/parser/SpecialTokensParser.scala
@@ -12,9 +12,9 @@ import com.johnsnowlabs.nlp.annotators.spell.context.WeightedLevenshtein
 import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.sql.{Encoder, Encoders, SparkSession}
 
-import scala.collection.JavaConversions._
-import scala.collection.mutable
 import scala.collection.mutable.Set
+import collection.JavaConverters._
+
 
 
 class TransducerSeqFeature(model: HasFeatures, override val name: String)
@@ -39,7 +39,7 @@ class TransducerSeqFeature(model: HasFeatures, override val name: String)
   }
 
   override def deserializeObject(spark: SparkSession, path: String, field: String): Option[Seq[SpecialClassParser]] = {
-    import scala.collection.JavaConversions._
+
     val uri = new java.net.URI(path.replaceAllLiterally("\\", "/"))
     val fs: FileSystem = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
     val dataPath = getFieldPath(path, field)
@@ -116,18 +116,18 @@ trait SpecialClassParser {
   def generateTransducer: ITransducer[Candidate]
 
   def replaceWithLabel(tmp: String): String = {
-    if(transducer.transduce(tmp, 0).toList.isEmpty)
+    if(!transducer.transduce(tmp, 0).iterator.hasNext)
       tmp
     else
       label
   }
 
   def setTransducer(t: ITransducer[Candidate]) = {
-      transducer = t
-      this
+    transducer = t
+    this
   }
 
-  def inVocabulary(word:String): Boolean = !transducer.transduce(word, 0).toList.isEmpty
+  def inVocabulary(word:String): Boolean = transducer.transduce(word, 0).iterator.hasNext
 }
 
 trait RegexParser extends SpecialClassParser {
@@ -135,15 +135,14 @@ trait RegexParser extends SpecialClassParser {
   var regex:String
 
   override def generateTransducer: ITransducer[Candidate] = {
-    import scala.collection.JavaConversions._
 
     // first step, enumerate the regular language
     val generator = new GreexGenerator(regex)
-    val matches = generator.generateAll
+    val matches = generator.generateAll.asScala
 
     // second step, create the transducer
     new TransducerBuilder().
-      dictionary(matches.toList.sorted, true).
+      dictionary(matches.toList.sorted.asJava, true).
       algorithm(Algorithm.STANDARD).
       defaultMaxDistance(maxDist).
       includeDistance(true).
@@ -157,11 +156,10 @@ trait VocabParser extends SpecialClassParser {
   var vocab: Set[String]
 
   def generateTransducer: ITransducer[Candidate] = {
-    import scala.collection.JavaConversions._
 
     // second step, create the transducer
     new TransducerBuilder().
-      dictionary(vocab.toList.sorted, true).
+      dictionary(vocab.toList.sorted.asJava, true).
       algorithm(Algorithm.STANDARD).
       defaultMaxDistance(maxDist).
       includeDistance(true).
@@ -256,7 +254,6 @@ class MainVocab() extends VocabParser with SerializableClass {
     serializeTransducer(aOutputStream, transducer)
   }
 }
-
 
 
 class NamesClass extends VocabParser with SerializableClass {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Scala/Java conversions that were used previously only worked with Scala 2.11.x. These changes enable using the same conversion code for 2.11/2.12.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
