### PR TITLE
PyDoc: Move generated HTML to api folder

### DIFF
--- a/python/docs/Makefile
+++ b/python/docs/Makefile
@@ -6,7 +6,7 @@
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
-BUILDDIR      = ./../../docs/api/python
+BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -17,8 +17,7 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 
-generate: Makefile
-	sphinx-apidoc -f -H "API Reference" -e --ext-autodoc --ext-doctest -d 3 -o ./reference ../sparknlp
-
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	rm -rf ../../docs/api/python
+	mv _build/html ../../docs/api/python

--- a/python/docs/README.md
+++ b/python/docs/README.md
@@ -1,9 +1,11 @@
 # How to build the PyDocs
 
+0. Change directories to this folder `spark-nlp/python/docs`
 1. Install requirements `requirements_doc.txt`
 2. run `make html`
+   1. This will generate the html and move it to `../../docs/api/python`
 
-The html will be available under `_build/html/index.html`.
+The html will be available under `../../docs/api/python/index.html`.
 
 ## Note
 The folder `_autosummary` should not be committed, as it is generated from


### PR DESCRIPTION
This ensures the pydoc will be available under spark-nlp/docs/api/python