### PR TITLE
Make the Java error appear first

### DIFF
--- a/python/sparknlp/pretrained.py
+++ b/python/sparknlp/pretrained.py
@@ -20,6 +20,7 @@ from pyspark.sql import DataFrame
 from sparknlp.annotator import *
 from sparknlp.base import LightPipeline
 from pyspark.ml import PipelineModel
+from py4j.protocol import Py4JJavaError
 
 
 def printProgress(stop):
@@ -54,6 +55,9 @@ class ResourceDownloader(object):
             t1.start()
             try:
                 j_obj = _internal._DownloadModel(reader.name, name, language, remote_loc, j_dwn).apply()
+            except Py4JJavaError as e:
+                sys.stdout.write("\n" + str(e))
+                raise e
             finally:
                 stop_threads = True
                 t1.join()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a simple cosmetic PR, in which we make the Java Exception appear at the top and leave the Py4J exceptions afterwards.
This is useful because our users want to read the exceptions coming from Spark-NLP first, and they don't care that much about the errors in the Python/Java interface.
All the information is going to be there, different order.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
