### PR TITLE
Add missing code block end

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,6 +758,7 @@ A sample of your software configuration in JSON on S3 (must be public access):
     }
 }
 ]
+```
 
 A sample of AWS CLI to launch EMR cluster:
 


### PR DESCRIPTION
Another small typo fix: it appears that the code block end "```" are missing between two code blocks so the two have been merged into one.