### PR TITLE
Add delimiter feature to CoNLL class

### DIFF
--- a/python/sparknlp/training.py
+++ b/python/sparknlp/training.py
@@ -70,6 +70,8 @@ class CoNLL(ExtendedJavaWrapper):
         Name of the label column, by default 'label'
     explodeSentences : bool, optional
         Whether to explode sentences to separate rows, by default True
+    delimiter: str, optional
+        Delimiter used to separate columns inside CoNLL file
 
     Examples
     --------
@@ -90,6 +92,7 @@ class CoNLL(ExtendedJavaWrapper):
     |BRUSSELS 1996-08-22                             |[BRUSSELS, 1996-08-22]                                    |[NNP, CD]                            |[B-LOC, O]                               |
     +------------------------------------------------+----------------------------------------------------------+-------------------------------------+-----------------------------------------+
     """
+
     def __init__(self,
                  documentCol='document',
                  sentenceCol='sentence',
@@ -100,6 +103,7 @@ class CoNLL(ExtendedJavaWrapper):
                  textCol='text',
                  labelCol='label',
                  explodeSentences=True,
+                 delimiter=' '
                  ):
         super(CoNLL, self).__init__("com.johnsnowlabs.nlp.training.CoNLL",
                                     documentCol,
@@ -110,7 +114,8 @@ class CoNLL(ExtendedJavaWrapper):
                                     conllPosIndex,
                                     textCol,
                                     labelCol,
-                                    explodeSentences)
+                                    explodeSentences,
+                                    delimiter)
 
     def readDataset(self, spark, path, read_as=ReadAs.TEXT):
         # ToDo Replace with std pyspark
@@ -182,9 +187,9 @@ class CoNLLU(ExtendedJavaWrapper):
     |What if Google Morphed Into GoogleOS?  |[What, if, Google, Morphed, Into, GoogleOS, ?]|[PRON, SCONJ, PROPN, VERB, ADP, PROPN, PUNCT]|[WP, IN, NNP, VBD, IN, NNP, .]|[what, if, Google, morph, into, GoogleOS, ?]|
     +---------------------------------------+----------------------------------------------+---------------------------------------------+------------------------------+--------------------------------------------+
     """
+
     def __init__(self, explodeSentences=True):
         super(CoNLLU, self).__init__("com.johnsnowlabs.nlp.training.CoNLLU", explodeSentences)
-
 
     def readDataset(self, spark, path, read_as=ReadAs.TEXT):
         """Reads the dataset from an external resource.
@@ -263,6 +268,7 @@ class POS(ExtendedJavaWrapper):
     +---------------------------------------------+
 
     """
+
     def __init__(self):
         super(POS, self).__init__("com.johnsnowlabs.nlp.training.POS")
 
@@ -329,6 +335,7 @@ class PubTator(ExtendedJavaWrapper):
     |25763772|[DCTN4, as, a, mo...|[NNP, IN, DT, NN,...|[B-T116, O, O, O,...|   [[sentence, 0], [...| [[word, DCTN4], [...|   [[word, DCTN4], [...|
     +--------+--------------------+--------------------+--------------------+-----------------------+---------------------+-----------------------+
     """
+
     def __init__(self):
         super(PubTator, self).__init__("com.johnsnowlabs.nlp.training.PubTator")
 

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddingsTestSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.nlp.annotators.{StopWordsCleaner, Tokenizer}
@@ -55,7 +72,7 @@ class BertEmbeddingsTestSpec extends FlatSpec {
 
   "Bert Embeddings" should "correctly work with empty tokens" taggedAs SlowTest in {
 
-    val smallCorpus = ResourceHelper.spark.read.option("header","true").csv("src/test/resources/embeddings/sentence_embeddings.csv")
+    val smallCorpus = ResourceHelper.spark.read.option("header", "true").csv("src/test/resources/embeddings/sentence_embeddings.csv")
 
     val documentAssembler = new DocumentAssembler()
       .setInputCol("text")

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/DistilBertEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/DistilBertEmbeddingsTestSpec.scala
@@ -76,6 +76,7 @@ class DistilBertEmbeddingsTestSpec extends FlatSpec {
 
     val conll = CoNLL()
     val training_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.train")
+    println(training_data.count())
 
     val embeddings = DistilBertEmbeddings.pretrained()
       .setInputCols("sentence", "token")

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/ElmoEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/ElmoEmbeddingsTestSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.nlp.annotators.Tokenizer

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsTestSpec.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.nlp.annotators.Tokenizer
@@ -11,8 +28,8 @@ class WordEmbeddingsTestSpec extends FlatSpec {
 
   "Word Embeddings" should "correctly embed clinical words not embed non-existent words" taggedAs SlowTest in {
 
-    val words = ResourceHelper.spark.read.option("header","true").csv("src/test/resources/embeddings/clinical_words.txt")
-    val notWords = ResourceHelper.spark.read.option("header","true").csv("src/test/resources/embeddings/not_words.txt")
+    val words = ResourceHelper.spark.read.option("header", "true").csv("src/test/resources/embeddings/clinical_words.txt")
+    val notWords = ResourceHelper.spark.read.option("header", "true").csv("src/test/resources/embeddings/not_words.txt")
 
     val documentAssembler = new DocumentAssembler()
       .setInputCol("word")
@@ -40,15 +57,15 @@ class WordEmbeddingsTestSpec extends FlatSpec {
     val wordsCoverage = WordEmbeddingsModel.withCoverageColumn(wordsP, "embeddings", "cov_embeddings")
     val notWordsCoverage = WordEmbeddingsModel.withCoverageColumn(notWordsP, "embeddings", "cov_embeddings")
 
-    wordsCoverage.select("word","cov_embeddings").show(1)
-    notWordsCoverage.select("word","cov_embeddings").show(1)
+    wordsCoverage.select("word", "cov_embeddings").show(1)
+    notWordsCoverage.select("word", "cov_embeddings").show(1)
 
-    val wordsOverallCoverage = WordEmbeddingsModel.overallCoverage(wordsCoverage,"embeddings").percentage
-    val notWordsOverallCoverage = WordEmbeddingsModel.overallCoverage(notWordsCoverage,"embeddings").percentage
+    val wordsOverallCoverage = WordEmbeddingsModel.overallCoverage(wordsCoverage, "embeddings").percentage
+    val notWordsOverallCoverage = WordEmbeddingsModel.overallCoverage(notWordsCoverage, "embeddings").percentage
 
     ResourceHelper.spark.createDataFrame(
       Seq(
-        ("Words", wordsOverallCoverage),("Not Words", notWordsOverallCoverage)
+        ("Words", wordsOverallCoverage), ("Not Words", notWordsOverallCoverage)
       )
     ).toDF("Dataset", "OverallCoverage").show(1)
 
@@ -59,7 +76,7 @@ class WordEmbeddingsTestSpec extends FlatSpec {
   "Word Embeddings" should "store and load from disk" taggedAs FastTest in {
 
     val data =
-      ResourceHelper.spark.read.option("header","true").csv("src/test/resources/embeddings/clinical_words.txt")
+      ResourceHelper.spark.read.option("header", "true").csv("src/test/resources/embeddings/clinical_words.txt")
 
     val documentAssembler = new DocumentAssembler()
       .setInputCol("word")


### PR DESCRIPTION
This PR introduces a `delimiter` param to CoNLL() in both Scala and Python. Usually, the delimiter in the CoNLL file is whitespace `' '`, however, some CoNLL files may use a different delimiter like tab `\t` etc. From now on the delimiter can be set during reading the CoNLL file:

```python
# by default it's space ' '
CoNLL(conllLabelIndex=1, delimiter='\t') \
         .readDataset(spark, 'train.conll')
```