### PR TITLE
Synchronize Scala and Python parameters' names

### DIFF
--- a/docs/en/annotator_entries/ContextSpellChecker.md
+++ b/docs/en/annotator_entries/ContextSpellChecker.md
@@ -214,10 +214,10 @@ val tokenizer = new Tokenizer()
 val spellChecker = new ContextSpellCheckerApproach()
   .setInputCols("token")
   .setOutputCol("corrected")
-  .setWordMaxDist(3)
+  .setWordMaxDistance(3)
   .setBatchSize(24)
   .setEpochs(8)
-  .setLMClasses(1650)  // dependant on vocabulary size
+  .setLanguageModelClasses(1650)  // dependant on vocabulary size
   // .addVocabClass("_NAME_", names) // Extra classes for correction could be added like this
 
 val pipeline = new Pipeline().setStages(Array(

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -2597,7 +2597,7 @@ class ContextSpellCheckerApproach(AnnotatorApproach):
     def setEpochs(self, count):
         return self._set(epochs=count)
 
-    def setInitialBatchSize(self, size):
+    def setBatchSize(self, size):
         return self._set(batchSize=size)
 
     def setInitialRate(self, rate):

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -981,7 +981,7 @@ class PerceptronApproach(AnnotatorApproach):
             nIterations=5
         )
 
-    def setPosCol(self, value):
+    def setPosColumn(self, value):
         return self._set(posCol=value)
 
     def setIterations(self, value):
@@ -3222,10 +3222,10 @@ class WordSegmenterApproach(AnnotatorApproach):
             nIterations=5, frequencyThreshold=5, ambiguityThreshold=0.97
         )
 
-    def setPosCol(self, value):
+    def setPosColumn(self, value):
         return self._set(posCol=value)
 
-    def setIterations(self, value):
+    def setNIterations(self, value):
         return self._set(nIterations=value)
 
     def setFrequencyThreshold(self, value):

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -1408,8 +1408,8 @@ class WordSegmenterTestSpec(unittest.TestCase):
         word_segmenter = WordSegmenterApproach() \
             .setInputCols("document") \
             .setOutputCol("token") \
-            .setPosCol("tags") \
-            .setIterations(1) \
+            .setPosColumn("tags") \
+            .setNIterations(1) \
             .fit(self.train)
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexMatcher.scala
@@ -1,9 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators
 
 import com.johnsnowlabs.nlp.AnnotatorApproach
 import com.johnsnowlabs.nlp.AnnotatorType.{CHUNK, DOCUMENT}
 import com.johnsnowlabs.nlp.annotators.param.ExternalResourceParam
 import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
+
 import org.apache.spark.ml.PipelineModel
 import org.apache.spark.ml.param.Param
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
@@ -13,7 +31,7 @@ import org.apache.spark.sql.Dataset
 /**
  * Uses a reference file to match a set of regular expressions and associate them with a provided identifier.
  *
- * A dictionary of predefined regular expressions must be provided with `setRules`.
+ * A dictionary of predefined regular expressions must be provided with `setExternalRules`.
  * The dictionary can be set in either in the form of a delimited text file or directly as an
  * [[com.johnsnowlabs.nlp.util.io.ExternalResource ExternalResource]].
  *
@@ -41,7 +59,7 @@ import org.apache.spark.sql.Dataset
  * val sentence = new SentenceDetector().setInputCols("document").setOutputCol("sentence")
  *
  * val regexMatcher = new RegexMatcher()
- *   .setRules("src/test/resources/regex-matcher/rules.txt",  ",")
+ *   .setExternalRules("src/test/resources/regex-matcher/rules.txt",  ",")
  *   .setInputCols(Array("sentence"))
  *   .setOutputCol("regex")
  *   .setStrategy("MATCH_ALL")
@@ -98,7 +116,7 @@ class RegexMatcher(override val uid: String) extends AnnotatorApproach[RegexMatc
    *
    * @group param
    * */
-  val rules: ExternalResourceParam = new ExternalResourceParam(this, "externalRules", "external resource to rules, needs 'delimiter' in options")
+  val externalRules: ExternalResourceParam = new ExternalResourceParam(this, "externalRules", "external resource to rules, needs 'delimiter' in options")
   /**
    * Strategy for which to match the expressions (Default: `"MATCH_ALL"`).
    * Possible values are:
@@ -135,9 +153,9 @@ class RegexMatcher(override val uid: String) extends AnnotatorApproach[RegexMatc
    *
    * @group setParam
    * */
-  def setRules(value: ExternalResource): this.type = {
+  def setExternalRules(value: ExternalResource): this.type = {
     require(value.options.contains("delimiter"), "RegexMatcher requires 'delimiter' option to be set in ExternalResource")
-    set(rules, value)
+    set(externalRules, value)
   }
 
 
@@ -147,11 +165,11 @@ class RegexMatcher(override val uid: String) extends AnnotatorApproach[RegexMatc
    *
    * @group setParam
    * */
-  def setRules(path: String,
-               delimiter: String,
-               readAs: ReadAs.Format = ReadAs.TEXT,
-               options: Map[String, String] = Map("format" -> "text")): this.type =
-    set(rules, ExternalResource(path, readAs, options ++ Map("delimiter" -> delimiter)))
+  def setExternalRules(path: String,
+                       delimiter: String,
+                       readAs: ReadAs.Format = ReadAs.TEXT,
+                       options: Map[String, String] = Map("format" -> "text")): this.type =
+    set(externalRules, ExternalResource(path, readAs, options ++ Map("delimiter" -> delimiter)))
 
 
   /**
@@ -172,9 +190,9 @@ class RegexMatcher(override val uid: String) extends AnnotatorApproach[RegexMatc
   def getStrategy: String = $(strategy).toString
 
   override def train(dataset: Dataset[_], recursivePipeline: Option[PipelineModel]): RegexMatcherModel = {
-    val processedRules = ResourceHelper.parseTupleText($(rules))
+    val processedRules = ResourceHelper.parseTupleText($(externalRules))
     new RegexMatcherModel()
-      .setRules(processedRules)
+      .setExternalRules(processedRules)
       .setStrategy($(strategy))
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexMatcherModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexMatcherModel.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators
 
 import com.johnsnowlabs.nlp.AnnotatorType.{CHUNK, DOCUMENT}
@@ -45,7 +62,7 @@ class RegexMatcherModel(override val uid: String) extends AnnotatorModel[RegexMa
    *
    * @group param
    * */
-  val rules: ArrayFeature[(String, String)] = new ArrayFeature[(String, String)](this, "rules")
+  val externalRules: ArrayFeature[(String, String)] = new ArrayFeature[(String, String)](this, "rules")
 
   /** MATCH_ALL|MATCH_FIRST|MATCH_COMPLETE
    *
@@ -72,13 +89,13 @@ class RegexMatcherModel(override val uid: String) extends AnnotatorModel[RegexMa
    *
    * @group setParam
    * */
-  def setRules(value: Array[(String, String)]): this.type = set(rules, value)
+  def setExternalRules(value: Array[(String, String)]): this.type = set(externalRules, value)
 
   /** Rules represented as Array of Tuples
    *
    * @group getParams
    * */
-  def getRules: Array[(String, String)] = $$(rules)
+  def getExternalRules: Array[(String, String)] = $$(externalRules)
 
   /** MATCH_ALL|MATCH_FIRST|MATCH_COMPLETE */
   private def getFactoryStrategy: MatchStrategy = $(strategy) match {
@@ -90,7 +107,7 @@ class RegexMatcherModel(override val uid: String) extends AnnotatorModel[RegexMa
 
   lazy private val matchFactory = RuleFactory
     .lateMatching(TransformStrategy.NO_TRANSFORM)(getFactoryStrategy)
-    .setRules($$(rules).map(r => new RegexRule(r._1, r._2)))
+    .setRules($$(externalRules).map(r => new RegexRule(r._1, r._2)))
 
   /** one-to-many annotation that returns matches as annotations */
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/btm/BigTextMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/btm/BigTextMatcher.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.btm
 
 import com.johnsnowlabs.collections.StorageSearchTrie
@@ -8,6 +25,7 @@ import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
 import com.johnsnowlabs.nlp.AnnotatorApproach
 import com.johnsnowlabs.storage.Database.Name
 import com.johnsnowlabs.storage.{Database, HasStorage, RocksDBConnection, StorageWriter}
+
 import org.apache.spark.ml.PipelineModel
 import org.apache.spark.ml.param.BooleanParam
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
@@ -90,7 +108,7 @@ class BigTextMatcher(override val uid: String) extends AnnotatorApproach[BigText
   /** Input annotator Types: DOCUMENT, TOKEN
    * @group anno
    */
-  override val inputAnnotatorTypes = Array(DOCUMENT, TOKEN)
+  override val inputAnnotatorTypes: Array[String] = Array(DOCUMENT, TOKEN)
 
   /** Output annotator Types: CHUNK
    * @group anno

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/btm/BigTextMatcherModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/btm/BigTextMatcherModel.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.btm
 
 import com.johnsnowlabs.collections.StorageSearchTrie
@@ -5,6 +22,7 @@ import com.johnsnowlabs.nlp.AnnotatorType._
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.storage.Database.Name
 import com.johnsnowlabs.storage.{Database, HasStorageModel, RocksDBConnection, StorageReadable, StorageReader}
+
 import org.apache.spark.ml.param.BooleanParam
 import org.apache.spark.ml.util.Identifiable
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronApproach.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.pos.perceptron
 
 import com.johnsnowlabs.nlp.AnnotatorApproach

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/vivekn/ViveknSentimentApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/vivekn/ViveknSentimentApproach.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.sda.vivekn
 
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
@@ -196,7 +213,7 @@ class ViveknSentimentApproach(override val uid: String)
     *
     * @group setParam
     **/
-  def setCorpusPrune(value: Int): this.type = set(pruneCorpus, value)
+  def setPruneCorpus(value: Int): this.type = set(pruneCorpus, value)
 
   override def train(dataset: Dataset[_], recursivePipeline: Option[PipelineModel]): ViveknSentimentModel = {
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala
@@ -1,9 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.spell.context
 
 import com.github.liblevenshtein.transducer.factory.TransducerBuilder
 import com.github.liblevenshtein.transducer.{Algorithm, Candidate}
+
 import com.johnsnowlabs.ml.tensorflow.{TensorflowSpell, TensorflowWrapper, Variables}
-import com.johnsnowlabs.nlp.annotator.SymmetricDeleteApproach
 import com.johnsnowlabs.nlp.annotators.ner.Verbose
 import com.johnsnowlabs.nlp.annotators.spell.context.parser._
 import com.johnsnowlabs.nlp.util.io.ResourceHelper

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.spell.context
 
 import java.util
@@ -167,7 +184,7 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
   val wordMaxDistance = new IntParam(this, "wordMaxDistance", "Maximum distance for the generated candidates for every word, minimum 1.")
 
   /** @group setParam */
-  def setWordMaxDist(k: Int): this.type = set(wordMaxDistance, k)
+  def setWordMaxDistance(k: Int): this.type = set(wordMaxDistance, k)
 
   /** Maximum number of candidates for every word (Default: `6`).
    *
@@ -255,7 +272,7 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
   val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
 
   /** @group setParam */
-  def setConfigProtoBytes(bytes: Array[Int]) = set(this.configProtoBytes, bytes)
+  def setConfigProtoBytes(bytes: Array[Int]): ContextSpellCheckerModel.this.type = set(this.configProtoBytes, bytes)
 
   /** @group getParam */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
@@ -295,7 +312,7 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
   }
 
   /* update a regex class */
-  def updateRegexClass(label: String, regex: String) = {
+  def updateRegexClass(label: String, regex: String): ContextSpellCheckerModel = {
     val classes = $$(specialTransducers)
     require(classes.count(_.label == label) == 1,
       s"Not found regex class $label. You can only update existing classes.")
@@ -310,7 +327,7 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
   }
 
   /* update a vocabulary class */
-  def updateVocabClass(label: String, vocabList: util.ArrayList[String], append: Boolean = true) = {
+  def updateVocabClass(label: String, vocabList: util.ArrayList[String], append: Boolean = true): ContextSpellCheckerModel = {
     val vocab = scala.collection.mutable.Set(vocabList.toArray.map(_.toString): _*)
     val classes = $$(specialTransducers)
     require(classes.count(_.label == label) == 1,
@@ -524,7 +541,7 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
     decodedSentPaths.values.flatten.toSeq
   }
 
-  def toOption(boolean: Boolean) = {
+  def toOption(boolean: Boolean): Option[Boolean] = {
     if (boolean)
       Some(boolean)
     else

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterApproach.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.ws
 
 import com.johnsnowlabs.nlp.AnnotatorApproach

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterModel.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.ws
 
 import com.johnsnowlabs.nlp.AnnotatorType.{DOCUMENT, TOKEN}

--- a/src/test/scala/com/johnsnowlabs/benchmarks/annotators/ws/WordSegmenterBenchmark.scala
+++ b/src/test/scala/com/johnsnowlabs/benchmarks/annotators/ws/WordSegmenterBenchmark.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.benchmarks.annotators.ws
 
 import com.johnsnowlabs.nlp.DocumentAssembler

--- a/src/test/scala/com/johnsnowlabs/nlp/AnnotatorBuilder.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/AnnotatorBuilder.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp
 
 import com.johnsnowlabs.nlp.annotator._
@@ -140,7 +157,7 @@ object AnnotatorBuilder extends FlatSpec { this: Suite =>
 
   def withRegexMatcher(dataset: Dataset[Row], strategy: String): Dataset[Row] = {
     val regexMatcher = new RegexMatcher()
-      .setRules(ExternalResource("src/test/resources/regex-matcher/rules.txt", ReadAs.TEXT, Map("delimiter" -> ",")))
+      .setExternalRules(ExternalResource("src/test/resources/regex-matcher/rules.txt", ReadAs.TEXT, Map("delimiter" -> ",")))
       .setStrategy(strategy)
       .setInputCols(Array("document"))
       .setOutputCol("regex")
@@ -193,7 +210,7 @@ object AnnotatorBuilder extends FlatSpec { this: Suite =>
       .setInputCols(Array("token", "sentence"))
       .setOutputCol("vivekn")
       .setSentimentCol("sentiment_label")
-      .setCorpusPrune(0)
+      .setPruneCorpus(0)
 
     val pipeline = new Pipeline()
       .setStages(Array(

--- a/src/test/scala/com/johnsnowlabs/nlp/LightPipelineTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/LightPipelineTestSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp
 
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
@@ -6,6 +23,7 @@ import com.johnsnowlabs.nlp.annotators.spell.norvig.NorvigSweetingApproach
 import com.johnsnowlabs.nlp.annotators.{Normalizer, Tokenizer}
 import com.johnsnowlabs.tags.{FastTest, SlowTest}
 import com.johnsnowlabs.util.Benchmark
+
 import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.apache.spark.sql.functions.when
 import org.apache.spark.sql.{Dataset, Row}
@@ -45,7 +63,7 @@ class LightPipelineTestSpec extends FlatSpec {
       .setInputCols(Array("spell", "sentence"))
       .setOutputCol("vivekn")
       .setSentimentCol("sentiment_label")
-      .setCorpusPrune(0)
+      .setPruneCorpus(0)
 
     val pipeline: Pipeline = new Pipeline()
       .setStages(Array(
@@ -92,7 +110,7 @@ class LightPipelineTestSpec extends FlatSpec {
       .setInputCols(Array("spell", "sentence"))
       .setOutputCol("vivekn")
       .setSentimentCol("sentiment_label")
-      .setCorpusPrune(0)
+      .setPruneCorpus(0)
 
     val pipeline: Pipeline = new Pipeline()
       .setStages(Array(

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/RegexMatcherBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/RegexMatcherBehaviors.scala
@@ -1,9 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators
 
-import com.johnsnowlabs.nlp.AnnotatorType.CHUNK
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorBuilder}
 import com.johnsnowlabs.tags.FastTest
-import com.johnsnowlabs.nlp.annotators._
 import com.johnsnowlabs.nlp.base._
 import org.apache.spark.sql.{Dataset, Row}
 import org.scalatest._
@@ -62,7 +77,7 @@ trait RegexMatcherBehaviors { this: FlatSpec =>
       val sentence = new SentenceDetector().setInputCols("document").setOutputCol("sentence")
 
       val regexMatcher = new RegexMatcher()
-        .setRules(ExternalResource("src/test/resources/regex-matcher/rules.txt", ReadAs.TEXT, Map("delimiter" -> ",")))
+        .setExternalRules(ExternalResource("src/test/resources/regex-matcher/rules.txt", ReadAs.TEXT, Map("delimiter" -> ",")))
         .setInputCols(Array("sentence"))
         .setOutputCol("regex")
         .setStrategy(strategy)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/WordSegmenterTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/WordSegmenterTest.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators
 
 import com.johnsnowlabs.nlp.AnnotatorType.TOKEN

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/sda/vivekn/ViveknSentimentTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/sda/vivekn/ViveknSentimentTestSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.sda.vivekn
 
 import com.johnsnowlabs.nlp._
@@ -5,6 +22,7 @@ import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.annotators.spell.norvig.NorvigSweetingApproach
 import com.johnsnowlabs.nlp.annotators.{Normalizer, Tokenizer}
 import com.johnsnowlabs.tags.FastTest
+
 import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.apache.spark.sql.Row
 import org.scalatest._
@@ -51,7 +69,7 @@ class ViveknSentimentTestSpec extends FlatSpec {
       .setInputCols(Array("token", "sentence"))
       .setOutputCol("vivekn")
       .setSentimentCol("sentiment_label")
-      .setCorpusPrune(0)
+      .setPruneCorpus(0)
 
     val pipeline = new Pipeline()
       .setStages(Array(
@@ -120,7 +138,7 @@ class ViveknSentimentTestSpec extends FlatSpec {
       .setInputCols(Array("spell", "sentence"))
       .setOutputCol("vivekn")
       .setSentimentCol("sentiment_label")
-      .setCorpusPrune(0)
+      .setPruneCorpus(0)
 
     val pipeline = new Pipeline()
       .setStages(Array(

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/SpellCheckerUseCase.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/SpellCheckerUseCase.scala
@@ -48,8 +48,8 @@ object SpellCheckerUseCase extends App  {
     .setInputCols("token")
     .setOutputCol("checked")
     .addVocabClass("_NAME_", javaNames)
-    .setLMClasses(1650)
-    .setWordMaxDist(3)
+    .setLanguageModelClasses(1650)
+    .setWordMaxDistance(3)
     .setEpochs(2)
 
   val pipelineTok = new Pipeline().setStages(Array(assembler, tokenizer)).fit(dataset)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.annotators.spell.context
 
 import com.johnsnowlabs.nlp.SparkAccessor.spark.implicits._
@@ -8,6 +25,7 @@ import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.annotators.spell.context.parser._
 import com.johnsnowlabs.nlp.{Annotation, DocumentAssembler, LightPipeline, SparkAccessor}
 import com.johnsnowlabs.tags.{FastTest, SlowTest}
+
 import org.apache.commons.io.FileUtils
 import org.apache.spark.ml.Pipeline
 import org.scalatest._
@@ -23,7 +41,7 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
   }
 
   trait distFile extends WeightedLevenshtein {
-    val weights = loadWeights("src/test/resources/dist.psv")
+    val weights: Map[String, Map[String, Float]] = loadWeights("src/test/resources/dist.psv")
   }
   // This test fails in GitHub Actions
   "Spell Checker" should "provide appropriate scores - sentence level" taggedAs SlowTest in {
@@ -31,7 +49,7 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
 
     def time[R](block: => R): R = {
       val t0 = System.nanoTime()
-      val result = block    // call-by-name
+      val result = block // call-by-name
       val t1 = System.nanoTime()
       println("Elapsed time: " + (t1 - t0) + "ns")
       result
@@ -59,7 +77,7 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
     val results = time {
       pipeline.transform(data).
         select("checked").
-        mapAnnotationsCol[Option[String]]("checked", "checked","language", (x:Seq[Annotation]) => x.head.metadata.get("cost")).
+        mapAnnotationsCol[Option[String]]("checked", "checked", "language", (x: Seq[Annotation]) => x.head.metadata.get("cost")).
         collect.map(_.getString(0).toDouble)
     }
 
@@ -91,7 +109,7 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
       val sc = spark.sparkContext.objectFile[SpecialClassParser](dataPathObject).collect().head
       assert(sc.transducer != null)
       sc match {
-        case vp:VocabParser => assert(vp.vocab != null)
+        case vp: VocabParser => assert(vp.vocab != null)
         case _ =>
       }
 
@@ -107,7 +125,7 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
       new MedicationClass("./src/test/resources/spell/meds.txt"),
       new DateToken)
 
-    specialClasses.foreach{ specialClass =>
+    specialClasses.foreach { specialClass =>
 
       val path = "special_class.ser"
       val f = new File(path)
@@ -126,7 +144,7 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
       val deserialized = in.readObject.asInstanceOf[SpecialClassParser]
       assert(deserialized.transducer != null)
       deserialized match {
-        case vp:VocabParser =>
+        case vp: VocabParser =>
           assert(vp.vocab != null)
         case _ =>
       }
@@ -219,7 +237,7 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
       .setOutputCol("checked")
 
     val pipeline = new Pipeline().setStages(Array(documentAssembler, tokenizer, spellChecker)).fit(data)
-    pipeline.transform(data).select("checked").show(truncate=false)
+    pipeline.transform(data).select("checked").show(truncate = false)
 
   }
 
@@ -274,7 +292,7 @@ class ContextSpellCheckerTestSpec extends FlatSpec {
       .setUseNewLines(true)
 
     val pipeline = new Pipeline().setStages(Array(documentAssembler, tokenizer, spellChecker)).fit(data)
-    pipeline.transform(data).select("checked").show(truncate=false)
+    pipeline.transform(data).select("checked").show(truncate = false)
 
   }
 


### PR DESCRIPTION
Hi @DevinTDHa 

- ContextSpellCheckerApproach, yes, the variables are the same in both but the setters and getters are different! I'll match the Scala with Python
- `WordSegmenterApproach`, `setPosCol` is for both Scala and Python. However, `setNIterations` is being synced for both Python and Scala
- `ViveknSentimentApproach` now has `setPruneCorpus` synced between both Scala and Python
- 'RegexMatcher' now has `setExternalRules` in both Scala and Python
- `PerceptronApproach` now has `setPosColumn` in both Scala and Python
- `ContextSpellCheckerApproach` has synced parameters between Python and Scala