### PR TITLE
Provide confidence scores for all available tags in NerDLModel and NerCrfModel

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/NerDatasetEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/NerDatasetEncoder.scala
@@ -1,6 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.nlp.annotators.common.WordpieceEmbeddingsSentence
+
+import scala.collection.Map
 
 class NerDatasetEncoder(val params: DatasetEncoderParams) extends Serializable {
 
@@ -10,16 +29,16 @@ class NerDatasetEncoder(val params: DatasetEncoderParams) extends Serializable {
     .map(p => (p._1, p._2 + 1))
     .toMap
 
-  val tag2Id = Map(params.defaultTag -> 0) ++ nonDefaultTags
-  val tags = tag2Id
+  val tag2Id: Map[String, Int] = Map(params.defaultTag -> 0) ++ nonDefaultTags
+  val tags: Array[String] = tag2Id
     .map(p => (p._2, p._1))
     .toArray
     .sortBy(p => p._1)
     .map(p => p._2)
 
-  val chars = params.chars.toArray
+  val chars: Array[Char] = params.chars.toArray
 
-  val char2Id = params.chars.zip(1 to params.chars.length).toMap
+  val char2Id: Map[Char, Int] = params.chars.zip(1 to params.chars.length).toMap
 
   def getOrElse[T](source: Array[T], i: Int, value: => T): T = {
     if (i < source.length)
@@ -45,7 +64,7 @@ class NerDatasetEncoder(val params: DatasetEncoderParams) extends Serializable {
       sentence =>
         val lengths = sentence.tokens.map(word => word.wordpiece.length)
         Range(0, maxSentenceLength)
-          .map{idx => getOrElse(lengths, idx, 0)}
+          .map { idx => getOrElse(lengths, idx, 0) }
           .toArray
     }
 
@@ -58,16 +77,16 @@ class NerDatasetEncoder(val params: DatasetEncoderParams) extends Serializable {
     val maxWordLength = wordLengths.flatten.max
 
     val wordEmbeddings =
-    Range(0, batchSize).map{i =>
-      val sentence = sentences(i)
-      Range(0, maxSentenceLength).map{j =>
-        if (j < sentence.tokens.length)
-          sentence.tokens(j).embeddings
-        else
-          params.emptyEmbeddings
+      Range(0, batchSize).map { i =>
+        val sentence = sentences(i)
+        Range(0, maxSentenceLength).map { j =>
+          if (j < sentence.tokens.length)
+            sentence.tokens(j).embeddings
+          else
+            params.emptyEmbeddings
 
+        }.toArray
       }.toArray
-    }.toArray
 
     val charIds =
       Range(0, batchSize).map { i =>
@@ -104,12 +123,18 @@ class NerDatasetEncoder(val params: DatasetEncoderParams) extends Serializable {
     )
   }
 
+  /**
+   * Converts Tag names to Identifiers
+   *
+   * @param tags batches of labels/classes for each sentence/document
+   * @return batches of tag ids for each sentence/document
+   */
   def encodeTags(tags: Array[Array[String]]): Array[Array[Int]] = {
     val batchSize = tags.length
     val maxSentence = tags.map(t => t.length).max
 
-    (0 until batchSize).map{i =>
-      (0 until maxSentence).map{j =>
+    (0 until batchSize).map { i =>
+      (0 until maxSentence).map { j =>
         val tag = getOrElse(tags(i), j, params.defaultTag)
         tag2Id.getOrElse(tag, 0)
       }.toArray
@@ -117,58 +142,67 @@ class NerDatasetEncoder(val params: DatasetEncoderParams) extends Serializable {
   }
 
   /**
-    * Converts Tag Identifiers to Source Names
-    *
-    * @param tagIds Tag Ids encoded for Tensorflow Model.
-    * @return Tag names
-    */
+   * Converts Tag Identifiers to Source Names
+   *
+   * @param tagIds Tag Ids encoded for Tensorflow Model.
+   * @return Tag names
+   */
   def decodeOutputData(tagIds: Array[Int]): Array[String] = {
     tagIds.map(id => getOrElse(tags, id, params.defaultTag))
   }
 
   /**
-    * Converts Tensorflow tags output to 2-dimensional Array with shape: (Batch, Sentence Length).
-    *
-    * @param tags 2-dimensional tensor in plain array
-    * @param sentenceLength Every sentence length (number of words).
-    * @return List of tags for each sentence
-    */
-  def convertBatchTags(tags: Array[String], sentenceLength: Array[Int], prob: Option[Seq[Double]]): Array[Array[(String, Option[Double])]] = {
-    val sentences = sentenceLength.length
-    val maxSentenceLength = tags.length / sentences
+   * Converts Tensorflow tags output to 2-dimensional Array with shape: (Batch, Sentence Length).
+   *
+   * @param predictedTags 2-dimensional tensor in plain array
+   * @param allTags All original tags
+   * @param sentenceLength Every sentence length (number of words).
+   * @return List of tags for each sentence
+   */
+  def convertBatchTags(predictedTags: Array[String],
+                       allTags: Array[String],
+                       sentenceLength: Array[Int],
+                       prob: Option[Seq[Array[Float]]]): Array[Array[(String, Option[Array[Map[String, String]]])]] = {
 
-    Range(0, sentences).map{i =>
-      Range(0, sentenceLength(i)).map{j => {
+    val sentences = sentenceLength.length
+    val maxSentenceLength = predictedTags.length / sentences
+
+    Range(0, sentences).map { i =>
+      Range(0, sentenceLength(i)).map { j => {
         val index = i * maxSentenceLength + j
-        (tags(index), prob.map(_(index)))
-      }}.toArray
+        val metaWithProb: Option[Array[Map[String, String]]] = {
+          if(prob.isDefined)
+            Some(allTags
+              .zipWithIndex
+              .map {case (t, i) => Map(t -> prob.map(_ (index)).getOrElse(Array.empty[String]).lift(i).getOrElse(0.0f).toString)})
+          else None
+        }
+
+        (predictedTags(index), metaWithProb)
+      }
+      }.toArray
     }.toArray
   }
 }
 
 /**
-  * Batch that contains data in Tensorflow input format.
-  */
-class NerBatch (
-  // Word vector representation. Shape: Batch x Max Sentence Length x Embeddings Dim
-  val wordEmbeddings: Array[Array[Array[Float]]],
-
-  // Char ids for every word in every sentence. Shape: Batch x Max Sentence Length x Max Word length
-  val charIds: Array[Array[Array[Int]]],
-
-  // Word Length of every sentence. Shape: Batch x Max Sentence Length
-  val wordLengths: Array[Array[Int]],
-
-  // Length of every batch sentence. Shape: Batch
-  val sentenceLengths: Array[Int],
-
-  // Max length of sentence
-  val maxLength: Int,
-
-  // Is current wordpiece is token start? Shape: Batch x Max Sentence Length
-  val isWordStart: Array[Array[Boolean]]
-)
-{
+ * Batch that contains data in Tensorflow input format.
+ *
+ * @param wordEmbeddings  Word vector representation. Shape: Batch x Max Sentence Length x Embeddings Dim
+ * @param charIds         Char ids for every word in every sentence. Shape: Batch x Max Sentence Length x Max Word length
+ * @param wordLengths     Word Length of every sentence. Shape: Batch x Max Sentence Length
+ * @param sentenceLengths Length of every batch sentence. Shape: Batch
+ * @param maxLength       Max length of sentence
+ * @param isWordStart     Is current wordpiece is token start? Shape: Batch x Max Sentence Length
+ */
+class NerBatch(
+                val wordEmbeddings: Array[Array[Array[Float]]],
+                val charIds: Array[Array[Array[Int]]],
+                val wordLengths: Array[Array[Int]],
+                val sentenceLengths: Array[Int],
+                val maxLength: Int,
+                val isWordStart: Array[Array[Boolean]]
+              ) {
   def batchSize: Int = wordEmbeddings.length
 }
 
@@ -176,7 +210,14 @@ object NerBatch {
   def empty = new NerBatch(Array.empty, Array.empty, Array.empty, Array.empty, 0, Array.empty)
 }
 
-
+/**
+ *
+ * @param tags list of unique tags
+ * @param chars list of unique characters
+ * @param emptyVector list of embeddings
+ * @param embeddingsDim dimension of embeddings
+ * @param defaultTag the default tag
+ */
 case class DatasetEncoderParams
 (
   tags: List[String],
@@ -185,5 +226,5 @@ case class DatasetEncoderParams
   embeddingsDim: Int,
   defaultTag: String = "O"
 ) {
-  val emptyEmbeddings = emptyVector.toArray
+  val emptyEmbeddings: Array[Float] = emptyVector.toArray
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/Tagged.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/Tagged.scala
@@ -1,10 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.common
 
 import com.johnsnowlabs.ml.crf.TextSentenceLabels
 import com.johnsnowlabs.nlp.Annotation
 import com.johnsnowlabs.nlp.AnnotatorType.{NAMED_ENTITY, POS}
 import com.johnsnowlabs.nlp.annotators.common.Annotated.{NerTaggedSentence, PosTaggedSentence}
-import org.apache.spark.sql.{DataFrame, Dataset, Row}
+import org.apache.spark.sql.{Dataset, Row}
+
+import scala.collection.Map
 import scala.util.Random
 
 
@@ -40,34 +59,38 @@ trait Tagged[T >: TaggedSentence <: TaggedSentence] extends Annotated[T] {
   }
 
   override def pack(items: Seq[T]): Seq[Annotation] = {
-    items.flatMap(item => item.indexedTaggedWords.map(tag =>
+    items.flatMap(item => item.indexedTaggedWords.map{ tag =>
+      val metadata =  if (tag.confidence.isDefined) {
+        Map("word" -> tag.word) ++ tag.confidence.getOrElse(Array.empty[Map[String, String]]).flatten
+      } else {
+        Map("word" -> tag.word) ++ Map.empty[String, String]
+      }
       new Annotation(
         annotatorType,
         tag.begin,
         tag.end,
         tag.tag,
-        Map("word" -> tag.word) ++ {
-          if (tag.confidence.isDefined)
-            Map("confidence" -> tag.confidence.get.toString)
-          else Map.empty[String, String]
-        })
-    ))
+        metadata
+      )
+    })
   }
 
   /**
-    * Method is usefull for testing.
-    * It's possible to collect:
-    * - correct labels TextSentenceLabels
-    * - and model prediction NerTaggedSentence
-    */
+   * Method is usefull for testing.
+   *
+   * @param dataset     dataset row
+   * @param taggedCols  list of tagged columns
+   * @param labelColumn label column
+   * @return
+   */
   def collectLabeledInstances(dataset: Dataset[Row],
-                          taggedCols: Seq[String],
-                          labelColumn: String): Array[(TextSentenceLabels, T)] = {
+                              taggedCols: Seq[String],
+                              labelColumn: String): Array[(TextSentenceLabels, T)] = {
 
     dataset
-      .select(labelColumn, taggedCols:_*)
+      .select(labelColumn, taggedCols: _*)
       .collect()
-      .flatMap{row =>
+      .flatMap { row =>
         val labelAnnotations = getAnnotations(row, 0)
         val sentenceAnnotations = (1 to taggedCols.length).flatMap(idx => getAnnotations(row, idx))
         val sentences = unpack(sentenceAnnotations)
@@ -80,12 +103,11 @@ trait Tagged[T >: TaggedSentence <: TaggedSentence] extends Annotated[T] {
     row.getAs[Seq[Row]](colNum).map(obj => Annotation(obj))
   }
 
-
   protected def getLabelsFromSentences(sentences: Seq[WordpieceEmbeddingsSentence],
                                        labelAnnotations: Seq[Annotation]): Seq[TextSentenceLabels] = {
     val sortedLabels = labelAnnotations.sortBy(a => a.begin).toArray
 
-    sentences.map{sentence =>
+    sentences.map { sentence =>
       // Extract labels only for wordpiece that are at the begin of tokens
       val tokens = sentence.tokens.filter(t => t.isWordStart)
       val labels = tokens.map { w =>
@@ -100,11 +122,10 @@ trait Tagged[T >: TaggedSentence <: TaggedSentence] extends Annotated[T] {
     }
   }
 
-
   protected def getLabelsFromTaggedSentences(sentences: Seq[TaggedSentence], labelAnnotations: Seq[Annotation]): Seq[TextSentenceLabels] = {
     val sortedLabels = labelAnnotations.sortBy(a => a.begin).toArray
 
-    sentences.map{sentence =>
+    sentences.map { sentence =>
       val labels = sentence.indexedTaggedWords.map { w =>
         val tag = Annotation.searchCoverage(sortedLabels, w.begin, w.end)
           .map(a => a.result)
@@ -118,11 +139,11 @@ trait Tagged[T >: TaggedSentence <: TaggedSentence] extends Annotated[T] {
   }
 }
 
-object PosTagged extends Tagged[PosTaggedSentence]{
+object PosTagged extends Tagged[PosTaggedSentence] {
   override def annotatorType: String = POS
 }
 
-object NerTagged extends Tagged[NerTaggedSentence]{
+object NerTagged extends Tagged[NerTaggedSentence] {
   override def annotatorType: String = NAMED_ENTITY
 
   def collectTrainingInstancesWithPos(dataset: Dataset[Row],
@@ -131,13 +152,13 @@ object NerTagged extends Tagged[NerTaggedSentence]{
   Array[(TextSentenceLabels, PosTaggedSentence, WordpieceEmbeddingsSentence)] = {
 
     val annotations = dataset
-      .select(labelColumn, posTaggedCols:_*)
+      .select(labelColumn, posTaggedCols: _*)
       .collect()
 
     annotations
-      .flatMap{row =>
+      .flatMap { row =>
         val labelAnnotations = this.getAnnotations(row, 0)
-        val sentenceAnnotations  = (1 to posTaggedCols.length).flatMap(idx => getAnnotations(row, idx))
+        val sentenceAnnotations = (1 to posTaggedCols.length).flatMap(idx => getAnnotations(row, idx))
         val sentences = PosTagged.unpack(sentenceAnnotations)
           .filter(s => s.indexedTaggedWords.nonEmpty)
           .sortBy(s => s.indexedTaggedWords.head.begin)
@@ -148,64 +169,59 @@ object NerTagged extends Tagged[NerTaggedSentence]{
 
         val labels = getLabelsFromTaggedSentences(sentences, labelAnnotations)
         labels.zip(sentences zip withEmbeddings)
-          .map{case (l, (s, w)) => (l, s, w)}
+          .map { case (l, (s, w)) => (l, s, w) }
       }
   }
 
-
-
-  /** FIXME: ColNums not always in the given order*/
+  /** FIXME: ColNums not always in the given order */
   def iterateOnDataframe(dataset: Dataset[Row],
                          sentenceCols: Seq[String],
                          labelColumn: String,
-                         batchSize:Int): Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]] = {
+                         batchSize: Int): Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]] = {
 
 
-      new Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]] {
+    new Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]] {
 
-        import com.johnsnowlabs.nlp.annotators.common.DatasetHelpers._
+      import com.johnsnowlabs.nlp.annotators.common.DatasetHelpers._
 
-        // Send batches, don't collect(), only keeping a single batch in memory anytime
-        val it = dataset
-          .select(labelColumn, sentenceCols: _*)
-          .randomize // to improve training
-          .toLocalIterator()
+      // Send batches, don't collect(), only keeping a single batch in memory anytime
+      val it = dataset
+        .select(labelColumn, sentenceCols: _*)
+        .randomize // to improve training
+        .toLocalIterator()
 
-        // create a batch
-        override def next(): Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = {
-          var count = 0
-          var thisBatch = Array.empty[(TextSentenceLabels, WordpieceEmbeddingsSentence)]
+      // create a batch
+      override def next(): Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)] = {
+        var count = 0
+        var thisBatch = Array.empty[(TextSentenceLabels, WordpieceEmbeddingsSentence)]
 
-          while (it.hasNext && count < batchSize) {
-            count += 1
-            val nextRow = it.next
+        while (it.hasNext && count < batchSize) {
+          count += 1
+          val nextRow = it.next
 
-            val labelAnnotations = getAnnotations(nextRow, 0)
-            val sentenceAnnotations = (1 to sentenceCols.length).flatMap(idx => getAnnotations(nextRow, idx))
-            val sentences = WordpieceEmbeddingsSentence.unpack(sentenceAnnotations)
-            val labels = getLabelsFromSentences(sentences, labelAnnotations)
-            val thisOne = labels.zip(sentences)
+          val labelAnnotations = getAnnotations(nextRow, 0)
+          val sentenceAnnotations = (1 to sentenceCols.length).flatMap(idx => getAnnotations(nextRow, idx))
+          val sentences = WordpieceEmbeddingsSentence.unpack(sentenceAnnotations)
+          val labels = getLabelsFromSentences(sentences, labelAnnotations)
+          val thisOne = labels.zip(sentences)
 
-            thisBatch = thisBatch ++ thisOne
-          }
-          thisBatch
+          thisBatch = thisBatch ++ thisOne
         }
-
-        override def hasNext: Boolean = it.hasNext
+        thisBatch
       }
+
+      override def hasNext: Boolean = it.hasNext
+    }
 
   }
 
-
-
-  /** FIXME: ColNums not always in the given order*/
-  def interateOnArray(inputArray: Array[Row],
-                      sentenceCols: Seq[String],
-                      labelColumn: String,
-                      batchSize:Int): Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]] = {
+  /** FIXME: ColNums not always in the given order */
+  def iterateOnArray(inputArray: Array[Row],
+                     sentenceCols: Seq[String],
+                     batchSize: Int): Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]] = {
     import com.johnsnowlabs.nlp.annotators.common.DatasetHelpers._
 
-     slice(Random.shuffle(inputArray.toSeq)
+    slice(Random.shuffle(inputArray.toSeq)
       .flatMap { row =>
         val labelAnnotations = this.getAnnotations(row, 0)
         val sentenceAnnotations = (1 to sentenceCols.length).flatMap(idx => getAnnotations(row, idx))
@@ -213,5 +229,5 @@ object NerTagged extends Tagged[NerTaggedSentence]{
         val labels = getLabelsFromSentences(sentences, labelAnnotations)
         labels.zip(sentences)
       }, batchSize)
-    }
+  }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TaggedSentence.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TaggedSentence.scala
@@ -1,8 +1,21 @@
-package com.johnsnowlabs.nlp.annotators.common
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-/**
-  * Created by Saif Addin on 5/20/2017.
-  */
+package com.johnsnowlabs.nlp.annotators.common
 
 /**
   * Structure to hold Sentences as list of words and POS-tags

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TaggedWord.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/TaggedWord.scala
@@ -1,15 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.common
 
 import scala.collection.Map
-
-/**
-  * Created by Saif Addin on 5/20/2017.
-  */
 
 /** Word tag pair */
 case class TaggedWord(word: String, tag: String)
 
 case class IndexedTaggedWord(word: String, tag: String, begin: Int = 0, end: Int = 0,
-                             confidence: Option[Float] = None, metadata: Map[String, String] = Map()) {
+                             confidence: Option[Array[Map[String, String]]] = None, metadata: Map[String, String] = Map()) {
   def toTaggedWord: TaggedWord = TaggedWord(this.word, this.tag)
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfApproach.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.ner.crf
 
 import com.johnsnowlabs.ml.crf.{CrfParams, LinearChainCrf}
@@ -8,14 +25,11 @@ import com.johnsnowlabs.nlp.annotators.param.ExternalResourceParam
 import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs}
 import com.johnsnowlabs.nlp.{AnnotatorApproach, AnnotatorType}
 import com.johnsnowlabs.storage.HasStorageRef
+
 import org.apache.spark.ml.PipelineModel
 import org.apache.spark.ml.param.{BooleanParam, DoubleParam, IntParam}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.sql.Dataset
-
-/*
-
-   */
 
 /**
   * Algorithm for training Named Entity Recognition Model
@@ -38,12 +52,12 @@ class NerCrfApproach(override val uid: String)
     *
     * @group anno
     **/
-  override val inputAnnotatorTypes = Array(DOCUMENT, TOKEN, POS, WORD_EMBEDDINGS)
+  override val inputAnnotatorTypes: Array[String] = Array(DOCUMENT, TOKEN, POS, WORD_EMBEDDINGS)
   /** Input annotator types : NAMED_ENTITY
     *
     * @group anno
     **/
-  override val outputAnnotatorType = NAMED_ENTITY
+  override val outputAnnotatorType: AnnotatorType = NAMED_ENTITY
 
   /** L2 regularization coefficient
     *

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfModel.scala
@@ -28,79 +28,81 @@ import org.apache.spark.ml.param.{BooleanParam, StringArrayParam}
 import org.apache.spark.ml.util._
 import org.apache.spark.sql.Dataset
 
+import scala.collection.Map
+
 
 /**
-  * Algorithm for training Named Entity Recognition Model
-  *
-  * This Named Entity recognition annotator allows for a generic model to be trained by utilizing a CRF machine learning algorithm. Its train data (train_ner) is either a labeled or an external CoNLL 2003 IOB based spark dataset with Annotations columns. Also the user has to provide word embeddings annotation column.
-  * Optionally the user can provide an entity dictionary file for better accuracy
-  *
-  * See [[https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/crf]] for further reference on this API.
-  */
+ * Algorithm for training Named Entity Recognition Model
+ *
+ * This Named Entity recognition annotator allows for a generic model to be trained by utilizing a CRF machine learning algorithm. Its train data (train_ner) is either a labeled or an external CoNLL 2003 IOB based spark dataset with Annotations columns. Also the user has to provide word embeddings annotation column.
+ * Optionally the user can provide an entity dictionary file for better accuracy
+ *
+ * See [[https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/crf]] for further reference on this API.
+ */
 class NerCrfModel(override val uid: String) extends AnnotatorModel[NerCrfModel] with HasSimpleAnnotate[NerCrfModel] with HasStorageRef {
 
   def this() = this(Identifiable.randomUID("NER"))
 
   /** List of Entities to recognize
-    *
-    * @group param
-    **/
+   *
+   * @group param
+   **/
   val entities = new StringArrayParam(this, "entities", "List of Entities to recognize")
   /** crfModel
-    *
-    * @group param
-    **/
+   *
+   * @group param
+   **/
   val model: StructFeature[LinearChainCrfModel] = new StructFeature[LinearChainCrfModel](this, "crfModel")
   /** dictionaryFeatures
-    *
-    * @group param
-    **/
+   *
+   * @group param
+   **/
   val dictionaryFeatures: MapFeature[String, String] = new MapFeature[String, String](this, "dictionaryFeatures")
   /** whether or not to calculate prediction confidence by token, includes in metadata
-    *
-    * @group param
-    **/
+   *
+   * @group param
+   **/
   val includeConfidence = new BooleanParam(this, "includeConfidence", "whether or not to calculate prediction confidence by token, includes in metadata")
 
   /** A  LinearChainCrfModel
-    *
-    * @group setParam
-    **/
+   *
+   * @group setParam
+   **/
   def setModel(crf: LinearChainCrfModel): NerCrfModel = set(model, crf)
 
   /** DictionaryFeatures
-    *
-    * @group setParam
-    **/
+   *
+   * @group setParam
+   **/
   def setDictionaryFeatures(dictFeatures: DictionaryFeatures): this.type = set(dictionaryFeatures, dictFeatures.dict)
 
   /** Entities to detect
-    *
-    * @group setParam
-    **/
+   *
+   * @group setParam
+   **/
   def setEntities(toExtract: Array[String]): NerCrfModel = set(entities, toExtract)
 
   /** Whether or not to calculate prediction confidence by token, includes in metadata
-    *
-    * @group setParam
-    **/
+   *
+   * @group setParam
+   **/
   def setIncludeConfidence(c: Boolean): this.type = set(includeConfidence, c)
 
   /** Whether or not to calculate prediction confidence by token, includes in metadata
-    *
-    * @group getParam
-    **/
+   *
+   * @group getParam
+   **/
   def getIncludeConfidence: Boolean = $(includeConfidence)
 
   setDefault(dictionaryFeatures, () => Map.empty[String, String])
   setDefault(includeConfidence, false)
 
   /**
-    * Predicts Named Entities in input sentences
-    *
-    * @param sentences POS tagged sentences.
-    * @return sentences with recognized Named Entities
-    */
+   * Predicts Named Entities in input sentences
+   *
+   * @param sentences POS tagged and WordpieceEmbeddings sentences
+   * @return sentences with recognized Named Entities
+   */
   def tag(sentences: Seq[(PosTaggedSentence, WordpieceEmbeddingsSentence)]): Seq[NerTaggedSentence] = {
     require(model.isSet, "model must be set before tagging")
 
@@ -125,15 +127,17 @@ class NerCrfModel(override val uid: String) extends AnnotatorModel[NerCrfModel] 
           val label = crf.metadata.labels(labelId)
 
           val alpha = if ($(includeConfidence)) {
-            Some(confidenceValues.apply(idx).max)
+            val scores = Some(confidenceValues.apply(idx))
+            Some(crf.metadata.labels
+              .zipWithIndex
+              .filter(x=> x._2 != 0)
+              .map {case (t, i) => Map(t -> scores.getOrElse(Array.empty[String]).lift(i).getOrElse(0.0f).toString)})
           } else None
-          //ToDo fix this part to match NerDLModel confidence scores
-          if (!isDefined(entities) || $(entities).isEmpty || $(entities).contains(label)) {
-            Some(IndexedTaggedWord(word.word, label, word.begin, word.end, None))
-          }
-          else {
+
+          if (!isDefined(entities) || $(entities).isEmpty || $(entities).contains(label))
+            Some(IndexedTaggedWord(word.word, label, word.begin, word.end, alpha))
+          else
             None
-          }
         }
 
       TaggedSentence(words)
@@ -154,14 +158,14 @@ class NerCrfModel(override val uid: String) extends AnnotatorModel[NerCrfModel] 
 
   def shrink(minW: Float): NerCrfModel = set(model, $$(model).shrink(minW))
 
-  override val inputAnnotatorTypes = Array(DOCUMENT, TOKEN, POS, WORD_EMBEDDINGS)
+  override val inputAnnotatorTypes: Array[String] = Array(DOCUMENT, TOKEN, POS, WORD_EMBEDDINGS)
 
   override val outputAnnotatorType: AnnotatorType = NAMED_ENTITY
 
 }
 
 trait ReadablePretrainedNerCrf extends ParamsAndFeaturesReadable[NerCrfModel] with HasPretrained[NerCrfModel] {
-  override val defaultModelName = Some("ner_crf")
+  override val defaultModelName: Option[String] = Some("ner_crf")
   /** Java compliant-overrides */
   override def pretrained(): NerCrfModel = super.pretrained()
   override def pretrained(name: String): NerCrfModel = super.pretrained(name)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfModel.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.ner.crf
 
 import com.johnsnowlabs.ml.crf.{FbCalculator, LinearChainCrfModel}
@@ -110,9 +127,9 @@ class NerCrfModel(override val uid: String) extends AnnotatorModel[NerCrfModel] 
           val alpha = if ($(includeConfidence)) {
             Some(confidenceValues.apply(idx).max)
           } else None
-
+          //ToDo fix this part to match NerDLModel confidence scores
           if (!isDefined(entities) || $(entities).isEmpty || $(entities).contains(label)) {
-            Some(IndexedTaggedWord(word.word, label, word.begin, word.end, alpha))
+            Some(IndexedTaggedWord(word.word, label, word.begin, word.end, None))
           }
           else {
             None

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -410,7 +410,7 @@ class NerDLApproach(override val uid: String)
   }
 
 
-  def getIteratorFunc(dataset:Dataset[Row]) = {
+  def getIteratorFunc(dataset:Dataset[Row]): () => Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]] = {
 
     if ($(enableMemoryOptimizer)) {
       () => NerTagged.iterateOnDataframe(dataset, getInputCols, $(labelColumn), $(batchSize))
@@ -420,7 +420,7 @@ class NerDLApproach(override val uid: String)
         .select($(labelColumn), getInputCols.toSeq: _*)
         .collect()
 
-      () => NerTagged.interateOnArray(inMemory, getInputCols, $(labelColumn), $(batchSize))
+      () => NerTagged.iterateOnArray(inMemory, getInputCols, $(batchSize))
 
     }
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.ner.dl
 
 import com.johnsnowlabs.ml.tensorflow._
@@ -9,6 +26,7 @@ import com.johnsnowlabs.nlp.annotators.ner.Verbose
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
 import com.johnsnowlabs.nlp.serialization.StructFeature
 import com.johnsnowlabs.storage.HasStorageRef
+
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.param.{BooleanParam, FloatParam, IntArrayParam, StringArrayParam}
 import org.apache.spark.ml.util.Identifiable
@@ -143,7 +161,7 @@ class NerDLModel(override val uid: String)
         val token = sentence.tokens(j)
         val label = labels(i)(j)
         if (token.isWordStart) {
-          Some(IndexedTaggedWord(token.token, label._1, token.begin, token.end, label._2.map(_.toFloat)))
+          Some(IndexedTaggedWord(token.token, label._1, token.begin, token.end, label._2))
         }
         else {
           None

--- a/src/test/scala/com/johnsnowlabs/benchmarks/spark/NerDLCoNLL2003.scala
+++ b/src/test/scala/com/johnsnowlabs/benchmarks/spark/NerDLCoNLL2003.scala
@@ -1,17 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.benchmarks.spark
 
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotators.common.NerTagged
 import com.johnsnowlabs.nlp.annotators.ner.dl.{NerDLApproach, NerDLModel}
 import com.johnsnowlabs.nlp.annotators.ner.{NerConverter, Verbose}
+import com.johnsnowlabs.nlp.embeddings.WordEmbeddingsModel
 import com.johnsnowlabs.nlp.training.CoNLL
-import com.johnsnowlabs.nlp.embeddings.WordEmbeddings
 import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs}
 import org.apache.spark.ml.PipelineModel
 
 
-object NerDLPipeline extends App {
-  val folder = "./"
+object NerDLCoNLL2003 extends App {
+  val folder = "src/test/resources/conll2003/"
 
   val trainFile = ExternalResource(folder + "eng.train", ReadAs.TEXT, Map.empty[String, String])
   val testFileA = ExternalResource(folder + "eng.testa", ReadAs.TEXT, Map.empty[String, String])
@@ -21,9 +38,7 @@ object NerDLPipeline extends App {
 
   def createPipeline() = {
 
-    val glove = new WordEmbeddings()
-      .setStoragePath("glove.6B.100d.txt", "TEXT")
-      .setDimension(100)
+    val glove = WordEmbeddingsModel.pretrained()
       .setInputCols("sentence", "token")
       .setOutputCol("glove")
 
@@ -82,7 +97,7 @@ object NerDLPipeline extends App {
     val df = nerReader.readDataset(SparkAccessor.benchmarkSpark, file.path).toDF()
     val transformed = model.transform(df)
 
-    val labeled = NerTagged.interateOnArray(transformed.collect(), Seq("sentence", "token", "glove"), "label", 2)
+    val labeled = NerTagged.iterateOnArray(transformed.collect(), Seq("sentence", "token", "glove"), 2)
 
     ner.measure(labeled, extended, outputLogsPath = "")
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/SparkAccessor.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/SparkAccessor.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp
 
 import org.apache.spark.sql.SparkSession
@@ -7,7 +24,8 @@ object SparkAccessor {
     .builder()
     .appName("test")
     .master("local[*]")
-    .config("spark.driver.memory", "4G")
+    .config("spark.driver.memory", "16G")
+    .config("spark.driver.maxResultSize", "0")
     .config("spark.kryoserializer.buffer.max","200M")
     .config("spark.serializer","org.apache.spark.serializer.KryoSerializer")
     .getOrCreate()
@@ -17,7 +35,8 @@ object SparkAccessor {
     .builder()
     .appName("benchmark")
     .master("local[*]")
-    .config("spark.driver.memory", "8G")
+    .config("spark.driver.memory", "16G")
+    .config("spark.driver.maxResultSize", "0")
     .config("spark.kryoserializer.buffer.max","200M")
     .config("spark.serializer","org.apache.spark.serializer.KryoSerializer")
     .getOrCreate()

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfApproachTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfApproachTestSpec.scala
@@ -1,19 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.ner.crf
 
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.tags.{FastTest, SlowTest}
+
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.scalatest.FlatSpec
 
 class NerCrfApproachTestSpec extends FlatSpec {
-  val spark = SparkAccessor.spark
+  val spark: SparkSession = SparkAccessor.spark
 
-  val nerSentence = DataBuilder.buildNerDataset(ContentProvider.nerCorpus)
+  val nerSentence: Dataset[Row] = DataBuilder.buildNerDataset(ContentProvider.nerCorpus)
   //  System.out.println(s"number of sentences in dataset ${nerSentence.count()}")
 
   // Dataset ready for NER tagger
-  val nerInputDataset = AnnotatorBuilder.withGlove(nerSentence)
+  val nerInputDataset: Dataset[Row] = AnnotatorBuilder.withGlove(nerSentence)
   //  System.out.println(s"number of sentences in dataset ${nerInputDataset.count()}")
-  val nerModel = AnnotatorBuilder.getNerCrfModel(nerSentence)
+  val nerModel: NerCrfModel = AnnotatorBuilder.getNerCrfModel(nerSentence)
 
   "NerCrfApproach" should "be serializable and deserializable correctly" taggedAs SlowTest in {
     nerModel.write.overwrite.save("./test_crf_pipeline")

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfCustomCase.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfCustomCase.scala
@@ -20,7 +20,6 @@ package com.johnsnowlabs.nlp.annotators.ner.crf
 import com.johnsnowlabs.nlp.embeddings.WordEmbeddingsModel
 import com.johnsnowlabs.nlp.training.CoNLL
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.nlp.{Finisher, LightPipeline}
 import com.johnsnowlabs.tags.SlowTest
 
 import org.apache.spark.ml.{Pipeline, PipelineModel}
@@ -33,11 +32,11 @@ class NerCrfCustomCase extends FlatSpec {
   val spark: SparkSession = ResourceHelper.spark
 
 
-  "NerCRF" should "read low trained model" taggedAs SlowTest in {
+  "NerCRF" should "train CoNLL dataset" taggedAs SlowTest in {
 
 
     val conll = CoNLL()
-    val test_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.testb")
+    val test_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.train")
 
     val embeddings = WordEmbeddingsModel.pretrained()
       .setInputCols("token", "sentence")
@@ -47,32 +46,30 @@ class NerCrfCustomCase extends FlatSpec {
       .setInputCols("pos", "token", "sentence", "embeddings")
       .setOutputCol("ner")
       .setLabelColumn("label")
-      .setMaxEpochs(5)
-
-    val finisher = new Finisher()
-      .setInputCols("ner")
+      .setMaxEpochs(50)
 
     val pipeline = new Pipeline()
       .setStages(Array(
         embeddings,
-        nerCrf,
-        finisher
+        nerCrf
       ))
 
     val model = pipeline.fit(test_data)
 
-    model.write.overwrite().save("./crfnerconll")
-    model.stages(4).asInstanceOf[NerCrfModel].write.overwrite().save("./crfnerconll-single")
+    model.write.overwrite().save("./tmp_nercrfpipeline")
+    model.stages(1).asInstanceOf[NerCrfModel].write.overwrite().save("./tmp_nercrfmodel")
 
   }
 
-  "NerCRF" should "read and predict" taggedAs SlowTest in {
-    val lp = new LightPipeline(PipelineModel.load("./crfnerconll"))
+  "NerCRF" should "load saved model and predict" taggedAs SlowTest in {
 
-    println(lp.annotate(
-      "Lung, right lower lobe, lobectomy: Grade 3"
-    ))
+    val conll = CoNLL()
+    val test_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.testb")
 
+    val m = PipelineModel.load("./tmp_nercrfpipeline")
+    m.stages(1).asInstanceOf[NerCrfModel].setIncludeConfidence(false)
+
+    m.transform(test_data.limit(2)).select("ner").show(false)
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfCustomCase.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfCustomCase.scala
@@ -1,67 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.ner.crf
 
-import com.johnsnowlabs.nlp.annotator.PerceptronModel
-import com.johnsnowlabs.nlp.annotators.Tokenizer
-import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
-import com.johnsnowlabs.nlp.embeddings.WordEmbeddings
+import com.johnsnowlabs.nlp.embeddings.WordEmbeddingsModel
+import com.johnsnowlabs.nlp.training.CoNLL
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.nlp.{DocumentAssembler, Finisher, LightPipeline, RecursivePipeline}
+import com.johnsnowlabs.nlp.{Finisher, LightPipeline}
 import com.johnsnowlabs.tags.SlowTest
-import org.apache.spark.ml.PipelineModel
+
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.SparkSession
+
 import org.scalatest._
 
 class NerCrfCustomCase extends FlatSpec {
 
-  val spark = ResourceHelper.spark
+  val spark: SparkSession = ResourceHelper.spark
 
-  import spark.implicits._
 
   "NerCRF" should "read low trained model" taggedAs SlowTest in {
 
-    val documentAssembler = new DocumentAssembler()
-      .setInputCol("text")
-      .setOutputCol("document")
 
-    val sentenceDetector = new SentenceDetector()
-      .setInputCols(Array("document"))
-      .setOutputCol("sentence")
+    val conll = CoNLL()
+    val test_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.testb")
 
-    val tokenizer = new Tokenizer()
-      .setInputCols(Array("sentence"))
-      .setOutputCol("token")
-
-    val pos = PerceptronModel.pretrained()
-      .setInputCols("sentence", "token")
-      .setOutputCol("pos")
-
-    val embeddings = new WordEmbeddings()
-      .setInputCols("pos", "token", "sentence")
+    val embeddings = WordEmbeddingsModel.pretrained()
+      .setInputCols("token", "sentence")
       .setOutputCol("embeddings")
-      .setStoragePath("./emb.bin", "BINARY")
-      .setDimension(200)
 
     val nerCrf = new NerCrfApproach()
       .setInputCols("pos", "token", "sentence", "embeddings")
       .setOutputCol("ner")
-      .setMinEpochs(50)
-      .setMaxEpochs(80)
       .setLabelColumn("label")
+      .setMaxEpochs(5)
 
     val finisher = new Finisher()
       .setInputCols("ner")
 
-    val recursivePipeline = new RecursivePipeline()
+    val pipeline = new Pipeline()
       .setStages(Array(
-        documentAssembler,
-        sentenceDetector,
-        tokenizer,
-        pos,
         embeddings,
         nerCrf,
         finisher
       ))
 
-    val model = recursivePipeline.fit(Seq.empty[String].toDF("text"))
+    val model = pipeline.fit(test_data)
 
     model.write.overwrite().save("./crfnerconll")
     model.stages(4).asInstanceOf[NerCrfModel].write.overwrite().save("./crfnerconll-single")

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.ner.dl
 
 import com.johnsnowlabs.nlp._


### PR DESCRIPTION
Currently, both `NerDLModel` and `NerCrfModel` only provide a confidence score for the predicted tag like the following:

```
[[named_entity, 0, 4, B-LOC, [word -> Japan, confidence -> 0.9998], []]
```

This PR introduces a full list of confidence scores with all the available tags in that model when `setIncludeConfidence` is set to `true` like the following:

```
[[named_entity, 0, 4, B-LOC, [B-LOC -> 0.9998, I-ORG -> 0.0, I-MISC -> 0.0, I-LOC -> 0.0, I-PER -> 0.0, B-MISC -> 0.0, B-ORG -> 1.0E-4, word -> Japan, O -> 0.0, B-PER -> 0.0], []]
```