### PR TITLE
Fix ChunkEmbeddings Array out of bounds exception

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
@@ -135,12 +135,7 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
   /** Internal constructor to submit a random UID */
   def this() = this(Identifiable.randomUID("CHUNK_EMBEDDINGS"))
 
-  private def calculateChunkEmbeddings(matrix : Array[Array[Float]], tokens: Array[TokenPieceEmbeddings]):Array[Float] = {
-    try{
-      val res = Array.ofDim[Float](matrix(0).length)
-    } catch {
-      case _: Exception => tokens
-    }
+  private def calculateChunkEmbeddings(matrix : Array[Array[Float]]):Array[Float] = {
     val res = Array.ofDim[Float](matrix(0).length)
     matrix(0).indices.foreach {
       j =>
@@ -190,7 +185,7 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
          * When we have more chunks than word embeddings
          * this happens when the embeddings has max sequence restriction like BERT, ALBERT, etc.
          */
-        if(finalEmbeddings.isEmpty)
+        if (finalEmbeddings.isEmpty)
           None
         else
           Some(Annotation(

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
@@ -200,7 +200,7 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
               "pieceId" -> "-1",
               "isWordStart" -> "true"
             ),
-            embeddings = calculateChunkEmbeddings(finalEmbeddings, tokensWithEmbeddings)
+            embeddings = calculateChunkEmbeddings(finalEmbeddings)
           ))
       } else {
         None

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
@@ -1,6 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.embeddings
 
-import com.johnsnowlabs.nlp.annotators.common.WordpieceEmbeddingsSentence
+import com.johnsnowlabs.nlp.annotators.common.{TokenPieceEmbeddings, WordpieceEmbeddingsSentence}
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasSimpleAnnotate}
 import org.apache.spark.ml.param.{BooleanParam, Param}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
@@ -18,70 +35,70 @@ object PoolingStrategy {
 }
 
 /** This annotator utilizes WordEmbeddings or BertEmbeddings to generate chunk embeddings from either Chunker, NGramGenerator, or NerConverter outputs.
-  *
-  * TIP:
-  *
-  * How to explode and convert these embeddings into Vectors or what’s known as Feature column so it can be used in Spark ML regression or clustering functions:
-  *
-  * {{{
-  * import org.apache.spark.ml.linalg.{Vector, Vectors}
-  *
-  * // Let's create a UDF to take array of embeddings and output Vectors
-  * val convertToVectorUDF = udf((matrix : Seq[Float]) => {
-  *     Vectors.dense(matrix.toArray.map(_.toDouble))
-  * })
-  *
-  * // Now let's explode the sentence_embeddings column and have a new feature column for Spark ML
-  * pipelineDF.select(explode($"chunk_embeddings.embeddings").as("chunk_embeddings_exploded"))
-  * .withColumn("features", convertToVectorUDF($"chunk_embeddings_exploded"))
-  * }}}
-  *
-  * See [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala]] for further reference on how to use this API.
-  *
-  * @groupname anno Annotator types
-  * @groupdesc anno Required input and expected output annotator types
-  * @groupname Ungrouped Members
-  * @groupname param Parameters
-  * @groupname setParam Parameter setters
-  * @groupname getParam Parameter getters
-  * @groupname Ungrouped Members
-  * @groupprio param  1
-  * @groupprio anno  2
-  * @groupprio Ungrouped 3
-  * @groupprio setParam  4
-  * @groupprio getParam  5
-  * @groupdesc Parameters A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
-  **/
+ *
+ * TIP:
+ *
+ * How to explode and convert these embeddings into Vectors or what’s known as Feature column so it can be used in Spark ML regression or clustering functions:
+ *
+ * {{{
+ * import org.apache.spark.ml.linalg.{Vector, Vectors}
+ *
+ * // Let's create a UDF to take array of embeddings and output Vectors
+ * val convertToVectorUDF = udf((matrix : Seq[Float]) => {
+ *     Vectors.dense(matrix.toArray.map(_.toDouble))
+ * })
+ *
+ * // Now let's explode the sentence_embeddings column and have a new feature column for Spark ML
+ * pipelineDF.select(explode($"chunk_embeddings.embeddings").as("chunk_embeddings_exploded"))
+ * .withColumn("features", convertToVectorUDF($"chunk_embeddings_exploded"))
+ * }}}
+ *
+ * See [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala]] for further reference on how to use this API.
+ *
+ * @groupname anno Annotator types
+ * @groupdesc anno Required input and expected output annotator types
+ * @groupname Ungrouped Members
+ * @groupname param Parameters
+ * @groupname setParam Parameter setters
+ * @groupname getParam Parameter getters
+ * @groupname Ungrouped Members
+ * @groupprio param  1
+ * @groupprio anno  2
+ * @groupprio Ungrouped 3
+ * @groupprio setParam  4
+ * @groupprio getParam  5
+ * @groupdesc Parameters A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
+ **/
 class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmbeddings] with HasSimpleAnnotate[ChunkEmbeddings] {
 
   import com.johnsnowlabs.nlp.AnnotatorType._
 
   /** Output annotator type : WORD_EMBEDDINGS
-    *
-    * @group anno
-    **/
+   *
+   * @group anno
+   **/
   override val outputAnnotatorType: AnnotatorType = WORD_EMBEDDINGS
   /** Input annotator type : CHUNK, WORD_EMBEDDINGS
-    *
-    * @group anno
-    **/
+   *
+   * @group anno
+   **/
   override val inputAnnotatorTypes: Array[AnnotatorType] = Array(CHUNK, WORD_EMBEDDINGS)
   /** Choose how you would like to aggregate Word Embeddings to Chunk Embeddings: AVERAGE or SUM
-    *
-    * @group param
-    **/
+   *
+   * @group param
+   **/
   val poolingStrategy = new Param[String](this, "poolingStrategy", "Choose how you would like to aggregate Word Embeddings to Chunk Embeddings: AVERAGE or SUM")
   /** Whether to discard default vectors for OOV words from the aggregation / pooling
-    *
-    * @group param
-    **/
+   *
+   * @group param
+   **/
   val skipOOV = new BooleanParam(this, "skipOOV", "Whether to discard default vectors for OOV words from the aggregation / pooling")
 
 
   /** PoolingStrategy must be either AVERAGE or SUM
-    *
-    * @group setParam
-    **/
+   *
+   * @group setParam
+   **/
   def setPoolingStrategy(strategy: String): this.type = {
     strategy.toLowerCase() match {
       case "average" => set(poolingStrategy, "AVERAGE")
@@ -91,22 +108,22 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
   }
 
   /** Whether to discard default vectors for OOV words from the aggregation / pooling
-    *
-    * @group setParam
-    **/
+   *
+   * @group setParam
+   **/
   def setSkipOOV(value: Boolean): this.type = set(skipOOV, value)
 
   /** Choose how you would like to aggregate Word Embeddings to Chunk Embeddings: AVERAGE or SUM
-    *
-    * @group getParam
-    **/
-  def getPoolingStrategy = $(poolingStrategy)
+   *
+   * @group getParam
+   **/
+  def getPoolingStrategy: String = $(poolingStrategy)
 
   /** Whether to discard default vectors for OOV words from the aggregation / pooling
-    *
-    * @group getParam
-    **/
-  def getSkipOOV = $(skipOOV)
+   *
+   * @group getParam
+   **/
+  def getSkipOOV: Boolean = $(skipOOV)
 
   setDefault(
     inputCols -> Array(CHUNK, WORD_EMBEDDINGS),
@@ -118,7 +135,12 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
   /** Internal constructor to submit a random UID */
   def this() = this(Identifiable.randomUID("CHUNK_EMBEDDINGS"))
 
-  private def calculateChunkEmbeddings(matrix : Array[Array[Float]]):Array[Float] = {
+  private def calculateChunkEmbeddings(matrix : Array[Array[Float]], tokens: Array[TokenPieceEmbeddings]):Array[Float] = {
+    try{
+      val res = Array.ofDim[Float](matrix(0).length)
+    } catch {
+      case _: Exception => tokens
+    }
     val res = Array.ofDim[Float](matrix(0).length)
     matrix(0).indices.foreach {
       j =>
@@ -133,11 +155,11 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
   }
 
   /**
-    * takes a document and annotations and produces new annotations of this annotator's annotation type
-    *
-    * @param annotations Annotations that correspond to inputAnnotationCols generated by previous annotators if any
-    * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
-    */
+   * takes a document and annotations and produces new annotations of this annotator's annotation type
+   *
+   * @param annotations Annotations that correspond to inputAnnotationCols generated by previous annotators if any
+   * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
+   */
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
 
     val documentsWithChunks = annotations
@@ -146,7 +168,6 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
     val embeddingsSentences = WordpieceEmbeddingsSentence.unpack(annotations)
 
     documentsWithChunks.flatMap { chunk =>
-      //TODO: Check why some chunks end up without WordEmbeddings
       val sentenceIdx = chunk.metadata.getOrElse("sentence", "0").toInt
       val chunkIdx = chunk.metadata.getOrElse("chunk", "0").toInt
 
@@ -165,20 +186,27 @@ class ChunkEmbeddings (override val uid: String) extends AnnotatorModel[ChunkEmb
 
         val finalEmbeddings = if (allEmbeddings.length > 0) allEmbeddings else tokensWithEmbeddings.map(_.embeddings)
 
-        Some(Annotation(
-          annotatorType = outputAnnotatorType,
-          begin = chunk.begin,
-          end = chunk.end,
-          result = chunk.result,
-          metadata = Map(
-            "sentence" -> sentenceIdx.toString,
-            "chunk" -> chunkIdx.toString,
-            "token" -> chunk.result.toString,
-            "pieceId" -> "-1",
-            "isWordStart" -> "true"
-          ),
-          embeddings = calculateChunkEmbeddings(finalEmbeddings)
-        ))
+        /**
+         * When we have more chunks than word embeddings
+         * this happens when the embeddings has max sequence restriction like BERT, ALBERT, etc.
+         */
+        if(finalEmbeddings.isEmpty)
+          None
+        else
+          Some(Annotation(
+            annotatorType = outputAnnotatorType,
+            begin = chunk.begin,
+            end = chunk.end,
+            result = chunk.result,
+            metadata = Map(
+              "sentence" -> sentenceIdx.toString,
+              "chunk" -> chunkIdx.toString,
+              "token" -> chunk.result,
+              "pieceId" -> "-1",
+              "isWordStart" -> "true"
+            ),
+            embeddings = calculateChunkEmbeddings(finalEmbeddings, tokensWithEmbeddings)
+          ))
       } else {
         None
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.nlp.AnnotatorType.{DOCUMENT, SENTENCE_EMBEDDINGS, WORD_EMBEDDINGS}

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.nlp.annotator.{Chunker, PerceptronModel}
@@ -7,6 +24,7 @@ import com.johnsnowlabs.nlp.base.{DocumentAssembler, RecursivePipeline}
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.nlp.{AnnotatorBuilder, EmbeddingsFinisher, Finisher}
 import com.johnsnowlabs.tags.FastTest
+
 import org.apache.spark.ml.Pipeline
 import org.scalatest._
 

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddingsTestSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.nlp.annotators.classifier.dl.{ClassifierDLApproach, ClassifierDLModel}
@@ -7,6 +24,7 @@ import com.johnsnowlabs.nlp.base.{DocumentAssembler, RecursivePipeline}
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.nlp.{AnnotatorBuilder, EmbeddingsFinisher, Finisher}
 import com.johnsnowlabs.tags.{FastTest, SlowTest}
+
 import org.apache.spark.sql.functions.size
 import org.scalatest._
 


### PR DESCRIPTION
In some cases when the length of the sentences is longer than available word embedding, we end up with Chunks without any embedding to match. This is due to max sequence limitation in some word embedding such as BERT, ALBERT, ELMO, XLNet, etc. 
This PR fixes the `Array out of bounds` exception by making sure the chunks have corresponding word embeddings.