### PR TITLE
Fix the issue with BertSentenceEmbeddings model in TF v2

### DIFF
--- a/docs/_posts/muhammetsnts/2021-06-15-sbertresolve_snomed_bodyStructure_med_en.md
+++ b/docs/_posts/muhammetsnts/2021-06-15-sbertresolve_snomed_bodyStructure_med_en.md
@@ -43,7 +43,7 @@ jsl_sbert_embedder = BertSentenceEmbeddings.pretrained('sbert_jsl_medium_uncased
       .setInputCols(["ner_chunk"])\
       .setOutputCol("sbert_embeddings")
 
-snomed_resolver = SentenceEntityResolverModel.pretrained("sbertresolve_snomed_bodyStructure_med, "en", "clinical/models) \
+snomed_resolver = SentenceEntityResolverModel.pretrained("sbertresolve_snomed_bodyStructure_med", "en", "clinical/models") \
       .setInputCols(["ner_chunk", "sbert_embeddings"]) \
       .setOutputCol("snomed_code")
 
@@ -65,7 +65,7 @@ val sbert_embedder = BertSentenceEmbeddings.pretrained("sbert_jsl_medium_uncased
      .setInputCols(["ner_chunk"])\
      .setOutputCol("sbert_embeddings")
 
-val snomed_resolver = SentenceEntityResolverModel.pretrained("sbertresolve_snomed_bodyStructure_med, "en", "clinical/models) \
+val snomed_resolver = SentenceEntityResolverModel.pretrained("sbertresolve_snomed_bodyStructure_med", "en", "clinical/models") \
      .setInputCols(["ner_chunk", "sbert_embeddings"]) \
      .setOutputCol("snomed_code")
 

--- a/docs/en/annotator_entries/RegexMatcher.md
+++ b/docs/en/annotator_entries/RegexMatcher.md
@@ -26,7 +26,7 @@ CHUNK
 {%- capture approach_description -%}
 Uses a reference file to match a set of regular expressions and associate them with a provided identifier.
 
-A dictionary of predefined regular expressions must be provided with `setRules`.
+A dictionary of predefined regular expressions must be provided with `setExternalRules`.
 The dictionary can be set as a delimited text file.
 
 Pretrained pipelines are available for this module, see [Pipelines](https://nlp.johnsnowlabs.com/docs/en/pipelines).
@@ -102,7 +102,7 @@ val documentAssembler = new DocumentAssembler().setInputCol("text").setOutputCol
 val sentence = new SentenceDetector().setInputCols("document").setOutputCol("sentence")
 
 val regexMatcher = new RegexMatcher()
-  .setRules("src/test/resources/regex-matcher/rules.txt",  ",")
+  .setExternalRules("src/test/resources/regex-matcher/rules.txt",  ",")
   .setInputCols(Array("sentence"))
   .setOutputCol("regex")
   .setStrategy("MATCH_ALL")

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexMatcher.scala
@@ -141,7 +141,7 @@ class RegexMatcher(override val uid: String) extends AnnotatorApproach[RegexMatc
    * ==Example==
    * {{{
    * val regexMatcher = new RegexMatcher()
-   *   .setRules(ExternalResource(
+   *   .setExternalRules(ExternalResource(
    *     "src/test/resources/regex-matcher/rules.txt",
    *     ReadAs.TEXT,
    *     Map("delimiter" -> ",")

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings.scala
@@ -275,7 +275,8 @@ class BertSentenceEmbeddings(override val uid: String)
           tensorflow,
           sentenceStartTokenId,
           sentenceEndTokenId,
-          configProtoBytes = getConfigProtoBytes
+          configProtoBytes = getConfigProtoBytes,
+          signatures = getSignatures
         )))
     }
 
@@ -356,7 +357,7 @@ trait ReadBertSentenceTensorflowModel extends ReadTensorflowModel {
 
   def readTensorflow(instance: BertSentenceEmbeddings, path: String, spark: SparkSession): Unit = {
 
-    val tf = readTensorflowModel(path, spark, "_bert_sentence_tf")
+    val tf = readTensorflowModel(path, spark, "_bert_sentence_tf", initAllTables = false)
     instance.setModelIfNotSet(spark, tf)
   }
 
@@ -388,6 +389,7 @@ trait ReadBertSentenceTensorflowModel extends ReadTensorflowModel {
       case None => throw new Exception("Cannot load signature definitions from model!")
     }
 
+    /** the order of setSignatures is important if we use getSignatures inside setModelIfNotSet */
     new BertSentenceEmbeddings()
       .setVocabulary(words)
       .setSignatures(_signatures)


### PR DESCRIPTION
This PR adds the missing `signatures` required to access the correct inputs/output in TF SavedModel 2.x.