### PR TITLE
Migrate MarianTransformer to TensorFlow v2 architecture and improve ModelSignatureConstants

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowMarian.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowMarian.scala
@@ -1,49 +1,42 @@
 package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sentencepiece._
+import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import com.johnsnowlabs.nlp.annotators.tokenizer.normalizer.MosesPunctNormalizer
 
 import scala.collection.JavaConverters._
 
 /** MarianTransformer: Fast Neural Machine Translation
-  *
-  * MarianTransformer uses models trained by MarianNMT.
-  *
-  * Marian is an efficient, free Neural Machine Translation framework written in pure C++ with minimal dependencies.
-  * It is mainly being developed by the Microsoft Translator team. Many academic (most notably the University of Edinburgh and in the past the Adam Mickiewicz University in Poznań) and commercial contributors help with its development.
-  *
-  * It is currently the engine behind the Microsoft Translator Neural Machine Translation services and being deployed by many companies, organizations and research projects (see below for an incomplete list).
-  *
-  * '''Sources''' :
-  * MarianNMT [[https://marian-nmt.github.io/]]
-  * Marian: Fast Neural Machine Translation in C++ [[https://www.aclweb.org/anthology/P18-4020/]]
-  *
-  * @param tensorflow           LanguageDetectorDL Model wrapper with TensorFlow Wrapper
-  * @param configProtoBytes     Configuration for TensorFlow session
-  * @param sppSrc               Contains the vocabulary for the target language.
-  * @param sppTrg               Contains the vocabulary for the source language
-  */
+ *
+ * MarianTransformer uses models trained by MarianNMT.
+ *
+ * Marian is an efficient, free Neural Machine Translation framework written in pure C++ with minimal dependencies.
+ * It is mainly being developed by the Microsoft Translator team. Many academic (most notably the University of Edinburgh and in the past the Adam Mickiewicz University in Poznań) and commercial contributors help with its development.
+ *
+ * It is currently the engine behind the Microsoft Translator Neural Machine Translation services and being deployed by many companies, organizations and research projects (see below for an incomplete list).
+ *
+ * '''Sources''' :
+ * MarianNMT [[https://marian-nmt.github.io/]]
+ * Marian: Fast Neural Machine Translation in C++ [[https://www.aclweb.org/anthology/P18-4020/]]
+ *
+ * @param tensorflow           LanguageDetectorDL Model wrapper with TensorFlow Wrapper
+ * @param configProtoBytes     Configuration for TensorFlow session
+ * @param sppSrc               Contains the vocabulary for the target language.
+ * @param sppTrg               Contains the vocabulary for the source language
+ */
 class TensorflowMarian(val tensorflow: TensorflowWrapper,
                        val sppSrc: SentencePieceWrapper,
                        val sppTrg: SentencePieceWrapper,
-                       configProtoBytes: Option[Array[Byte]] = None
+                       configProtoBytes: Option[Array[Byte]] = None,
+                       signatures: Option[Map[String, String]] = None
                       ) extends Serializable {
 
-  private val encoderInputIdsKey = "encoder_input_ids:0"
-  private val encoderOutputsKey = "encoder_outputs:0"
-  private val encoderAttentionMaskKey = "encoder_attention_mask:0"
-  private val decoderInputIdsKey = "decoder_input_ids:0"
-  private val decoderEncoderInputKey = "decoder_encoder_state:0"
-  private val decoderAttentionMaskKey = "decoder_attention_mask:0"
-  private val decoderPaddingMaskKey = "decoder_padding_mask:0"
-  private val decoderCausalMaskKey = "decoder_causal_mask:0"
-  private val decoderOutputsKey = "decoder_outputs:0"
+  val _tfMarianSignatures: Map[String, String] = signatures.getOrElse(ModelSignatureManager.apply())
 
   private val langCodeRe = ">>.+<<".r
-  private val infFloat = Float.NegativeInfinity
 
-  def process(batch: Seq[Array[Long]], maxOutputLength: Int, paddingTokenId: Long, eosTokenId: Long, vocabSize: Int): Array[Array[Long]] = {
+  def process(batch: Seq[Array[Int]], maxOutputLength: Int, paddingTokenId: Int, eosTokenId: Int, vocabSize: Int): Array[Array[Int]] = {
 
     /* Actual size of each sentence to skip padding in the TF model */
     val sequencesLength = batch.map(x => x.length).toArray
@@ -53,9 +46,12 @@ class TensorflowMarian(val tensorflow: TensorflowWrapper,
     val tensorEncoder = new TensorResources()
     val inputDim = batch.length * maxSentenceLength
 
-    val encoderInputIdsBuffers = tensorEncoder.createLongBuffer(batch.length * maxSentenceLength)
-    val encoderAttentionMaskBuffers = tensorEncoder.createLongBuffer(batch.length * maxSentenceLength)
-    val decoderAttentionMaskBuffers = tensorEncoder.createLongBuffer(batch.length  * maxSentenceLength)
+    //    val encoderInputIdsBuffers = tensorEncoder.createLongBuffer(batch.length * maxSentenceLength)
+    //    val encoderAttentionMaskBuffers = tensorEncoder.createLongBuffer(batch.length * maxSentenceLength)
+    //    val decoderAttentionMaskBuffers = tensorEncoder.createLongBuffer(batch.length  * maxSentenceLength)
+    val encoderInputIdsBuffers = tensorEncoder.createIntBuffer(batch.length * maxSentenceLength)
+    val encoderAttentionMaskBuffers = tensorEncoder.createIntBuffer(batch.length * maxSentenceLength)
+    val decoderAttentionMaskBuffers = tensorEncoder.createIntBuffer(batch.length  * maxSentenceLength)
 
     val shape = Array(batch.length.toLong, maxSentenceLength)
 
@@ -64,24 +60,24 @@ class TensorflowMarian(val tensorflow: TensorflowWrapper,
       val offset = idx * maxSentenceLength
       val diff = maxSentenceLength - tokenIds.length
 
-      val s = tokenIds.take(maxSentenceLength) ++ Array.fill[Long](diff)(paddingTokenId)
+      val s = tokenIds.take(maxSentenceLength) ++ Array.fill[Int](diff)(paddingTokenId)
       encoderInputIdsBuffers.offset(offset).write(s)
-      val mask = s.map(x =>  if (x != paddingTokenId) 1L else 0L)
+      val mask = s.map(x =>  if (x != paddingTokenId) 1 else 0)
       encoderAttentionMaskBuffers.offset(offset).write(mask)
       decoderAttentionMaskBuffers.offset(offset).write(mask)
     }
 
-    val encoderInputIdsTensors = tensorEncoder.createLongBufferTensor(shape, encoderInputIdsBuffers)
-    val encoderAttentionMaskKeyTensors = tensorEncoder.createLongBufferTensor(shape, encoderAttentionMaskBuffers)
-    val decoderAttentionMaskTensors = tensorEncoder.createLongBufferTensor(shape, decoderAttentionMaskBuffers)
+    val encoderInputIdsTensors = tensorEncoder.createIntBufferTensor(shape, encoderInputIdsBuffers)
+    val encoderAttentionMaskKeyTensors = tensorEncoder.createIntBufferTensor(shape, encoderAttentionMaskBuffers)
+    val decoderAttentionMaskTensors = tensorEncoder.createIntBufferTensor(shape, decoderAttentionMaskBuffers)
 
     val session = tensorflow.getTFHubSession(configProtoBytes = configProtoBytes)
     val runner = session.runner
 
     runner
-      .feed(encoderInputIdsKey, encoderInputIdsTensors)
-      .feed(encoderAttentionMaskKey, encoderAttentionMaskKeyTensors)
-      .fetch(encoderOutputsKey)
+      .feed(_tfMarianSignatures.getOrElse(ModelSignatureConstants.EncoderInputIds.key, "missing_encoder_input_ids"), encoderInputIdsTensors)
+      .feed(_tfMarianSignatures.getOrElse(ModelSignatureConstants.EncoderAttentionMask.key, "missing_encoder_attention_mask"), encoderAttentionMaskKeyTensors)
+      .fetch(_tfMarianSignatures.getOrElse(ModelSignatureConstants.EncoderOutput.key, "missing_last_hidden_state"))
 
     val encoderOuts = runner.run().asScala
     val encoderOutsFloats = TensorResources.extractFloats(encoderOuts.head)
@@ -93,7 +89,6 @@ class TensorflowMarian(val tensorflow: TensorflowWrapper,
 
     // Run decoder
     val decoderEncoderStateBuffers = tensorEncoder.createFloatBuffer(batch.length * maxSentenceLength * dim)
-    //TODO: There must be a better way to calculate offsets
     batch.zipWithIndex.foreach{case (_, index) =>
       var offset = index * maxSentenceLength * dim
       encoderOutsBatch(index).foreach(encoderOutput => {
@@ -116,52 +111,30 @@ class TensorflowMarian(val tensorflow: TensorflowWrapper,
       val decoderInputLength = decoderInputs.head.length
       val tensorDecoder = new TensorResources()
 
-      val decoderInputBuffers = tensorDecoder.createLongBuffer(batch.length * decoderInputLength)
-      val decoderPaddingMaskBuffers = tensorDecoder.createLongBuffer(batch.length * decoderInputLength)
-      val decoderCasualMaskBuffers = tensorDecoder.createFloatBuffer(decoderInputLength * decoderInputLength)
+      val decoderInputBuffers = tensorDecoder.createIntBuffer(batch.length * decoderInputLength)
 
       decoderInputs.zipWithIndex.foreach{ case (pieceIds, idx) =>
         val offset = idx * decoderInputLength
         decoderInputBuffers.offset(offset).write(pieceIds)
-        val paddingMasks = pieceIds.map(_ => if(pieceIds.length == 1) 1L else 0L)
-        decoderPaddingMaskBuffers.offset(offset).write(paddingMasks)
       }
 
-      for(i <- 0 until decoderInputLength){
-        val temp = Array.ofDim[Float](decoderInputLength)
-        val offset = i*decoderInputLength
-        for(j <- 0 until decoderInputLength){
-          if(i < j){
-            temp(j) = infFloat
-          }else{
-            temp(j) = 0.0f
-          }
-        }
-        decoderCasualMaskBuffers.offset(offset).write(temp)
-      }
-
-      val decoderInputTensors = tensorDecoder.createLongBufferTensor(
+      val decoderInputTensors = tensorDecoder.createIntBufferTensor(
         Array(batch.length.toLong, decoderInputLength), decoderInputBuffers)
-      val decoderPaddingMaskTensors = tensorDecoder.createLongBufferTensor(
-        Array(batch.length.toLong, decoderInputLength), decoderPaddingMaskBuffers)
-      val decoderCausalMaskTensors = tensorDecoder.createFloatBufferTensor(
-        Array(decoderInputLength.toLong, decoderInputLength), decoderCasualMaskBuffers)
+
 
       val runner = session.runner
 
       runner
-        .feed(decoderEncoderInputKey, decoderEncoderStateTensors)
-        .feed(decoderInputIdsKey, decoderInputTensors)
-        .feed(decoderAttentionMaskKey, decoderAttentionMaskTensors)
-        .feed(decoderPaddingMaskKey, decoderPaddingMaskTensors)
-        .feed(decoderCausalMaskKey, decoderCausalMaskTensors)
-        .fetch(decoderOutputsKey)
+        .feed(_tfMarianSignatures.getOrElse(ModelSignatureConstants.DecoderEncoderInputIds.key, "missing_encoder_state"), decoderEncoderStateTensors)
+        .feed(_tfMarianSignatures.getOrElse(ModelSignatureConstants.DecoderInputIds.key, "missing_decoder_input_ids"), decoderInputTensors)
+        .feed(_tfMarianSignatures.getOrElse(ModelSignatureConstants.DecoderAttentionMask.key, "missing_encoder_attention_mask"), decoderAttentionMaskTensors)
+        .fetch(_tfMarianSignatures.getOrElse(ModelSignatureConstants.DecoderOutput.key, "missing_output_0"))
 
       val decoderOuts = runner.run().asScala
       val decoderOutputs = TensorResources.extractFloats(decoderOuts.head)
         .grouped(vocabSize).toArray.grouped(decoderInputLength).toArray
 
-      val outputIds = decoderOutputs.map(batch => batch.map(input => input.indexOf(input.max)).last).map(_.toLong)
+      val outputIds = decoderOutputs.map(batch => batch.map(input => input.indexOf(input.max)).last)
       decoderInputs = decoderInputs.zip(outputIds).map(x => x._1 ++ Array(x._2))
       modelOutputs = modelOutputs.zip(outputIds).map(x => {
         if (x._1.contains(eosTokenId)) {
@@ -176,8 +149,6 @@ class TensorflowMarian(val tensorflow: TensorflowWrapper,
       tensorDecoder.clearTensors()
       tensorDecoder.clearSession(decoderOuts)
       decoderInputTensors.close()
-      decoderCausalMaskTensors.close()
-      decoderPaddingMaskTensors.close()
 
       stopDecoder = !modelOutputs.exists(o => o.last != eosTokenId) ||
         (modelOutputs.head.length > math.max(maxOutputLength, maxSentenceLength))
@@ -191,13 +162,13 @@ class TensorflowMarian(val tensorflow: TensorflowWrapper,
     modelOutputs.map(x => x.filter(y => y != eosTokenId && y != paddingTokenId))
   }
 
-  def decode(sentences: Array[Array[Long]], vocabsArray: Array[String]): Seq[String] = {
+  def decode(sentences: Array[Array[Int]], vocabsArray: Array[String]): Seq[String] = {
 
     sentences.map { s =>
-      val filteredPads = s.filter(x => x != 0L)
+      val filteredPads = s.filter(x => x != 0)
       val pieceTokens = filteredPads.map {
         pieceId =>
-          vocabsArray(pieceId.toInt)
+          vocabsArray(pieceId)
       }
       sppTrg.getSppModel.decodePieces(pieceTokens.toList.asJava)
     }
@@ -205,7 +176,7 @@ class TensorflowMarian(val tensorflow: TensorflowWrapper,
   }
 
   def encode(sentences: Seq[Annotation], normalizer: MosesPunctNormalizer, maxSeqLength: Int, vocabsArray: Array[String],
-             langId: Long, unknownTokenId: Long, eosTokenId: Long): Seq[Array[Long]] = {
+             langId: Int, unknownTokenId: Int, eosTokenId: Int): Seq[Array[Int]] = {
 
     sentences.map { s =>
       // remove language code from the source text
@@ -215,15 +186,15 @@ class TensorflowMarian(val tensorflow: TensorflowWrapper,
 
       val pieceIds = pieceTokens.map {
         piece =>
-          val pieceId = vocabsArray.indexOf(piece).toLong
-          if (pieceId > 0L) {
+          val pieceId = vocabsArray.indexOf(piece)
+          if (pieceId > 0) {
             pieceId
           } else {
             unknownTokenId
           }
       }
 
-      if(langId > 0L)
+      if(langId > 0)
         Array(langId) ++ pieceIds.take(maxSeqLength) ++ Array(eosTokenId)
       else
         pieceIds.take(maxSeqLength) ++ Array(eosTokenId)
@@ -245,16 +216,16 @@ class TensorflowMarian(val tensorflow: TensorflowWrapper,
 
     val normalizer = new MosesPunctNormalizer()
 
-    val paddingTokenId = vocabs.indexOf("<pad>").toLong
-    val unknownTokenId = vocabs.indexOf("<unk>").toLong
-    val eosTokenId = vocabs.indexOf("</s>").toLong
+    val paddingTokenId = vocabs.indexOf("<pad>")
+    val unknownTokenId = vocabs.indexOf("<unk>")
+    val eosTokenId = vocabs.indexOf("</s>")
     val vocabSize = vocabs.toSeq.length
 
     val langIdPieceId = if (langId.nonEmpty) {
-      vocabs.indexOf(langId).toLong
+      vocabs.indexOf(langId)
     } else {
       val lang = langCodeRe.findFirstIn(sentences.head.result.trim).getOrElse(-1L)
-      vocabs.indexOf(lang).toLong
+      vocabs.indexOf(lang)
     }
 
     val batchDecoder = sentences.grouped(batchSize).toArray.flatMap { batch =>

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowSerializeModel.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowSerializeModel.scala
@@ -64,7 +64,8 @@ trait WriteTensorflowModel {
                               spark: SparkSession,
                               tensorflow: TensorflowWrapper,
                               suffix: String, filename: String,
-                              configProtoBytes: Option[Array[Byte]] = None
+                              configProtoBytes: Option[Array[Byte]] = None,
+                              savedSignatures: Option[Map[String, String]] = None
                             ): Unit = {
 
     val uri = new java.net.URI(path.replaceAllLiterally("\\", "/"))
@@ -77,7 +78,7 @@ trait WriteTensorflowModel {
     val tfFile = Paths.get(tmpFolder, filename).toString
 
     // 2. Save Tensorflow state
-    tensorflow.saveToFileV1V2(tfFile, configProtoBytes)
+    tensorflow.saveToFileV1V2(tfFile, configProtoBytes, savedSignatures = savedSignatures)
 
     // 3. Copy to dest folder
     fs.copyFromLocalFile(new Path(tfFile), new Path(path))
@@ -85,7 +86,6 @@ trait WriteTensorflowModel {
     // 4. Remove tmp folder
     FileUtils.deleteDirectory(new File(tmpFolder))
   }
-
 
   def writeTensorflowHub(
                           path: String,
@@ -125,7 +125,8 @@ trait ReadTensorflowModel {
                            zipped: Boolean = true,
                            useBundle: Boolean = false,
                            tags: Array[String] = Array.empty,
-                           initAllTables: Boolean = false
+                           initAllTables: Boolean = false,
+                           savedSignatures: Option[Map[String, String]] = None
                          ): TensorflowWrapper = {
 
     LoadsContrib.loadContribToCluster(spark)
@@ -142,7 +143,7 @@ trait ReadTensorflowModel {
 
     // 3. Read Tensorflow state
     val (tf, _) = TensorflowWrapper.read(new Path(tmpFolder, tfFile).toString,
-      zipped, tags = tags, useBundle = useBundle, initAllTables = initAllTables)
+      zipped, tags = tags, useBundle = useBundle, initAllTables = initAllTables, savedSignatures = savedSignatures)
 
     // 4. Remove tmp folder
     FileHelper.delete(tmpFolder)

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/sign/ModelSignatureConstants.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/sign/ModelSignatureConstants.scala
@@ -121,6 +121,41 @@ object ModelSignatureConstants {
     override val value: String = "pooled_output:0"
   }
 
+  case object EncoderInputIds extends TFInfoNameMapper {
+    override val key: String = "encoder_input_ids"
+    override val value: String = "encoder_encoder_input_ids:0"
+  }
+
+  case object EncoderAttentionMask extends TFInfoNameMapper {
+    override val key: String = "encoder_attention_mask"
+    override val value: String = "encoder_encoder_attention_mask:0"
+  }
+
+  case object EncoderOutput extends TFInfoNameMapper {
+    override val key: String = "last_hidden_state"
+    override val value: String = "StatefulPartitionedCall_1:0"
+  }
+
+  case object DecoderInputIds extends TFInfoNameMapper {
+    override val key: String = "decoder_input_ids"
+    override val value: String = "decoder_decoder_input_ids:0"
+  }
+
+  case object DecoderEncoderInputIds extends TFInfoNameMapper {
+    override val key: String = "encoder_state"
+    override val value: String = "decoder_encoder_state:0"
+  }
+
+  case object DecoderAttentionMask extends TFInfoNameMapper {
+    override val key: String = "encoder_attention_mask"
+    override val value: String = "decoder_encoder_attention_mask:0"
+  }
+
+  case object DecoderOutput extends TFInfoNameMapper {
+    override val key: String = "output_0"
+    override val value: String = "StatefulPartitionedCall:0"
+  }
+
   /** Retrieve signature patterns for a given provider
    *
    * @param modelProvider : the provider library that built the model and the signatures

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/sign/ModelSignatureConstants.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/sign/ModelSignatureConstants.scala
@@ -147,8 +147,8 @@ object ModelSignatureConstants {
   }
 
   case object DecoderAttentionMask extends TFInfoNameMapper {
-    override val key: String = "encoder_attention_mask"
-    override val value: String = "decoder_encoder_attention_mask:0"
+    override val key: String = "decoder_attention_mask"
+    override val value: String = "decoder_decoder_attention_mask:0"
   }
 
   case object DecoderOutput extends TFInfoNameMapper {

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/sign/ModelSignatureManager.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/sign/ModelSignatureManager.scala
@@ -182,9 +182,7 @@ object ModelSignatureManager {
 
     val modelProvider = classifyProvider(signDefNames)
 
-    var adoptedKeys = convertToAdoptedKeys(signDefNames)
-
-    adoptedKeys = Map(
+    val adoptedKeys = convertToAdoptedKeys(signDefNames) + (
       "filenameTensorName_" -> saverDef.getFilenameTensorName.replaceAll(":0", ""),
       "restoreOpName_" -> saverDef.getRestoreOpName.replaceAll(":0", ""),
       "saveTensorName_" -> saverDef.getSaveTensorName.replaceAll(":0", "")

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/sign/ModelSignatureManager.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/sign/ModelSignatureManager.scala
@@ -20,6 +20,7 @@ package com.johnsnowlabs.ml.tensorflow.sign
 import org.slf4j.{Logger, LoggerFactory}
 import org.tensorflow.SavedModelBundle
 import org.tensorflow.proto.framework.TensorInfo
+import org.tensorflow.proto.util.SaverDef
 
 import java.util
 import scala.util.matching.Regex
@@ -174,13 +175,21 @@ object ModelSignatureManager {
    * @param model         loaded SavedModelBundle
    * @return the list ot matching signatures as tuples
    * */
-  def extractSignatures(model: SavedModelBundle): Option[Map[String, String]] = {
+  def extractSignatures(model: SavedModelBundle, saverDef: SaverDef): Option[Map[String, String]] = {
 
     val signatureCandidates = getSignaturesFromModel(model)
     val signDefNames: Map[String, String] = signatureCandidates.filterKeys(_.contains(ModelSignatureConstants.Name.key))
 
     val modelProvider = classifyProvider(signDefNames)
 
-    Option(convertToAdoptedKeys(signDefNames))
+    var adoptedKeys = convertToAdoptedKeys(signDefNames)
+
+    adoptedKeys = Map(
+      "filenameTensorName_" -> saverDef.getFilenameTensorName.replaceAll(":0", ""),
+      "restoreOpName_" -> saverDef.getRestoreOpName.replaceAll(":0", ""),
+      "saveTensorName_" -> saverDef.getSaveTensorName.replaceAll(":0", "")
+    )
+
+    Option(adoptedKeys)
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
@@ -20,8 +20,8 @@ package com.johnsnowlabs.nlp.annotators.seq2seq
 import com.johnsnowlabs.ml.tensorflow._
 import com.johnsnowlabs.ml.tensorflow.sentencepiece._
 import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.serialization.MapFeature
 import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
-
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.param.{IntArrayParam, IntParam, Param, StringArrayParam}
 import org.apache.spark.ml.util.Identifiable
@@ -164,6 +164,23 @@ class MarianTransformer(override val uid: String) extends
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
   /**
+   * It contains TF model signatures for the laded saved model
+   *
+   * @group param
+   * */
+  val signatures = new MapFeature[String, String](model = this, name = "signatures")
+
+  /** @group setParam */
+  def setSignatures(value: Map[String, String]): this.type = {
+    if (get(signatures).isEmpty)
+      set(signatures, value)
+    this
+  }
+
+  /** @group getParam */
+  def getSignatures: Option[Map[String, String]] = get(this.signatures)
+
+  /**
    * The Tensorflow Marian Model
    *
    * @group param
@@ -221,7 +238,7 @@ class MarianTransformer(override val uid: String) extends
 
   override def onWrite(path: String, spark: SparkSession): Unit = {
     super.onWrite(path, spark)
-    writeTensorflowModel(path, spark, getModelIfNotSet.tensorflow, "_marian", MarianTransformer.tfFile, configProtoBytes = getConfigProtoBytes)
+    writeTensorflowModelV2(path, spark, getModelIfNotSet.tensorflow, "_marian", MarianTransformer.tfFile, configProtoBytes = getConfigProtoBytes, savedSignatures = getSignatures)
     writeSentencePieceModel(path, spark, getModelIfNotSet.sppSrc, "_src_marian", MarianTransformer.sppFile + "_src")
     writeSentencePieceModel(path, spark, getModelIfNotSet.sppTrg, "_trg_marian", MarianTransformer.sppFile + "_trg")
 
@@ -250,7 +267,7 @@ trait ReadMarianMTTensorflowModel extends ReadTensorflowModel with ReadSentenceP
   override val sppFile: String = "marian_spp"
 
   def readTensorflow(instance: MarianTransformer, path: String, spark: SparkSession): Unit = {
-    val tf = readTensorflowModel(path, spark, "_marian_tf")
+    val tf = readTensorflowModel(path, spark, "_marian_tf", savedSignatures = instance.getSignatures)
     val sppSrc = readSentencePieceModel(path, spark, "_src_marian", sppFile + "_src")
     val sppTrg = readSentencePieceModel(path, spark, "_trg_marian", sppFile + "_trg")
     instance.setModelIfNotSet(spark, tf, sppSrc, sppTrg)
@@ -281,12 +298,19 @@ trait ReadMarianMTTensorflowModel extends ReadTensorflowModel with ReadSentenceP
     val words = ResourceHelper.parseLines(vocabResource)
       .zipWithIndex.toMap.toSeq.sortBy(_._2).map(x => x._1.mkString).toArray
 
-    val (wrapper, _) = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"))
+    val (wrapper, signatures) = TensorflowWrapper.read(folder, zipped = false, useBundle = true, tags = Array("serve"))
     val sppSrc = SentencePieceWrapper.read(sppSrcModel.toString)
     val sppTrg = SentencePieceWrapper.read(sppTrgModel.toString)
 
+    val _signatures = signatures match {
+      case Some(s) => s
+      case None => throw new Exception("Cannot load signature definitions from model!")
+    }
+
+    /** the order of setSignatures is important is we use getSignatures inside setModelIfNotSet */
     val marianMT = new MarianTransformer()
       .setVocabulary(words)
+      .setSignatures(_signatures)
       .setModelIfNotSet(spark, wrapper, sppSrc, sppTrg)
 
     marianMT

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
@@ -196,7 +196,8 @@ class MarianTransformer(override val uid: String) extends
             tensorflow,
             sppSrc,
             sppTrg,
-            configProtoBytes = getConfigProtoBytes
+            configProtoBytes = getConfigProtoBytes,
+            signatures = getSignatures
           )
         )
       )

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/DistilBertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/DistilBertEmbeddings.scala
@@ -311,10 +311,15 @@ trait ReadDistilBertTensorflowModel extends ReadTensorflowModel {
 
     val (wrapper, signatures) = TensorflowWrapper.read(tfModelPath, zipped = false, useBundle = true)
 
+    val _signatures = signatures match {
+      case Some(s) => s
+      case None => throw new Exception("Cannot load signature definitions from model!")
+    }
+
     /** the order of setSignatures is important is we use getSignatures inside setModelIfNotSet */
     new DistilBertEmbeddings()
       .setVocabulary(words)
-      .setSignatures(signatures.get)
+      .setSignatures(_signatures)
       .setModelIfNotSet(spark, wrapper)
   }
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddingsTestSpec.scala
@@ -152,10 +152,10 @@ class BertEmbeddingsTestSpec extends FlatSpec {
     val embeddings = BertEmbeddings.loadSavedModel(tfModelPath, ResourceHelper.spark)
       .setInputCols(Array("token", "document"))
       .setOutputCol("bert")
+      .setStorageRef("tf_hub_bert_test")
 
     val pipeline = new Pipeline().setStages(Array(document, tokenizer, embeddings))
 
-    // FIXME write is working - load is not
     pipeline.fit(ddd).write.overwrite().save("./tmp_bert_pipeline")
     val pipelineModel = PipelineModel.load("./tmp_bert_pipeline")
 

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddingsTestSpec.scala
@@ -1,13 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.embeddings
 
-import com.johnsnowlabs.nlp.annotator.SentenceDetectorDLModel
+import com.johnsnowlabs.nlp.annotator.{SentenceDetectorDLModel, Tokenizer}
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.training.CoNLL
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.tags.{FastTest, SlowTest}
 import com.johnsnowlabs.util.Benchmark
-import org.apache.spark.ml.Pipeline
+import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.functions.{col, explode, size}
 import org.scalatest._
@@ -124,4 +141,36 @@ class BertSentenceEmbeddingsTestSpec extends FlatSpec {
 
     assert(totalSentences == totalEmbeddings)
   }
+
+  "BertSentenceEmbeddings" should "correctly load custom model with extracted signatures" taggedAs SlowTest in {
+
+    import ResourceHelper.spark.implicits._
+
+    val ddd = Seq(
+      "Something is weird on the notebooks, something is happening."
+    ).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val tfModelPath = "src/test/resources/tf-hub-bert/model"
+
+    val embeddings = BertSentenceEmbeddings.loadSavedModel(tfModelPath, ResourceHelper.spark)
+      .setInputCols("document")
+      .setOutputCol("bert")
+      .setStorageRef("tf_hub_bert_test")
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, embeddings))
+
+    pipeline.fit(ddd).write.overwrite().save("./tmp_bert_pipeline")
+    val pipelineModel = PipelineModel.load("./tmp_bert_pipeline")
+
+    pipelineModel.transform(ddd)
+  }
+
 }


### PR DESCRIPTION
- In this PR MarianTransformer will only support models exported in TensorFlow v2 architecture with the support of ModelSignatureConstants. This change helps to take advantage of new optimizations in TensorFlow 2.x and also made the process of exporting and maintaining the code easier for the team

- Some improvements were done in ModelSignatureConstants to preserve `saveDef` required values in signature for saving/restoring of TF v2 models.

**WARNING:** Due to this change, the previous models (online/offline) will not work. Around 640+ models/pipelines must be exported and uploaded again for the upcoming Spark NLP 3.1.0 release.