### PR TITLE
Add confidence score to NerConverter metadata and fix a bug for dirty documents

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerConverter.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerConverter.scala
@@ -1,68 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.ner
 
 import com.johnsnowlabs.nlp.AnnotatorType.{CHUNK, DOCUMENT, NAMED_ENTITY, TOKEN}
 import com.johnsnowlabs.nlp.annotators.common.NerTagged
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, AnnotatorType, ParamsAndFeaturesReadable, HasSimpleAnnotate}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, AnnotatorType, HasSimpleAnnotate, ParamsAndFeaturesReadable}
+
 import org.apache.spark.ml.param.{BooleanParam, StringArrayParam}
 import org.apache.spark.ml.util.Identifiable
 
-import scala.collection.Map
+import scala.collection.immutable.Map
 
 /**
-  * Converts IOB or IOB2 representation of NER to user-friendly.
-  * See https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging)
-  *
-  * @groupname anno Annotator types
-  * @groupdesc anno Required input and expected output annotator types
-  * @groupname Ungrouped Members
-  * @groupname param Parameters
-  * @groupname setParam Parameter setters
-  * @groupname getParam Parameter getters
-  * @groupname Ungrouped Members
-  * @groupprio param  1
-  * @groupprio anno  2
-  * @groupprio Ungrouped 3
-  * @groupprio setParam  4
-  * @groupprio getParam  5
-  * @groupdesc Parameters A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
-  */
+ * Converts IOB or IOB2 representation of NER to user-friendly.
+ * See https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging)
+ *
+ * @groupname anno Annotator types
+ * @groupdesc anno Required input and expected output annotator types
+ * @groupname Ungrouped Members
+ * @groupname param Parameters
+ * @groupname setParam Parameter setters
+ * @groupname getParam Parameter getters
+ * @groupname Ungrouped Members
+ * @groupprio param  1
+ * @groupprio anno  2
+ * @groupprio Ungrouped 3
+ * @groupprio setParam  4
+ * @groupprio getParam  5
+ * @groupdesc Parameters A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
+ */
 class NerConverter(override val uid: String) extends AnnotatorModel[NerConverter] with HasSimpleAnnotate[NerConverter] {
 
   def this() = this(Identifiable.randomUID("NER_CONVERTER"))
 
   /** Input Annotator Type : DOCUMENT, TOKEN, NAMED_ENTITY
-    *
-    * @group anno
-    **/
+   *
+   * @group anno
+   **/
   override val inputAnnotatorTypes: Array[String] = Array(DOCUMENT, TOKEN, NAMED_ENTITY)
   /** Output Annotator Type : CHUNK
-    *
-    * @group anno
-    **/
+   *
+   * @group anno
+   **/
   override val outputAnnotatorType: AnnotatorType = CHUNK
 
   /** If defined, list of entities to process. The rest will be ignored. Do not include IOB prefix on labels
-    *
-    * @group param
-    **/
+   *
+   * @group param
+   **/
   val whiteList: StringArrayParam = new StringArrayParam(this, "whiteList", "If defined, list of entities to process. The rest will be ignored. Do not include IOB prefix on labels")
 
   /** If defined, list of entities to process. The rest will be ignored. Do not include IOB prefix on labels
-    *
-    * @group setParam
-    **/
+   *
+   * @group setParam
+   **/
   def setWhiteList(list: String*): NerConverter.this.type = set(whiteList, list.toArray)
 
   /** Whether to preserve the original position of the tokens in the original document or use the modified tokens
-    *
-    * @group param
-    **/
+   *
+   * @group param
+   **/
   val preservePosition: BooleanParam = new BooleanParam(this, "preservePosition", "Whether to preserve the original position of the tokens in the original document or use the modified tokens")
 
   /** Whether to preserve the original position of the tokens in the original document or use the modified tokens
-    *
-    * @group setParam
-    **/
+   *
+   * @group setParam
+   **/
   def setPreservePosition(value: Boolean): this.type = set(preservePosition, value)
 
   setDefault(
@@ -71,20 +89,26 @@ class NerConverter(override val uid: String) extends AnnotatorModel[NerConverter
 
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
     val sentences = NerTagged.unpack(annotations)
-    val docs = annotations.filter(a => a.annotatorType == AnnotatorType.DOCUMENT)
+    val docs = annotations.filter(a => a.annotatorType == AnnotatorType.DOCUMENT && sentences.exists(
+      b => b.indexedTaggedWords.exists(c => c.begin >= a.begin && c.end <= a.end)
+    ))
+
     val entities = sentences.zip(docs.zipWithIndex).flatMap { case (sentence, doc) =>
-      NerTagsEncoding.fromIOB(sentence, doc._1, sentenceIndex=doc._2, $(preservePosition))
+      NerTagsEncoding.fromIOB(sentence, doc._1, sentenceIndex = doc._2, $(preservePosition))
     }
 
     entities.filter(entity => get(whiteList).forall(validEntity => validEntity.contains(entity.entity))).
       zipWithIndex.map{case (entity, idx) =>
+      val baseMetadata = Map("entity" -> entity.entity, "sentence" -> entity.sentenceId, "chunk" -> idx.toString)
+      val metadata = if(entity.confidence.isEmpty) baseMetadata else baseMetadata + ("confidence" -> entity.confidence.get.toString)
       Annotation(
         outputAnnotatorType,
         entity.start,
         entity.end,
         entity.text,
-        Map("entity" -> entity.entity, "sentence" -> entity.sentenceId, "chunk" -> idx.toString)
+        metadata
       )
+
     }
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerTagsEncoding.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerTagsEncoding.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.ner
 
 import com.johnsnowlabs.nlp.Annotation
@@ -7,16 +24,16 @@ import scala.collection.mutable.ArrayBuffer
 
 
 /**
-  * Works with different NER representations as tags
-  * Supports: IOB and IOB2 https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging)
-  */
+ * Works with different NER representations as tags
+ * Supports: IOB and IOB2 https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging)
+ */
 object NerTagsEncoding {
 
   /**
-    * Converts from IOB or IOB2 to list of NamedEntity
-    * @param doc Source doc text
-    * @return Extracted Named Entities
-    */
+   * Converts from IOB or IOB2 to list of NamedEntity
+   * @param doc Source doc text
+   * @return Extracted Named Entities
+   */
   def fromIOB(sentence: NerTaggedSentence, doc: Annotation, sentenceIndex: Int = 0, originalOffset: Boolean = true): Seq[NamedEntity] = {
     val result = ArrayBuffer[NamedEntity]()
 
@@ -30,17 +47,25 @@ object NerTagsEncoding {
       val end = sentence.indexedTaggedWords(endIdx).end - doc.begin
       require(start <= end && end <= doc.result.length, s"Failed to flush entities in NerConverter. " +
         s"Chunk offsets $start - $end are not within tokens:\n${sentence.words.mkString("||")}\nfor sentence:\n${doc.result}")
+      val confidenceArray = sentence.indexedTaggedWords.slice(startIdx, endIdx + 1).flatMap(_.metadata.values)
+      val finalConfidenceArray = try {
+        confidenceArray.map(x => x.trim.toFloat)
+      } catch {
+        case _: Exception => Array.empty[Float]
+      }
+      val confidence = if(finalConfidenceArray.isEmpty) None else Some(finalConfidenceArray.sum / finalConfidenceArray.length)
       val content = if(originalOffset) doc.result.substring(start, end + 1) else sentence.indexedTaggedWords(startIdx).word
       val entity = NamedEntity(
         sentence.indexedTaggedWords(startIdx).begin,
         sentence.indexedTaggedWords(endIdx).end,
         lastTag.get,
         content,
-        sentenceIndex.toString
+        sentenceIndex.toString,
+        confidence
       )
-
       result.append(entity)
       lastTag = None
+
     }
 
     for (i <- 0 until words) {
@@ -69,4 +94,4 @@ object NerTagsEncoding {
 
 }
 
-case class NamedEntity(start: Int, end: Int, entity: String, text: String, sentenceId: String)
+case class NamedEntity(start: Int, end: Int, entity: String, text: String, sentenceId: String, confidence: Option[Float])

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/NerConverterTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/NerConverterTest.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.ner
 
 import com.johnsnowlabs.nlp.annotator._
@@ -6,11 +23,12 @@ import com.johnsnowlabs.nlp.embeddings.WordEmbeddingsModel
 import com.johnsnowlabs.nlp.training.CoNLL
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.tags.SlowTest
+
 import org.scalatest._
 
 class NerConverterTest extends FlatSpec {
 
-  "NeConverter" should "correctly use any TOKEN type input" taggedAs SlowTest in {
+  "NerConverter" should "correctly use any TOKEN type input" taggedAs SlowTest in {
 
     val conll = CoNLL()
     val training_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/ner-corpus/test_ner_dataset.txt")
@@ -68,5 +86,75 @@ class NerConverterTest extends FlatSpec {
 
   }
 
+  "NeConverter" should "correctly work in a pipeline with per-processing" taggedAs SlowTest in {
+    import ResourceHelper.spark.implicits._
+
+    val testDF = Seq(
+      "word1 word2 word3 word4.word5 john,doe........... john.doe texas.floria, "
+    ).toDF("text")
+
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+      .setCleanupMode("inplace_full")
+
+    val document_normalizer = new DocumentNormalizer()
+      .setInputCols("document")
+      .setOutputCol("document_normalized")
+
+    val sentenceDetector = new SentenceDetector()
+      .setInputCols("document_normalized")
+      .setOutputCol("sentence")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("sentence"))
+      .setOutputCol("token")
+      .setMinLength(2)
+      .setSplitChars(Array("-", ","))
+      .setContextChars(Array("(", ")", "?", "!"))
+
+    val normalize = new Normalizer()
+      .setInputCols("token")
+      .setOutputCol("token_normalized")
+      .setSlangMatchCase(true)
+
+    val embeddings = BertEmbeddings.pretrained("small_bert_L2_128")
+      .setInputCols("sentence", "token_normalized")
+      .setOutputCol("embeddings")
+
+    val ner = NerDLModel.pretrained("onto_small_bert_L2_128")
+      .setInputCols("sentence", "token_normalized", "embeddings")
+      .setOutputCol("ner")
+      .setIncludeConfidence(true)
+
+    val converter = new NerConverter()
+      .setInputCols("sentence", "token_normalized", "ner")
+      .setOutputCol("entities")
+      .setPreservePosition(false)
+
+    val recursivePipeline = new RecursivePipeline()
+      .setStages(Array(
+        documentAssembler,
+        document_normalizer,
+        sentenceDetector,
+        tokenizer,
+        normalize,
+        embeddings,
+        ner,
+        converter
+      ))
+
+    val nermodel = recursivePipeline.fit(testDF).transform(testDF)
+
+    nermodel.select("document.result").show(1, false)
+    nermodel.select("document_normalized.result").show(1, false)
+    nermodel.select("sentence.result").show(1, false)
+    nermodel.select("token.result").show(1, false)
+    nermodel.select("token_normalized.result").show(1, false)
+    nermodel.select("embeddings.result").show(1, false)
+    nermodel.select("entities.result").show(1, false)
+    nermodel.select("entities").show(1, false)
+
+  }
 }
 


### PR DESCRIPTION
This PR introduces an average of confidence scores for predicted tags as entities. It also makes sure the sentences/documents have valid tokens to avoid exceptions when chunks don't belong to a sentence/document.

Example of metadata in NerConverter when `setIncludeConfidence` is set to `true`:

```
[chunk, 30, 37, john, [entity -> PERSON, sentence -> 0, chunk -> 0, confidence -> 0.44035]
```