### PR TITLE
Fix wrong version return in sparknlp.version()

### DIFF
--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -234,4 +234,4 @@ def version():
     str
         The current Spark NLP version.
     """
-    return '3.1.1'
+    return '3.1.3'


### PR DESCRIPTION
This PR fixes the wrong return version when `sparknlp.version()` is used in Python. This is not affecting any functionality, however, it is important to return a correct version when users need to make sure they have upgraded `spark-nlp`.