### PR TITLE
fix datematecher utils for relatives dates

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
@@ -51,7 +51,7 @@ trait DateMatcherUtils extends Params {
 
   /** Relative dates, e.g. tomorrow */
   private val relativeDate = "(?i)(next|last)\\s(week|month|year)".r
-  private val relativeDay = "(?i)(today|tomorrow|yesterday|past tomorrow|day before|day after|day before yesterday|day after tomorrow)".r
+  private val relativeDay = "(?i)(today|tomorrow|yesterday|past tomorrow|day before yesterday|day after tomorrow|day before|day after)".r
   private val relativeExactDay = "(?i)(next|last|past)\\s(mon|tue|wed|thu|fri)".r
 
   /** standard time representations e.g. 05:42:16 or 5am */

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/DateMatcherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/DateMatcherTestSpec.scala
@@ -57,9 +57,21 @@ class DateMatcherTestSpec extends FlatSpec with DateMatcherBehaviors {
     calendar.add(Calendar.DAY_OF_MONTH, 1)
     calendar
   }
+
+  val afterTomorrowCalendar: Calendar = {
+    val calendar = Calendar.getInstance
+    calendar.add(Calendar.DAY_OF_MONTH, 2)
+    calendar
+  }
   val yesterdayCalendar: Calendar = {
     val calendar = Calendar.getInstance
     calendar.add(Calendar.DAY_OF_MONTH, -1)
+    calendar
+  }
+
+  val beforeYesterdayCalendar: Calendar = {
+    val calendar = Calendar.getInstance
+    calendar.add(Calendar.DAY_OF_MONTH, -2)
     calendar
   }
 
@@ -102,7 +114,9 @@ class DateMatcherTestSpec extends FlatSpec with DateMatcherBehaviors {
     //NS: "3 days from now",
     //NS: "three weeks ago",
     ("day after", Some(tomorrowCalendar)),
+    ("day after tomorrow", Some(afterTomorrowCalendar)),
     ("the day before", Some(yesterdayCalendar)),
+    ("the day before yesterday", Some(beforeYesterdayCalendar)),
     //"the monday after",
     //"the monday before"
     //NS: "2 fridays before",


### PR DESCRIPTION
There is a bug in DateMatcher when try to recognize the followings values `day after tomorrow` and `day before yesterday`

## Description
There is a bug in DateMatcher when try to recognize the followings values `day after tomorrow` and `day before yesterday`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
