### PR TITLE
Avoid exceptions due to corrupt merges in RoBERTa tokenizer 

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaEmbeddings.scala
@@ -408,7 +408,10 @@ trait ReadRobertaTensorflowModel extends ReadTensorflowModel {
     val mergesResource = new ExternalResource(mergesFile.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
     val merges = ResourceHelper.parseLines(mergesResource)
 
-    val bytePairs: Map[(String, String), Int] = merges.map(_.split(" ")).map { case Array(c1, c2) => (c1, c2) }.zipWithIndex.toMap
+    val bytePairs: Map[(String, String), Int] = merges.map(_.split(" "))
+      .filter(w => w.length == 2)
+      .map { case Array(c1, c2) => (c1, c2) }
+      .zipWithIndex.toMap
 
     val (wrapper, signatures) = TensorflowWrapper.read(tfModelPath, zipped = false, useBundle = true)
 


### PR DESCRIPTION
This PR makes sure a bad input inside the merges.txt won't result in an exception during the use of `.loadSavedModel` function. if for any reason the delimiter in the merges.txt file is not a whitespace, it will discard that row.