### PR TITLE
Add includeAllConfidenceScores param to NerDLModel and NerDLApproach

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -1553,6 +1553,10 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
                               "whether to include confidence scores in annotation metadata",
                               TypeConverters.toBoolean)
 
+    includeAllConfidenceScores = Param(Params._dummy(), "includeAllConfidenceScores",
+                                       "whether to include all confidence scores in annotation metadata or just the score of the predicted tag",
+                                       TypeConverters.toBoolean)
+
     enableOutputLogs = Param(Params._dummy(), "enableOutputLogs",
                              "Whether to use stdout in addition to Spark logs.",
                              TypeConverters.toBoolean)
@@ -1605,6 +1609,9 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     def setIncludeConfidence(self, value):
         return self._set(includeConfidence=value)
 
+    def setIncludeAllConfidenceScores(self, value):
+        return self._set(includeAllConfidenceScores=value)
+
     def setEnableOutputLogs(self, value):
         return self._set(enableOutputLogs=value)
 
@@ -1630,6 +1637,7 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
             validationSplit=float(0.0),
             evaluationLogExtended=False,
             includeConfidence=False,
+            includeAllConfidenceScores=False,
             enableOutputLogs=False,
             enableMemoryOptimizer=False
         )
@@ -1645,6 +1653,7 @@ class NerDLModel(AnnotatorModel, HasStorageRef, HasBatchedAnnotate):
         )
         self._setDefault(
             includeConfidence=False,
+            includeAllConfidenceScores=False,
             batchSize=8
         )
 
@@ -1652,6 +1661,9 @@ class NerDLModel(AnnotatorModel, HasStorageRef, HasBatchedAnnotate):
     includeConfidence = Param(Params._dummy(), "includeConfidence",
                               "whether to include confidence scores in annotation metadata",
                               TypeConverters.toBoolean)
+    includeAllConfidenceScores = Param(Params._dummy(), "includeAllConfidenceScores",
+                                       "whether to include all confidence scores in annotation metadata or just the score of the predicted tag",
+                                       TypeConverters.toBoolean)
     classes = Param(Params._dummy(), "classes",
                     "get the tags used to trained this NerDLModel",
                     TypeConverters.toListString)
@@ -1661,6 +1673,9 @@ class NerDLModel(AnnotatorModel, HasStorageRef, HasBatchedAnnotate):
 
     def setIncludeConfidence(self, value):
         return self._set(includeConfidence=value)
+
+    def setIncludeAllConfidenceScores(self, value):
+        return self._set(includeAllConfidenceScores=value)
 
     @staticmethod
     def pretrained(name="ner_dl", lang="en", remote_loc=None):

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/NerDatasetEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/NerDatasetEncoder.scala
@@ -154,15 +154,17 @@ class NerDatasetEncoder(val params: DatasetEncoderParams) extends Serializable {
   /**
    * Converts Tensorflow tags output to 2-dimensional Array with shape: (Batch, Sentence Length).
    *
-   * @param predictedTags 2-dimensional tensor in plain array
-   * @param allTags All original tags
+   * @param predictedTags  2-dimensional tensor in plain array
+   * @param allTags        All original tags
    * @param sentenceLength Every sentence length (number of words).
    * @return List of tags for each sentence
    */
   def convertBatchTags(predictedTags: Array[String],
                        allTags: Array[String],
                        sentenceLength: Array[Int],
-                       prob: Option[Seq[Array[Float]]]): Array[Array[(String, Option[Array[Map[String, String]]])]] = {
+                       prob: Option[Seq[Array[Float]]],
+                       includeAllConfidenceScores: Boolean
+                      ): Array[Array[(String, Option[Array[Map[String, String]]])]] = {
 
     val sentences = sentenceLength.length
     val maxSentenceLength = predictedTags.length / sentences
@@ -170,13 +172,23 @@ class NerDatasetEncoder(val params: DatasetEncoderParams) extends Serializable {
     Range(0, sentences).map { i =>
       Range(0, sentenceLength(i)).map { j => {
         val index = i * maxSentenceLength + j
-        val metaWithProb: Option[Array[Map[String, String]]] = {
-          if(prob.isDefined)
+        val metaWithProb: Option[Array[Map[String, String]]] = if (prob.isDefined) {
+          if (includeAllConfidenceScores) {
             Some(allTags
               .zipWithIndex
-              .map {case (t, i) => Map(t -> prob.map(_ (index)).getOrElse(Array.empty[String]).lift(i).getOrElse(0.0f).toString)})
-          else None
-        }
+              .map {
+                case (t, i) => Map(
+                  t -> prob
+                    .map(_ (index))
+                    .getOrElse(Array.empty[String])
+                    .lift(i)
+                    .getOrElse(0.0f)
+                    .toString)
+              })
+          } else {
+            Some(Array(Map("confidence" -> prob.map(_ (index)).getOrElse(Array.empty[String]).lift(0).getOrElse(0.0f).toString)))
+          }
+        } else None
 
         (predictedTags(index), metaWithProb)
       }
@@ -212,11 +224,11 @@ object NerBatch {
 
 /**
  *
- * @param tags list of unique tags
- * @param chars list of unique characters
- * @param emptyVector list of embeddings
+ * @param tags          list of unique tags
+ * @param chars         list of unique characters
+ * @param emptyVector   list of embeddings
  * @param embeddingsDim dimension of embeddings
- * @param defaultTag the default tag
+ * @param defaultTag    the default tag
  */
 case class DatasetEncoderParams
 (

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -53,7 +53,8 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
 
   def predict(dataset: Array[WordpieceEmbeddingsSentence],
               configProtoBytes: Option[Array[Byte]] = None,
-              includeConfidence: Boolean = false): Array[Array[(String, Option[Array[Map[String, String]]])]] = {
+              includeConfidence: Boolean = false,
+              includeAllConfidenceScores: Boolean): Array[Array[(String, Option[Array[Map[String, String]]])]] = {
 
     val result = ArrayBuffer[Array[(String, Option[Array[Map[String, String]]])]]()
 
@@ -67,7 +68,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
       else {
         val tensors = new TensorResources()
 
-        val calculator = tensorflow.getSession(configProtoBytes=configProtoBytes).runner
+        val calculator = tensorflow.getSession(configProtoBytes = configProtoBytes).runner
           .feed(sentenceLengthsKey, tensors.createTensor(batchInput.sentenceLengths))
           .feed(wordEmbeddingsKey, tensors.createTensor(batchInput.wordEmbeddings))
           .feed(wordLengthsKey, tensors.createTensor(batchInput.wordLengths))
@@ -91,22 +92,41 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
               require(scores.length % tagIds.length == 0, "tag size mismatch against feed size. please report an issue.")
               val exp = scores.map(s => math.exp(s.toDouble)).grouped(scores.length / tagIds.length).toSeq
               // val probs = exp.map(g => try{BigDecimal(g.map(_ / g.sum).max).setScale(4, BigDecimal.RoundingMode.HALF_UP).toDouble}catch{case _: Exception => 0.0d})
-              val probs = exp.map(d => d.map(_ / d.sum).map(p => try {
-                BigDecimal(p).setScale(4, BigDecimal.RoundingMode.HALF_UP).toFloat
-              } catch{case _: Exception => 0.0f}))
-
+              val probs = if (includeAllConfidenceScores) {
+                //Only include the score of the predicted tag
+                exp.map(d => d.map(_ / d.sum).map(p => try {
+                  BigDecimal(p).setScale(4, BigDecimal.RoundingMode.HALF_UP).toFloat
+                } catch {
+                  case _: Exception => 0.0f
+                }))
+              } else {
+                exp.map(
+                  d => try {
+                    Array(BigDecimal(d.map(_ / d.sum).max)
+                      .setScale(4, BigDecimal.RoundingMode.HALF_UP)
+                      .toFloat)
+                  } catch {
+                    case _: Exception => Array(0.0f)
+                  })
+              }
               Some(probs)
             } else {
               None
             }
-          } catch { case _: Exception =>
-            Option(Seq.fill(tagIds.length)(Array.fill(allTags.length)(0.0f)))
+          } catch {
+            case _: Exception =>
+              Option(Seq.fill(tagIds.length)(Array.fill(allTags.length)(0.0f)))
           }
         }
 
         val predictedTags = encoder.decodeOutputData(tagIds)
 
-        val sentenceTags = encoder.convertBatchTags(predictedTags, allTags, batchInput.sentenceLengths, confidence)
+        val sentenceTags = encoder.convertBatchTags(
+          predictedTags,
+          allTags,
+          batchInput.sentenceLengths,
+          confidence,
+          includeAllConfidenceScores = includeAllConfidenceScores)
 
         result.appendAll(sentenceTags)
       }
@@ -118,23 +138,23 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
   def getPiecesTags(tokenTags: TextSentenceLabels, sentence: WordpieceEmbeddingsSentence): Array[String] = {
     var i = -1
 
-    sentence.tokens.map{ _ =>
+    sentence.tokens.map { _ =>
       i += 1
       tokenTags.labels(i)
     }
   }
 
   def getPiecesTags(tokenTags: Array[TextSentenceLabels], sentences: Array[WordpieceEmbeddingsSentence])
-  :Array[Array[String]] = {
-    tokenTags.zip(sentences).map{
+  : Array[Array[String]] = {
+    tokenTags.zip(sentences).map {
       case (tags, sentence) => getPiecesTags(tags, sentence)
     }
   }
 
   def train(trainDataset: => Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]],
-            trainLength:Long,
+            trainLength: Long,
             validDataset: => Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]],
-            validLength:Long,
+            validLength: Long,
             lr: Float,
             po: Float,
             dropout: Float,
@@ -148,7 +168,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
             includeConfidence: Boolean = false,
             enableOutputLogs: Boolean = false,
             outputLogsPath: String,
-            uuid: String  = Identifiable.randomUID("annotator")
+            uuid: String = Identifiable.randomUID("annotator")
            ): Unit = {
 
     log(s"Name of the selected graph: $graphFileName", Verbose.Epochs)
@@ -156,7 +176,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
 
     // Initialize
     if (startEpoch == 0)
-      tensorflow.createSession(configProtoBytes=configProtoBytes).runner.addTarget(initKey).run()
+      tensorflow.createSession(configProtoBytes = configProtoBytes).runner.addTarget(initKey).run()
 
     println(s"Training started - total epochs: $endEpoch - lr: $lr - batch size: $batchSize - labels: ${encoder.tags.length} " +
       s"- chars: ${encoder.chars.length} - training examples: $trainLength"
@@ -170,9 +190,9 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
 
       val learningRate = lr / (1 + po * epoch)
 
-      println(s"Epoch ${epoch+1}/$endEpoch started, lr: $learningRate, dataset size: $trainLength")
+      println(s"Epoch ${epoch + 1}/$endEpoch started, lr: $learningRate, dataset size: $trainLength")
       outputLog("\n", uuid, enableOutputLogs, outputLogsPath)
-      outputLog(s"Epoch ${epoch+1}/$endEpoch started, lr: $learningRate, dataset size: $trainLength", uuid, enableOutputLogs, outputLogsPath)
+      outputLog(s"Epoch ${epoch + 1}/$endEpoch started, lr: $learningRate, dataset size: $trainLength", uuid, enableOutputLogs, outputLogsPath)
 
       val time = System.nanoTime()
       var batches = 0
@@ -185,7 +205,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
         val batchTags = encoder.encodeTags(tags)
 
         val tensors = new TensorResources()
-        val calculated = tensorflow.getSession(configProtoBytes=configProtoBytes).runner
+        val calculated = tensorflow.getSession(configProtoBytes = configProtoBytes).runner
           .feed(sentenceLengthsKey, tensors.createTensor(batchInput.sentenceLengths))
           .feed(wordEmbeddingsKey, tensors.createTensor(batchInput.wordEmbeddings))
 
@@ -206,16 +226,15 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
         batches += 1
       }
 
-      val endTime = (System.nanoTime() - time)/1e9
-      println(f"Epoch ${epoch+1}/$endEpoch - $endTime%.2fs - loss: $loss - batches: $batches")
+      val endTime = (System.nanoTime() - time) / 1e9
+      println(f"Epoch ${epoch + 1}/$endEpoch - $endTime%.2fs - loss: $loss - batches: $batches")
       outputLog("\n", uuid, enableOutputLogs, outputLogsPath)
-      outputLog(f"Epoch ${epoch+1}/$endEpoch - $endTime%.2fs - loss: $loss - batches: $batches", uuid, enableOutputLogs, outputLogsPath)
-
+      outputLog(f"Epoch ${epoch + 1}/$endEpoch - $endTime%.2fs - loss: $loss - batches: $batches", uuid, enableOutputLogs, outputLogsPath)
 
 
       if (validationSplit > 0.0) {
-        println(s"Quality on validation dataset (${validationSplit*100}%), validation examples = $validLength")
-        outputLog(s"Quality on validation dataset (${validationSplit*100}%), validation examples = $validLength", uuid, enableOutputLogs, outputLogsPath)
+        println(s"Quality on validation dataset (${validationSplit * 100}%), validation examples = $validLength")
+        outputLog(s"Quality on validation dataset (${validationSplit * 100}%), validation examples = $validLength", uuid, enableOutputLogs, outputLogsPath)
         measure(validDataset, extended = evaluationLogExtended, includeConfidence = includeConfidence, enableOutputLogs = enableOutputLogs, outputLogsPath = outputLogsPath, uuid = uuid)
       }
 
@@ -234,12 +253,12 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
     val rec = tp.toFloat / (tp.toFloat + fn.toFloat)
     val f1 = 2 * ((prec * rec) / (prec + rec))
 
-    (if (prec.isNaN) 0f else prec, if(rec.isNaN) 0f else rec, if (f1.isNaN) 0 else f1)
+    (if (prec.isNaN) 0f else prec, if (rec.isNaN) 0f else rec, if (f1.isNaN) 0 else f1)
   }
 
   def tagsForTokens(labels: Array[(String, Option[Array[Map[String, String]]])], pieces: WordpieceEmbeddingsSentence): Array[(String, Option[Array[Map[String, String]]])] = {
-    labels.zip(pieces.tokens).flatMap{
-      case(l, p) =>
+    labels.zip(pieces.tokens).flatMap {
+      case (l, p) =>
         if (p.isWordStart)
           Some(l)
         else
@@ -251,12 +270,13 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
   Array[Array[(String, Option[Array[Map[String, String]]])]] = {
 
     labels.zip(pieces)
-      .map{case (l, p) => tagsForTokens(l, p)}
+      .map { case (l, p) => tagsForTokens(l, p) }
   }
 
   def measure(labeled: Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]],
               extended: Boolean = false,
               includeConfidence: Boolean = false,
+              includeAllConfidenceScores: Boolean = false,
               enableOutputLogs: Boolean = false,
               outputLogsPath: String,
               uuid: String = Identifiable.randomUID("annotator")
@@ -273,7 +293,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
 
     for (batch <- labeled) {
 
-      val sentencePredictedTags = predict(batch.map(_._2), includeConfidence = includeConfidence)
+      val sentencePredictedTags = predict(batch.map(_._2), includeConfidence = includeConfidence, includeAllConfidenceScores = includeAllConfidenceScores)
 
       val sentenceTokenTags = tagsForTokens(sentencePredictedTags, batch.map(_._2))
 
@@ -308,7 +328,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
       }
     }
 
-    val endTime = (System.nanoTime() - started)/1e9
+    val endTime = (System.nanoTime() - started) / 1e9
     println(f"time to finish evaluation: $endTime%.2fs")
     outputLog(f"time to finish evaluation: $endTime%.2fs", uuid, enableOutputLogs, outputLogsPath)
 
@@ -339,8 +359,8 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
       totalPercByClass = totalPercByClass + prec
       totalRecByClass = totalRecByClass + rec
     }
-    val macroPercision = totalPercByClass/notEmptyLabels.length
-    val macroRecall = totalRecByClass/notEmptyLabels.length
+    val macroPercision = totalPercByClass / notEmptyLabels.length
+    val macroRecall = totalRecByClass / notEmptyLabels.length
     val macroF1 = 2 * ((macroPercision * macroRecall) / (macroPercision + macroRecall))
 
     if (extended) {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/Tagged.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/Tagged.scala
@@ -48,14 +48,18 @@ trait Tagged[T >: TaggedSentence <: TaggedSentence] extends Annotated[T] {
           annotation = Some(tagAnnotations.next)
 
         val tag = if (annotation.isDefined && annotation.get.begin == token.begin) {
-           annotation.get.result
+          annotation.get.result
         } else
           emptyTag
         // etract the confidence score belong to the tag
-        val metadata = try{
-          Map(tag -> annotation.get.metadata(tag))
-        } catch { case _: Exception =>
-          Map.empty[String, String]
+        val metadata = try {
+          if (annotation.get.metadata.isDefinedAt("confidence"))
+            Map(tag -> annotation.get.metadata("confidence"))
+          else
+            Map(tag -> annotation.get.metadata(tag))
+        } catch {
+          case _: Exception =>
+            Map.empty[String, String]
         }
 
         IndexedTaggedWord(token.token, tag, token.begin, token.end, metadata = metadata)
@@ -66,8 +70,8 @@ trait Tagged[T >: TaggedSentence <: TaggedSentence] extends Annotated[T] {
   }
 
   override def pack(items: Seq[T]): Seq[Annotation] = {
-    items.flatMap(item => item.indexedTaggedWords.map{ tag =>
-      val metadata =  if (tag.confidence.isDefined) {
+    items.flatMap(item => item.indexedTaggedWords.map { tag =>
+      val metadata = if (tag.confidence.isDefined) {
         Map("word" -> tag.word) ++ tag.confidence.getOrElse(Array.empty[Map[String, String]]).flatten
       } else {
         Map("word" -> tag.word) ++ Map.empty[String, String]

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -19,6 +19,7 @@ import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.tensorflow.Graph
 import org.tensorflow.proto.framework.GraphDef
 
+import scala.collection.mutable
 import scala.util.Random
 
 /**
@@ -35,7 +36,7 @@ import scala.util.Random
  *   - a [[com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector SentenceDetector]],
  *   - a [[com.johnsnowlabs.nlp.annotators.Tokenizer Tokenizer]] and
  *   - a [[com.johnsnowlabs.nlp.embeddings.WordEmbeddingsModel WordEmbeddingsModel]]
- *   (any embeddings can be chosen, e.g. [[com.johnsnowlabs.nlp.embeddings.BertEmbeddings BertEmbeddings]] for BERT based embeddings).
+ *     (any embeddings can be chosen, e.g. [[com.johnsnowlabs.nlp.embeddings.BertEmbeddings BertEmbeddings]] for BERT based embeddings).
  *
  * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/tree/master/jupyter/training/english/dl-ner Spark NLP Workshop]]
  * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala NerDLSpec]].
@@ -195,6 +196,12 @@ class NerDLApproach(override val uid: String)
    * @group param
    * */
   val includeConfidence = new BooleanParam(this, "includeConfidence", "Whether to include confidence scores in annotation metadata")
+
+  /** whether to include all confidence scores in annotation metadata or just score of the predicted tag
+   *
+   * @group param
+   * */
+  val includeAllConfidenceScores = new BooleanParam(this, "includeAllConfidenceScores", "whether to include all confidence scores in annotation metadata")
 
   /** Folder path to save training logs (Default: `""`)
    *
@@ -367,6 +374,12 @@ class NerDLApproach(override val uid: String)
    * */
   def setIncludeConfidence(value: Boolean): NerDLApproach.this.type = set(this.includeConfidence, value)
 
+  /** whether to include confidence scores for all tags rather than just for the predicted one
+   *
+   * @group setParam
+   * */
+  def setIncludeAllConfidenceScores(value: Boolean): this.type = set(this.includeAllConfidenceScores, value)
+
   setDefault(
     minEpochs -> 0,
     maxEpochs -> 70,
@@ -379,6 +392,7 @@ class NerDLApproach(override val uid: String)
     validationSplit -> 0.0f,
     evaluationLogExtended -> false,
     includeConfidence -> false,
+    includeAllConfidenceScores -> false,
     enableOutputLogs -> false,
     outputLogsPath -> "",
     enableMemoryOptimizer -> false
@@ -489,8 +503,7 @@ class NerDLApproach(override val uid: String)
 
   }
 
-
-  def getDataSetParams(dsIt: Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]]) = {
+  def getDataSetParams(dsIt: Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]]): (mutable.Set[String], mutable.Set[Char], Int, Long) = {
 
     var labels = scala.collection.mutable.Set[String]()
     var chars = scala.collection.mutable.Set[Char]()
@@ -499,7 +512,7 @@ class NerDLApproach(override val uid: String)
 
     // try to be frugal with memory and with number of passes thru the iterator
     for (batch <- dsIt) {
-      dsLen += batch.size
+      dsLen += batch.length
       for (datapoint <- batch) {
 
         for (label <- datapoint._1.labels)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
@@ -167,10 +167,17 @@ class NerDLModel(override val uid: String)
    * */
   val includeConfidence = new BooleanParam(this, "includeConfidence", "Whether to include confidence scores in annotation metadata")
 
+  /** whether to include all confidence scores in annotation metadata or just score of the predicted tag
+   *
+   * @group param
+   * */
+  val includeAllConfidenceScores = new BooleanParam(this, "includeAllConfidenceScores", "whether to include all confidence scores in annotation metadata")
+
   val classes = new StringArrayParam(this, "classes", "keep an internal copy of classes for Python")
 
   setDefault(
     includeConfidence -> false,
+    includeAllConfidenceScores -> false,
     batchSize -> 8
   )
 
@@ -198,6 +205,12 @@ class NerDLModel(override val uid: String)
    * */
   def setIncludeConfidence(value: Boolean): this.type = set(this.includeConfidence, value)
 
+  /** whether to include confidence scores for all tags rather than just for the predicted one
+   *
+   * @group setParam
+   * */
+  def setIncludeAllConfidenceScores(value: Boolean): this.type = set(this.includeAllConfidenceScores, value)
+
   /** Minimum probability. Used only if there is no CRF on top of LSTM layer.
    *
    * @group getParam
@@ -222,6 +235,12 @@ class NerDLModel(override val uid: String)
    * */
   def getIncludeConfidence: Boolean = $(includeConfidence)
 
+  /** whether to include all confidence scores in annotation metadata or just the score of the predicted tag
+   *
+   * @group getParam
+   * */
+  def getIncludeAllConfidenceScores: Boolean = $(includeAllConfidenceScores)
+
   /** get the tags used to trained this NerDLModel
    *
    * @group getParam
@@ -237,7 +256,12 @@ class NerDLModel(override val uid: String)
   def tag(tokenized: Array[Array[WordpieceEmbeddingsSentence]]): Seq[Array[NerTaggedSentence]] = {
     val batch = tokenized.zipWithIndex.flatMap { case (t, i) => t.map(RowIdentifiedSentence(i, _)) }
     // Predict
-    val labels = getModelIfNotSet.predict(batch.map(_.rowSentence), getConfigProtoBytes, includeConfidence = $(includeConfidence))
+    val labels = getModelIfNotSet.predict(
+      batch.map(_.rowSentence),
+      getConfigProtoBytes,
+      includeConfidence = $(includeConfidence),
+      includeAllConfidenceScores = $(includeAllConfidenceScores),
+    )
 
     val outputBatches = Array.fill[Array[NerTaggedSentence]](tokenized.length)(Array.empty)
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/NerConverterTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/NerConverterTest.scala
@@ -59,6 +59,7 @@ class NerConverterTest extends FlatSpec {
     val ner = NerDLModel.pretrained()
       .setInputCols("sentence", "cleaned", "embeddings")
       .setOutputCol("ner")
+      .setIncludeConfidence(true)
 
     val converter = new NerConverter()
       .setInputCols("sentence", "cleaned", "ner")
@@ -126,6 +127,7 @@ class NerConverterTest extends FlatSpec {
       .setInputCols("sentence", "token_normalized", "embeddings")
       .setOutputCol("ner")
       .setIncludeConfidence(true)
+      .setIncludeAllConfidenceScores(true)
 
     val converter = new NerConverter()
       .setInputCols("sentence", "token_normalized", "ner")

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
@@ -271,5 +271,27 @@ class NerDLSpec extends FlatSpec {
     }
   }
 
+  "NerDLModel" should "work with confidence scores enabled" taggedAs SlowTest in {
+
+    val conll = CoNLL(explodeSentences = false)
+    val training_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.train")
+
+    val embeddings = WordEmbeddingsModel.pretrained()
+
+    val nerModel = NerDLModel.pretrained()
+      .setInputCols("sentence", "token", "embeddings")
+      .setOutputCol("ner")
+      .setIncludeConfidence(true)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        embeddings,
+        nerModel
+      ))
+
+    val pipelineDF = pipeline.fit(training_data).transform(training_data)
+    pipelineDF.select("ner").show(1, false)
+  }
+
 }
 


### PR DESCRIPTION
This param allows outputting only the confidence score for the predicted label instead of all labels. In some cases with lots of NER tags, this param helps to improve the speed. (by default it's set to false)