### PR TITLE
updated script for colab

### DIFF
--- a/scripts/colab_setup.sh
+++ b/scripts/colab_setup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 #default values for pyspark, spark-nlp, and SPARK_HOME
-SPARKNLP="3.1.1"
-PYSPARK="3.0.3"
-SPARKHOME="/content/spark-3.1.2-bin-hadoop2.7"
+SPARKNLP="3.1.0"
+PYSPARK="3.0.2"
+SPARKHOME="/content/spark-3.0.3-bin-hadoop2.7"
 
 while getopts s:p: option
 do


### PR DESCRIPTION
Downgraded  Pyspark to 3.0.2  and Spark NLP to 3.1.0 because of compatibility issues for some pretrained pipelines in the training workshop certification notebooks.

To reproduce issues, run [this notebook](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/1.SparkNLP_Basics.ipynb) with old default versions

```
SPARKNLP="3.1.1"
PYSPARK="3.0.3"
```
