### PR TITLE
Introducing DistilBertForTokenClassification annotator

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -9877,7 +9877,7 @@ class DistilBertForTokenClassification(AnnotatorModel,
         self._setDefault(
             batchSize=8,
             maxSentenceLength=128,
-            caseSensitive=False
+            caseSensitive=True
         )
 
     @staticmethod

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -9803,7 +9803,6 @@ class XlmRoBertaEmbeddings(AnnotatorModel,
 class BertForTokenClassification(AnnotatorModel,
                                  HasCaseSensitiveProperties,
                                  HasBatchedAnnotate):
-
     name = "BERT_FOR_TOKEN_CLASSIFICATION"
 
     maxSentenceLength = Param(Params._dummy(),
@@ -9823,7 +9822,8 @@ class BertForTokenClassification(AnnotatorModel,
         return self._set(maxSentenceLength=value)
 
     @keyword_only
-    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.BertForTokenClassification", java_model=None):
+    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.BertForTokenClassification",
+                 java_model=None):
         super(BertForTokenClassification, self).__init__(
             classname=classname,
             java_model=java_model
@@ -9844,3 +9844,49 @@ class BertForTokenClassification(AnnotatorModel,
     def pretrained(name="bert_base_token_classifier_conll03", lang="en", remote_loc=None):
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(BertForTokenClassification, name, lang, remote_loc)
+
+
+class DistilBertForTokenClassification(AnnotatorModel,
+                                 HasCaseSensitiveProperties,
+                                 HasBatchedAnnotate):
+    name = "DISTILBERT_FOR_TOKEN_CLASSIFICATION"
+
+    maxSentenceLength = Param(Params._dummy(),
+                              "maxSentenceLength",
+                              "Max sentence length to process",
+                              typeConverter=TypeConverters.toInt)
+
+    configProtoBytes = Param(Params._dummy(),
+                             "configProtoBytes",
+                             "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
+                             TypeConverters.toListString)
+
+    def setConfigProtoBytes(self, b):
+        return self._set(configProtoBytes=b)
+
+    def setMaxSentenceLength(self, value):
+        return self._set(maxSentenceLength=value)
+
+    @keyword_only
+    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.DistilBertForTokenClassification",
+                 java_model=None):
+        super(DistilBertForTokenClassification, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        self._setDefault(
+            batchSize=8,
+            maxSentenceLength=128,
+            caseSensitive=False
+        )
+
+    @staticmethod
+    def loadSavedModel(folder, spark_session):
+        from sparknlp.internal import _DistilBertTokenClassifierLoader
+        jModel = _DistilBertTokenClassifierLoader(folder, spark_session._jsparkSession)._java_obj
+        return DistilBertForTokenClassification(java_model=jModel)
+
+    @staticmethod
+    def pretrained(name="distilbert_base_token_classifier_conll03", lang="en", remote_loc=None):
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(DistilBertForTokenClassification, name, lang, remote_loc)

--- a/python/sparknlp/internal.py
+++ b/python/sparknlp/internal.py
@@ -361,3 +361,10 @@ class _BertTokenClassifierLoader(ExtendedJavaWrapper):
     def __init__(self, path, jspark):
         super(_BertTokenClassifierLoader, self).__init__(
             "com.johnsnowlabs.nlp.annotators.classifier.dl.BertForTokenClassification.loadSavedModel", path, jspark)
+
+
+class _DistilBertTokenClassifierLoader(ExtendedJavaWrapper):
+    def __init__(self, path, jspark):
+        super(_DistilBertTokenClassifierLoader, self).__init__(
+            "com.johnsnowlabs.nlp.annotators.classifier.dl.DistilBertForTokenClassification.loadSavedModel", path,
+            jspark)

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBertTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBertTokenClassification.scala
@@ -18,9 +18,8 @@
 package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import com.johnsnowlabs.nlp.annotators.common._
-
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
 import scala.collection.JavaConverters._
@@ -101,6 +100,10 @@ class TensorflowBertTokenClassification(val tensorflowWrapper: TensorflowWrapper
 
     val outs = runner.run().asScala
     val rawScores = TensorResources.extractFloats(outs.head)
+
+    outs.foreach(_.close())
+    tensors.clearSession(outs)
+    tensors.clearTensors()
 
     val dim = rawScores.length / (batchLength * maxSentenceLength)
     val batchScores: Array[Array[Array[Float]]] = rawScores.grouped(dim).map(scores =>

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowDistilBertTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowDistilBertTokenClassification.scala
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.ml.tensorflow
+
+import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
+
+import org.tensorflow.ndarray.buffer.IntDataBuffer
+
+import scala.collection.JavaConverters._
+
+/**
+ *
+ * @param tensorflowWrapper    Bert Model wrapper with TensorFlow Wrapper
+ * @param sentenceStartTokenId Id of sentence start Token
+ * @param sentenceEndTokenId   Id of sentence end Token.
+ * @param configProtoBytes     Configuration for TensorFlow session
+ * @param tags                 labels which model was trained with in order
+ * @param signatures           TF v2 signatures in Spark NLP
+ * */
+class TensorflowDistilBertTokenClassification(val tensorflowWrapper: TensorflowWrapper,
+                                              sentenceStartTokenId: Int,
+                                              sentenceEndTokenId: Int,
+                                              configProtoBytes: Option[Array[Byte]] = None,
+                                              tags: Map[String, Int],
+                                              signatures: Option[Map[String, String]] = None
+                                       ) extends Serializable {
+
+  val _tfDistilBertSignatures: Map[String, String] = signatures.getOrElse(ModelSignatureManager.apply())
+
+  /** Encode the input sequence to indexes IDs adding padding where necessary */
+  def encode(sentences: Seq[(WordpieceTokenizedSentence, Int)], maxSequenceLength: Int): Seq[Array[Int]] = {
+    val maxSentenceLength =
+      Array(
+        maxSequenceLength - 2,
+        sentences.map { case (wpTokSentence, _) => wpTokSentence.tokens.length }.max).min
+
+    sentences
+      .map { case (wpTokSentence, _) =>
+        val tokenPieceIds = wpTokSentence.tokens.map(t => t.pieceId)
+        val padding = Array.fill(maxSentenceLength - tokenPieceIds.length)(0)
+
+        Array(sentenceStartTokenId) ++ tokenPieceIds.take(maxSentenceLength) ++ Array(sentenceEndTokenId) ++ padding
+      }
+  }
+
+  def calcluateSoftmax(scores: Array[Float]): Array[Float] = {
+    val exp = scores.map(x => math.exp(x))
+    exp.map(x => x / exp.sum).map(_.toFloat)
+  }
+
+  def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
+    val tensors = new TensorResources()
+
+    val maxSentenceLength = batch.map(encodedSentence => encodedSentence.length).max
+    val batchLength = batch.length
+
+    val tokenBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+    val maskBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+    val segmentBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+
+    // [nb of encoded sentences , maxSentenceLength]
+    val shape = Array(batch.length.toLong, maxSentenceLength)
+
+    batch.zipWithIndex
+      .foreach { case (sentence, idx) =>
+        val offset = idx * maxSentenceLength
+        tokenBuffers.offset(offset).write(sentence)
+        maskBuffers.offset(offset).write(sentence.map(x => if (x == 0) 0 else 1))
+        segmentBuffers.offset(offset).write(Array.fill(maxSentenceLength)(0))
+      }
+
+    val session = tensorflowWrapper.getTFHubSession(configProtoBytes = configProtoBytes, savedSignatures = signatures, initAllTables = false)
+    val runner = session.runner
+
+    val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
+    val maskTensors = tensors.createIntBufferTensor(shape, maskBuffers)
+    val segmentTensors = tensors.createIntBufferTensor(shape, segmentBuffers)
+
+    runner
+      .feed(_tfDistilBertSignatures.getOrElse(ModelSignatureConstants.InputIds.key, "missing_input_id_key"), tokenTensors)
+      .feed(_tfDistilBertSignatures.getOrElse(ModelSignatureConstants.AttentionMask.key, "missing_input_mask_key"), maskTensors)
+      .fetch(_tfDistilBertSignatures.getOrElse(ModelSignatureConstants.LogitsOutput.key, "missing_logits_key"))
+
+    val outs = runner.run().asScala
+    val rawScores = TensorResources.extractFloats(outs.head)
+
+    outs.foreach(_.close())
+    tensors.clearSession(outs)
+    tensors.clearTensors()
+
+    val dim = rawScores.length / (batchLength * maxSentenceLength)
+    val batchScores: Array[Array[Array[Float]]] = rawScores.grouped(dim).map(scores =>
+      calcluateSoftmax(scores)).toArray.grouped(maxSentenceLength).toArray
+
+    batchScores
+  }
+
+  def predict(sentences: Seq[WordpieceTokenizedSentence],
+              originalTokenSentences: Seq[TokenizedSentence],
+              batchSize: Int,
+              maxSentenceLength: Int,
+             ): Seq[Annotation] = {
+
+    /*Run embeddings calculation by batches*/
+    sentences.zipWithIndex.grouped(batchSize).flatMap { batch =>
+      val encoded = encode(batch, maxSentenceLength)
+      val vectors = tag(encoded)
+
+      /*Combine tokens and calculated embeddings*/
+      batch.zip(vectors).flatMap { case (sentence, tokenVectors) =>
+        val tokenLength = sentence._1.tokens.length
+
+        /*All wordpiece embeddings*/
+        val tokenEmbeddings = tokenVectors.slice(1, tokenLength + 1)
+
+        /*Word-level and span-level alignment with Tokenizer
+        https://github.com/google-research/bert#tokenization
+
+        ### Input
+        orig_tokens = ["John", "Johanson", "'s",  "house"]
+        labels      = ["NNP",  "NNP",      "POS", "NN"]
+
+        # bert_tokens == ["[CLS]", "john", "johan", "##son", "'", "s", "house", "[SEP]"]
+        # orig_to_tok_map == [1, 2, 4, 6]*/
+
+        val labelsWithScores = sentence._1.tokens.zip(tokenEmbeddings).flatMap {
+          case (token, scores) =>
+            originalTokenSentences(sentence._2).indexedTokens.find(
+              p => p.begin == token.begin).map {
+              token =>
+                val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
+                val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
+                Annotation(
+                  annotatorType = AnnotatorType.ENTITY,
+                  begin = token.begin,
+                  end = token.end,
+                  result = label,
+                  metadata = Map("sentence" -> sentence._2.toString) ++ meta
+                )
+            }
+        }
+        labelsWithScores.toSeq
+      }
+    }.toSeq
+  }
+
+}
+
+

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -19,7 +19,7 @@ package com.johnsnowlabs.nlp
 
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.ReadSentencePieceModel
 import com.johnsnowlabs.nlp.annotators.btm.ReadablePretrainedBigTextMatcher
-import com.johnsnowlabs.nlp.annotators.classifier.dl.{ReadBertForTokenTensorflowModel, ReadClassifierDLTensorflowModel, ReadMultiClassifierDLTensorflowModel, ReadSentimentDLTensorflowModel, ReadablePretrainedBertForTokenModel, ReadablePretrainedClassifierDL, ReadablePretrainedMultiClassifierDL, ReadablePretrainedSentimentDL}
+import com.johnsnowlabs.nlp.annotators.classifier.dl.{ReadBertForTokenTensorflowModel, ReadClassifierDLTensorflowModel, ReadDistilBertForTokenTensorflowModel, ReadMultiClassifierDLTensorflowModel, ReadSentimentDLTensorflowModel, ReadablePretrainedBertForTokenModel, ReadablePretrainedClassifierDL, ReadablePretrainedDistilBertForTokenModel, ReadablePretrainedMultiClassifierDL, ReadablePretrainedSentimentDL}
 import com.johnsnowlabs.nlp.annotators.{ReadablePretrainedLemmatizer, ReadablePretrainedStopWordsCleanerModel, ReadablePretrainedTextMatcher, ReadablePretrainedTokenizer}
 import com.johnsnowlabs.nlp.annotators.ner.crf.ReadablePretrainedNerCrf
 import com.johnsnowlabs.nlp.annotators.ner.dl.{ReadablePretrainedNerDL, ReadsNERGraph, WithGraphResolver}
@@ -333,5 +333,9 @@ package object annotator {
   type BertForTokenClassification = com.johnsnowlabs.nlp.annotators.classifier.dl.BertForTokenClassification
 
   object BertForTokenClassification extends ReadablePretrainedBertForTokenModel with ReadBertForTokenTensorflowModel
+
+  type DistilBertForTokenClassification = com.johnsnowlabs.nlp.annotators.classifier.dl.DistilBertForTokenClassification
+
+  object DistilBertForTokenClassification extends ReadablePretrainedDistilBertForTokenModel with ReadDistilBertForTokenTensorflowModel
 
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala
@@ -45,7 +45,7 @@ import java.io.File
  *
  * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models?task=Text+Classification Models Hub]].
  *
- * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala BertEmbeddingsTestSpec]].
+ * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassificationTestSpec.scala BertForTokenClassificationTestSpec]].
  * Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. The Spark NLP Workshop
  * example shows how to import them [[https://github.com/JohnSnowLabs/spark-nlp/discussions/5669]].
  *

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
@@ -233,7 +233,7 @@ class DistilBertForTokenClassification(override val uid: String)
   setDefault(
     batchSize -> 8,
     maxSentenceLength -> 128,
-    caseSensitive -> false
+    caseSensitive -> true
   )
 
   def tokenizeWithAlignment(tokens: Seq[TokenizedSentence]): Seq[WordpieceTokenizedSentence] = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.ml.tensorflow._
+import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.annotators.tokenizer.wordpiece.{BasicTokenizer, WordpieceEncoder}
+import com.johnsnowlabs.nlp.serialization.MapFeature
+import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
+
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.param.{IntArrayParam, IntParam}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.SparkSession
+
+import java.io.File
+
+/**
+ * DistilBertForTokenClassification can load Bert Models with a token classification head on top (a linear layer on top of the hidden-states output)
+ * e.g. for Named-Entity-Recognition (NER) tasks.
+ *
+ * Pretrained models can be loaded with `pretrained` of the companion object:
+ * {{{
+ * val embeddings = DistilBertForTokenClassification.pretrained()
+ *   .setInputCols("token", "document")
+ *   .setOutputCol("label")
+ * }}}
+ * The default model is `"distilbert_base_token_classifier_conll03"`, if no name is provided.
+ *
+ * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models?task=Text+Classification Models Hub]].
+ *
+ * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassificationTestSpec.scala DistilBertForTokenClassificationTestSpec]].
+ * Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. The Spark NLP Workshop
+ * example shows how to import them [[https://github.com/JohnSnowLabs/spark-nlp/discussions/5669]].
+ *
+ * ==Example==
+ * {{{
+ * import spark.implicits._
+ * import com.johnsnowlabs.nlp.base._
+ * import com.johnsnowlabs.nlp.annotator._
+ * import org.apache.spark.ml.Pipeline
+ *
+ * val documentAssembler = new DocumentAssembler()
+ *   .setInputCol("text")
+ *   .setOutputCol("document")
+ *
+ * val tokenizer = new Tokenizer()
+ *   .setInputCols("document")
+ *   .setOutputCol("token")
+ *
+ * val tokenClassifier = DistilBertForTokenClassification.pretrained()
+ *   .setInputCols("token", "document")
+ *   .setOutputCol("label")
+ *   .setCaseSensitive(true)
+ *
+ * val pipeline = new Pipeline().setStages(Array(
+ *   documentAssembler,
+ *   tokenizer,
+ *   tokenClassifier
+ * ))
+ *
+ * val data = Seq("John Lenon was born in London and lived in Paris. My name is Sarah and I live in London").toDF("text")
+ * val result = pipeline.fit(data).transform(data)
+ *
+ * result.select("label.result").show(false)
+ * +------------------------------------------------------------------------------------+
+ * |result                                                                              |
+ * +------------------------------------------------------------------------------------+
+ * |[B-PER, I-PER, O, O, O, B-LOC, O, O, O, B-LOC, O, O, O, O, B-PER, O, O, O, O, B-LOC]|
+ * +------------------------------------------------------------------------------------+
+ * }}}
+ *
+ * @see [[DistilBertForTokenClassification]] for sentence-level embeddings
+ * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
+ * @param uid required uid for storing annotator to disk
+ * @groupname anno Annotator types
+ * @groupdesc anno Required input and expected output annotator types
+ * @groupname Ungrouped Members
+ * @groupname param Parameters
+ * @groupname setParam Parameter setters
+ * @groupname getParam Parameter getters
+ * @groupname Ungrouped Members
+ * @groupprio param  1
+ * @groupprio anno  2
+ * @groupprio Ungrouped 3
+ * @groupprio setParam  4
+ * @groupprio getParam  5
+ * @groupdesc param A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
+ * */
+class DistilBertForTokenClassification(override val uid: String)
+  extends AnnotatorModel[DistilBertForTokenClassification]
+    with HasBatchedAnnotate[DistilBertForTokenClassification]
+    with WriteTensorflowModel
+    with HasCaseSensitiveProperties {
+
+  def this() = this(Identifiable.randomUID("DISTILBERT_FOR_TOKEN_CLASSIFICATION"))
+
+  /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */
+  override val inputAnnotatorTypes: Array[String] = Array(AnnotatorType.DOCUMENT, AnnotatorType.TOKEN)
+  override val outputAnnotatorType: AnnotatorType = AnnotatorType.ENTITY
+
+  /** @group setParam */
+  def sentenceStartTokenId: Int = {
+    $$(vocabulary)("[CLS]")
+  }
+
+  /** @group setParam */
+  def sentenceEndTokenId: Int = {
+    $$(vocabulary)("[SEP]")
+  }
+
+  /**
+   * Vocabulary used to encode the words to ids with WordPieceEncoder
+   *
+   * @group param
+   * */
+  val vocabulary: MapFeature[String, Int] = new MapFeature(this, "vocabulary")
+
+  /** @group setParam */
+  def setVocabulary(value: Map[String, Int]): this.type = set(vocabulary, value)
+
+
+  /**
+   * Labels used to decode predicted IDs back to string tags
+   *
+   * @group param
+   * */
+  val labels: MapFeature[String, Int] = new MapFeature(this, "labels")
+
+  /** @group setParam */
+  def setLabels(value: Map[String, Int]): this.type = set(labels, value)
+
+  def getLabels: Map[String, Int] = $$(labels)
+
+  /** ConfigProto from tensorflow, serialized into byte array. Get with `config_proto.SerializeToString()`
+   *
+   * @group param
+   * */
+  val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
+
+  /** @group setParam */
+  def setConfigProtoBytes(bytes: Array[Int]): DistilBertForTokenClassification.this.type = set(this.configProtoBytes, bytes)
+
+  /** @group getParam */
+  def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
+
+  /** Max sentence length to process (Default: `128`)
+   *
+   * @group param
+   * */
+  val maxSentenceLength = new IntParam(this, "maxSentenceLength", "Max sentence length to process")
+
+  /** @group setParam */
+  def setMaxSentenceLength(value: Int): this.type = {
+    require(value <= 512, "BERT models do not support sequences longer than 512 because of trainable positional embeddings.")
+    require(value >= 1, "The maxSentenceLength must be at least 1")
+    set(maxSentenceLength, value)
+    this
+  }
+
+  /** @group getParam */
+  def getMaxSentenceLength: Int = $(maxSentenceLength)
+
+  /**
+   * It contains TF model signatures for the laded saved model
+   *
+   * @group param
+   * */
+  val signatures = new MapFeature[String, String](model = this, name = "signatures")
+
+  /** @group setParam */
+  def setSignatures(value: Map[String, String]): this.type = {
+    if (get(signatures).isEmpty)
+      set(signatures, value)
+    this
+  }
+
+  /** @group getParam */
+  def getSignatures: Option[Map[String, String]] = get(this.signatures)
+
+  private var _model: Option[Broadcast[TensorflowDistilBertTokenClassification]] = None
+
+  /** @group setParam */
+  def setModelIfNotSet(spark: SparkSession, tensorflowWrapper: TensorflowWrapper): DistilBertForTokenClassification = {
+    if (_model.isEmpty) {
+      _model = Some(
+        spark.sparkContext.broadcast(
+          new TensorflowDistilBertTokenClassification(
+            tensorflowWrapper,
+            sentenceStartTokenId,
+            sentenceEndTokenId,
+            configProtoBytes = getConfigProtoBytes,
+            tags = getLabels,
+            signatures = getSignatures
+          )
+        )
+      )
+    }
+
+    this
+  }
+
+  /** @group getParam */
+  def getModelIfNotSet: TensorflowDistilBertTokenClassification = _model.get.value
+
+
+  /** Whether to lowercase tokens or not
+   *
+   * @group setParam
+   * */
+  override def setCaseSensitive(value: Boolean): this.type = {
+    if (get(caseSensitive).isEmpty)
+      set(this.caseSensitive, value)
+    this
+  }
+
+  setDefault(
+    batchSize -> 8,
+    maxSentenceLength -> 128,
+    caseSensitive -> false
+  )
+
+  def tokenizeWithAlignment(tokens: Seq[TokenizedSentence]): Seq[WordpieceTokenizedSentence] = {
+    val basicTokenizer = new BasicTokenizer($(caseSensitive))
+    val encoder = new WordpieceEncoder($$(vocabulary))
+
+    tokens.map { tokenIndex =>
+      // filter empty and only whitespace tokens
+      val bertTokens = tokenIndex.indexedTokens.filter(x => x.token.nonEmpty && !x.token.equals(" ")).map { token =>
+        val content = if ($(caseSensitive)) token.token else token.token.toLowerCase()
+        val sentenceBegin = token.begin
+        val sentenceEnd = token.end
+        val sentenceInedx = tokenIndex.sentenceIndex
+        val result = basicTokenizer.tokenize(Sentence(content, sentenceBegin, sentenceEnd, sentenceInedx))
+        if (result.nonEmpty) result.head else IndexedToken("")
+      }
+      val wordpieceTokens = bertTokens.flatMap(token => encoder.encode(token)).take($(maxSentenceLength))
+      WordpieceTokenizedSentence(wordpieceTokens)
+    }
+  }
+
+  /**
+   * takes a document and annotations and produces new annotations of this annotator's annotation type
+   *
+   * @param batchedAnnotations Annotations that correspond to inputAnnotationCols generated by previous annotators if any
+   * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
+   */
+  override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
+    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations.map(annotations =>
+      TokenizedWithSentence.unpack(annotations).toArray
+    ).toArray
+    /*Return empty if the real tokens are empty*/
+    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+      val tokenized = tokenizeWithAlignment(tokenizedSentences)
+
+      getModelIfNotSet.predict(
+        tokenized,
+        tokenizedSentences,
+        $(batchSize),
+        $(maxSentenceLength)
+      )
+    }) else {
+      Seq(Seq.empty[Annotation])
+    }
+  }
+
+
+  override def onWrite(path: String, spark: SparkSession): Unit = {
+    super.onWrite(path, spark)
+    writeTensorflowModelV2(path, spark, getModelIfNotSet.tensorflowWrapper, "_distilbert_classification", BertForTokenClassification.tfFile, configProtoBytes = getConfigProtoBytes)
+  }
+
+}
+
+trait ReadablePretrainedDistilBertForTokenModel extends ParamsAndFeaturesReadable[DistilBertForTokenClassification] with HasPretrained[DistilBertForTokenClassification] {
+  override val defaultModelName: Some[String] = Some("distilbert_base_token_classifier_conll03")
+
+  /** Java compliant-overrides */
+  override def pretrained(): DistilBertForTokenClassification = super.pretrained()
+
+  override def pretrained(name: String): DistilBertForTokenClassification = super.pretrained(name)
+
+  override def pretrained(name: String, lang: String): DistilBertForTokenClassification = super.pretrained(name, lang)
+
+  override def pretrained(name: String, lang: String, remoteLoc: String): DistilBertForTokenClassification = super.pretrained(name, lang, remoteLoc)
+}
+
+trait ReadDistilBertForTokenTensorflowModel extends ReadTensorflowModel {
+  this: ParamsAndFeaturesReadable[DistilBertForTokenClassification] =>
+
+  override val tfFile: String = "distilbert_classification_tensorflow"
+
+  def readTensorflow(instance: DistilBertForTokenClassification, path: String, spark: SparkSession): Unit = {
+
+    val tf = readTensorflowModel(path, spark, "_distilbert_classification_tf", initAllTables = false)
+    instance.setModelIfNotSet(spark, tf)
+  }
+
+  addReader(readTensorflow)
+
+  def loadSavedModel(tfModelPath: String, spark: SparkSession): DistilBertForTokenClassification = {
+
+    val f = new File(tfModelPath)
+    val savedModel = new File(tfModelPath, "saved_model.pb")
+
+    require(f.exists, s"Folder $tfModelPath not found")
+    require(f.isDirectory, s"File $tfModelPath is not folder")
+    require(
+      savedModel.exists(),
+      s"savedModel file saved_model.pb not found in folder $tfModelPath"
+    )
+
+    val vocabPath = new File(tfModelPath + "/assets", "vocab.txt")
+    require(vocabPath.exists(), s"Vocabulary file vocab.txt not found in folder $tfModelPath/assets/")
+
+    val vocabResource = new ExternalResource(vocabPath.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
+    val words = ResourceHelper.parseLines(vocabResource).zipWithIndex.toMap
+
+    val labelsPath = new File(tfModelPath + "/assets", "labels.txt")
+    require(labelsPath.exists(), s"Labels file labels.txt not found in folder $tfModelPath/assets/")
+
+    val labelsResource = new ExternalResource(labelsPath.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
+    val labels = ResourceHelper.parseLines(labelsResource).zipWithIndex.toMap
+
+    val (wrapper, signatures) = TensorflowWrapper.read(tfModelPath, zipped = false, useBundle = true)
+
+    val _signatures = signatures match {
+      case Some(s) => s
+      case None => throw new Exception("Cannot load signature definitions from model!")
+    }
+
+    /** the order of setSignatures is important if we use getSignatures inside setModelIfNotSet */
+    new DistilBertForTokenClassification()
+      .setVocabulary(words)
+      .setLabels(labels)
+      .setSignatures(_signatures)
+      .setModelIfNotSet(spark, wrapper)
+  }
+}
+
+/**
+ * This is the companion object of [[DistilBertForTokenClassification]]. Please refer to that class for the documentation.
+ */
+object DistilBertForTokenClassification extends ReadablePretrainedDistilBertForTokenModel with ReadDistilBertForTokenTensorflowModel

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -19,7 +19,7 @@ package com.johnsnowlabs.nlp.pretrained
 
 import com.johnsnowlabs.nlp.{DocumentAssembler, pretrained}
 import com.johnsnowlabs.nlp.annotators._
-import com.johnsnowlabs.nlp.annotators.classifier.dl.{ClassifierDLModel, MultiClassifierDLModel, SentimentDLModel}
+import com.johnsnowlabs.nlp.annotators.classifier.dl.{BertForTokenClassification, ClassifierDLModel, DistilBertForTokenClassification, MultiClassifierDLModel, SentimentDLModel}
 import com.johnsnowlabs.nlp.annotators.ld.dl.LanguageDetectorDL
 import com.johnsnowlabs.nlp.annotators.ner.crf.NerCrfModel
 import com.johnsnowlabs.nlp.annotators.ner.dl.NerDLModel
@@ -40,17 +40,20 @@ import com.johnsnowlabs.nlp.pretrained.ResourceDownloader.{listPretrainedResourc
 import com.johnsnowlabs.nlp.pretrained.ResourceType.ResourceType
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.util.{Build, ConfigHelper, FileHelper, Version}
-import org.apache.spark.ml.util.DefaultParamsReadable
-import org.apache.spark.ml.{PipelineModel, PipelineStage}
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
+
 import com.amazonaws.AmazonClientException
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{DefaultAWSCredentialsProviderChain, _}
+
+import org.apache.spark.ml.util.DefaultParamsReadable
+import org.apache.spark.ml.{PipelineModel, PipelineStage}
+
 import org.apache.hadoop.fs.FileSystem
 
 
@@ -490,7 +493,9 @@ object PythonResourceDownloader {
     "WordSegmenterModel" -> WordSegmenterModel,
     "DistilBertEmbeddings" -> DistilBertEmbeddings,
     "RoBertaEmbeddings" -> RoBertaEmbeddings,
-    "XlmRoBertaEmbeddings" -> XlmRoBertaEmbeddings
+    "XlmRoBertaEmbeddings" -> XlmRoBertaEmbeddings,
+    "BertForTokenClassification" -> BertForTokenClassification,
+    "DistilBertForTokenClassification" -> DistilBertForTokenClassification
   )
 
   def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassificationTestSpec.scala
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.training.CoNLL
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.SlowTest
+import com.johnsnowlabs.util.Benchmark
+
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.functions.{col, explode, size}
+import org.scalatest._
+
+class DistilBertForTokenClassificationTestSpec extends FlatSpec {
+
+  import ResourceHelper.spark.implicits._
+
+  "DistilBertForTokenClassification" should "correctly load custom model with extracted signatures" taggedAs SlowTest in {
+
+    val ddd = Seq(
+      "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London",
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21"
+    ).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val tokenClassifier = DistilBertForTokenClassification.pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, tokenClassifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("token.result").show(false)
+    pipelineDF.select("label.result").show(false)
+    pipelineDF
+      .withColumn("token_size", size(col("token")))
+      .withColumn("label_size", size(col("label")))
+      .where(col("token_size") =!= col("label_size"))
+      .select("token_size", "label_size", "token.result", "label.result")
+      .show(false)
+
+    val totalTokens = pipelineDF.select(explode($"token.result")).count.toInt
+    val totalEmbeddings = pipelineDF.select(explode($"label.result")).count.toInt
+
+    println(s"total tokens: $totalTokens")
+    println(s"total embeddings: $totalEmbeddings")
+
+  }
+
+  "DistilBertForTokenClassification" should "be saved and loaded correctly" taggedAs SlowTest in {
+
+    import ResourceHelper.spark.implicits._
+
+    val ddd = Seq(
+      "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London",
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21"
+    ).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val tokenClassifier = DistilBertForTokenClassification.pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, tokenClassifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("label.result").show(false)
+
+    Benchmark.time("Time to save DistilBertForTokenClassification pipeline model") {
+      pipelineModel.write.overwrite().save("./tmp_bertfortoken_pipeline")
+    }
+
+    Benchmark.time("Time to save BertForTokenClassification model") {
+      pipelineModel.stages.last.asInstanceOf[BertForTokenClassification].write.overwrite().save("./tmp_bertfortoken_model")
+    }
+
+    val loadedPipelineModel = PipelineModel.load("./tmp_bertfortoken_pipeline")
+    loadedPipelineModel.transform(ddd).select("label.result").show(false)
+
+    val loadedDistilBertModel = DistilBertForTokenClassification.load("./tmp_bertfortoken_model")
+    loadedDistilBertModel.getLabels
+
+  }
+
+  "DistilBertForTokenClassification" should "benchmark test" taggedAs SlowTest in {
+
+    val conll = CoNLL()
+    val training_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.train")
+
+    val tokenClassifier = DistilBertForTokenClassification.pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("ner")
+      .setCaseSensitive(true)
+      .setMaxSentenceLength(512)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        tokenClassifier
+      ))
+
+    val pipelineDF = pipeline.fit(training_data).transform(training_data)
+    Benchmark.time("Time to save DistilBertForTokenClassification results") {
+      pipelineDF.write.mode("overwrite").parquet("./tmp_bert_token_classifier")
+    }
+
+    println("missing tokens/tags: ")
+    pipelineDF.withColumn("sentence_size", size(col("sentence")))
+      .withColumn("token_size", size(col("token")))
+      .withColumn("ner_size", size(col("ner")))
+      .where(col("token_size") =!= col("ner_size"))
+      .select("sentence_size", "token_size", "ner_size", "token.result", "ner.result")
+      .show(false)
+
+    println("total sentences: ", pipelineDF.select(explode($"sentence.result")).count)
+    val totalTokens = pipelineDF.select(explode($"token.result")).count.toInt
+    val totalTags = pipelineDF.select(explode($"ner.result")).count.toInt
+
+    println(s"total tokens: $totalTokens")
+    println(s"total embeddings: $totalTags")
+
+    assert(totalTokens == totalTags)
+  }
+}


### PR DESCRIPTION
This PR allows the use of models trained/saved in HF for `DistilBertForTokenClassification` in Spark NLP