### PR TITLE
Dynamically extract special tokens ids from SP models in XlmRobertaEmbeddings

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlmRoberta.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlmRoberta.scala
@@ -56,25 +56,22 @@ import scala.collection.JavaConverters._
  * @param tensorflowWrapper    XlmRoberta Model wrapper with TensorFlowWrapper
  * @param spp                  XlmRoberta SentencePiece model with SentencePieceWrapper
  * @param batchSize            size of batch
- * @param sentenceStartTokenId piece id for starting sequence '''<s>'''
- * @param sentenceEndTokenId   piece id for ending sequence '''</s>'''
- * @param padTokenId           piece id for padding '''<pad>'''
  * @param configProtoBytes     Configuration for TensorFlow session
  */
 
 class TensorflowXlmRoberta(val tensorflowWrapper: TensorflowWrapper,
                            val spp: SentencePieceWrapper,
                            batchSize: Int,
-                           sentenceStartTokenId: Int,
-                           sentenceEndTokenId: Int,
-                           padTokenId: Int,
                            configProtoBytes: Option[Array[Byte]] = None,
                            signatures: Option[Map[String, String]] = None
                           ) extends Serializable {
 
   val _tfRoBertaSignatures: Map[String, String] = signatures.getOrElse(ModelSignatureManager.apply())
 
-  private val SentencePieceDelimiterId = 13
+  private val SentenceStartTokenId = spp.getSppModel.pieceToId("<s>")
+  private val SentenceEndTokenId = spp.getSppModel.pieceToId("</s>")
+  private val SentencePadTokenId = spp.getSppModel.pieceToId("<pad>")
+  private val SentencePieceDelimiterId = spp.getSppModel.pieceToId("▁")
 
   def prepareBatchInputs(sentences: Seq[(WordpieceTokenizedSentence, Int)], maxSequenceLength: Int): Seq[Array[Int]] = {
     val maxSentenceLength =
@@ -85,9 +82,9 @@ class TensorflowXlmRoberta(val tensorflowWrapper: TensorflowWrapper,
     sentences
       .map { case (wpTokSentence, _) =>
         val tokenPieceIds = wpTokSentence.tokens.map(t => t.pieceId)
-        val padding = Array.fill(maxSentenceLength - tokenPieceIds.length)(padTokenId)
+        val padding = Array.fill(maxSentenceLength - tokenPieceIds.length)(SentencePadTokenId)
 
-        Array(sentenceStartTokenId) ++ tokenPieceIds.take(maxSentenceLength) ++ Array(sentenceEndTokenId) ++ padding
+        Array(SentenceStartTokenId) ++ tokenPieceIds.take(maxSentenceLength) ++ Array(SentenceEndTokenId) ++ padding
       }
   }
 
@@ -110,11 +107,11 @@ class TensorflowXlmRoberta(val tensorflowWrapper: TensorflowWrapper,
         val offset = idx * maxSentenceLength
         val diff = maxSentenceLength - tokenIds.length
 
-        val padding = Array.fill(diff)(padTokenId)
+        val padding = Array.fill(diff)(SentencePadTokenId)
         val newTokenIds = tokenIds ++ padding
 
         tokenBuffers.offset(offset).write(newTokenIds)
-        maskBuffers.offset(offset).write(newTokenIds.map(x => if (x == padTokenId) 0 else 1))
+        maskBuffers.offset(offset).write(newTokenIds.map(x => if (x == SentencePadTokenId) 0 else 1))
       }
 
     val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
@@ -195,7 +192,7 @@ class TensorflowXlmRoberta(val tensorflowWrapper: TensorflowWrapper,
   }
 
   def tokenizeWithAlignment(sentences: Seq[TokenizedSentence], maxSeqLength: Int, caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = {
-    val encoder = new SentencepieceEncoder(spp, caseSensitive, 6, pieceIdFromZero = true)
+    val encoder = new SentencepieceEncoder(spp, caseSensitive, SentencePieceDelimiterId, pieceIdFromZero = true)
 
     val sentecneTokenPieces = sentences.map { s =>
       val shrinkedSentence = s.indexedTokens.take(maxSeqLength - 2)

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/sentencepiece/SentencepieceEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/sentencepiece/SentencepieceEncoder.scala
@@ -21,10 +21,10 @@ import com.johnsnowlabs.nlp.annotators.common.{IndexedToken, TokenPiece}
 
 /**
  *
- * @param spp           StencePieceWrapper loaded from either from disk or a saved Spark NLP model
- * @param caseSensitive whether it cares about uppercase or lowercases
- * @param delimiterId   what is the part prefix id
- * @param pieceIdFromZero   whether or not pieceId should be as is or plus 1
+ * @param spp             StencePieceWrapper loaded from either from disk or a saved Spark NLP model
+ * @param caseSensitive   whether it cares about uppercase or lowercases
+ * @param delimiterId     what is the part prefix id
+ * @param pieceIdFromZero whether or not pieceId should be as is or plus 1
  */
 private[ml] class SentencepieceEncoder
 (
@@ -43,12 +43,13 @@ private[ml] class SentencepieceEncoder
     val text = token.token
     var start = 0
     var end = text.length
+    val normalizedDelimiterId = if (pieceIdFromZero) delimiterId + 1 else delimiterId
 
     val tokenContent = if (caseSensitive) token.token else token.token.toLowerCase()
     val wordPieces = spp.getSppModel.encodeAsPieces(tokenContent).toArray.map(x => x.toString)
     val encodedIds = spp.getSppModel.encodeAsIds(tokenContent)
     val pieceIds = if (pieceIdFromZero) encodedIds.map(x => x + 1) else encodedIds
-    wordPieces.zip(pieceIds).filter(id => id._2 != delimiterId).map { piece =>
+    wordPieces.zip(pieceIds).filter(id => id._2 != normalizedDelimiterId).map { piece =>
       val tokenPiece = TokenPiece(piece._1, token.token, piece._2, start == 0, token.begin + start, token.end)
       start = end
       end = text.length

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
@@ -151,18 +151,6 @@ class XlmRoBertaEmbeddings(override val uid: String)
   /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */
   def this() = this(Identifiable.randomUID("XLM_ROBERTA_EMBEDDINGS"))
 
-  def sentenceStartTokenId: Int = {
-    0
-  }
-
-  def sentenceEndTokenId: Int = {
-    2
-  }
-
-  def padTokenId: Int = {
-    1
-  }
-
   /** ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
    *
    * @group param

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
@@ -220,9 +220,6 @@ class XlmRoBertaEmbeddings(override val uid: String)
             tensorflowWrapper,
             spp,
             $(batchSize),
-            sentenceStartTokenId,
-            sentenceEndTokenId,
-            padTokenId,
             configProtoBytes = getConfigProtoBytes,
             signatures = getSignatures
           )


### PR DESCRIPTION
Prior to this PR, the special tokens inside XlmRobertaEmbeddings were had-coded based on their actual values taken from the SentencePiece model. This PR uses the `pieceToId` function to access the values dynamically to allow support for custom SP models with different special token ids.