### PR TITLE
Pydoc Update

### DIFF
--- a/python/docs/Makefile
+++ b/python/docs/Makefile
@@ -17,7 +17,10 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 
+html: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	bash move_folders_for_gh.sh
+	rm -rf ../../docs/api/python; mv _build/html ../../docs/api/python
+
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-	rm -rf ../../docs/api/python
-	mv _build/html ../../docs/api/python

--- a/python/docs/move_folders_for_gh.sh
+++ b/python/docs/move_folders_for_gh.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
+# this script is compatible with macOS (the sed command)
 
 echo "Move _static"
-grep -RiIl '_static' _build | xargs sed -i 's/_static/static/g'
-mv _build/html/_static _build/html/static
+grep -RiIl '_static' _build | xargs sed -i '' -e 's/_static/static/g'
+cp -r _build/html/_static _build/html/static
 
 echo "Move _modules"
-grep -RiIl '_modules' _build | xargs sed -i 's/_modules/modules/g'
-mv _build/html/_modules _build/html/modules
+grep -RiIl '_modules' _build | xargs sed -i '' -e 's/_modules/modules/g'
+cp -r _build/html/_modules _build/html/modules
 
 echo "Move references/_autosummary"
-grep -RiIl '_autosummary' _build | xargs sed -i 's/_autosummary/autosummary/g'
-mv _build/html/reference/_autosummary _build/html/reference/autosummary
+grep -RiIl '_autosummary' _build | xargs sed -i '' -e 's/_autosummary/autosummary/g'
+cp -r _build/html/reference/_autosummary _build/html/reference/autosummary
 
 rm -rf _build/html/_sources

--- a/python/docs/move_folders_for_gh.sh
+++ b/python/docs/move_folders_for_gh.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "Move _static"
+grep -RiIl '_static' _build | xargs sed -i 's/_static/static/g'
+mv _build/html/_static _build/html/static
+
+echo "Move _modules"
+grep -RiIl '_modules' _build | xargs sed -i 's/_modules/modules/g'
+mv _build/html/_modules _build/html/modules
+
+echo "Move references/_autosummary"
+grep -RiIl '_autosummary' _build | xargs sed -i 's/_autosummary/autosummary/g'
+mv _build/html/reference/_autosummary _build/html/reference/autosummary
+
+rm -rf _build/html/_sources

--- a/python/docs/move_folders_for_gh.sh
+++ b/python/docs/move_folders_for_gh.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
-# this script is compatible with macOS (the sed command)
 
 echo "Move _static"
-grep -RiIl '_static' _build | xargs sed -i '' -e 's/_static/static/g'
-cp -r _build/html/_static _build/html/static
+grep -RiIl '_static' _build | xargs sed -i 's/_static/static/g'
+mv _build/html/_static _build/html/static
 
 echo "Move _modules"
-grep -RiIl '_modules' _build | xargs sed -i '' -e 's/_modules/modules/g'
-cp -r _build/html/_modules _build/html/modules
+grep -RiIl '_modules' _build | xargs sed -i 's/_modules/modules/g'
+mv _build/html/_modules _build/html/modules
 
 echo "Move references/_autosummary"
-grep -RiIl '_autosummary' _build | xargs sed -i '' -e 's/_autosummary/autosummary/g'
-cp -r _build/html/reference/_autosummary _build/html/reference/autosummary
+grep -RiIl '_autosummary' _build | xargs sed -i 's/_autosummary/autosummary/g'
+mv _build/html/reference/_autosummary _build/html/reference/autosummary
 
 rm -rf _build/html/_sources

--- a/python/docs/user_guide/training.rst
+++ b/python/docs/user_guide/training.rst
@@ -8,8 +8,8 @@ POS Dataset
 ===========
 
 In order to train a Part of Speech Tagger annotator
-(:class:`sparknlp.annotator.PerceptronApproach`), we need to
-get corpus data as a Spark dataframe. :class:`sparknlp.training.POS` reads a plain text file
+(:class:`PerceptronApproach <sparknlp.annotator.PerceptronApproach>`), we need to
+get corpus data as a Spark dataframe. :class:`POS <sparknlp.training.POS>` reads a plain text file
 and transforms it to a Spark dataset.
 
 **Input File Format**::
@@ -47,10 +47,37 @@ as a Spark dataframe. :class:`sparknlp.training.CoNLL` reads a plain text file a
 >>> from sparknlp.training import CoNLL
 >>> training_conll = CoNLL().readDataset(spark, "./src/main/resources/conll2003/eng.train")
 
+CoNLLU Dataset
+=============
+
+In order to train a :class:`DependencyParserApproach <sparknlp.annotator.DependencyParserApproach>` annotator, we need to get
+`CoNLL-U <https://universaldependencies.org/format.html>`_ format data
+as a Spark dataframe. :class:`CoNLLU <sparknlp.training.CoNLLU>` reads a plain text file and transforms it to a Spark dataset.
+
+**Input File Format**::
+
+    -DOCSTART- -X- -X- O
+
+    EU NNP B-NP B-ORG
+    rejects VBZ B-VP O
+    German JJ B-NP B-MISC
+    call NN I-NP O
+    to TO B-VP O
+    boycott VB I-VP O
+    British JJ B-NP B-MISC
+    lamb NN I-NP O
+    . . O O
+
+**Example**
+
+>>> from sparknlp.training import CoNLLU
+>>> conlluFile = "src/test/resources/conllu/en.test.conllu"
+>>> conllDataSet = CoNLLU(False).readDataset(spark, conlluFile)
+
 Spell Checkers Dataset
 ======================
-In order to train a :class:`sparknlp.annotator.NorvigSweetingApproach` or
-:class:`sparknlp.annotator.SymmetricDeleteApproach`, we need to get corpus data as a spark
+In order to train a :class:`NorvigSweetingApproach <sparknlp.annotator.NorvigSweetingApproach>` or
+:class:`SymmetricDeleteApproach <sparknlp.annotator.SymmetricDeleteApproach>`, we need to get corpus data as a spark
 dataframe. We can read any plain text file and transform it to a Spark dataset.
 
 **Example**
@@ -62,7 +89,7 @@ PubTator Dataset
 ================
 The PubTator format includes medical papers’ titles, abstracts, and tagged chunks
 (see PubTator Docs and MedMentions Docs for more information).
-We can create a Spark DataFrame from a PubTator text file with :class:`sparknlp.training.PubTator`.
+We can create a Spark DataFrame from a PubTator text file with :class:`PubTator <sparknlp.training.PubTator>`.
 
 **Input File Format**::
 

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -668,7 +668,8 @@ class RegexTokenizer(AnnotatorModel):
 class ChunkTokenizer(Tokenizer):
     """Tokenizes and flattens extracted NER chunks.
 
-    The ChunkTokenizer will split the extracted NER ``CHUNK`` type Annotations and will create ``TOKEN`` type Annotations.
+    The ChunkTokenizer will split the extracted NER ``CHUNK`` type Annotations
+    and will create ``TOKEN`` type Annotations.
     The result is then flattened, resulting in a single array.
 
     ====================== ======================
@@ -685,57 +686,45 @@ class ChunkTokenizer(Tokenizer):
     Examples
     --------
 
-    .. code-block:: python
-
-        import sparknlp
-        from sparknlp.base import *
-        from sparknlp.common import *
-        from sparknlp.annotator import *
-        from sparknlp.training import *
-        from pyspark.ml import Pipeline
-
-        documentAssembler = DocumentAssembler() \\
-            .setInputCol("text") \\
-            .setOutputCol("document")
-
-        sentenceDetector = SentenceDetector() \\
-            .setInputCols(["document"]) \\
-            .setOutputCol("sentence")
-
-        tokenizer = Tokenizer() \\
-            .setInputCols(["sentence"]) \\
-            .setOutputCol("token")
-
-        entityExtractor = TextMatcher() \\
-            .setInputCols(["sentence", "token"]) \\
-            .setEntities("src/test/resources/entity-extractor/test-chunks.txt", ReadAs.TEXT) \\
-            .setOutputCol("entity")
-
-        chunkTokenizer = ChunkTokenizer() \\
-            .setInputCols(["entity"]) \\
-            .setOutputCol("chunk_token")
-
-        pipeline = Pipeline().setStages([
-              documentAssembler,
-              sentenceDetector,
-              tokenizer,
-              entityExtractor,
-              chunkTokenizer
-            ])
-
-        data = spark.createDataFrame([[
-            "Hello world, my name is Michael, I am an artist and I work at Benezar",
-            "Robert, an engineer from Farendell, graduated last year. The other one, Lucas, graduated last week."
-        ]]).toDF("text")
-        result = pipeline.fit(data).transform(data)
-
-        result.selectExpr("entity.result as entity" , "chunk_token.result as chunk_token").show(truncate=False)
-        +-----------------------------------------------+---------------------------------------------------+
-        |entity                                         |chunk_token                                        |
-        +-----------------------------------------------+---------------------------------------------------+
-        |[world, Michael, work at Benezar]              |[world, Michael, work, at, Benezar]                |
-        |[engineer from Farendell, last year, last week]|[engineer, from, Farendell, last, year, last, week]|
-        +-----------------------------------------------+---------------------------------------------------+
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> sentenceDetector = SentenceDetector() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("sentence")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["sentence"]) \\
+    ...     .setOutputCol("token")
+    >>> entityExtractor = TextMatcher() \\
+    ...     .setInputCols(["sentence", "token"]) \\
+    ...     .setEntities("src/test/resources/entity-extractor/test-chunks.txt", ReadAs.TEXT) \\
+    ...     .setOutputCol("entity")
+    >>> chunkTokenizer = ChunkTokenizer() \\
+    ...     .setInputCols(["entity"]) \\
+    ...     .setOutputCol("chunk_token")
+    >>> pipeline = Pipeline().setStages([
+    ...         documentAssembler,
+    ...         sentenceDetector,
+    ...         tokenizer,
+    ...         entityExtractor,
+    ...         chunkTokenizer
+    ... ])
+    >>> data = spark.createDataFrame([
+    ...     ["Hello world, my name is Michael, I am an artist and I work at Benezar"],
+    ...     ["Robert, an engineer from Farendell, graduated last year. The other one, Lucas, graduated last week."]
+    >>> ]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.selectExpr("entity.result as entity" , "chunk_token.result as chunk_token").show(truncate=False)
+    +-----------------------------------------------+---------------------------------------------------+
+    |entity                                         |chunk_token                                        |
+    +-----------------------------------------------+---------------------------------------------------+
+    |[world, Michael, work at Benezar]              |[world, Michael, work, at, Benezar]                |
+    |[engineer from Farendell, last year, last week]|[engineer, from, Farendell, last, year, last, week]|
+    +-----------------------------------------------+---------------------------------------------------+
 
     """
     name = 'ChunkTokenizer'
@@ -913,9 +902,12 @@ class Stemmer(AnnotatorModel):
 
 
 class Chunker(AnnotatorModel):
-    """This annotator matches a pattern of part-of-speech tags in order to return meaningful phrases from document.
-    Extracted part-of-speech tags are mapped onto the sentence, which can then be parsed by regular expressions.
-    The part-of-speech tags are wrapped by angle brackets ``<>`` to be easily distinguishable in the text itself.
+    """This annotator matches a pattern of part-of-speech tags in order to
+    return meaningful phrases from document. Extracted part-of-speech tags are
+    mapped onto the sentence, which can then be parsed by regular expressions.
+    The part-of-speech tags are wrapped by angle brackets ``<>`` to be easily
+    distinguishable in the text itself.
+
     This example sentence will result in the form:
 
     .. code-block:: none
@@ -926,16 +918,15 @@ class Chunker(AnnotatorModel):
 
     To then extract these tags, ``regexParsers`` need to be set with e.g.:
 
-    .. code-block:: python
-
-        chunker = Chunker() \\
-            .setInputCols(["sentence", "pos"]) \\
-            .setOutputCol("chunk") \\
-            .setRegexParsers(["<NNP>+", "<NNS>+"])
+    >>> chunker = Chunker() \\
+    ...    .setInputCols(["sentence", "pos"]) \\
+    ...    .setOutputCol("chunk") \\
+    ...    .setRegexParsers(["<NNP>+", "<NNS>+"])
 
 
-    When defining the regular expressions, tags enclosed in angle brackets are treated as groups, so here specifically
-    ``"<NNP>+"`` means 1 or more nouns in succession. Additional patterns can also be set with ``addRegexParsers``.
+    When defining the regular expressions, tags enclosed in angle brackets are
+    treated as groups, so here specifically ``"<NNP>+"`` means 1 or more nouns
+    in succession.
 
     For more extended examples see the `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/3.SparkNLP_Pretrained_Models.ipynb>`__.
 
@@ -949,62 +940,50 @@ class Chunker(AnnotatorModel):
     ----------
 
     regexParsers
-        an array of grammar based chunk parsers
+        An array of grammar based chunk parsers
 
     Examples
     --------
 
-    .. code-block:: python
-
-        import sparknlp
-        from sparknlp.base import *
-        from sparknlp.common import *
-        from sparknlp.annotator import *
-        from sparknlp.training import *
-        from pyspark.ml import Pipeline
-
-        documentAssembler = DocumentAssembler() \\
-            .setInputCol("text") \\
-            .setOutputCol("document")
-
-        sentence = SentenceDetector() \\
-            .setInputCols(["document"]) \\
-            .setOutputCol("sentence")
-
-        tokenizer = Tokenizer() \\
-            .setInputCols(["sentence"]) \\
-            .setOutputCol("token")
-
-        POSTag = PerceptronModel.pretrained() \\
-            .setInputCols(["document", "token"]) \\
-            .setOutputCol("pos")
-
-        chunker = Chunker() \\
-            .setInputCols(["sentence", "pos"]) \\
-            .setOutputCol("chunk") \\
-            .setRegexParsers(["<NNP>+", "<NNS>+"])
-
-        pipeline = Pipeline() \\
-            .setStages([
-              documentAssembler,
-              sentence,
-              tokenizer,
-              POSTag,
-              chunker
-            ])
-
-        data = spark.createDataFrame([["Peter Pipers employees are picking pecks of pickled peppers."]]).toDF("text")
-        result = pipeline.fit(data).transform(data)
-
-        result.selectExpr("explode(chunk) as result").show(truncate=False)
-        +-------------------------------------------------------------+
-        |result                                                       |
-        +-------------------------------------------------------------+
-        |[chunk, 0, 11, Peter Pipers, [sentence -> 0, chunk -> 0], []]|
-        |[chunk, 13, 21, employees, [sentence -> 0, chunk -> 1], []]  |
-        |[chunk, 35, 39, pecks, [sentence -> 0, chunk -> 2], []]      |
-        |[chunk, 52, 58, peppers, [sentence -> 0, chunk -> 3], []]    |
-        +-------------------------------------------------------------+
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> sentence = SentenceDetector() \\
+    ...     .setInputCols("document") \\
+    ...     .setOutputCol("sentence")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["sentence"]) \\
+    ...     .setOutputCol("token")
+    >>> POSTag = PerceptronModel.pretrained() \\
+    ...     .setInputCols("document", "token") \\
+    ...     .setOutputCol("pos")
+    >>> chunker = Chunker() \\
+    ...     .setInputCols("sentence", "pos") \\
+    ...     .setOutputCol("chunk") \\
+    ...     .setRegexParsers(["<NNP>+", "<NNS>+"])
+    >>> pipeline = Pipeline() \\
+    ...     .setStages([
+    ...       documentAssembler,
+    ...       sentence,
+    ...       tokenizer,
+    ...       POSTag,
+    ...       chunker
+    ...     ])
+    >>> data = spark.createDataFrame([["Peter Pipers employees are picking pecks of pickled peppers."]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.selectExpr("explode(chunk) as result").show(truncate=False)
+    +-------------------------------------------------------------+
+    |result                                                       |
+    +-------------------------------------------------------------+
+    |[chunk, 0, 11, Peter Pipers, [sentence -> 0, chunk -> 0], []]|
+    |[chunk, 13, 21, employees, [sentence -> 0, chunk -> 1], []]  |
+    |[chunk, 35, 39, pecks, [sentence -> 0, chunk -> 2], []]      |
+    |[chunk, 52, 58, peppers, [sentence -> 0, chunk -> 3], []]    |
+    +-------------------------------------------------------------+
 
     """
 
@@ -1020,6 +999,24 @@ class Chunker(AnnotatorModel):
         super(Chunker, self).__init__(classname="com.johnsnowlabs.nlp.annotators.Chunker")
 
     def setRegexParsers(self, value):
+        """Set an array of grammar based chunk parsers.
+
+        POS classes should be enclosed in angle brackets, then treated as
+        groups.
+
+        Parameters
+        ----------
+        value : List[str]
+            Array of grammar based chunk parsers
+
+
+        Examples
+        --------
+        >>> chunker = Chunker() \\
+        ...     .setInputCols("sentence", "pos") \\
+        ...     .setOutputCol("chunk") \\
+        ...     .setRegexParsers(["<NNP>+", "<NNS>+"])
+        """
         return self._set(regexParsers=value)
 
 
@@ -6101,9 +6098,9 @@ class NGramGenerator(AnnotatorModel):
 
 
 class ChunkEmbeddings(AnnotatorModel):
-    """This annotator utilizes WordEmbeddings, BertEmbeddings etc. to generate chunk embeddings from either
-    Chunker, NGramGenerator,
-    or NerConverter outputs.
+    """This annotator utilizes WordEmbeddings, BertEmbeddings etc. to generate
+    chunk embeddings from either Chunker, NGramGenerator, or NerConverter
+    outputs.
 
     For extended examples of usage, see the `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/3.SparkNLP_Pretrained_Models.ipynb>`__.
 
@@ -6117,75 +6114,69 @@ class ChunkEmbeddings(AnnotatorModel):
     ----------
 
     poolingStrategy
-        Choose how you would like to aggregate Word Embeddings to Chunk Embeddings, by default AVERAGE
+        Choose how you would like to aggregate Word Embeddings to Chunk
+        Embeddings, by default AVERAGE.
+        Possible Values: ``AVERAGE, SUM``
     skipOOV
-        Whether to discard default vectors for OOV words from the aggregation / pooling
+        Whether to discard default vectors for OOV words from the
+        aggregation/pooling.
 
     Examples
     --------
 
-    .. code-block:: python
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
 
-        import sparknlp
-        from sparknlp.base import *
-        from sparknlp.common import *
-        from sparknlp.annotator import *
-        from sparknlp.training import *
-        from pyspark.ml import Pipeline
+    Extract the Embeddings from the NGrams
 
-        # Extract the Embeddings from the NGrams
-        documentAssembler = DocumentAssembler() \\
-            .setInputCol("text") \\
-            .setOutputCol("document")
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> sentence = SentenceDetector() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("sentence")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["sentence"]) \\
+    ...     .setOutputCol("token")
+    >>> nGrams = NGramGenerator() \\
+    ...     .setInputCols(["token"]) \\
+    ...     .setOutputCol("chunk") \\
+    ...     .setN(2)
+    >>> embeddings = WordEmbeddingsModel.pretrained() \\
+    ...     .setInputCols(["sentence", "token"]) \\
+    ...     .setOutputCol("embeddings") \\
+    ...     .setCaseSensitive(False)
 
-        sentence = SentenceDetector() \\
-            .setInputCols(["document"]) \\
-            .setOutputCol("sentence")
+    Convert the NGram chunks into Word Embeddings
 
-        tokenizer = Tokenizer() \\
-            .setInputCols(["sentence"]) \\
-            .setOutputCol("token")
-
-        nGrams = NGramGenerator() \\
-            .setInputCols(["token"]) \\
-            .setOutputCol("chunk") \\
-            .setN(2)
-
-        embeddings = WordEmbeddingsModel.pretrained() \\
-            .setInputCols(["sentence", "token"]) \\
-            .setOutputCol("embeddings") \\
-            .setCaseSensitive(False)
-
-        # Convert the NGram chunks into Word Embeddings
-        chunkEmbeddings = ChunkEmbeddings() \\
-            .setInputCols(["chunk", "embeddings"]) \\
-            .setOutputCol("chunk_embeddings") \\
-            .setPoolingStrategy("AVERAGE")
-
-        pipeline = Pipeline() \\
-            .setStages([
-              documentAssembler,
-              sentence,
-              tokenizer,
-              nGrams,
-              embeddings,
-              chunkEmbeddings
-            ])
-
-        data = spark.createDataFrame([["This is a sentence."]]).toDF("text")
-        result = pipeline.fit(data).transform(data)
-
-        result.selectExpr("explode(chunk_embeddings) as result") \\
-            .select("result.annotatorType", "result.result", "result.embeddings") \\
-            .show(5, 80)
-        +---------------+----------+--------------------------------------------------------------------------------+
-        |  annotatorType|    result|                                                                      embeddings|
-        +---------------+----------+--------------------------------------------------------------------------------+
-        |word_embeddings|   This is|[-0.55661, 0.42829502, 0.86661, -0.409785, 0.06316501, 0.120775, -0.0732005, ...|
-        |word_embeddings|      is a|[-0.40674996, 0.22938299, 0.50597, -0.288195, 0.555655, 0.465145, 0.140118, 0...|
-        |word_embeddings|a sentence|[0.17417, 0.095253006, -0.0530925, -0.218465, 0.714395, 0.79860497, 0.0129999...|
-        |word_embeddings|sentence .|[0.139705, 0.177955, 0.1887775, -0.45545, 0.20030999, 0.461557, -0.07891501, ...|
-        +---------------+----------+--------------------------------------------------------------------------------+
+    >>> chunkEmbeddings = ChunkEmbeddings() \\
+    ...     .setInputCols(["chunk", "embeddings"]) \\
+    ...     .setOutputCol("chunk_embeddings") \\
+    ...     .setPoolingStrategy("AVERAGE")
+    >>> pipeline = Pipeline() \\
+    ...     .setStages([
+    ...       documentAssembler,
+    ...       sentence,
+    ...       tokenizer,
+    ...       nGrams,
+    ...       embeddings,
+    ...       chunkEmbeddings
+    ...     ])
+    >>> data = spark.createDataFrame([["This is a sentence."]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.selectExpr("explode(chunk_embeddings) as result") \\
+    ...     .select("result.annotatorType", "result.result", "result.embeddings") \\
+    ...     .show(5, 80)
+    +---------------+----------+--------------------------------------------------------------------------------+
+    |  annotatorType|    result|                                                                      embeddings|
+    +---------------+----------+--------------------------------------------------------------------------------+
+    |word_embeddings|   This is|[-0.55661, 0.42829502, 0.86661, -0.409785, 0.06316501, 0.120775, -0.0732005, ...|
+    |word_embeddings|      is a|[-0.40674996, 0.22938299, 0.50597, -0.288195, 0.555655, 0.465145, 0.140118, 0...|
+    |word_embeddings|a sentence|[0.17417, 0.095253006, -0.0530925, -0.218465, 0.714395, 0.79860497, 0.0129999...|
+    |word_embeddings|sentence .|[0.139705, 0.177955, 0.1887775, -0.45545, 0.20030999, 0.461557, -0.07891501, ...|
+    +---------------+----------+--------------------------------------------------------------------------------+
 
     """
 
@@ -6206,8 +6197,15 @@ class ChunkEmbeddings(AnnotatorModel):
     skipOOV = Param(Params._dummy(), "skipOOV", "Whether to discard default vectors for OOV words from the aggregation / pooling ", typeConverter=TypeConverters.toBoolean)
 
     def setPoolingStrategy(self, strategy):
-        """
-        Sets the value of :py:attr:`poolingStrategy`.
+        """Set how to aggregate Word Embeddings to Chunk Embeddings, by default
+        AVERAGE.
+
+        Possible Values: ``AVERAGE, SUM``
+
+        Parameters
+        ----------
+        strategy : str
+            Aggregation Strategy
         """
         if strategy == "AVERAGE":
             return self._set(poolingStrategy=strategy)
@@ -6217,8 +6215,14 @@ class ChunkEmbeddings(AnnotatorModel):
             return self._set(poolingStrategy="AVERAGE")
 
     def setSkipOOV(self, value):
-        """
-        Sets the value of :py:attr:`skipOOV`.
+        """Set whether to discard default vectors for OOV words from the
+        aggregation/pooling.
+
+        Parameters
+        ----------
+        value : bool
+            whether to discard default vectors for OOV words from the
+            aggregation/pooling.
         """
         return self._set(skipOOV=value)
 

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -6754,17 +6754,12 @@ class ElmoEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasCaseSensitivePr
 class ClassifierDLApproach(AnnotatorApproach):
     """Trains a ClassifierDL for generic Multi-class Text Classification.
 
-    ClassifierDL uses the state-of-the-art Universal Sentence Encoder as an input for text classifications.
-    The ClassifierDL annotator uses a deep learning model (DNNs) we have built inside TensorFlow and supports up to
-    100 classes.
+    ClassifierDL uses the state-of-the-art Universal Sentence Encoder as an
+    input for text classifications.
+    The ClassifierDL annotator uses a deep learning model (DNNs) we have built
+    inside TensorFlow and supports up to 100 classes.
 
-    For instantiated/pretrained models, see ClassifierDLModel.
-
-    **Notes**:
-      - This annotator accepts a label column of a single item in either type of String, Int, Float, or Double.
-      - UniversalSentenceEncoder,
-        BertSentenceEmbeddings, or
-        SentenceEmbeddings can be used for the ``inputCol``.
+    For instantiated/pretrained models, see :class:`.ClassifierDLModel`.
 
     For extended examples of usage, see the Spark NLP Workshop
     `Spark NLP Workshop  <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.Text_Classification_with_ClassifierDL.ipynb>`__.
@@ -6788,7 +6783,9 @@ class ClassifierDLApproach(AnnotatorApproach):
     configProtoBytes
         ConfigProto from tensorflow, serialized into byte array.
     validationSplit
-        Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.
+        Choose the proportion of training dataset to be validated against the
+        model on each Epoch. The value should be between 0.0 and 1.0 and by
+        default it is 0.0 and off.
     enableOutputLogs
         Whether to use stdout in addition to Spark logs, by default False
     outputLogsPath
@@ -6798,58 +6795,54 @@ class ClassifierDLApproach(AnnotatorApproach):
     verbose
         Level of verbosity during training
     randomSeed
-        Random seed
+        Random seed for shuffling
+
+    Notes
+    -----
+    - This annotator accepts a label column of a single item in either type of
+      String, Int, Float, or Double.
+    - UniversalSentenceEncoder, Transformer based embeddings, or
+      SentenceEmbeddings can be used for the ``inputCol``.
 
     Examples
     --------
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.common import *
+    >>> from sparknlp.annotator import *
+    >>> from sparknlp.training import *
+    >>> from pyspark.ml import Pipeline
 
-    .. code-block:: python
+    In this example, the training data ``"sentiment.csv"`` has the form of::
 
-        import sparknlp
-        from sparknlp.base import *
-        from sparknlp.common import *
-        from sparknlp.annotator import *
-        from sparknlp.training import *
-        from pyspark.ml import Pipeline
-        # In this example, the training data `"sentiment.csv"` has the form of
-        #
-        # text,label
-        # This movie is the best movie I have wached ever! In my opinion this movie can win an award.,0
-        # This was a terrible movie! The acting was bad really bad!,1
-        # ...
-        #
-        # Then traning can be done like so:
+        text,label
+        This movie is the best movie I have wached ever! In my opinion this movie can win an award.,0
+        This was a terrible movie! The acting was bad really bad!,1
+        ...
 
-        smallCorpus = spark.read.option("header","True").csv("src/test/resources/classifier/sentiment.csv")
+    Then traning can be done like so:
 
-        documentAssembler = DocumentAssembler() \\
-            .setInputCol("text") \\
-            .setOutputCol("document")
-
-        useEmbeddings = UniversalSentenceEncoder.pretrained() \\
-            .setInputCols(["document"]) \\
-            .setOutputCol("sentence_embeddings")
-
-        docClassifier = ClassifierDLApproach() \\
-            .setInputCols(["sentence_embeddings"]) \\
-            .setOutputCol("category") \\
-            .setLabelColumn("label") \\
-            .setBatchSize(64) \\
-            .setMaxEpochs(20) \\
-            .setLr(5e-3) \\
-            .setDropout(0.5)
-
-        pipeline = Pipeline() \\
-            .setStages(
-              [
-                documentAssembler,
-                useEmbeddings,
-                docClassifier
-              ]
-            )
-
-        pipelineModel = pipeline.fit(smallCorpus)
-
+    >>> smallCorpus = spark.read.option("header","True").csv("src/test/resources/classifier/sentiment.csv")
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> useEmbeddings = UniversalSentenceEncoder.pretrained() \\
+    ...     .setInputCols("document") \\
+    ...     .setOutputCol("sentence_embeddings")
+    >>> docClassifier = ClassifierDLApproach() \\
+    ...     .setInputCols("sentence_embeddings") \\
+    ...     .setOutputCol("category") \\
+    ...     .setLabelColumn("label") \\
+    ...     .setBatchSize(64) \\
+    ...     .setMaxEpochs(20) \\
+    ...     .setLr(5e-3) \\
+    ...     .setDropout(0.5)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     useEmbeddings,
+    ...     docClassifier
+    ... ])
+    >>> pipelineModel = pipeline.fit(smallCorpus)
     """
 
     lr = Param(Params._dummy(), "lr", "Learning Rate", TypeConverters.toFloat)
@@ -6880,12 +6873,33 @@ class ClassifierDLApproach(AnnotatorApproach):
     randomSeed = Param(Params._dummy(), "randomSeed", "Random seed", TypeConverters.toInt)
 
     def setVerbose(self, value):
+        """Set level of verbosity during training
+
+        Parameters
+        ----------
+        value : int
+            Level of verbosity
+        """
         return self._set(verbose=value)
 
     def setRandomSeed(self, seed):
+        """Set random seed for shuffling
+
+        Parameters
+        ----------
+        seed : int
+            Random seed for shuffling
+        """
         return self._set(randomSeed=seed)
 
     def setLabelColumn(self, value):
+        """Set name of column for data labels
+
+        Parameters
+        ----------
+        value : str
+            Column for data labels
+        """
         return self._set(labelColumn=value)
 
     def setConfigProtoBytes(self, b):
@@ -6899,31 +6913,82 @@ class ClassifierDLApproach(AnnotatorApproach):
         return self._set(configProtoBytes=b)
 
     def setLr(self, v):
+        """Set Learning Rate, by default 0.005
+
+        Parameters
+        ----------
+        v : float
+            Learning Rate
+        """
         self._set(lr=v)
         return self
 
     def setBatchSize(self, v):
+        """Set batch size, by default 64
+
+        Parameters
+        ----------
+        v : int
+            Batch size
+        """
         self._set(batchSize=v)
         return self
 
     def setDropout(self, v):
+        """Set dropout coefficient, by default 0.5
+
+        Parameters
+        ----------
+        v : float
+            Dropout coefficient
+        """
         self._set(dropout=v)
         return self
 
     def setMaxEpochs(self, epochs):
+        """Set maximum number of epochs to train, by default 30
+
+        Parameters
+        ----------
+        epochs : int
+            Maximum number of epochs to train
+        """
         return self._set(maxEpochs=epochs)
 
     def _create_model(self, java_model):
         return ClassifierDLModel(java_model=java_model)
 
     def setValidationSplit(self, v):
+        """Set the proportion of training dataset to be validated against the
+        model on each Epoch, by default it is 0.0 and off. The value should be
+        between 0.0 and 1.0.
+
+        Parameters
+        ----------
+        v : float
+            Proportion of training dataset to be validated
+        """
         self._set(validationSplit=v)
         return self
 
     def setEnableOutputLogs(self, value):
+        """Set whether to use stdout in addition to Spark logs, by default False
+
+        Parameters
+        ----------
+        value : bool
+            Whether to use stdout in addition to Spark logs
+        """
         return self._set(enableOutputLogs=value)
 
     def setOutputLogsPath(self, p):
+        """Set folder path to save training logs
+
+        Parameters
+        ----------
+        p : str
+            Folder path to save training logs
+        """
         return self._set(outputLogsPath=p)
 
     @keyword_only
@@ -6941,26 +7006,27 @@ class ClassifierDLApproach(AnnotatorApproach):
 class ClassifierDLModel(AnnotatorModel, HasStorageRef):
     """ClassifierDL for generic Multi-class Text Classification.
 
-    ClassifierDL uses the state-of-the-art Universal Sentence Encoder as an input for text classifications.
-    The ClassifierDL annotator uses a deep learning model (DNNs) we have built inside TensorFlow and supports up to
+    ClassifierDL uses the state-of-the-art Universal Sentence Encoder as an
+    input for text classifications. The ClassifierDL annotator uses a deep
+    learning model (DNNs) we have built inside TensorFlow and supports up to
     100 classes.
 
-    This is the instantiated model of the ClassifierDLApproach.
+    This is the instantiated model of the :class:`.ClassifierDLApproach`.
     For training your own model, please see the documentation of that class.
 
     Pretrained models can be loaded with ``pretrained`` of the companion object:
 
-    .. code-block:: python
+    >>> classifierDL = ClassifierDLModel.pretrained() \\
+    ...     .setInputCols(["sentence_embeddings"]) \\
+    ...     .setOutputCol("classification")
 
-        classifierDL = ClassifierDLModel.pretrained() \\
-            .setInputCols(["sentence_embeddings"]) \\
-            .setOutputCol("classification")
+    The default model is ``"classifierdl_use_trec6"``, if no name is provided.
+    It uses embeddings from the UniversalSentenceEncoder and is trained on the
+    `TREC-6 <https://deepai.org/dataset/trec-6#:~:text=The%20TREC%20dataset%20is%20dataset,50%20has%20finer%2Dgrained%20labels>`__
+    dataset.
 
-
-    The default model is ``"classifierdl_use_trec6"``, if no name is provided. It uses embeddings from the
-    UniversalSentenceEncoder and is trained on the
-    `TREC-6 <https://deepai.org/dataset/trec-6#:~:text=The%20TREC%20dataset%20is%20dataset,50%20has%20finer%2Dgrained%20labels>`__ dataset.
-    For available pretrained models please see the `Models Hub <https://nlp.johnsnowlabs.com/models?task=Text+Classification>`__.
+    For available pretrained models please see the
+    `Models Hub <https://nlp.johnsnowlabs.com/models?task=Text+Classification>`__.
 
     For extended examples of usage, see the
     `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.Text_Classification_with_ClassifierDL.ipynb>`__.
@@ -6977,61 +7043,50 @@ class ClassifierDLModel(AnnotatorModel, HasStorageRef):
     configProtoBytes
         ConfigProto from tensorflow, serialized into byte array.
     classes
-        get the tags used to trained this ClassifierDLModel
+        Get the tags used to trained this ClassifierDLModel
 
     Examples
     --------
 
-    .. code-block:: python
-
-        import sparknlp
-        from sparknlp.base import *
-        from sparknlp.common import *
-        from sparknlp.annotator import *
-        from sparknlp.training import *
-        from pyspark.ml import Pipeline
-
-        documentAssembler = DocumentAssembler() \\
-            .setInputCol("text") \\
-            .setOutputCol("document")
-
-        sentence = SentenceDetector() \\
-            .setInputCols(["document"]) \\
-            .setOutputCol("sentence")
-
-        useEmbeddings = UniversalSentenceEncoder.pretrained() \\
-            .setInputCols(["document"]) \\
-            .setOutputCol("sentence_embeddings")
-
-        sarcasmDL = ClassifierDLModel.pretrained("classifierdl_use_sarcasm") \\
-            .setInputCols(["sentence_embeddings"]) \\
-            .setOutputCol("sarcasm")
-
-        pipeline = Pipeline() \\
-            .setStages([
-              documentAssembler,
-              sentence,
-              useEmbeddings,
-              sarcasmDL
-            ])
-
-        data = spark.createDataFrame([[
-            "I'm ready!",
-            "If I could put into words how much I love waking up at 6 am on Mondays I would."
-        ]]).toDF("text")
-        result = pipeline.fit(data).transform(data)
-
-        result.selectExpr("explode(arrays_zip(sentence, sarcasm)) as out") \\
-            .selectExpr("out.sentence.result as sentence", "out.sarcasm.result as sarcasm") \\
-            .show(truncate=False)
-        +-------------------------------------------------------------------------------+-------+
-        |sentence                                                                       |sarcasm|
-        +-------------------------------------------------------------------------------+-------+
-        |I'm ready!                                                                     |normal |
-        |If I could put into words how much I love waking up at 6 am on Mondays I would.|sarcasm|
-        +-------------------------------------------------------------------------------+-------+
-
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> sentence = SentenceDetector() \\
+    ...     .setInputCols("document") \\
+    ...     .setOutputCol("sentence")
+    >>> useEmbeddings = UniversalSentenceEncoder.pretrained() \\
+    ...     .setInputCols("document") \\
+    ...     .setOutputCol("sentence_embeddings")
+    >>> sarcasmDL = ClassifierDLModel.pretrained("classifierdl_use_sarcasm") \\
+    ...     .setInputCols("sentence_embeddings") \\
+    ...     .setOutputCol("sarcasm")
+    >>> pipeline = Pipeline() \\
+    ...     .setStages([
+    ...       documentAssembler,
+    ...       sentence,
+    ...       useEmbeddings,
+    ...       sarcasmDL
+    ...     ])
+    >>> data = spark.createDataFrame([
+    ...     ["I'm ready!"],
+    ...     ["If I could put into words how much I love waking up at 6 am on Mondays I would."]
+    ... ]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.selectExpr("explode(arrays_zip(sentence, sarcasm)) as out") \\
+    ...     .selectExpr("out.sentence.result as sentence", "out.sarcasm.result as sarcasm") \\
+    ...     .show(truncate=False)
+    +-------------------------------------------------------------------------------+-------+
+    |sentence                                                                       |sarcasm|
+    +-------------------------------------------------------------------------------+-------+
+    |I'm ready!                                                                     |normal |
+    |If I could put into words how much I love waking up at 6 am on Mondays I would.|sarcasm|
+    +-------------------------------------------------------------------------------+-------+
     """
+
     name = "ClassifierDLModel"
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.ClassifierDLModel", java_model=None):
@@ -7063,15 +7118,16 @@ class ClassifierDLModel(AnnotatorModel, HasStorageRef):
         Parameters
         ----------
         name : str, optional
-            Name of the pretrained model, by default "???"
+            Name of the pretrained model, by default "classifierdl_use_trec6"
         lang : str, optional
             Language of the pretrained model, by default "en"
         remote_loc : str, optional
-            Optional remote address of the resource, by default None
+            Optional remote address of the resource, by default None. Will use
+            Spark NLPs repositories otherwise.
 
         Returns
         -------
-        ???
+        ClassifierDLModel
             The restored model
         """
         from sparknlp.pretrained import ResourceDownloader

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -525,6 +525,22 @@ class TokenizerModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="token_rules", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(TokenizerModel, name, lang, remote_loc)
 
@@ -1595,6 +1611,22 @@ class LemmatizerModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="lemma_antbnc", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(LemmatizerModel, name, lang, remote_loc)
 
@@ -2060,6 +2092,22 @@ class TextMatcherModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name, lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(TextMatcherModel, name, lang, remote_loc)
 
@@ -2236,6 +2284,22 @@ class BigTextMatcherModel(AnnotatorModel, HasStorageModel):
 
     @staticmethod
     def pretrained(name, lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(TextMatcherModel, name, lang, remote_loc)
 
@@ -2462,6 +2526,22 @@ class PerceptronModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="pos_anc", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(PerceptronModel, name, lang, remote_loc)
 
@@ -3012,6 +3092,22 @@ class ViveknSentimentModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="sentiment_vivekn", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(ViveknSentimentModel, name, lang, remote_loc)
 
@@ -3276,6 +3372,22 @@ class NorvigSweetingModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="spellcheck_norvig", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(NorvigSweetingModel, name, lang, remote_loc)
 
@@ -3497,6 +3609,22 @@ class SymmetricDeleteModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="spellcheck_sd", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(SymmetricDeleteModel, name, lang, remote_loc)
 
@@ -3807,6 +3935,22 @@ class NerCrfModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="ner_crf", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(NerCrfModel, name, lang, remote_loc)
 
@@ -3822,9 +3966,10 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     2003 IOB with ``Annotation`` type columns. The data should have columns of type ``DOCUMENT, TOKEN, WORD_EMBEDDINGS`` and an
     additional label column of annotator type ``NAMED_ENTITY``.
     Excluding the label, this can be done with for example
-    * a SentenceDetector,
-    * a Tokenizer and
-    * a WordEmbeddingsModel (any embeddings can be chosen, e.g. BertEmbeddings for BERT based embeddings).
+
+    - a SentenceDetector,
+    - a Tokenizer and
+    - a WordEmbeddingsModel (any embeddings can be chosen, e.g. BertEmbeddings for BERT based embeddings).
 
     For extended examples of usage, see the `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/tree/master/jupyter/training/english/dl-ner>`__.
 
@@ -3860,7 +4005,7 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     graphFolder
         Folder path that contain external graph files
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     useContrib
         whether to use contrib LSTM Cells. Not compatible with Windows. Might slightly improve accuracy
     validationSplit
@@ -3976,6 +4121,13 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     enableMemoryOptimizer = Param(Params._dummy(), "enableMemoryOptimizer", "Whether to optimize for large datasets or not. Enabling this option can slow down training.", TypeConverters.toBoolean)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setGraphFolder(self, p):
@@ -4093,7 +4245,7 @@ class NerDLModel(AnnotatorModel, HasStorageRef, HasBatchedAnnotate):
     batchSize
         Size of every batch, by default 8
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     includeConfidence
         whether to include confidence scores in annotation metadata, by default False
     includeAllConfidenceScores
@@ -4179,6 +4331,13 @@ class NerDLModel(AnnotatorModel, HasStorageRef, HasBatchedAnnotate):
                     TypeConverters.toListString)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setIncludeConfidence(self, value):
@@ -4189,6 +4348,22 @@ class NerDLModel(AnnotatorModel, HasStorageRef, HasBatchedAnnotate):
 
     @staticmethod
     def pretrained(name="ner_dl", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(NerDLModel, name, lang, remote_loc)
 
@@ -4501,6 +4676,22 @@ class DependencyParserModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="dependency_conllu", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(DependencyParserModel, name, lang, remote_loc)
 
@@ -4768,6 +4959,22 @@ class TypedDependencyParserModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="dependency_typed_conllu", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(TypedDependencyParserModel, name, lang, remote_loc)
 
@@ -5047,6 +5254,22 @@ class WordEmbeddingsModel(AnnotatorModel, HasEmbeddingsProperties, HasStorageMod
 
     @staticmethod
     def pretrained(name="glove_100d", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(WordEmbeddingsModel, name, lang, remote_loc)
 
@@ -5060,44 +5283,29 @@ class BertEmbeddings(AnnotatorModel,
                      HasCaseSensitiveProperties,
                      HasStorageRef,
                      HasBatchedAnnotate):
-    """Token-level embeddings using BERT. BERT (Bidirectional Encoder Representations from Transformers) provides dense
-    vector representations for natural language by using a deep, pre-trained neural network with the Transformer architecture.
+    """Token-level embeddings using BERT.
+
+    BERT (Bidirectional Encoder Representations from Transformers) provides
+    dense vector representations for natural language by using a deep,
+    pre-trained neural network with the Transformer architecture.
 
     Pretrained models can be loaded with ``pretrained`` of the companion object:
 
-    .. code-block:: python
-
-        embeddings = BertEmbeddings.pretrained() \\
-            .setInputCols(["token", "document"]) \\
-            .setOutputCol("bert_embeddings")
+    >>> embeddings = BertEmbeddings.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("bert_embeddings")
 
 
     The default model is ``"small_bert_L2_768"``, if no name is provided.
 
-    For available pretrained models please see the `Models Hub <https://nlp.johnsnowlabs.com/models?task=Embeddings>`__.
+    For available pretrained models please see the
+    `Models Hub <https://nlp.johnsnowlabs.com/models?task=Embeddings>`__.
 
-    For extended examples of usage, see the `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/blogposts/3.NER_with_BERT.ipynb>`__.
-    Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. The Spark NLP Workshop
-    example shows how to import them https://github.com/JohnSnowLabs/spark-nlp/discussions/5669.
-
-    **Sources** :
-
-    `BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding <https://arxiv.org/abs/1810.04805>`__
-
-    https://github.com/google-research/bert
-
-    **Paper abstract**
-
-    *We introduce a new language representation model called BERT, which stands for Bidirectional Encoder Representations
-    from Transformers. Unlike recent language representation models, BERT is designed to pre-train deep bidirectional
-    representations from unlabeled text by jointly conditioning on both left and right context in all layers. As a
-    result, the pre-trained BERT model can be fine-tuned with just one additional output layer to create
-    state-of-the-art models for a wide range of tasks, such as question answering and language inference, without
-    substantial task-specific architecture modifications. BERT is conceptually simple and empirically powerful. It
-    obtains new state-of-the-art results on eleven natural language processing tasks, including pushing the GLUE score
-    to 80.5% (7.7% point absolute improvement), MultiNLI accuracy to 86.7% (4.6% absolute improvement), SQuAD v1.1
-    question answering Test F1 to 93.2 (1.5 point absolute improvement) and SQuAD v2.0 Test F1 to 83.1 (5.1 point
-    absolute improvement).*
+    For extended examples of usage, see the
+    `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/blogposts/3.NER_with_BERT.ipynb>`__.
+    Models from the HuggingFace 🤗 Transformers library are also compatible with
+    Spark NLP 🚀. To see which models are compatible and how to import them see
+    the `Transformers Page <https://nlp.johnsnowlabs.com/docs/en/transformers#import-transformers-into-spark-nlp>`_.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -5117,128 +5325,10 @@ class BertEmbeddings(AnnotatorModel,
     maxSentenceLength
         Max sentence length to process, by default 128
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
 
-    Examples
-    --------
-
-    .. code-block:: python
-
-        import sparknlp
-        from sparknlp.base import *
-        from sparknlp.common import *
-        from sparknlp.annotator import *
-        from sparknlp.training import *
-        from pyspark.ml import Pipeline
-
-        documentAssembler = DocumentAssembler() \\
-            .setInputCol("text") \\
-            .setOutputCol("document")
-
-        tokenizer = Tokenizer() \\
-            .setInputCols(["document"]) \\
-            .setOutputCol("token")
-
-        embeddings = BertEmbeddings.pretrained("small_bert_L2_128", "en") \\
-            .setInputCols(["token", "document"]) \\
-            .setOutputCol("bert_embeddings")
-
-        embeddingsFinisher = EmbeddingsFinisher() \\
-            .setInputCols(["bert_embeddings"]) \\
-            .setOutputCols("finished_embeddings") \\
-            .setOutputAsVector(True)
-
-        pipeline = Pipeline().setStages([
-            documentAssembler,
-            tokenizer,
-            embeddings,
-            embeddingsFinisher
-        ])
-
-        data = spark.createDataFrame([["This is a sentence."]]).toDF("text")
-        result = pipeline.fit(data).transform(data)
-
-        result.selectExpr("explode(finished_embeddings) as result").show(5, 80)
-        +--------------------------------------------------------------------------------+
-        |                                                                          result|
-        +--------------------------------------------------------------------------------+
-        |[-2.3497989177703857,0.480538547039032,-0.3238905668258667,-1.612930893898010...|
-        |[-2.1357314586639404,0.32984697818756104,-0.6032363176345825,-1.6791689395904...|
-        |[-1.8244884014129639,-0.27088963985443115,-1.059438943862915,-0.9817547798156...|
-        |[-1.1648050546646118,-0.4725411534309387,-0.5938255786895752,-1.5780693292617...|
-        |[-0.9125322699546814,0.4563939869403839,-0.3975459933280945,-1.81611204147338...|
-        +--------------------------------------------------------------------------------+
-
-    """
-
-    name = "BertEmbeddings"
-
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
-    configProtoBytes = Param(Params._dummy(),
-                             "configProtoBytes",
-                             "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
-                             TypeConverters.toListString)
-
-    def setConfigProtoBytes(self, b):
-        return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        return self._set(maxSentenceLength=value)
-
-    @keyword_only
-    def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.BertEmbeddings", java_model=None):
-        super(BertEmbeddings, self).__init__(
-            classname=classname,
-            java_model=java_model
-        )
-        self._setDefault(
-            dimension=768,
-            batchSize=8,
-            maxSentenceLength=128,
-            caseSensitive=False
-        )
-
-    @staticmethod
-    def loadSavedModel(folder, spark_session):
-        from sparknlp.internal import _BertLoader
-        jModel = _BertLoader(folder, spark_session._jsparkSession)._java_obj
-        return BertEmbeddings(java_model=jModel)
-
-
-    @staticmethod
-    def pretrained(name="small_bert_L2_768", lang="en", remote_loc=None):
-        from sparknlp.pretrained import ResourceDownloader
-        return ResourceDownloader.downloadModel(BertEmbeddings, name, lang, remote_loc)
-
-
-class BertSentenceEmbeddings(AnnotatorModel,
-                             HasEmbeddingsProperties,
-                             HasCaseSensitiveProperties,
-                             HasStorageRef,
-                             HasBatchedAnnotate):
-    """Sentence-level embeddings using BERT. BERT (Bidirectional Encoder Representations from Transformers) provides dense
-    vector representations for natural language by using a deep, pre-trained neural network with the Transformer architecture.
-
-    Pretrained models can be loaded with ``pretrained`` of the companion object:
-
-    .. code-block:: python
-
-        embeddings = BertSentenceEmbeddings.pretrained() \\
-            .setInputCols(["sentence"]) \\
-            .setOutputCol("sentence_bert_embeddings")
-
-
-    The default model is ``"sent_small_bert_L2_768"``, if no name is provided.
-
-    For available pretrained models please see the `Models Hub <https://nlp.johnsnowlabs.com/models?task=Embeddings>`__.
-
-    For extended examples of usage, see the `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BERT%20Sentence.ipynb>`__.
-
-    **Sources** :
+    References
+    ----------
 
     `BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding <https://arxiv.org/abs/1810.04805>`__
 
@@ -5256,6 +5346,159 @@ class BertSentenceEmbeddings(AnnotatorModel,
     to 80.5% (7.7% point absolute improvement), MultiNLI accuracy to 86.7% (4.6% absolute improvement), SQuAD v1.1
     question answering Test F1 to 93.2 (1.5 point absolute improvement) and SQuAD v2.0 Test F1 to 83.1 (5.1 point
     absolute improvement).*
+
+    Examples
+    --------
+
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("token")
+    >>> embeddings = BertEmbeddings.pretrained("small_bert_L2_128", "en") \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("bert_embeddings")
+    >>> embeddingsFinisher = EmbeddingsFinisher() \\
+    ...     .setInputCols(["bert_embeddings"]) \\
+    ...     .setOutputCols("finished_embeddings") \\
+    ...     .setOutputAsVector(True)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     tokenizer,
+    ...     embeddings,
+    ...     embeddingsFinisher
+    ... ])
+    >>> data = spark.createDataFrame([["This is a sentence."]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.selectExpr("explode(finished_embeddings) as result").show(5, 80)
+    +--------------------------------------------------------------------------------+
+    |                                                                          result|
+    +--------------------------------------------------------------------------------+
+    |[-2.3497989177703857,0.480538547039032,-0.3238905668258667,-1.612930893898010...|
+    |[-2.1357314586639404,0.32984697818756104,-0.6032363176345825,-1.6791689395904...|
+    |[-1.8244884014129639,-0.27088963985443115,-1.059438943862915,-0.9817547798156...|
+    |[-1.1648050546646118,-0.4725411534309387,-0.5938255786895752,-1.5780693292617...|
+    |[-0.9125322699546814,0.4563939869403839,-0.3975459933280945,-1.81611204147338...|
+    +--------------------------------------------------------------------------------+
+    """
+
+    name = "BertEmbeddings"
+
+    maxSentenceLength = Param(Params._dummy(),
+                              "maxSentenceLength",
+                              "Max sentence length to process",
+                              typeConverter=TypeConverters.toInt)
+
+    configProtoBytes = Param(Params._dummy(),
+                             "configProtoBytes",
+                             "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
+                             TypeConverters.toListString)
+
+    def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
+        return self._set(configProtoBytes=b)
+
+    def setMaxSentenceLength(self, value):
+        """Set max sentence length to process
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
+        return self._set(maxSentenceLength=value)
+
+    @keyword_only
+    def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.BertEmbeddings", java_model=None):
+        super(BertEmbeddings, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        self._setDefault(
+            dimension=768,
+            batchSize=8,
+            maxSentenceLength=128,
+            caseSensitive=False
+        )
+
+    @staticmethod
+    def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        BertEmbeddings
+            The restored model
+        """
+        from sparknlp.internal import _BertLoader
+        jModel = _BertLoader(folder, spark_session._jsparkSession)._java_obj
+        return BertEmbeddings(java_model=jModel)
+
+
+    @staticmethod
+    def pretrained(name="small_bert_L2_768", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "small_bert_L2_768"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        BertEmbeddings
+            The restored model
+        """
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(BertEmbeddings, name, lang, remote_loc)
+
+
+class BertSentenceEmbeddings(AnnotatorModel,
+                             HasEmbeddingsProperties,
+                             HasCaseSensitiveProperties,
+                             HasStorageRef,
+                             HasBatchedAnnotate):
+    """Sentence-level embeddings using BERT. BERT (Bidirectional Encoder
+    Representations from Transformers) provides dense vector representations for
+    natural language by using a deep, pre-trained neural network with the
+    Transformer architecture.
+
+    Pretrained models can be loaded with ``pretrained`` of the companion object:
+
+    >>>embeddings = BertSentenceEmbeddings.pretrained() \\
+    ...    .setInputCols(["sentence"]) \\
+    ...    .setOutputCol("sentence_bert_embeddings")
+
+
+    The default model is ``"sent_small_bert_L2_768"``, if no name is provided.
+
+    For available pretrained models please see the
+    `Models Hub <https://nlp.johnsnowlabs.com/models?task=Embeddings>`__.
+
+    For extended examples of usage, see the
+    `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BERT%20Sentence.ipynb>`__.
 
     ====================== =======================
     Input Annotation types Output Annotation type
@@ -5277,56 +5520,64 @@ class BertSentenceEmbeddings(AnnotatorModel,
     isLong
         Use Long type instead of Int type for inputs buffer - Some Bert models require Long instead of Int.
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
+
+    References
+    ----------
+
+    `BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding <https://arxiv.org/abs/1810.04805>`__
+
+    https://github.com/google-research/bert
+
+    **Paper abstract**
+
+    *We introduce a new language representation model called BERT, which stands for Bidirectional Encoder Representations
+    from Transformers. Unlike recent language representation models, BERT is designed to pre-train deep bidirectional
+    representations from unlabeled text by jointly conditioning on both left and right context in all layers. As a
+    result, the pre-trained BERT model can be fine-tuned with just one additional output layer to create
+    state-of-the-art models for a wide range of tasks, such as question answering and language inference, without
+    substantial task-specific architecture modifications. BERT is conceptually simple and empirically powerful. It
+    obtains new state-of-the-art results on eleven natural language processing tasks, including pushing the GLUE score
+    to 80.5% (7.7% point absolute improvement), MultiNLI accuracy to 86.7% (4.6% absolute improvement), SQuAD v1.1
+    question answering Test F1 to 93.2 (1.5 point absolute improvement) and SQuAD v2.0 Test F1 to 83.1 (5.1 point
+    absolute improvement).*
 
     Examples
     --------
 
-    .. code-block:: python
-
-        import sparknlp
-        from sparknlp.base import *
-        from sparknlp.common import *
-        from sparknlp.annotator import *
-        from sparknlp.training import *
-        from pyspark.ml import Pipeline
-
-        documentAssembler = DocumentAssembler() \\
-            .setInputCol("text") \\
-            .setOutputCol("document")
-
-        sentence = SentenceDetector() \\
-            .setInputCols(["document"]) \\
-            .setOutputCol("sentence")
-
-        embeddings = BertSentenceEmbeddings.pretrained("sent_small_bert_L2_128") \\
-            .setInputCols(["sentence"]) \\
-            .setOutputCol("sentence_bert_embeddings")
-
-        embeddingsFinisher = EmbeddingsFinisher() \\
-            .setInputCols(["sentence_bert_embeddings"]) \\
-            .setOutputCols("finished_embeddings") \\
-            .setOutputAsVector(True)
-
-        pipeline = Pipeline().setStages([
-            documentAssembler,
-            sentence,
-            embeddings,
-            embeddingsFinisher
-        ])
-
-        data = spark.createDataFrame([["John loves apples. Mary loves oranges. John loves Mary."]]).toDF("text")
-        result = pipeline.fit(data).transform(data)
-
-        result.selectExpr("explode(finished_embeddings) as result").show(5, 80)
-        +--------------------------------------------------------------------------------+
-        |                                                                          result|
-        +--------------------------------------------------------------------------------+
-        |[-0.8951074481010437,0.13753940165042877,0.3108254075050354,-1.65693199634552...|
-        |[-0.6180210709571838,-0.12179657071828842,-0.191165953874588,-1.4497021436691...|
-        |[-0.822715163230896,0.7568016648292542,-0.1165061742067337,-1.59048593044281,...|
-        +--------------------------------------------------------------------------------+
-
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> sentence = SentenceDetector() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("sentence")
+    >>> embeddings = BertSentenceEmbeddings.pretrained("sent_small_bert_L2_128") \\
+    ...     .setInputCols(["sentence"]) \\
+    ...     .setOutputCol("sentence_bert_embeddings")
+    >>> embeddingsFinisher = EmbeddingsFinisher() \\
+    ...     .setInputCols(["sentence_bert_embeddings"]) \\
+    ...     .setOutputCols("finished_embeddings") \\
+    ...     .setOutputAsVector(True)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     sentence,
+    ...     embeddings,
+    ...     embeddingsFinisher
+    ... ])
+    >>> data = spark.createDataFrame([["John loves apples. Mary loves oranges. John loves Mary."]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.selectExpr("explode(finished_embeddings) as result").show(5, 80)
+    +--------------------------------------------------------------------------------+
+    |                                                                          result|
+    +--------------------------------------------------------------------------------+
+    |[-0.8951074481010437,0.13753940165042877,0.3108254075050354,-1.65693199634552...|
+    |[-0.6180210709571838,-0.12179657071828842,-0.191165953874588,-1.4497021436691...|
+    |[-0.822715163230896,0.7568016648292542,-0.1165061742067337,-1.59048593044281,...|
+    +--------------------------------------------------------------------------------+
     """
 
     name = "BertSentenceEmbeddings"
@@ -5347,12 +5598,35 @@ class BertSentenceEmbeddings(AnnotatorModel,
                              TypeConverters.toListString)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setMaxSentenceLength(self, value):
+        """Set max sentence length to process
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
         return self._set(maxSentenceLength=value)
 
     def setIsLong(self, value):
+        """Set whether to use Long type instead of Int type for inputs buffer.
+
+        Some Bert models require Long instead of Int.
+
+        Parameters
+        ----------
+        value : bool
+            Whether to use Long type instead of Int type for inputs buffer
+        """
         return self._set(isLong=value)
 
     @keyword_only
@@ -5370,12 +5644,42 @@ class BertSentenceEmbeddings(AnnotatorModel,
 
     @staticmethod
     def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        BertSentenceEmbeddings
+            The restored model
+        """
         from sparknlp.internal import _BertSentenceLoader
         jModel = _BertSentenceLoader(folder, spark_session._jsparkSession)._java_obj
         return BertSentenceEmbeddings(java_model=jModel)
 
     @staticmethod
     def pretrained(name="sent_small_bert_L2_768", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "sent_small_bert_L2_768"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        BertSentenceEmbeddings
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(BertSentenceEmbeddings, name, lang, remote_loc)
 
@@ -5616,6 +5920,22 @@ class StopWordsCleaner(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="stopwords_en", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(StopWordsCleaner, name, lang, remote_loc)
 
@@ -6039,7 +6359,7 @@ class UniversalSentenceEncoder(AnnotatorModel, HasEmbeddingsProperties, HasStora
     loadSP
         Whether to load SentencePiece ops file which is required only by multi-lingual models, by default False
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
 
     Examples
     --------
@@ -6108,6 +6428,13 @@ class UniversalSentenceEncoder(AnnotatorModel, HasEmbeddingsProperties, HasStora
         return self._set(loadSP=value)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     @keyword_only
@@ -6122,6 +6449,20 @@ class UniversalSentenceEncoder(AnnotatorModel, HasEmbeddingsProperties, HasStora
 
     @staticmethod
     def loadSavedModel(folder, spark_session, loadsp=False):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.internal import _USELoader
         jModel = _USELoader(folder, spark_session._jsparkSession, loadsp)._java_obj
         return UniversalSentenceEncoder(java_model=jModel)
@@ -6129,6 +6470,22 @@ class UniversalSentenceEncoder(AnnotatorModel, HasEmbeddingsProperties, HasStora
 
     @staticmethod
     def pretrained(name="tfhub_use", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(UniversalSentenceEncoder, name, lang, remote_loc)
 
@@ -6194,7 +6551,7 @@ class ElmoEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasCaseSensitivePr
     caseSensitive
         Whether to ignore case in tokens for embeddings matching
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     poolingLayer
         Set ELMO pooling layer to: word_emb, lstm_outputs1, lstm_outputs2, or elmo, by default word_emb
 
@@ -6269,6 +6626,13 @@ class ElmoEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasCaseSensitivePr
                          typeConverter=TypeConverters.toString)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setBatchSize(self, value):
@@ -6299,6 +6663,20 @@ class ElmoEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasCaseSensitivePr
 
     @staticmethod
     def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.internal import _ElmoLoader
         jModel = _ElmoLoader(folder, spark_session._jsparkSession)._java_obj
         return ElmoEmbeddings(java_model=jModel)
@@ -6306,6 +6684,22 @@ class ElmoEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasCaseSensitivePr
 
     @staticmethod
     def pretrained(name="elmo", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(ElmoEmbeddings, name, lang, remote_loc)
 
@@ -6345,7 +6739,7 @@ class ClassifierDLApproach(AnnotatorApproach):
     maxEpochs
         Maximum number of epochs to train, by default 30
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     validationSplit
         Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.
     enableOutputLogs
@@ -6448,6 +6842,13 @@ class ClassifierDLApproach(AnnotatorApproach):
         return self._set(labelColumn=value)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setLr(self, v):
@@ -6527,7 +6928,7 @@ class ClassifierDLModel(AnnotatorModel, HasStorageRef):
     ----------
 
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     classes
         get the tags used to trained this ClassifierDLModel
 
@@ -6599,10 +7000,33 @@ class ClassifierDLModel(AnnotatorModel, HasStorageRef):
                     TypeConverters.toListString)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     @staticmethod
     def pretrained(name="classifierdl_use_trec6", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(ClassifierDLModel, name, lang, remote_loc)
 
@@ -6612,39 +7036,71 @@ class AlbertEmbeddings(AnnotatorModel,
                        HasCaseSensitiveProperties,
                        HasStorageRef,
                        HasBatchedAnnotate):
-    """ALBERT: A LITE BERT FOR SELF-SUPERVISED LEARNING OF LANGUAGE REPRESENTATIONS - Google Research, Toyota Technological Institute at Chicago
+    """ALBERT: A Lite Bert For Self-Supervised Learning Of Language
+    Representations - Google Research, Toyota Technological Institute at Chicago
 
     These word embeddings represent the outputs generated by the Albert model.
-    All official Albert releases by google in TF-HUB are supported with this Albert Wrapper:
+    All official Albert releases by google in TF-HUB are supported with this
+    Albert Wrapper:
 
     **Ported TF-Hub Models:**
 
-    ``"albert_base_uncased"``    | `albert_base <https://tfhub.dev/google/albert_base/3>`__       |  768-embed-dim,   12-layer,  12-heads, 12M parameters
+    ============================ ============================================================== =====================================================
+    Model Name                   TF-Hub Model                                                   Model Properties
+    ============================ ============================================================== =====================================================
+    ``"albert_base_uncased"``    `albert_base <https://tfhub.dev/google/albert_base/3>`__       768-embed-dim,   12-layer,  12-heads, 12M parameters
+    ``"albert_large_uncased"``   `albert_large <https://tfhub.dev/google/albert_large/3>`__     1024-embed-dim,  24-layer,  16-heads, 18M parameters
+    ``"albert_xlarge_uncased"``  `albert_xlarge <https://tfhub.dev/google/albert_xlarge/3>`__   2048-embed-dim,  24-layer,  32-heads, 60M parameters
+    ``"albert_xxlarge_uncased"`` `albert_xxlarge <https://tfhub.dev/google/albert_xxlarge/3>`__ 4096-embed-dim,  12-layer,  64-heads, 235M parameters
+    ============================ ============================================================== =====================================================
 
-    ``"albert_large_uncased"``   | `albert_large <https://tfhub.dev/google/albert_large/3>`__     |  1024-embed-dim,  24-layer,  16-heads, 18M parameters
-
-    ``"albert_xlarge_uncased"``  | `albert_xlarge <https://tfhub.dev/google/albert_xlarge/3>`__   |  2048-embed-dim,  24-layer,  32-heads, 60M parameters
-
-    ``"albert_xxlarge_uncased"`` | `albert_xxlarge <https://tfhub.dev/google/albert_xxlarge/3>`__ |  4096-embed-dim,  12-layer,  64-heads, 235M parameters
-
-    This model requires input tokenization with SentencePiece model, which is provided by Spark-NLP (See tokenizers package).
+    This model requires input tokenization with SentencePiece model, which is
+    provided by Spark-NLP (See tokenizers package).
 
     Pretrained models can be loaded with ``pretrained`` of the companion object:
 
-    .. code-block:: python
-
-        embeddings = AlbertEmbeddings.pretrained() \\
-         .setInputCols(["sentence", "token"]) \\
-         .setOutputCol("embeddings")
+    >>> embeddings = AlbertEmbeddings.pretrained() \\
+    ...    .setInputCols(["sentence", "token"]) \\
+    ...    .setOutputCol("embeddings")
 
 
     The default model is ``"albert_base_uncased"``, if no name is provided.
 
-    For extended examples of usage, see the `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/dl-ner/ner_albert.ipynb>`__.
-    Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. The Spark NLP Workshop
-    example shows how to import them https://github.com/JohnSnowLabs/spark-nlp/discussions/5669.
+    For extended examples of usage, see the `Spark NLP Workshop
+    <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/dl-ner/ner_albert.ipynb>`__.
+    Models from the HuggingFace 🤗 Transformers library are also compatible with
+    Spark NLP 🚀. The Spark NLP Workshop example shows how to import them
+    https://github.com/JohnSnowLabs/spark-nlp/discussions/5669.
 
-    **Sources:**
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT, TOKEN``    ``WORD_EMBEDDINGS``
+    ====================== ======================
+
+    Parameters
+    ----------
+
+    batchSize
+        Size of every batch, by default 8
+    dimension
+        Number of embedding dimensions, by default 768
+    caseSensitive
+        Whether to ignore case in tokens for embeddings matching, by default False
+    configProtoBytes
+        ConfigProto from tensorflow, serialized into byte array.
+    maxSentenceLength
+        Max sentence length to process, by default 128
+
+    Notes
+    -----
+
+    ALBERT uses repeating layers which results in a small memory footprint,
+    however the computational cost remains similar to a BERT-like architecture with
+    the same number of hidden layers as it has to iterate through the same number of (repeating) layers.
+
+    References
+    ----------
 
     `ALBERT: A LITE BERT FOR SELF-SUPERVISED LEARNING OF LANGUAGE REPRESENTATIONS <https://arxiv.org/pdf/1909.11942.pdf>`__
 
@@ -6664,82 +7120,44 @@ class AlbertEmbeddings(AnnotatorModel,
     multi-sentence inputs. As a result, our best model establishes new state-of-the-art
     results on the GLUE, RACE, and SQuAD benchmarks while having fewer parameters compared to BERT-large.*
 
-    **Tips:**
-    ALBERT uses repeating layers which results in a small memory footprint,
-    however the computational cost remains similar to a BERT-like architecture with
-    the same number of hidden layers as it has to iterate through the same number of (repeating) layers.
-
-    ====================== ======================
-    Input Annotation types Output Annotation type
-    ====================== ======================
-    ``DOCUMENT, TOKEN``    ``WORD_EMBEDDINGS``
-    ====================== ======================
-
-    Parameters
-    ----------
-
-    batchSize
-        Size of every batch, by default 8
-    dimension
-        Number of embedding dimensions, by default 768
-    caseSensitive
-        Whether to ignore case in tokens for embeddings matching, by default False
-    configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
-    maxSentenceLength
-        Max sentence length to process, by default 128
-
     Examples
     --------
 
-    .. code-block:: python
-
-        import sparknlp
-        from sparknlp.base import *
-        from sparknlp.common import *
-        from sparknlp.annotator import *
-        from sparknlp.training import *
-        from pyspark.ml import Pipeline
-
-        documentAssembler = DocumentAssembler() \\
-            .setInputCol("text") \\
-            .setOutputCol("document")
-
-        tokenizer = Tokenizer() \\
-            .setInputCols(["document"]) \\
-            .setOutputCol("token")
-
-        embeddings = AlbertEmbeddings.pretrained() \\
-            .setInputCols(["token", "document"]) \\
-            .setOutputCol("embeddings")
-
-        embeddingsFinisher = EmbeddingsFinisher() \\
-            .setInputCols(["embeddings"]) \\
-            .setOutputCols("finished_embeddings") \\
-            .setOutputAsVector(True) \\
-            .setCleanAnnotations(False)
-
-        pipeline = Pipeline().setStages([
-            documentAssembler,
-            tokenizer,
-            embeddings,
-            embeddingsFinisher
-        ])
-
-        data = spark.createDataFrame([["This is a sentence."]]).toDF("text")
-        result = pipeline.fit(data).transform(data)
-
-        result.selectExpr("explode(finished_embeddings) as result").show(5, 80)
-        +--------------------------------------------------------------------------------+
-        |                                                                          result|
-        +--------------------------------------------------------------------------------+
-        |[1.1342473030090332,-1.3855540752410889,0.9818322062492371,-0.784737348556518...|
-        |[0.847029983997345,-1.047153353691101,-0.1520637571811676,-0.6245765686035156...|
-        |[-0.009860038757324219,-0.13450059294700623,2.707749128341675,1.2916892766952...|
-        |[-0.04192575812339783,-0.5764210224151611,-0.3196685314178467,-0.527840495109...|
-        |[0.15583214163780212,-0.1614152491092682,-0.28423872590065,-0.135491415858268...|
-        +--------------------------------------------------------------------------------+
-
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["document"]) \\
+    >>> embeddings = AlbertEmbeddings.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("embeddings")
+    >>> embeddingsFinisher = EmbeddingsFinisher() \\
+    ...     .setInputCols(["embeddings"]) \\
+    ...     .setOutputCols("finished_embeddings") \\
+    ...     .setOutputAsVector(True) \\
+    ...     .setCleanAnnotations(False)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     tokenizer,
+    ...     embeddings,
+    ...     embeddingsFinisher
+    ... ])
+    >>> data = spark.createDataFrame([["This is a sentence."]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.selectExpr("explode(finished_embeddings) as result").show(5, 80)
+    +--------------------------------------------------------------------------------+
+    |                                                                          result|
+    +--------------------------------------------------------------------------------+
+    |[1.1342473030090332,-1.3855540752410889,0.9818322062492371,-0.784737348556518...|
+    |[0.847029983997345,-1.047153353691101,-0.1520637571811676,-0.6245765686035156...|
+    |[-0.009860038757324219,-0.13450059294700623,2.707749128341675,1.2916892766952...|
+    |[-0.04192575812339783,-0.5764210224151611,-0.3196685314178467,-0.527840495109...|
+    |[0.15583214163780212,-0.1614152491092682,-0.28423872590065,-0.135491415858268...|
+    +--------------------------------------------------------------------------------+
     """
 
     name = "AlbertEmbeddings"
@@ -6755,9 +7173,23 @@ class AlbertEmbeddings(AnnotatorModel,
                               typeConverter=TypeConverters.toInt)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setMaxSentenceLength(self, value):
+        """Set max sentence length to process
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
         return self._set(maxSentenceLength=value)
 
     @keyword_only
@@ -6775,12 +7207,42 @@ class AlbertEmbeddings(AnnotatorModel,
 
     @staticmethod
     def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        AlbertEmbeddings
+            The restored model
+        """
         from sparknlp.internal import _AlbertLoader
         jModel = _AlbertLoader(folder, spark_session._jsparkSession)._java_obj
         return AlbertEmbeddings(java_model=jModel)
 
     @staticmethod
     def pretrained(name="albert_base_uncased", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "albert_base_uncased"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        AlbertEmbeddings
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(AlbertEmbeddings, name, lang, remote_loc)
 
@@ -6856,7 +7318,7 @@ class XlnetEmbeddings(AnnotatorModel,
     caseSensitive
         Whether to ignore case in tokens for embeddings matching, by default True
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     maxSentenceLength
         Max sentence length to process, by default 128
 
@@ -6926,9 +7388,23 @@ class XlnetEmbeddings(AnnotatorModel,
                               typeConverter=TypeConverters.toInt)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setMaxSentenceLength(self, value):
+        """Set max sentence length to process
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
         return self._set(maxSentenceLength=value)
 
     @keyword_only
@@ -6946,12 +7422,42 @@ class XlnetEmbeddings(AnnotatorModel,
 
     @staticmethod
     def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.internal import _XlnetLoader
         jModel = _XlnetLoader(folder, spark_session._jsparkSession)._java_obj
         return XlnetEmbeddings(java_model=jModel)
 
     @staticmethod
     def pretrained(name="xlnet_base_cased", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(XlnetEmbeddings, name, lang, remote_loc)
 
@@ -7016,7 +7522,7 @@ class ContextSpellCheckerApproach(AnnotatorApproach):
     maxWindowLen
         Maximum size for the window used to remember history prior to every correction.
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
 
     Examples
     --------
@@ -7200,6 +7706,13 @@ class ContextSpellCheckerApproach(AnnotatorApproach):
         return self._set(maxWindowLen=length)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def addVocabClass(self, label, vocab, userdist=3):
@@ -7279,7 +7792,7 @@ class ContextSpellCheckerModel(AnnotatorModel):
     compareLowcase
         If true will compare tokens in low case with vocabulary
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
 
     Examples
     --------
@@ -7398,6 +7911,13 @@ class ContextSpellCheckerModel(AnnotatorModel):
         return self._set(gamma=g)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def getWordClasses(self):
@@ -7429,6 +7949,22 @@ class ContextSpellCheckerModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="spellcheck_dl", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(ContextSpellCheckerModel, name, lang, remote_loc)
 
@@ -7469,7 +8005,7 @@ class SentimentDLApproach(AnnotatorApproach):
     maxEpochs
         Maximum number of epochs to train, by default 30
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     validationSplit
         Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off.
     enableOutputLogs
@@ -7577,6 +8113,13 @@ class SentimentDLApproach(AnnotatorApproach):
         return self._set(labelColumn=value)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setLr(self, v):
@@ -7662,7 +8205,7 @@ class SentimentDLModel(AnnotatorModel, HasStorageRef):
     ----------
 
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     threshold
         The minimum threshold for the final result otheriwse it will be neutral, by default 0.6
     thresholdLabel
@@ -7736,6 +8279,13 @@ class SentimentDLModel(AnnotatorModel, HasStorageRef):
                     TypeConverters.toListString)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setThreshold(self, v):
@@ -7747,6 +8297,22 @@ class SentimentDLModel(AnnotatorModel, HasStorageRef):
 
     @staticmethod
     def pretrained(name="sentimentdl_use_imdb", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(SentimentDLModel, name, lang, remote_loc)
 
@@ -7785,7 +8351,7 @@ class LanguageDetectorDL(AnnotatorModel, HasStorageRef):
     ----------
 
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     threshold
         The minimum threshold for the final result otheriwse it will be either neutral or the value set in thresholdLabel, by default 0.5
     thresholdLabel
@@ -7859,6 +8425,13 @@ class LanguageDetectorDL(AnnotatorModel, HasStorageRef):
                       "get the languages used to trained the model",
                       TypeConverters.toListString)
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setThreshold(self, v):
@@ -7873,6 +8446,22 @@ class LanguageDetectorDL(AnnotatorModel, HasStorageRef):
 
     @staticmethod
     def pretrained(name="ld_wiki_tatoeba_cnn_21", lang="xx", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(LanguageDetectorDL, name, lang, remote_loc)
 
@@ -7922,7 +8511,7 @@ class MultiClassifierDLApproach(AnnotatorApproach):
     maxEpochs
         Maximum number of epochs to train, by default 10
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     validationSplit
         Choose the proportion of training dataset to be validated against the model on each Epoch. The value should be between 0.0 and 1.0 and by default it is 0.0 and off, by default 0.0
     enableOutputLogs
@@ -8050,6 +8639,13 @@ class MultiClassifierDLApproach(AnnotatorApproach):
         return self._set(labelColumn=v)
 
     def setConfigProtoBytes(self, v):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        v : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=v)
 
     def setLr(self, v):
@@ -8145,7 +8741,7 @@ class MultiClassifierDLModel(AnnotatorModel, HasStorageRef):
     ----------
 
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     threshold
         The minimum threshold for each label to be accepted, by default 0.5
     classes
@@ -8219,10 +8815,33 @@ class MultiClassifierDLModel(AnnotatorModel, HasStorageRef):
         return self
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     @staticmethod
     def pretrained(name="multiclassifierdl_use_toxic", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(MultiClassifierDLModel, name, lang, remote_loc)
 
@@ -8522,6 +9141,22 @@ class SentenceDetectorDLModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="sentence_detector_dl", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(SentenceDetectorDLModel, name, lang, remote_loc)
 
@@ -8873,6 +9508,22 @@ class WordSegmenterModel(AnnotatorModel):
 
     @staticmethod
     def pretrained(name="wordseg_pku", lang="zh", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(WordSegmenterModel, name, lang, remote_loc)
 
@@ -8934,7 +9585,7 @@ class T5Transformer(AnnotatorModel):
     ----------
 
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     task
         Transformer's task, e.g. summarize>
     minOutputLength
@@ -9020,6 +9671,13 @@ class T5Transformer(AnnotatorModel):
     noRepeatNgramSize = Param(Params._dummy(),  "noRepeatNgramSize", "If set to int > 0, all ngrams of that size can only occur once", typeConverter=TypeConverters.toInt)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setTask(self, value):
@@ -9059,12 +9717,42 @@ class T5Transformer(AnnotatorModel):
 
     @staticmethod
     def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.internal import _T5Loader
         jModel = _T5Loader(folder, spark_session._jsparkSession)._java_obj
         return T5Transformer(java_model=jModel)
 
     @staticmethod
     def pretrained(name="t5_small", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(T5Transformer, name, lang, remote_loc)
 
@@ -9124,7 +9812,7 @@ class MarianTransformer(AnnotatorModel, HasBatchedAnnotate):
     batchSize
         Size of every batch, by default 8
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
     langId
         Transformer's task, e.g. summarize>, by default ""
     maxInputLength
@@ -9191,6 +9879,13 @@ class MarianTransformer(AnnotatorModel, HasBatchedAnnotate):
     maxOutputLength = Param(Params._dummy(), "maxOutputLength", "Controls the maximum length for decoder outputs (target language texts)", typeConverter=TypeConverters.toInt)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setLangId(self, value):
@@ -9217,12 +9912,42 @@ class MarianTransformer(AnnotatorModel, HasBatchedAnnotate):
 
     @staticmethod
     def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.internal import _MarianLoader
         jModel = _MarianLoader(folder, spark_session._jsparkSession)._java_obj
         return MarianTransformer(java_model=jModel)
 
     @staticmethod
     def pretrained(name="opus_mt_en_fr", lang="xx", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(MarianTransformer, name, lang, remote_loc)
 
@@ -9292,7 +10017,7 @@ class DistilBertEmbeddings(AnnotatorModel,
     maxSentenceLength
         Max sentence length to process, by default 128
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
 
     Examples
     --------
@@ -9362,9 +10087,23 @@ class DistilBertEmbeddings(AnnotatorModel,
                              TypeConverters.toListString)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setMaxSentenceLength(self, value):
+        """Set max sentence length to process
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
         return self._set(maxSentenceLength=value)
 
     @keyword_only
@@ -9382,6 +10121,20 @@ class DistilBertEmbeddings(AnnotatorModel,
 
     @staticmethod
     def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.internal import _DistilBertLoader
         jModel = _DistilBertLoader(folder, spark_session._jsparkSession)._java_obj
         return DistilBertEmbeddings(java_model=jModel)
@@ -9389,6 +10142,22 @@ class DistilBertEmbeddings(AnnotatorModel,
 
     @staticmethod
     def pretrained(name="distilbert_base_cased", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(DistilBertEmbeddings, name, lang, remote_loc)
 
@@ -9455,7 +10224,7 @@ class RoBertaEmbeddings(AnnotatorModel,
     maxSentenceLength
         Max sentence length to process, by default 128
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
 
     Examples
     --------
@@ -9525,9 +10294,23 @@ class RoBertaEmbeddings(AnnotatorModel,
                              TypeConverters.toListString)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setMaxSentenceLength(self, value):
+        """Set max sentence length to process
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
         return self._set(maxSentenceLength=value)
 
     @keyword_only
@@ -9545,6 +10328,20 @@ class RoBertaEmbeddings(AnnotatorModel,
 
     @staticmethod
     def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.internal import _RoBertaLoader
         jModel = _RoBertaLoader(folder, spark_session._jsparkSession)._java_obj
         return RoBertaEmbeddings(java_model=jModel)
@@ -9552,6 +10349,22 @@ class RoBertaEmbeddings(AnnotatorModel,
 
     @staticmethod
     def pretrained(name="roberta_base", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(RoBertaEmbeddings, name, lang, remote_loc)
 
@@ -9622,7 +10435,7 @@ class XlmRoBertaEmbeddings(AnnotatorModel,
     maxSentenceLength
         Max sentence length to process, by default 128
     configProtoBytes
-        ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+        ConfigProto from tensorflow, serialized into byte array.
 
     Examples
     --------
@@ -9692,9 +10505,23 @@ class XlmRoBertaEmbeddings(AnnotatorModel,
                              TypeConverters.toListString)
 
     def setConfigProtoBytes(self, b):
+        """Set configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
         return self._set(configProtoBytes=b)
 
     def setMaxSentenceLength(self, value):
+        """Set max sentence length to process
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
         return self._set(maxSentenceLength=value)
 
     @keyword_only
@@ -9712,6 +10539,20 @@ class XlmRoBertaEmbeddings(AnnotatorModel,
 
     @staticmethod
     def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.internal import _XlmRoBertaLoader
         jModel = _XlmRoBertaLoader(folder, spark_session._jsparkSession)._java_obj
         return XlmRoBertaEmbeddings(java_model=jModel)
@@ -9719,5 +10560,21 @@ class XlmRoBertaEmbeddings(AnnotatorModel,
 
     @staticmethod
     def pretrained(name="xlm_roberta_base", lang="xx", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "???"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None
+
+        Returns
+        -------
+        ???
+            The restored model
+        """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(XlmRoBertaEmbeddings, name, lang, remote_loc)

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -2113,13 +2113,13 @@ class TextMatcherModel(AnnotatorModel):
 
 
 class BigTextMatcher(AnnotatorApproach, HasStorage):
-    """Annotator to match exact phrases (by token) provided in a file against a Document.
+    """Annotator to match exact phrases (by token) provided in a file against a
+    Document.
 
     A text file of predefined phrases must be provided with ``setStoragePath``.
-    The text file can als be set directly as an
-    ExternalResource.
 
-    In contrast to the normal ``TextMatcher``, the ``BigTextMatcher`` is designed for large corpora.
+    In contrast to the normal ``TextMatcher``, the ``BigTextMatcher`` is
+    designed for large corpora.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -2133,7 +2133,7 @@ class BigTextMatcher(AnnotatorApproach, HasStorage):
     entities
         ExternalResource for entities
     caseSensitive
-        whether to ignore case in index lookups , by default True
+        whether to ignore case in index lookups, by default True
     mergeOverlapping
         whether to merge overlapping matched chunks, by default False
     tokenizer
@@ -2142,48 +2142,41 @@ class BigTextMatcher(AnnotatorApproach, HasStorage):
     Examples
     --------
 
-    .. code-block:: python
+    In this example, the entities file is of the form::
 
-        import sparknlp
-        from sparknlp.base import *
-        from sparknlp.common import *
-        from sparknlp.annotator import *
-        from sparknlp.training import *
-        from pyspark.ml import Pipeline
-        # In this example, the entities file is of the form
-        #
-        # ...
-        # dolore magna aliqua
-        # lorem ipsum dolor. sit
-        # laborum
-        # ...
-        #
-        # where each line represents an entity phrase to be extracted.
+        ...
+        dolore magna aliqua
+        lorem ipsum dolor. sit
+        laborum
+        ...
 
-        documentAssembler = DocumentAssembler() \\
-            .setInputCol("text") \\
-            .setOutputCol("document")
+    where each line represents an entity phrase to be extracted.
 
-        tokenizer = Tokenizer() \\
-            .setInputCols(["document"]) \\
-            .setOutputCol("token")
-
-        data = spark.createDataFrame([["Hello dolore magna aliqua. Lorem ipsum dolor. sit in laborum"]]).toDF("text")
-        entityExtractor = BigTextMatcher() \\
-            .setInputCols(["document", "token"]) \\
-            .setStoragePath("src/test/resources/entity-extractor/test-phrases.txt", ReadAs.TEXT) \\
-            .setOutputCol("entity") \\
-            .setCaseSensitive(False)
-
-        pipeline = Pipeline().setStages([documentAssembler, tokenizer, entityExtractor])
-        results = pipeline.fit(data).transform(data)
-        results.selectExpr("explode(entity)").show(truncate=False)
-        +--------------------------------------------------------------------+
-        |col                                                                 |
-        +--------------------------------------------------------------------+
-        |[chunk, 6, 24, dolore magna aliqua, [sentence -> 0, chunk -> 0], []]|
-        |[chunk, 53, 59, laborum, [sentence -> 0, chunk -> 1], []]           |
-        +--------------------------------------------------------------------+
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols("document") \\
+    ...     .setOutputCol("token")
+    >>> data = spark.createDataFrame([["Hello dolore magna aliqua. Lorem ipsum dolor. sit in laborum"]]).toDF("text")
+    >>> entityExtractor = BigTextMatcher() \\
+    ...     .setInputCols("document", "token") \\
+    ...     .setStoragePath("src/test/resources/entity-extractor/test-phrases.txt", ReadAs.TEXT) \\
+    ...     .setOutputCol("entity") \\
+    ...     .setCaseSensitive(False)
+    >>> pipeline = Pipeline().setStages([documentAssembler, tokenizer, entityExtractor])
+    >>> results = pipeline.fit(data).transform(data)
+    >>> results.selectExpr("explode(entity)").show(truncate=False)
+    +--------------------------------------------------------------------+
+    |col                                                                 |
+    +--------------------------------------------------------------------+
+    |[chunk, 6, 24, dolore magna aliqua, [sentence -> 0, chunk -> 0], []]|
+    |[chunk, 53, 59, laborum, [sentence -> 0, chunk -> 1], []]           |
+    +--------------------------------------------------------------------+
 
     """
 
@@ -2217,21 +2210,56 @@ class BigTextMatcher(AnnotatorApproach, HasStorage):
         return TextMatcherModel(java_model=java_model)
 
     def setEntities(self, path, read_as=ReadAs.TEXT, options={"format": "text"}):
+        """Set ExternalResource for entities
+
+        Parameters
+        ----------
+        path : str
+            Path to the resource
+        read_as : str, optional
+            How to read the resource, by default ReadAs.TEXT
+        options : dict, optional
+            Options for reading the resource, by default {"format": "text"}
+        """
         return self._set(entities=ExternalResource(path, read_as, options.copy()))
 
     def setCaseSensitive(self, b):
+        """Set whether to ignore case in index lookups, by default True
+
+        Parameters
+        ----------
+        b : bool
+            Whether to ignore case in index lookups
+        """
         return self._set(caseSensitive=b)
 
     def setMergeOverlapping(self, b):
+        """Set whether to merge overlapping matched chunks, by default False
+
+        Parameters
+        ----------
+        b : bool
+            Whether to merge overlapping matched chunks
+
+        """
         return self._set(mergeOverlapping=b)
 
     def setTokenizer(self, tokenizer_model):
+        """Set TokenizerModel to use to tokenize input file for building a Trie
+
+        Parameters
+        ----------
+        tokenizer_model : :class:`TokenizerModel <sparknlp.annotator.TokenizerModel>`
+            TokenizerModel to use to tokenize input file
+
+        """
         tokenizer_model._transfer_params_to_java()
         return self._set(tokenizer_model._java_obj)
 
 
 class BigTextMatcherModel(AnnotatorModel, HasStorageModel):
     """Instantiated model of the BigTextMatcher.
+
     For usage and examples see the documentation of the main class.
 
     ====================== ======================
@@ -2244,11 +2272,11 @@ class BigTextMatcherModel(AnnotatorModel, HasStorageModel):
     ----------
 
     caseSensitive
-        whether to ignore case in index lookups
+        Whether to ignore case in index lookups
     mergeOverlapping
-        whether to merge overlapping matched chunks. Defaults false
+        Whether to merge overlapping matched chunks, by default False
     searchTrie
-        searchTrie
+        SearchTrie
 
 
     """
@@ -2277,9 +2305,23 @@ class BigTextMatcherModel(AnnotatorModel, HasStorageModel):
         )
 
     def setMergeOverlapping(self, b):
+        """Set whether to ignore case in index lookups
+
+        Parameters
+        ----------
+        b : bool
+            Whether to ignore case in index lookups
+        """
         return self._set(mergeOverlapping=b)
 
     def setCaseSensitive(self, v):
+        """Set whether to merge overlapping matched chunks, by default False
+
+        Parameters
+        ----------
+        v : bool
+            Whether to merge overlapping matched chunks, by default False
+        """
         return self._set(caseSensitive=v)
 
     @staticmethod
@@ -2289,15 +2331,16 @@ class BigTextMatcherModel(AnnotatorModel, HasStorageModel):
         Parameters
         ----------
         name : str, optional
-            Name of the pretrained model, by default "???"
+            Name of the pretrained model
         lang : str, optional
             Language of the pretrained model, by default "en"
         remote_loc : str, optional
-            Optional remote address of the resource, by default None
+            Optional remote address of the resource, by default None. Will use
+            Spark NLPs repositories otherwise.
 
         Returns
         -------
-        ???
+        TextMatcherModel
             The restored model
         """
         from sparknlp.pretrained import ResourceDownloader

--- a/python/sparknlp/base.py
+++ b/python/sparknlp/base.py
@@ -15,11 +15,9 @@
 
 """Contains all the basic components to create a Spark NLP Pipeline.
 
-Notes
------
-This module contains extensions to the Spark Pipeline interface in the form of
-the :class:`LightPipeline` and :class:`RecursivePipeline` which offer additional
-functionality.
+This module contains basic transformers and extensions to the Spark Pipeline
+interface. These are the :class:`LightPipeline` and :class:`RecursivePipeline`
+which offer additional functionality.
 """
 
 from abc import ABC
@@ -36,24 +34,42 @@ import sparknlp.internal as _internal
 
 
 class LightPipeline:
+    """Creates a LightPipeline from a Spark PipelineModel.
+
+    LightPipeline is a Spark NLP specific Pipeline class equivalent to Spark
+    ML Pipeline. The difference is that it’s execution does not hold to
+    Spark principles, instead it computes everything locally (but in
+    parallel) in order to achieve fast results when dealing with small
+    amounts of data. This means, we do not input a Spark Dataframe, but a
+    string or an Array of strings instead, to be annotated. To create Light
+    Pipelines, you need to input an already trained (fit) Spark ML Pipeline.
+    It’s transform() stage is converted into annotate() instead.
+
+    Parameters
+    ----------
+    pipelineModel : :class:`pyspark.ml.PipelineModel`
+        The PipelineModel containing Spark NLP Annotators
+    parse_embeddings : bool, optional
+        Whether to parse embeddings, by default False
+
+    Examples
+    --------
+    >>> from sparknlp.base import LightPipeline
+    >>> light = LightPipeline(pipeline.fit(data))
+    >>> light.annotate("We are very happy about Spark NLP")
+    {
+        'document': ['We are very happy about Spark NLP'],
+        'lemmas': ['We', 'be', 'very', 'happy', 'about', 'Spark', 'NLP'],
+        'pos': ['PRP', 'VBP', 'RB', 'JJ', 'IN', 'NNP', 'NNP'],
+        'sentence': ['We are very happy about Spark NLP'],
+        'spell': ['We', 'are', 'very', 'happy', 'about', 'Spark', 'NLP'],
+        'stems': ['we', 'ar', 'veri', 'happi', 'about', 'spark', 'nlp'],
+        'token': ['We', 'are', 'very', 'happy', 'about', 'Spark', 'NLP']
+    }
+
+    """
+
     def __init__(self, pipelineModel, parse_embeddings=False):
-        """Creates a LightPipeline from a Spark PipelineModel.
-
-        LightPipeline is a Spark NLP specific Pipeline class equivalent to Spark ML Pipeline.
-        The difference is that it’s execution does not hold to Spark principles, instead it
-        computes everything locally (but in parallel) in order to achieve fast results when
-        dealing with small amounts of data. This means, we do not input a Spark Dataframe, but
-        a string or an Array of strings instead, to be annotated. To create Light Pipelines,
-        you need to input an already trained (fit) Spark ML Pipeline. It’s transform() stage
-        is converted into annotate() instead.
-
-        Parameters
-        ----------
-        pipelineModel : PipelineModel
-            The PipelineModel containing Spark NLP Annotators
-        parse_embeddings : bool, optional
-            Whether to prase embeddings, by default False
-        """
         self.pipeline_model = pipelineModel
         self._lightPipeline = _internal._LightPipeline(pipelineModel, parse_embeddings).apply()
 
@@ -72,6 +88,20 @@ class LightPipeline:
         return annotations
 
     def fullAnnotate(self, target):
+        """Annotates the data provided into Annotations.
+
+        The data should be either a list or a str.
+
+        Parameters
+        ----------
+        target : list or str
+            The data to be annotated
+
+        Returns
+        -------
+        list or str
+            The result of the annotation
+        """
         result = []
         if type(target) is str:
             target = [target]
@@ -83,7 +113,20 @@ class LightPipeline:
         return result
 
     def annotate(self, target):
+        """Annotates the data provided, extracting the results.
 
+        The data should be either a list or a str.
+
+        Parameters
+        ----------
+        target : list or str
+            The data to be annotated
+
+        Returns
+        -------
+        list or str
+            The result of the annotation
+        """
         def reformat(annotations):
             return {k: list(v) for k, v in annotations.items()}
 
@@ -99,17 +142,72 @@ class LightPipeline:
         return result
 
     def transform(self, dataframe):
+        """Transforms a dataframe provided with the stages of the LightPipeline.
+
+        Parameters
+        ----------
+        dataframe : :class:`pyspark.sql.DataFrame`
+            The Dataframe to be transformed
+
+        Returns
+        -------
+        :class:`pyspark.sql.DataFrame`
+            The transformed DataFrame
+        """
         return self.pipeline_model.transform(dataframe)
 
     def setIgnoreUnsupported(self, value):
+        """Set whether to ignore unsupported AnnotatorModels.
+
+        Parameters
+        ----------
+        value : bool
+            Whether to ignore unsupported AnnotatorModels.
+
+        Returns
+        -------
+        LightPipeline
+            The current LightPipeline
+        """
         self._lightPipeline.setIgnoreUnsupported(value)
         return self
 
     def getIgnoreUnsupported(self):
+        """Get whether to ignore unsupported AnnotatorModels.
+
+        Returns
+        -------
+        bool
+            Whether to ignore unsupported AnnotatorModels.
+        """
         return self._lightPipeline.getIgnoreUnsupported()
 
 
 class RecursivePipeline(Pipeline, JavaEstimator):
+    """Recursive pipelines are Spark NLP specific pipelines that allow a Spark
+    ML Pipeline to know about itself on every Pipeline Stage task.
+
+    This allows annotators to utilize this same pipeline against external
+    resources to process them in the same way the user decides.
+
+    Only some of the annotators take advantage of this. RecursivePipeline
+    behaves exactly the same as normal Spark ML pipelines, so they can be used
+    with the same intention.
+
+    Examples
+    --------
+
+    >>> from sparknlp.annotator import *
+    >>> from sparknlp.base import *
+    >>> recursivePipeline = RecursivePipeline(stages=[
+    ...     documentAssembler,
+    ...     sentenceDetector,
+    ...     tokenizer,
+    ...     lemmatizer,
+    ...     finisher
+    ... ])
+
+    """
     @keyword_only
     def __init__(self, *args, **kwargs):
         super(RecursivePipeline, self).__init__(*args, **kwargs)
@@ -149,7 +247,12 @@ class RecursivePipeline(Pipeline, JavaEstimator):
 
 
 class RecursivePipelineModel(PipelineModel):
+    """Fitted RecursivePipeline.
 
+    Behaves the same as a Spark PipelineModel does. Not intended to be
+    initialized by itself. To create a RecursivePipelineModel please fit data to
+    a :class:`RecursivePipeline <sparknlp.base.RecursivePipeline>`.
+    """
     def __init__(self, pipeline_model):
         super(PipelineModel, self).__init__()
         self.stages = pipeline_model.stages
@@ -167,14 +270,82 @@ class RecursivePipelineModel(PipelineModel):
 
 
 class HasRecursiveFit(RecursiveEstimator, ABC):
+    """Properties for the implementation of the RecursivePipeline."""
     pass
 
 
 class HasRecursiveTransform(RecursiveTransformer):
+    """Properties for the implementation of the RecursivePipeline."""
     pass
 
 
 class DocumentAssembler(AnnotatorTransformer):
+    """Prepares data into a format that is processable by Spark NLP.
+
+    This is the entry point for every Spark NLP pipeline. The
+    ``DocumentAssembler`` can read either a ``String`` column or an
+    ``Array[String]``. Additionally, setCleanupMode can be used to pre-process
+    the text (Default: ``disabled``). For possible options please refer the
+    parameters section.
+
+    For more extended examples on document pre-processing see the
+    `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb>`__.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``NONE``               ``DOCUMENT``
+    ====================== ======================
+
+    Parameters
+    ----------
+
+    inputCol
+        Input column name
+    outputCol
+        Output column name
+    idCol
+        Name of String type column for row id.
+    metadataCol
+        Name of Map type column with metadata information
+    calculationsCol
+        Name of float vector map column to use for embeddings and other
+        representations.
+    cleanupMode
+        How to cleanup the document , by default disabled.
+        Possible values: ``disabled, inplace, inplace_full, shrink, shrink_full,
+        each, each_full, delete_full``
+
+    Examples
+    --------
+
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from pyspark.ml import Pipeline
+    >>> data = spark.createDataFrame([["Spark NLP is an open-source text processing library."]]).toDF("text")
+    >>> documentAssembler = DocumentAssembler().setInputCol("text").setOutputCol("document")
+    >>> result = documentAssembler.transform(data)
+    >>> result.select("document").show(truncate=False)
+    +----------------------------------------------------------------------------------------------+
+    |document                                                                                      |
+    +----------------------------------------------------------------------------------------------+
+    |[[document, 0, 51, Spark NLP is an open-source text processing library., [sentence -> 0], []]]|
+    +----------------------------------------------------------------------------------------------+
+    >>> result.select("document").printSchema()
+    root
+    |-- document: array (nullable = True)
+    |    |-- element: struct (containsNull = True)
+    |    |    |-- annotatorType: string (nullable = True)
+    |    |    |-- begin: integer (nullable = False)
+    |    |    |-- end: integer (nullable = False)
+    |    |    |-- result: string (nullable = True)
+    |    |    |-- metadata: map (nullable = True)
+    |    |    |    |-- key: string
+    |    |    |    |-- value: string (valueContainsNull = True)
+    |    |    |-- embeddings: array (nullable = True)
+    |    |    |    |-- element: float (containsNull = False)
+
+    """
 
     inputCol = Param(Params._dummy(), "inputCol", "input column name", typeConverter=TypeConverters.toString)
     outputCol = Param(Params._dummy(), "outputCol", "output column name", typeConverter=TypeConverters.toString)
@@ -195,27 +366,146 @@ class DocumentAssembler(AnnotatorTransformer):
         return self._set(**kwargs)
 
     def setInputCol(self, value):
+        """Set input column name.
+
+        Parameters
+        ----------
+        value : str
+            Name of the input column
+        """
         return self._set(inputCol=value)
 
     def setOutputCol(self, value):
+        """Set output column name.
+
+        Parameters
+        ----------
+        value : str
+            Name of the Output Column
+        """
         return self._set(outputCol=value)
 
     def setIdCol(self, value):
+        """Set name of string type column for row id.
+
+        Parameters
+        ----------
+        value : str
+            Name of the Id Column
+        """
         return self._set(idCol=value)
 
     def setMetadataCol(self, value):
+        """Set name for Map type column with metadata information.
+
+        Parameters
+        ----------
+        value : str
+            Name of the metadata column
+        """
         return self._set(metadataCol=value)
 
     def setCalculationsCol(self, value):
+        """Set name of float vector map column to use for embeddings and other
+        representations.
+
+        Parameters
+        ----------
+        value : str
+            Name of the calculations column
+        """
         return self._set(metadataCol=value)
 
     def setCleanupMode(self, value):
+        """Set how to cleanup the document , by default disabled.
+        Possible values: ``disabled, inplace, inplace_full, shrink, shrink_full,
+        each, each_full, delete_full``
+
+        Parameters
+        ----------
+        value : str
+            Cleanup mode
+        """
         if value.strip().lower() not in ['disabled', 'inplace', 'inplace_full', 'shrink', 'shrink_full', 'each', 'each_full', 'delete_full']:
             raise Exception("Cleanup mode possible values: disabled, inplace, inplace_full, shrink, shrink_full, each, each_full, delete_full")
         return self._set(cleanupMode=value)
 
 
 class TokenAssembler(AnnotatorTransformer, AnnotatorProperties):
+    """This transformer reconstructs a ``DOCUMENT`` type annotation from tokens,
+    usually after these have been normalized, lemmatized, normalized, spell
+    checked, etc, in order to use this document annotation in further
+    annotators. Requires ``DOCUMENT`` and ``TOKEN`` type annotations as input.
+
+    For more extended examples on document pre-processing see the
+    `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb>`__.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT, TOKEN``    ``DOCUMENT``
+    ====================== ======================
+
+    Parameters
+    ----------
+
+    preservePosition
+        Whether to preserve the actual position of the tokens or reduce them to
+        one space
+
+    Examples
+    --------
+
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+
+    First, the text is tokenized and cleaned
+
+    >>> documentAssembler = DocumentAssembler() \\
+    ...    .setInputCol("text") \\
+    ...    .setOutputCol("document")
+    >>> sentenceDetector = SentenceDetector() \\
+    ...    .setInputCols(["document"]) \\
+    ...    .setOutputCol("sentences")
+    >>> tokenizer = Tokenizer() \\
+    ...    .setInputCols(["sentences"]) \\
+    ...    .setOutputCol("token")
+    >>> normalizer = Normalizer() \\
+    ...    .setInputCols(["token"]) \\
+    ...    .setOutputCol("normalized") \\
+    ...    .setLowercase(False)
+    >>> stopwordsCleaner = StopWordsCleaner() \\
+    ...    .setInputCols(["normalized"]) \\
+    ...    .setOutputCol("cleanTokens") \\
+    ...    .setCaseSensitive(False)
+
+    Then the TokenAssembler turns the cleaned tokens into a ``DOCUMENT`` type
+    structure.
+
+    >>> tokenAssembler = TokenAssembler() \\
+    ...    .setInputCols(["sentences", "cleanTokens"]) \\
+    ...    .setOutputCol("cleanText")
+    >>> data = spark.createDataFrame([["Spark NLP is an open-source text processing library for advanced natural language processing."]]) \\
+    ...    .toDF("text")
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     sentenceDetector,
+    ...     tokenizer,
+    ...     normalizer,
+    ...     stopwordsCleaner,
+    ...     tokenAssembler
+    ... ]).fit(data)
+    >>> result = pipeline.transform(data)
+    >>> result.select("cleanText").show(truncate=False)
+    +---------------------------------------------------------------------------------------------------------------------------+
+    |cleanText                                                                                                                  |
+    +---------------------------------------------------------------------------------------------------------------------------+
+    |[[document, 0, 80, Spark NLP opensource text processing library advanced natural language processing, [sentence -> 0], []]]|
+    +---------------------------------------------------------------------------------------------------------------------------+
+
+    """
 
     name = "TokenAssembler"
     preservePosition = Param(Params._dummy(), "preservePosition", "whether to preserve the actual position of the tokens or reduce them to one space", typeConverter=TypeConverters.toBoolean)
@@ -230,10 +520,79 @@ class TokenAssembler(AnnotatorTransformer, AnnotatorProperties):
         return self._set(**kwargs)
 
     def setPreservePosition(self, value):
+        """Set whether to preserve the actual position of the tokens or reduce
+        them to one space.
+
+        Parameters
+        ----------
+        value : str
+            Name of the Id Column
+        """
         return self._set(preservePosition=value)
 
 
 class Doc2Chunk(AnnotatorTransformer, AnnotatorProperties):
+    """Converts ``DOCUMENT`` type annotations into ``CHUNK`` type with the
+    contents of a ``chunkCol``.
+
+    Chunk text must be contained within input ``DOCUMENT``. May be either
+    ``StringType`` or ``ArrayType[StringType]`` (using setIsArray). Useful for
+    annotators that require a CHUNK type input.
+
+    For more extended examples on document pre-processing see the
+    `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb>`__.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT``           ``CHUNK``
+    ====================== ======================
+
+    Parameters
+    ----------
+
+    chunkCol
+        Column that contains the string. Must be part of DOCUMENT
+    startCol
+        Column that has a reference of where the chunk begins
+    startColByTokenIndex
+        Whether start column is prepended by whitespace tokens
+    isArray
+        Whether the chunkCol is an array of strings, by default False
+    failOnMissing
+        Whether to fail the job if a chunk is not found within document.
+        Return empty otherwise
+    lowerCase
+        Whether to lower case for matching case
+
+    Examples
+    --------
+
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.common import *
+    >>> from sparknlp.annotator import *
+    >>> from sparknlp.training import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler().setInputCol("text").setOutputCol("document")
+    >>> chunkAssembler = Doc2Chunk() \\
+    ...     .setInputCols("document") \\
+    ...     .setChunkCol("target") \\
+    ...     .setOutputCol("chunk") \\
+    ...     .setIsArray(True)
+    >>> data = spark.createDataFrame([[
+    ...     "Spark NLP is an open-source text processing library for advanced natural language processing.",
+    ...     ["Spark NLP", "text processing library", "natural language processing"]
+    ... ]]).toDF("text", "target")
+    >>> pipeline = Pipeline().setStages([documentAssembler, chunkAssembler]).fit(data)
+    >>> result = pipeline.transform(data)
+    >>> result.selectExpr("chunk.result", "chunk.annotatorType").show(truncate=False)
+    +-----------------------------------------------------------------+---------------------+
+    |result                                                           |annotatorType        |
+    +-----------------------------------------------------------------+---------------------+
+    |[Spark NLP, text processing library, natural language processing]|[chunk, chunk, chunk]|
+    +-----------------------------------------------------------------+---------------------+
+    """
 
     chunkCol = Param(Params._dummy(), "chunkCol", "column that contains string. Must be part of DOCUMENT", typeConverter=TypeConverters.toString)
     startCol = Param(Params._dummy(), "startCol", "column that has a reference of where chunk begins", typeConverter=TypeConverters.toString)
@@ -256,25 +615,115 @@ class Doc2Chunk(AnnotatorTransformer, AnnotatorProperties):
         return self._set(**kwargs)
 
     def setChunkCol(self, value):
+        """Set column that contains the string. Must be part of DOCUMENT.
+
+        Parameters
+        ----------
+        value : str
+            Name of the Chunk Column
+        """
         return self._set(chunkCol=value)
 
     def setIsArray(self, value):
+        """Set whether the chunkCol is an array of strings.
+
+        Parameters
+        ----------
+        value : bool
+            Whether the chunkCol is an array of strings
+        """
         return self._set(isArray=value)
 
     def setStartCol(self, value):
+        """Set column that has a reference of where chunk begins.
+
+        Parameters
+        ----------
+        value : str
+            Name of the reference column
+        """
         return self._set(startCol=value)
 
     def setStartColByTokenIndex(self, value):
+        """Set whether start column is prepended by whitespace tokens.
+
+        Parameters
+        ----------
+        value : bool
+            whether start column is prepended by whitespace tokens
+        """
         return self._set(startColByTokenIndex=value)
 
     def setFailOnMissing(self, value):
+        """Set whether to fail the job if a chunk is not found within document.
+        Return empty otherwise.
+
+        Parameters
+        ----------
+        value : bool
+            Whether to fail job on missing chunks
+        """
         return self._set(failOnMissing=value)
 
     def setLowerCase(self, value):
+        """Set whether to lower case for matching case
+
+        Parameters
+        ----------
+        value : bool
+            Name of the Id Column
+        """
         return self._set(lowerCase=value)
 
 
 class Chunk2Doc(AnnotatorTransformer, AnnotatorProperties):
+    """Converts a ``CHUNK`` type column back into ``DOCUMENT``. Useful when
+    trying to re-tokenize or do further analysis on a ``CHUNK`` result.
+
+    For more extended examples on document pre-processing see the
+    `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb>`__.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``CHUNK``              ``DOCUMENT``
+    ====================== ======================
+
+    Parameters
+    ----------
+
+    None
+
+    Examples
+    --------
+
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.pretrained import PretrainedPipeline
+
+    Location entities are extracted and converted back into ``DOCUMENT`` type for
+    further processing.
+
+    >>> data = spark.createDataFrame([[1, "New York and New Jersey aren't that far apart actually."]]).toDF("id", "text")
+
+    Define pretrained pipeline that extracts Named Entities amongst other things
+    and apply `Chunk2Doc` on it.
+
+    >>> pipeline = PretrainedPipeline("explain_document_dl")
+    >>> chunkToDoc = Chunk2Doc().setInputCols("entities").setOutputCol("chunkConverted")
+    >>> explainResult = pipeline.transform(data)
+
+    Show results.
+
+    >>> result = chunkToDoc.transform(explainResult)
+    >>> result.selectExpr("explode(chunkConverted)").show(truncate=False)
+    +------------------------------------------------------------------------------+
+    |col                                                                           |
+    +------------------------------------------------------------------------------+
+    |[document, 0, 7, New York, [entity -> LOC, sentence -> 0, chunk -> 0], []]    |
+    |[document, 13, 22, New Jersey, [entity -> LOC, sentence -> 0, chunk -> 1], []]|
+    +------------------------------------------------------------------------------+
+    """
 
     name = "Chunk2Doc"
 
@@ -289,6 +738,73 @@ class Chunk2Doc(AnnotatorTransformer, AnnotatorProperties):
 
 
 class Finisher(AnnotatorTransformer):
+    """Converts annotation results into a format that easier to use.
+
+    It is useful to extract the results from Spark NLP Pipelines. The Finisher
+    outputs annotation(s) values into ``String``.
+
+    For more extended examples on document pre-processing see the
+    `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb>`__.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``ANY``                ``NONE``
+    ====================== ======================
+
+    Parameters
+    ----------
+
+    inputCols
+        Input annotations
+    outputCols
+        Output finished annotation cols
+    valueSplitSymbol
+        Character separating values, by default #
+    annotationSplitSymbol
+        Character separating annotations, by default @
+    cleanAnnotations
+        Whether to remove annotation columns, by default True
+    includeMetadata
+        Whether to include annotation metadata, by default False
+    outputAsArray
+        Finisher generates an Array with the results instead of string, by
+        default True
+    parseEmbeddingsVectors
+        Whether to include embeddings vectors in the process, by default False
+
+    Examples
+    --------
+
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from sparknlp.pretrained import PretrainedPipeline
+    >>> data = spark.createDataFrame([[1, "New York and New Jersey aren't that far apart actually."]]).toDF("id", "text")
+
+    Define pretrained pipeline that extracts Named Entities amongst other things
+    and apply the `Finisher` on it.
+
+    >>> pipeline = PretrainedPipeline("explain_document_dl")
+    >>> finisher = Finisher().setInputCols("entities").setOutputCols("output")
+    >>> explainResult = pipeline.transform(data)
+
+    Show results.
+
+    >>> explainResult.selectExpr("explode(entities)").show(truncate=False)
+    +------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |entities                                                                                                                                              |
+    +------------------------------------------------------------------------------------------------------------------------------------------------------+
+    |[[chunk, 0, 7, New York, [entity -> LOC, sentence -> 0, chunk -> 0], []], [chunk, 13, 22, New Jersey, [entity -> LOC, sentence -> 0, chunk -> 1], []]]|
+    +------------------------------------------------------------------------------------------------------------------------------------------------------+
+    >>> result = finisher.transform(explainResult)
+    >>> result.select("output").show(truncate=False)
+    +----------------------+
+    |output                |
+    +----------------------+
+    |[New York, New Jersey]|
+    +----------------------+
+    """
 
     inputCols = Param(Params._dummy(), "inputCols", "input annotations", typeConverter=TypeConverters.toListString)
     outputCols = Param(Params._dummy(), "outputCols", "output finished annotation cols", typeConverter=TypeConverters.toListString)
@@ -319,37 +835,187 @@ class Finisher(AnnotatorTransformer):
         return self._set(**kwargs)
 
     def setInputCols(self, *value):
+        """Set column names of input annotations.
+
+        Parameters
+        ----------
+        *value : List[str]
+            List of input columns
+        """
         if len(value) == 1 and type(value[0]) == list:
             return self._set(inputCols=value[0])
         else:
             return self._set(inputCols=list(value))
 
     def setOutputCols(self, *value):
+        """Set column names of finished output annotations.
+
+        Parameters
+        ----------
+        *value : List[str]
+            List of output columns
+        """
         if len(value) == 1 and type(value[0]) == list:
             return self._set(outputCols=value[0])
         else:
             return self._set(outputCols=list(value))
 
     def setValueSplitSymbol(self, value):
+        """Set character separating values, by default #.
+
+        Parameters
+        ----------
+        value : str
+            Character to separate annotations
+        """
         return self._set(valueSplitSymbol=value)
 
     def setAnnotationSplitSymbol(self, value):
+        """Set character separating annotations, by default @.
+
+        Parameters
+        ----------
+        value : str
+            ...
+        """
         return self._set(annotationSplitSymbol=value)
 
     def setCleanAnnotations(self, value):
+        """Set whether to remove annotation columns, by default True.
+
+        Parameters
+        ----------
+        value : bool
+            Whether to remove annotation columns
+        """
         return self._set(cleanAnnotations=value)
 
     def setIncludeMetadata(self, value):
+        """Set whether to include annotation metadata
+
+        Parameters
+        ----------
+        value : bool
+            Whether to include annotation metadata
+        """
         return self._set(includeMetadata=value)
 
     def setOutputAsArray(self, value):
+        """Set whether to generate an array with the results instead of a string
+
+        Parameters
+        ----------
+        value : bool
+            Whether to generate an array with the results instead of a string
+        """
         return self._set(outputAsArray=value)
 
     def setParseEmbeddingsVectors(self, value):
+        """Set whether to include embeddings vectors in the process
+
+        Parameters
+        ----------
+        value : bool
+            Whether to include embeddings vectors in the process
+        """
         return self._set(parseEmbeddingsVectors=value)
 
 
 class EmbeddingsFinisher(AnnotatorTransformer):
+    """Extracts embeddings from Annotations into a more easily usable form.
+
+    This is useful for example:
+
+    - WordEmbeddings,
+    - Transformer based embeddings such as BertEmbeddings,
+    - SentenceEmbeddings and
+    - ChunkEmbeddings, etc.
+
+    By using ``EmbeddingsFinisher`` you can easily transform your embeddings
+    into array of floats or vectors which are compatible with Spark ML functions
+    such as LDA, K-mean, Random Forest classifier or any other functions that
+    require a ``featureCol``.
+
+    For more extended examples see the
+    `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.1_Text_classification_examples_in_SparkML_SparkNLP.ipynb>`__.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``EMBEDDINGS``         ``NONE``
+    ====================== ======================
+
+    Parameters
+    ----------
+
+    inputCols
+        Names of input annotation columns containing embeddings
+    outputCols
+        Names of finished output columns
+    cleanAnnotations
+        Whether to remove all the existing annotation columns, by default False
+    outputAsVector
+        Whether to output the embeddings as Vectors instead of arrays,
+        by default False
+
+    Examples
+    --------
+
+    First extract embeddings.
+
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...    .setInputCol("text") \\
+    ...    .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...    .setInputCols("document") \\
+    ...    .setOutputCol("token")
+    >>> normalizer = Normalizer() \\
+    ...    .setInputCols("token") \\
+    ...    .setOutputCol("normalized")
+    >>> stopwordsCleaner = StopWordsCleaner() \\
+    ...    .setInputCols("normalized") \\
+    ...    .setOutputCol("cleanTokens") \\
+    ...    .setCaseSensitive(False)
+    >>> gloveEmbeddings = WordEmbeddingsModel.pretrained() \\
+    ...    .setInputCols("document", "cleanTokens") \\
+    ...    .setOutputCol("embeddings") \\
+    ...    .setCaseSensitive(False)
+    >>> embeddingsFinisher = EmbeddingsFinisher() \\
+    ...    .setInputCols("embeddings") \\
+    ...    .setOutputCols("finished_sentence_embeddings") \\
+    ...    .setOutputAsVector(True) \\
+    ...    .setCleanAnnotations(False)
+    >>> data = spark.createDataFrame([["Spark NLP is an open-source text processing library."]]) \\
+    ...    .toDF("text")
+    >>> pipeline = Pipeline().setStages([
+    ...    documentAssembler,
+    ...    tokenizer,
+    ...    normalizer,
+    ...    stopwordsCleaner,
+    ...    gloveEmbeddings,
+    ...    embeddingsFinisher
+    ... ]).fit(data)
+    >>> result = pipeline.transform(data)
+
+    Show results.
+
+    >>> resultWithSize = result.selectExpr("explode(finished_sentence_embeddings) as embeddings")
+    >>> resultWithSize.show(5, 80)
+    +--------------------------------------------------------------------------------+
+    |                                                                      embeddings|
+    +--------------------------------------------------------------------------------+
+    |[0.1619900017976761,0.045552998781204224,-0.03229299932718277,-0.685609996318...|
+    |[-0.42416998744010925,1.1378999948501587,-0.5717899799346924,-0.5078899860382...|
+    |[0.08621499687433243,-0.15772999823093414,-0.06067200005054474,0.395359992980...|
+    |[-0.4970499873161316,0.7164199948310852,0.40119001269340515,-0.05761000141501...|
+    |[-0.08170200139284134,0.7159299850463867,-0.20677000284194946,0.0295659992843...|
+    +--------------------------------------------------------------------------------+
+
+    """
 
     inputCols = Param(Params._dummy(), "inputCols", "name of input annotation cols containing embeddings", typeConverter=TypeConverters.toListString)
     outputCols = Param(Params._dummy(), "outputCols", "output EmbeddingsFinisher ouput cols", typeConverter=TypeConverters.toListString)
@@ -372,19 +1038,53 @@ class EmbeddingsFinisher(AnnotatorTransformer):
         return self._set(**kwargs)
 
     def setInputCols(self, *value):
+        """Set name of input annotation columns containing embeddings
+
+        Parameters
+        ----------
+        *value : List[str]
+            List of input annotation columns
+        """
+
         if len(value) == 1 and type(value[0]) == list:
             return self._set(inputCols=value[0])
         else:
             return self._set(inputCols=list(value))
 
     def setOutputCols(self, *value):
+        """Set names of finished output columns
+
+        Parameters
+        ----------
+        *value : List[str]
+            List of input annotation columns
+        """
+
         if len(value) == 1 and type(value[0]) == list:
             return self._set(outputCols=value[0])
         else:
             return self._set(outputCols=list(value))
 
     def setCleanAnnotations(self, value):
+        """Set whether to remove all the existing annotation columns, by default
+        False.
+
+        Parameters
+        ----------
+        value : bool
+            Whether to remove all the existing annotation columns
+        """
+
         return self._set(cleanAnnotations=value)
 
     def setOutputAsVector(self, value):
+        """Set whether to output the embeddings as Vectors instead of arrays,
+        by default False
+
+        Parameters
+        ----------
+        value : bool
+            Whether to output the embeddings as Vectors instead of arrays
+        """
+
         return self._set(outputAsVector=value)

--- a/python/sparknlp/common.py
+++ b/python/sparknlp/common.py
@@ -41,24 +41,52 @@ class AnnotatorProperties(Params):
                           )
 
     def setInputCols(self, *value):
+        """Set column names of input annotations.
+
+        Parameters
+        ----------
+        *value : List[str]
+            List of input columns
+        """
         if len(value) == 1 and type(value[0]) == list:
             return self._set(inputCols=value[0])
         else:
             return self._set(inputCols=list(value))
 
     def getInputCols(self):
+        """Get current column names of input annotations."""
         self.getOrDefault(self.inputCols)
 
     def setOutputCol(self, value):
+        """Set output column name of annotations.
+
+        Parameters
+        ----------
+        value : str
+            Name of output column
+        """
         return self._set(outputCol=value)
 
     def getOutputCol(self):
+        """Get output column name of annotations."""
         self.getOrDefault(self.outputCol)
 
     def setLazyAnnotator(self, value):
+        """Set whether Annotator should be evaluated lazily in a
+        RecursivePipeline
+
+        Parameters
+        ----------
+        value : bool
+            Whether Annotator should be evaluated lazily in a
+        RecursivePipeline
+        """
         return self._set(lazyAnnotator=value)
 
     def getLazyAnnotator(self):
+        """Get whether Annotator should be evaluated lazily in a
+        RecursivePipeline
+        """
         self.getOrDefault(self.lazyAnnotator)
 
 
@@ -87,9 +115,17 @@ class HasEmbeddingsProperties(Params):
                       typeConverter=TypeConverters.toInt)
 
     def setDimension(self, value):
+        """Set embeddings dimension.
+
+        Parameters
+        ----------
+        value : int
+            Embeddings dimension
+        """
         return self._set(dimension=value)
 
     def getDimension(self):
+        """Get embeddings dimension."""
         return self.getOrDefault(self.dimension)
 
 
@@ -100,9 +136,23 @@ class HasStorageRef:
                        TypeConverters.toString)
 
     def setStorageRef(self, value):
+        """Set unique reference name for identification
+
+        Parameters
+        ----------
+        value : str
+            Unique reference name for identification
+        """
         return self._set(storageRef=value)
 
     def getStorageRef(self):
+        """Get unique reference name for identification
+
+        Returns
+        -------
+        str
+            Unique reference name for identification
+        """
         return self.getOrDefault("storageRef")
 
 
@@ -111,9 +161,23 @@ class HasBatchedAnnotate:
     batchSize = Param(Params._dummy(), "batchSize", "Size of every batch", TypeConverters.toInt)
 
     def setBatchSize(self, v):
+        """Set batch size
+
+        Parameters
+        ----------
+        v : int
+            Batch size
+        """
         return self._set(batchSize=v)
 
     def getBatchSize(self):
+        """Get current batch size
+
+        Returns
+        -------
+        int
+            Current batch size
+        """
         return self.getOrDefault("batchSize")
 
 
@@ -124,9 +188,23 @@ class HasCaseSensitiveProperties:
                           typeConverter=TypeConverters.toBoolean)
 
     def setCaseSensitive(self, value):
+        """Set whether to ignore case in tokens for embeddings matching
+
+        Parameters
+        ----------
+        value : bool
+            Whether to ignore case in tokens for embeddings matching
+        """
         return self._set(caseSensitive=value)
 
     def getCaseSensitive(self):
+        """Get whether to ignore case in tokens for embeddings matching
+
+        Returns
+        -------
+        bool
+            Whether to ignore case in tokens for embeddings matching
+        """
         return self.getOrDefault(self.caseSensitive)
 
 
@@ -138,9 +216,23 @@ class HasExcludableStorage:
                            typeConverter=TypeConverters.toBoolean)
 
     def setIncludeStorage(self, value):
+        """Set whether to include indexed storage in trained model
+
+        Parameters
+        ----------
+        value : bool
+            Whether to include indexed storage in trained model
+        """
         return self._set(includeStorage=value)
 
     def getIncludeStorage(self):
+        """Get whether to include indexed storage in trained model
+
+        Returns
+        -------
+        bool
+            Whether to include indexed storage in trained model
+        """
         return self.getOrDefault("includeStorage")
 
 
@@ -152,9 +244,29 @@ class HasStorage(HasStorageRef, HasCaseSensitiveProperties, HasExcludableStorage
                         typeConverter=TypeConverters.identity)
 
     def setStoragePath(self, path, read_as):
+        """Set path to file
+
+        Parameters
+        ----------
+        path : str
+            Path to file
+        read_as : str
+            How to interpret the file
+
+        Notes
+        -----
+        See :class:`ReadAs <sparknlp.common.ReadAs>` for reading options.
+        """
         return self._set(storagePath=ExternalResource(path, read_as, {}))
 
     def getStoragePath(self):
+        """Get path to file
+
+        Returns
+        -------
+        str
+            path to file
+        """
         return self.getOrDefault("storagePath")
 
 
@@ -206,12 +318,37 @@ def RegexRule(rule, identifier):
 
 
 class ReadAs(object):
+    """Object that contains constants for how to read Spark Resources.
+
+    Possible values are:
+
+    ================= =======================================
+    Value             Description
+    ================= =======================================
+    ``ReadAs.TEXT``   Read the resource as text.
+    ``ReadAs.SPARK``  Read the resource as a Spark DataFrame.
+    ``ReadAs.BINARY`` Read the resource as a binary file.
+    ================= =======================================
+    """
     TEXT = "TEXT"
     SPARK = "SPARK"
     BINARY = "BINARY"
 
 
 def ExternalResource(path, read_as=ReadAs.TEXT, options={}):
+    """Returns a representation fo an External Resource.
+
+    How the resource is read can be set with `read_as`.
+
+    Parameters
+    ----------
+    path : str
+        Path to the resource
+    read_as : str, optional
+        How to read the resource, by default ReadAs.TEXT
+    options : dict, optional
+        Options to read the resource, by default {}
+    """
     return _internal._ExternalResource(path, read_as, options).apply()
 
 

--- a/src/main/scala/com/johnsnowlabs/nlp/Chunk2Doc.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Chunk2Doc.scala
@@ -8,7 +8,7 @@ import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
   * `CHUNK` result.
   *
   * For more extended examples on document pre-processing see the
-  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers_v3.0.ipynb Spark NLP Workshop]].
+  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb Spark NLP Workshop]].
   *
   * ==Example==
   * Location entities are extracted and converted back into `DOCUMENT` type for further processing

--- a/src/main/scala/com/johnsnowlabs/nlp/Doc2Chunk.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Doc2Chunk.scala
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory
   * (using [[setIsArray]]). Useful for annotators that require a CHUNK type input.
   *
   * For more extended examples on document pre-processing see the
-  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers_v3.0.ipynb Spark NLP Workshop]].
+  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb Spark NLP Workshop]].
   *
   * ==Example==
   * {{{

--- a/src/main/scala/com/johnsnowlabs/nlp/DocumentAssembler.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/DocumentAssembler.scala
@@ -14,7 +14,7 @@ import org.apache.spark.sql.{DataFrame, Dataset, Row}
   * can be used to pre-process the text (Default: `disabled`). For possible options please refer the parameters section.
   *
   * For more extended examples on document pre-processing see the
-  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers_v3.0.ipynb Spark NLP Workshop]].
+  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb Spark NLP Workshop]].
   *
   * ==Example==
   * {{{

--- a/src/main/scala/com/johnsnowlabs/nlp/Finisher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Finisher.scala
@@ -11,7 +11,7 @@ import org.apache.spark.sql.types._
   * Pipelines. The Finisher outputs annotation(s) values into `String`.
   *
   * For more extended examples on document pre-processing see the
-  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers_v3.0.ipynb Spark NLP Workshop]].
+  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb Spark NLP Workshop]].
   *
   * ==Example==
   * {{{

--- a/src/main/scala/com/johnsnowlabs/nlp/TokenAssembler.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/TokenAssembler.scala
@@ -11,7 +11,7 @@ import scala.collection.mutable.ArrayBuffer
   * Requires `DOCUMENT` and `TOKEN` type annotations as input.
   *
   * For more extended examples on document pre-processing see the
-  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers_v3.0.ipynb Spark NLP Workshop]].
+  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb Spark NLP Workshop]].
   *
   * ==Example==
   * {{{

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Chunker.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Chunker.scala
@@ -26,7 +26,7 @@ import scala.util.matching.Regex
   * When defining the regular expressions, tags enclosed in angle brackets are treated as groups, so here specifically
   * `"<NNP>+"` means 1 or more nouns in succession. Additional patterns can also be set with `addRegexParsers`.
   *
-  * For more extended examples see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/2c6dc86a442e9bcf0977af80a980b1eda0621611/tutorials/Certification_Trainings/Public/databricks_notebooks/2.4/3.SparkNLP_Pretrained_Models.ipynb Spark NLP Workshop]]
+  * For more extended examples see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/3.SparkNLP_Pretrained_Models.ipynb Spark NLP Workshop]]
   * and the  [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ChunkerTestSpec.scala ChunkerTestSpec]].
   *
   * ==Example==

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcher.scala
@@ -43,7 +43,7 @@ import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
  *
  * Pretrained pipelines are available for this module, see [[https://nlp.johnsnowlabs.com/docs/en/pipelines Pipelines]].
  *
- * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers_v3.0.ipynb Spark NLP Workshop]]
+ * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb Spark NLP Workshop]]
  * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/DateMatcherTestSpec.scala DateMatcherTestSpec]].
  *
  * ==Example==

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/MultiDateMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/MultiDateMatcher.scala
@@ -20,7 +20,7 @@ import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
   *
   * For example `"The 31st of April in the year 2008"` will be converted into `2008/04/31`.
   *
-  * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers_v3.0.ipynb Spark NLP Workshop]]
+  * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb Spark NLP Workshop]]
   * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/MultiDateMatcherTestSpec.scala MultiDateMatcherTestSpec]].
   *
   * ==Example==

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLModel.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.{Dataset, SparkSession}
  * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models?task=Text+Classification Models Hub]].
  *
  * For extended examples of usage, see the
- * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/5.Text_Classification_with_ClassifierDL_v3.0.ipynb Spark NLP Workshop]]
+ * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.Text_Classification_with_ClassifierDL.ipynb Spark NLP Workshop]]
  * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLTestSpec.scala ClassifierDLTestSpec]].
  *
  * ==Example==

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLModel.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.{Dataset, SparkSession}
  * the IMDB dataset.
  * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models?task=Sentiment+Analysis Models Hub]].
  *
- * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/5.Text_Classification_with_ClassifierDL_v3.0.ipynb Spark NLP Workshop]]
+ * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.Text_Classification_with_ClassifierDL.ipynb Spark NLP Workshop]]
  * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLTestSpec.scala SentimentDLTestSpec]].
  *
  * ==Example==

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/keyword.yake/YakeModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/keyword.yake/YakeModel.scala
@@ -51,7 +51,7 @@ import scala.math.sqrt
  * Note that each keyword will be given a keyword score greater than 0 (The lower the score better the keyword).
  * Therefore to filter the keywords, an upper bound for the score can be set with `setThreshold`.
  *
- * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/8.Keyword_Extraction_YAKE_v3.0.ipynb Spark NLP Workshop]]
+ * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/8.Keyword_Extraction_YAKE.ipynb Spark NLP Workshop]]
  * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/keyword/yake/YakeTestSpec.scala YakeTestSpec]].
  *
  *  '''Sources''' :

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserModel.scala
@@ -26,7 +26,7 @@ import org.apache.spark.ml.util.Identifiable
  * The default model is `"dependency_conllu"`, if no name is provided.
  * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models Models Hub]].
  *
- * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/3.SparkNLP_Pretrained_Models_v3.0.ipynb Spark NLP Workshop]]
+ * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/3.SparkNLP_Pretrained_Models.ipynb Spark NLP Workshop]]
  * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserApproachTestSpec.scala DependencyParserApproachTestSpec]].
  *
  * ==Example==

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/parser/typdep/TypedDependencyParserModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/parser/typdep/TypedDependencyParserModel.scala
@@ -27,7 +27,7 @@ import org.apache.spark.ml.util.Identifiable
  * The default model is `"dependency_typed_conllu"`, if no name is provided.
  * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models Models Hub]].
  *
- * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/3.SparkNLP_Pretrained_Models_v3.0.ipynb Spark NLP Workshop]]
+ * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/3.SparkNLP_Pretrained_Models.ipynb Spark NLP Workshop]]
  * and the [[https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/annotators/parser/typdep/TypedDependencyModelTestSpec.scala TypedDependencyModelTestSpec]].
  *
  * ==Example==

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
@@ -38,7 +38,7 @@ object PoolingStrategy {
  * [[com.johnsnowlabs.nlp.annotators.Chunker Chunker]], [[com.johnsnowlabs.nlp.annotators.NGramGenerator NGramGenerator]],
  * or [[com.johnsnowlabs.nlp.annotators.ner.NerConverter NerConverter]] outputs.
  *
- * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/3.SparkNLP_Pretrained_Models_v3.0.ipynb Spark NLP Workshop]]
+ * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/3.SparkNLP_Pretrained_Models.ipynb Spark NLP Workshop]]
  * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala ChunkEmbeddingsTestSpec]].
  *
  * ==Example==

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.{DataFrame, Dataset}
   * This can be configured with `setPoolingStrategy`, which either be `"AVERAGE"` or `"SUM"`.
   *
   * For more extended examples see the
-  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Healthcare/databricks_notebooks/12.%20Named_Entity_Disambiguation_v3.0.ipynb Spark NLP Workshop]].
+  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.1_Text_classification_examples_in_SparkML_SparkNLP.ipynb Spark NLP Workshop]].
   * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddingsTestSpec.scala SentenceEmbeddingsTestSpec]].
   *
   * ==Example==

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder.scala
@@ -42,7 +42,7 @@ import java.io.File
  * The default model is `"tfhub_use"`, if no name is provided.
  * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models?task=Embeddings Models Hub]].
  *
- * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/2.4/3.SparkNLP_Pretrained_Models.ipynb Spark NLP Workshop]]
+ * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/3.SparkNLP_Pretrained_Models.ipynb Spark NLP Workshop]]
  * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoderTestSpec.scala UniversalSentenceEncoderTestSpec]].
  *
  * '''Sources:'''

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddings.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.Dataset
   * Statistics about the rate of converted tokens, can be retrieved with [[WordEmbeddingsModel WordEmbeddingsModel.withCoverageColumn]]
   * and [[WordEmbeddingsModel WordEmbeddingsModel.overallCoverage]].
   *
-  * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/2.4/3.SparkNLP_Pretrained_Models.ipynb Spark NLP Workshop]]
+  * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/3.SparkNLP_Pretrained_Models.ipynb Spark NLP Workshop]]
   * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsTestSpec.scala WordEmbeddingsTestSpec]].
   *
   * ==Example==

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
@@ -45,7 +45,7 @@ import org.apache.spark.sql.{DataFrame, Row}
   *     1.0
   *     }}}
   *
-  * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/2.4/3.SparkNLP_Pretrained_Models.ipynb Spark NLP Workshop]]
+  * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/3.SparkNLP_Pretrained_Models.ipynb Spark NLP Workshop]]
   * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsTestSpec.scala WordEmbeddingsTestSpec]].
   *
   * ==Example==

--- a/src/main/scala/com/johnsnowlabs/nlp/training/CoNLLU.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/training/CoNLLU.scala
@@ -13,6 +13,27 @@ case class CoNLLUDocument(text: String,
                           lemma: Seq[PosTaggedSentence]
                         )
 
+/** Instantiates the class to read a CoNLL-U dataset.
+ *
+ * The dataset should be in the format of [[https://universaldependencies.org/format.html CoNLL-U]]
+ * and needs to be specified with `readDataset`, which will create a dataframe with the data.
+ *
+ * ==Example==
+ * {{{
+ * import com.johnsnowlabs.nlp.training.CoNLLU
+ *
+ * val conlluFile = "src/test/resources/conllu/en.test.conllu"
+ * val conllDataSet = CoNLLU(false).readDataset(ResourceHelper.spark, conlluFile)
+ * conllDataSet.selectExpr("text", "form.result as form", "upos.result as upos", "xpos.result as xpos", "lemma.result as lemma")
+ *   .show(1, false)
+ * +---------------------------------------+----------------------------------------------+---------------------------------------------+------------------------------+--------------------------------------------+
+ * |text                                   |form                                          |upos                                         |xpos                          |lemma                                       |
+ * +---------------------------------------+----------------------------------------------+---------------------------------------------+------------------------------+--------------------------------------------+
+ * |What if Google Morphed Into GoogleOS?  |[What, if, Google, Morphed, Into, GoogleOS, ?]|[PRON, SCONJ, PROPN, VERB, ADP, PROPN, PUNCT]|[WP, IN, NNP, VBD, IN, NNP, .]|[what, if, Google, morph, into, GoogleOS, ?]|
+ * +---------------------------------------+----------------------------------------------+---------------------------------------------+------------------------------+--------------------------------------------+
+ * }}}
+ * @param explodeSentences Whether to split each sentence into a separate row
+ */
 case class CoNLLU(explodeSentences: Boolean = true) {
 
   private val annotationType = ArrayType(Annotation.dataType)

--- a/src/main/scala/com/johnsnowlabs/nlp/training/PubTator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/training/PubTator.scala
@@ -25,6 +25,28 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 
 
+/** The PubTator format includes medical papers’ titles, abstracts, and tagged chunks.
+ *
+ * For more information see [[http://bioportal.bioontology.org/ontologies/EDAM?p=classes&conceptid=format_3783 PubTator Docs]]
+ * and [[http://github.com/chanzuckerberg/MedMentions MedMentions Docs]].
+ *
+ * `readDataset` is used to create a Spark DataFrame from a PubTator text file.
+ *
+ * ==Example==
+ * {{{
+ * import com.johnsnowlabs.nlp.training.PubTator
+ *
+ * val pubTatorFile = "./src/test/resources/corpus_pubtator_sample.txt"
+ * val pubTatorDataSet = PubTator().readDataset(ResourceHelper.spark, pubTatorFile)
+ * pubTatorDataSet.show(1)
+ * +--------+--------------------+--------------------+--------------------+-----------------------+---------------------+-----------------------+
+ * |  doc_id|      finished_token|        finished_pos|        finished_ner|finished_token_metadata|finished_pos_metadata|finished_label_metadata|
+ * +--------+--------------------+--------------------+--------------------+-----------------------+---------------------+-----------------------+
+ * |25763772|[DCTN4, as, a, mo...|[NNP, IN, DT, NN,...|[B-T116, O, O, O,...|   [[sentence, 0], [...| [[word, DCTN4], [...|   [[word, DCTN4], [...|
+ * +--------+--------------------+--------------------+--------------------+-----------------------+---------------------+-----------------------+
+ * }}}
+ *
+ */
 case class PubTator() {
 
   def readDataset(spark: SparkSession, path: String, isPaddedToken: Boolean = true): DataFrame = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# Still WIP
## Description
<!--- Describe your changes in detail -->
This PR continues to create a PyDoc documentation for the Python Spark NLP package in the [numpydoc style](https://numpydoc.readthedocs.io/en/latest/format.html).

The PR also includes some minor fixes for the scala doc and other documentation related sources.

### To-Do:

- [x] sparknlp.base
- [x] sparknlp.training
- [ ] sparknlp.functions
- [ ] sparknlp.annotator
  - [x] AlbertEmbeddings
  - [x] BertEmbeddings
  - [x] BertSentenceEmbeddings
  - [x] BigTextMatcher
  - [x] BigTextMatcherModel
  - [x] ChunkEmbeddings
  - [x] ChunkTokenizer
  - [x] ChunkTokenizerModel
  - [x] Chunker
  - [x] ClassifierDLApproach
  - [x] ClassifierDLModel
  - [ ] ContextSpellCheckerApproach
  - [ ] ContextSpellCheckerModel
  - [ ] DateMatcher
  - [ ] DateMatcherUtils
  - [ ] DependencyParserApproach
  - [ ] DependencyParserModel
  - [ ] DistilBertEmbeddings
  - [ ] DocumentNormalizer
  - [ ] ElmoEmbeddings
  - [ ] LanguageDetectorDL
  - [ ] Lemmatizer
  - [ ] LemmatizerModel
  - [ ] MarianTransformer
  - [ ] MultiClassifierDLApproach
  - [ ] MultiClassifierDLModel
  - [ ] MultiDateMatcher
  - [ ] NGramGenerator
  - [ ] NerApproach
  - [ ] NerConverter
  - [ ] NerCrfApproach
  - [ ] NerCrfModel
  - [ ] NerDLApproach
  - [ ] NerDLModel
  - [ ] NerOverwriter
  - [ ] Normalizer
  - [ ] NormalizerModel
  - [ ] NorvigSweetingApproach
  - [ ] NorvigSweetingModel
  - [ ] PerceptronApproach
  - [ ] PerceptronModel
  - [ ] RecursiveTokenizer
  - [ ] RecursiveTokenizerModel
  - [ ] RegexMatcher
  - [ ] RegexMatcherModel
  - [ ] RegexTokenizer
  - [ ] RoBertaEmbeddings
  - [ ] SentenceDetector
  - [ ] SentenceDetectorDLApproach
  - [ ] SentenceDetectorDLModel
  - [ ] SentenceEmbeddings
  - [ ] SentimentDLApproach
  - [ ] SentimentDLModel
  - [ ] SentimentDetector
  - [ ] SentimentDetectorModel
  - [ ] Stemmer
  - [ ] StopWordsCleaner
  - [ ] SymmetricDeleteApproach
  - [ ] SymmetricDeleteModel
  - [ ] T5Transformer
  - [ ] TextMatcher
  - [ ] TextMatcherModel
  - [ ] Token2Chunk
  - [ ] Tokenizer
  - [ ] TokenizerModel
  - [ ] TypedDependencyParserApproach
  - [ ] TypedDependencyParserModel
  - [ ] UniversalSentenceEncoder
  - [ ] ViveknSentimentApproach
  - [ ] ViveknSentimentModel
  - [ ] WordEmbeddings
  - [ ] WordEmbeddingsModel
  - [ ] WordSegmenterApproach
  - [ ] WordSegmenterModel
  - [ ] XlmRoBertaEmbeddings
  - [ ] XlnetEmbeddings
  - [ ] YakeModel



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improves usability for the python package, especially with showing doc strings for functions in notebooks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No changes to functionality, Tests have been re run
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
