### PR TITLE
added scala example code to licensed models

### DIFF
--- a/docs/_posts/HashamUlHaq/2021-03-31-ner_radiology_en.md
+++ b/docs/_posts/HashamUlHaq/2021-03-31-ner_radiology_en.md
@@ -47,6 +47,18 @@ model = nlpPipeline.fit(spark.createDataFrame([['''Bilateral breast ultrasound w
 results = model.transform(data)
 ```
 
+```scala
+...
+val radiology_ner = MedicalNerModel().pretrained("ner_radiology", "en", "clinical/models")
+  .setInputCols(Array("sentence", "token", "embeddings"))
+  .setOutputCol("ner")
+
+val nlpPipeline = new Pipeline().setStages(Array(document_assembler, sentence_detector, tokenizer, word_embeddings, radiology_ner, ner_converter))
+
+val result = nlpPipeline.fit(Seq.empty[""].toDS.toDF("text")).transform(data)
+
+```
+
 </div>
 
 ## Results

--- a/docs/_posts/aydinmyilmaz/2021-01-18-ner_radiology_en.md
+++ b/docs/_posts/aydinmyilmaz/2021-01-18-ner_radiology_en.md
@@ -38,15 +38,23 @@ Use as part of an NLP pipeline with the following stages: DocumentAssembler, Sen
 radiology_ner = NerDLModel.pretrained("ner_radiology", "en", "clinical/models") \
   .setInputCols(["sentence", "token", "embeddings"]) \
   .setOutputCol("ner")
-...
 nlpPipeline = Pipeline(stages=[document_assembler, sentence_detector, tokenizer, word_embeddings, radiology_ner, ner_converter])
-
+...
 model = nlpPipeline.fit(spark.createDataFrame([['''Bilateral breast ultrasound was subsequently performed, which demonstrated an ovoid mass measuring approximately 0.5 x 0.5 x 0.4 cm in diameter located within the anteromedial aspect of the left shoulder. This mass demonstrates isoechoic echotexture to the adjacent muscle, with no evidence of internal color flow. This may represent benign fibrous tissue or a lipoma.''']]).toDF("text"))
 
 results = model.transform(data)
 ```
 
+```scala
+...
+val radiology_ner = NerDLModel().pretrained("ner_radiology", "en", "clinical/models")
+  .setInputCols(Array("sentence", "token", "embeddings"))
+  .setOutputCol("ner")
 
+val nlpPipeline = new Pipeline().setStages(Array(document_assembler, sentence_detector, tokenizer, word_embeddings, radiology_ner, ner_converter))
+val result = nlpPipeline.fit(Seq.empty[""].toDS.toDF("text")).transform(data)
+
+```
 </div>
 
 ## Results

--- a/docs/_posts/aydinmyilmaz/2021-01-18-re_bodypart_problem_en.md
+++ b/docs/_posts/aydinmyilmaz/2021-01-18-re_bodypart_problem_en.md
@@ -53,6 +53,23 @@ model = pipeline.fit(spark.createDataFrame([[""]]).toDF("text"))
 results = LightPipeline(model).fullAnnotate('''No neurologic deficits other than some numbness in his left hand.''')
 ```
 
+```scala
+...
+val ner_tagger = sparknlp.annotators.NerDLModel()
+    .pretrained('jsl_ner_wip_greedy_clinical','en','clinical/models')
+    .setInputCols("sentences", "tokens", "embeddings")
+    .setOutputCol("ner_tags") 
+
+val reModel = RelationExtractionModel().pretrained("re_bodypart_problem","en","clinical/models")
+    .setInputCols(Array("word_embeddings","chunk","pos","dependency"))
+    .setOutput("relations")
+    .setRelationPairs(Array('symptom-external_body_part_or_region'))
+
+val nlpPipeline = new Pipeline().setStages(Array(documenter, sentencer, tokenizer, words_embedder, pos_tagger, ner_tagger, ner_chunker, dependency_parser, reModel))
+val model = nlpPipeline.fit(Seq.empty[""].toDS.toDF("text"))
+
+val results = LightPipeline(model).fullAnnotate('''No neurologic deficits other than some numbness in his left hand.''')
+```
 
 </div>
 

--- a/docs/_posts/aydinmyilmaz/2021-01-18-re_date_clinical_en.md
+++ b/docs/_posts/aydinmyilmaz/2021-01-18-re_date_clinical_en.md
@@ -35,7 +35,7 @@ Use as part of an nlp pipeline with the following stages: DocumentAssembler, Sen
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
 ```python
-ner_tagger = sparknlp.annotators.NerDLModel()\ .pretrained('jsl_ner_wip_greedy_clinical','en','clinical/models')\ 
+ner_tagger = sparknlp.annotators.NerDLModel().pretrained('jsl_ner_wip_greedy_clinical','en','clinical/models')\ 
   .setInputCols("sentences", "tokens", "embeddings")\ 
   .setOutputCol("ner_tags")
 
@@ -45,13 +45,33 @@ re_model = RelationExtractionModel()
 .setOutputCol("relations")
 .setMaxSyntacticDistance(3)\ #default: 0 .setPredictionThreshold(0.9)\ #default: 0.5 .setRelationPairs(["test-date", "symptom-date"]) # Possible relation pairs. Default: All Relations.
 
-nlp_pipeline = Pipeline(stages=[ documenter, sentencer,tokenizer, words_embedder, pos_tagger, ner_tagger,ner_chunker, dependency_parser,re_model])
+nlp_pipeline = Pipeline(stages=[documenter, sentencer,tokenizer, words_embedder, pos_tagger, ner_tagger, ner_chunker, dependency_parser,re_model])
 
 light_pipeline = LightPipeline(nlp_pipeline.fit(spark.createDataFrame([['']]).toDF("text")))
 
 annotations = light_pipeline.fullAnnotate('''This 73 y/o patient had CT on 1/12/95, with progressive memory and cognitive decline since 8/11/94.''')
 ```
 
+```scala
+...
+val ner_tagger = sparknlp.annotators.NerDLModel().pretrained('jsl_ner_wip_greedy_clinical','en','clinical/models')
+      .setInputCols("sentences", "tokens", "embeddings")
+      .setOutputCol("ner_tags")
+
+val re_model = RelationExtractionModel()
+        .pretrained("re_date", "en", 'clinical/models')
+        .setInputCols(Array("embeddings", "pos_tags", "ner_chunks", "dependencies"))
+        .setOutputCol("relations")
+        .setMaxSyntacticDistance(3) #default: 0 
+        .setPredictionThreshold(0.9) #default: 0.5 
+        .setRelationPairs(Array("test-date", "symptom-date")) # Possible relation pairs. Default: All Relations.
+
+val nlpPipeline = new Pipeline().setStages(Array(documenter, sentencer,tokenizer, words_embedder, pos_tagger, ner_tagger, ner_chunker, dependency_parser,re_model))
+
+val light_pipeline = LightPipeline(nlpPipeline.fit(Seq.empty[""].toDS.toDF("text")))
+
+val annotations = light_pipeline.fullAnnotate('''This 73 y/o patient had CT on 1/12/95, with progressive memory and cognitive decline since 8/11/94.''')
+```
 
 </div>
 

--- a/docs/_posts/aydinmyilmaz/2021-01-20-ner_deid_augmented_en.md
+++ b/docs/_posts/aydinmyilmaz/2021-01-20-ner_deid_augmented_en.md
@@ -34,11 +34,11 @@ This model is trained with the ‘embeddings_clinical’ word embeddings, so be 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPythonNLU.html %}
 ```python
-model = NerDLModel.pretrained("ner_deid_augmented","en","clinical/models")\
+ner_model = NerDLModel.pretrained("ner_deid_augmented","en","clinical/models")\
 	.setInputCols(["sentence","token","word_embeddings"])\
 	.setOutputCol("ner")
 
-nlpPipeline = Pipeline(stages=[document_assembler, sentence_detector, tokenizer, word_embeddings, model, ner_converter])
+nlpPipeline = Pipeline(stages=[document_assembler, sentence_detector, tokenizer, word_embeddings, ner_model, ner_converter])
 
 model = nlpPipeline.fit(spark.createDataFrame([[""]]).toDF("text"))
 
@@ -46,6 +46,18 @@ results = model.transform(spark.createDataFrame(pd.DataFrame({"text": ["""HISTOR
 
 ```
 
+```scala
+...
+val ner_model = NerDLModel.pretrained("ner_deid_augmented","en","clinical/models")
+	.setInputCols(Array("sentence","token","word_embeddings"))
+	.setOutputCol("ner")
+
+val nlpPipeline = new Pipeline().setStages(Array(document_assembler, sentence_detector, tokenizer, word_embeddings, ner_model, ner_converter))
+
+val model = nlpPipeline.fit(Seq.empty[""].toDS.toDF("text"))
+
+val results = LightPipeline(model).fullAnnotate('''HISTORY OF PRESENT ILLNESS: Mr. Smith is a 60-year-old white male veteran with multiple comorbidities, who has a history of bladder cancer diagnosed approximately two years ago by the VA Hospital, Dr. John Green (2347165768). He underwent a resection there. He was to be admitted to the Day Hospital for cystectomy. He was seen in Urology Clinic and Radiology Clinic on 02/04/2003. HOSPITAL COURSE: Mr. Smith presented to the Day Hospital in anticipation for Urology surgery. On evaluation, EKG, echocardiogram was abnormal, a Cardiology consult was obtained. A cardiac adenosine stress MRI was then proceeded, same was positive for inducible ischemia, mild-to-moderate inferolateral subendocardial infarction with peri-infarct ischemia. In addition, inducible ischemia seen in the inferior lateral septum. Mr. Smith underwent a left heart catheterization, which revealed two vessel coronary artery disease. The RCA, proximal was 95% stenosed and the distal 80% stenosed. The mid LAD was 85% stenosed and the distal LAD was 85% stenosed. There was four Multi-Link Vision bare metal stents placed to decrease all four lesions to 0%. Following intervention, Mr. Smith was admitted to 7 Ardmore Tower under Cardiology Service under the direction of Dr. Hart. Mr. Smith had a noncomplicated post-intervention hospital course. He was stable for discharge home on 02/07/2003 with instructions to take Plavix daily for one month and Urology is aware of the same.''')
+```
 
 </div>
 

--- a/docs/_posts/aydinmyilmaz/2021-01-27-ner_clinical_en.md
+++ b/docs/_posts/aydinmyilmaz/2021-01-27-ner_clinical_en.md
@@ -35,12 +35,9 @@ Use as part of an nlp pipeline with the following stages: DocumentAssembler, Sen
 {% include programmingLanguageSelectScalaPythonNLU.html %}
 ```python
 ...
-
-
 clinical_ner = NerDLModel.pretrained("ner_clinical_large", "en", "clinical/models") \
   .setInputCols(["sentence", "token", "embeddings"]) \
   .setOutputCol("ner")
-
 ...
 
 nlpPipeline = Pipeline(stages=[document_assembler, sentence_detector, tokenizer, word_embeddings_clinical, clinical_ner, ner_converter])
@@ -48,6 +45,19 @@ nlpPipeline = Pipeline(stages=[document_assembler, sentence_detector, tokenizer,
 model = nlpPipeline.fit(spark.createDataFrame([[""]]).toDF("text"))
 
 results = model.transform(data)
+```
+
+```scala
+...
+val clinical_ner = NerDLModel.pretrained("ner_clinical_large", "en", "clinical/models")
+  .setInputCols(Array("sentence", "token", "embeddings"))
+  .setOutputCol("ner")
+
+val nlpPipeline = new Pipeline().setStages(Array(document_assembler, sentence_detector, tokenizer, word_embeddings_clinical, clinical_ner, ner_converter))
+
+val model = nlpPipeline.fit(Seq.empty[""].toDS.toDF("text"))
+
+val results = LightPipeline(model).fullAnnotate(data)
 ```
 
 </div>

--- a/docs/_posts/aydinmyilmaz/2021-01-28-deidentify_dl_en.md
+++ b/docs/_posts/aydinmyilmaz/2021-01-28-deidentify_dl_en.md
@@ -47,6 +47,25 @@ deid= DeIdentificationModel.pretrained("deidentify_dl", "en", "clinical/models")
 deid_text = deid.transform(result)
 ```
 
+```scala
+...
+val deid_ner = NerDLModel.pretrained("ner_deid_large", "en", "clinical/models")
+  .setInputCols(Array("sentence", "token", "embeddings"))
+  .setOutputCol("ner")
+
+val nlpPipeline = new Pipeline().setStages(Array(documentAssembler, sentenceDetector, tokenizer, word_embeddings, deid_ner, ner_converter))
+
+val model = nlpPipeline.fit(Seq.empty[""].toDS.toDF("text"))
+
+val results = LightPipeline(model).fullAnnotate("""Patient AIQING, 25 month years-old , born in Beijing, was transfered to the The Johns Hopkins Hospital. Phone number: (541) 754-3010. MSW 100009632582 for his colonic polyps. He wants to know the results from them. He is not taking hydrochlorothiazide and is curious about his blood pressure. He said he has cut his alcohol back to 6 pack once a week. He has cut back his cigarettes to one time per week. P:   Follow up with Dr. Hobbs in 3 months. Gilbert P. Perez, M.D.""")
+
+val deid= DeIdentificationModel.pretrained("deidentify_dl", "en", "clinical/models")
+      .setInputCols(Array("sentence", "token", "ner_chunk"))
+      .setOutputCol("obfuscated")
+      .setMode("obfuscate")
+
+val deid_text = deid.transform(result)
+```
 </div>
 
 ## Results


### PR DESCRIPTION
### Scala codes added to the following models
-     2021-01-18-ner_radiology_en.md
-     2021-03-31-ner_radiology_en
-     2021-01-18-re_bodypart_directions_en.md
-     2021-01-18-re_bodypart_problem_en.md
-     2021-01-18-re_bodypart_proceduretest_en.md
-     2021-01-18-re_date_clinical_en.md
-     2021-01-20-ner_deid_augmented_en.md
-     2021-03-31-ner_deid_augmented_en
-     2021-01-27-ner_clinical_en.md
-     2021-01-28-deidentify_dl_en.md