### PR TITLE
Preserve existing metadata in BertSentenceEmbeddings

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
@@ -288,7 +288,7 @@ class TensorflowBert(val tensorflowWrapper: TensorflowWrapper,
           begin = sentence.start,
           end = sentence.end,
           result = sentence.content,
-          metadata = Map("sentence" -> sentence.index.toString,
+          metadata = sentence.metadata ++ Map("sentence" -> sentence.index.toString,
             "token" -> sentence.content,
             "pieceId" -> "-1",
             "isWordStart" -> "true"

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBert.scala
@@ -283,16 +283,22 @@ class TensorflowBert(val tensorflowWrapper: TensorflowWrapper,
       }
 
       sentencesBatch.zip(embeddings).map { case (sentence, vectors) =>
+        val metadata = Map("sentence" -> sentence.index.toString,
+          "token" -> sentence.content,
+          "pieceId" -> "-1",
+          "isWordStart" -> "true"
+        )
+        val finalMetadata = if (sentence.metadata.isDefined) {
+          sentence.metadata.getOrElse(Map.empty) ++ metadata
+        } else {
+          metadata
+        }
         Annotation(
           annotatorType = AnnotatorType.SENTENCE_EMBEDDINGS,
           begin = sentence.start,
           end = sentence.end,
           result = sentence.content,
-          metadata = sentence.metadata ++ Map("sentence" -> sentence.index.toString,
-            "token" -> sentence.content,
-            "pieceId" -> "-1",
-            "isWordStart" -> "true"
-          ),
+          metadata = finalMetadata,
           embeddings = vectors
         )
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceSplit.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceSplit.scala
@@ -18,15 +18,17 @@ package com.johnsnowlabs.nlp.annotators.common
 
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 
+import scala.collection.Map
+
 /**
-  * structure representing a sentence and its boundaries
-  */
-case class Sentence(content: String, start: Int, end: Int, index: Int)
+ * structure representing a sentence and its boundaries
+ */
+case class Sentence(content: String, start: Int, end: Int, index: Int, metadata: Map[String, String] = null)
 
 object Sentence {
   def fromTexts(texts: String*): Seq[Sentence] = {
     var idx = 0
-    texts.zipWithIndex.map{ case(text, textIndex) =>
+    texts.zipWithIndex.map { case (text, textIndex) =>
       val sentence = Sentence(text, idx, idx + text.length - 1, textIndex)
       idx += text.length + 1
       sentence
@@ -35,32 +37,33 @@ object Sentence {
 }
 
 /**
-  * Helper object to work work with Sentence
-  */
+ * Helper object to work work with Sentence
+ */
 object SentenceSplit extends Annotated[Sentence] {
   override def annotatorType: String = AnnotatorType.DOCUMENT
 
   override def unpack(annotations: Seq[Annotation]): Seq[Sentence] = {
     annotations.filter(_.annotatorType == annotatorType)
       .zipWithIndex.map { case (annotation, index) =>
-      Sentence(annotation.result, annotation.begin, annotation.end, index)
+      Sentence(annotation.result, annotation.begin, annotation.end, index, annotation.metadata)
     }
   }
 
   override def pack(items: Seq[Sentence]): Seq[Annotation] = {
-    items.sortBy(i => i.start).zipWithIndex.map{case (item, index) => Annotation(
+    items.sortBy(i => i.start).zipWithIndex.map { case (item, index) => Annotation(
       annotatorType,
       item.start,
       item.end,
       item.content,
       Map("sentence" -> index.toString)
-    )}
+    )
+    }
   }
 }
 
 /**
-  * Helper object to work work with Chunks
-  */
+ * Helper object to work work with Chunks
+ */
 object ChunkSplit extends Annotated[Sentence] {
   override def annotatorType: String = AnnotatorType.CHUNK
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceSplit.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceSplit.scala
@@ -23,7 +23,7 @@ import scala.collection.Map
 /**
  * structure representing a sentence and its boundaries
  */
-case class Sentence(content: String, start: Int, end: Int, index: Int, metadata: Map[String, String] = null)
+case class Sentence(content: String, start: Int, end: Int, index: Int, metadata: Option[Map[String, String]] = None)
 
 object Sentence {
   def fromTexts(texts: String*): Seq[Sentence] = {
@@ -45,7 +45,7 @@ object SentenceSplit extends Annotated[Sentence] {
   override def unpack(annotations: Seq[Annotation]): Seq[Sentence] = {
     annotations.filter(_.annotatorType == annotatorType)
       .zipWithIndex.map { case (annotation, index) =>
-      Sentence(annotation.result, annotation.begin, annotation.end, index, annotation.metadata)
+      Sentence(annotation.result, annotation.begin, annotation.end, index, Option(annotation.metadata))
     }
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddingsTestSpec.scala
@@ -17,10 +17,11 @@
 package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.nlp.annotator.{SentenceDetectorDLModel, Tokenizer}
+import com.johnsnowlabs.nlp.annotators.RegexMatcher
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
-import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.base.{Chunk2Doc, DocumentAssembler}
 import com.johnsnowlabs.nlp.training.CoNLL
-import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
 import com.johnsnowlabs.tags.{FastTest, SlowTest}
 import com.johnsnowlabs.util.Benchmark
 import org.apache.spark.ml.{Pipeline, PipelineModel}
@@ -170,6 +171,43 @@ class BertSentenceEmbeddingsTestSpec extends AnyFlatSpec {
     val pipelineModel = PipelineModel.load("./tmp_bert_pipeline")
 
     pipelineModel.transform(ddd)
+  }
+
+  "BertSentenceEmbeddings" should "correctly propagate metadata" taggedAs FastTest in {
+
+    val testData = ResourceHelper.spark.createDataFrame(Seq(
+      (1, "\"My first sentence with the first rule. This is my second sentence with ceremonies rule")
+    )).toDF("id", "text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentence = new SentenceDetector()
+      .setInputCols("document")
+      .setOutputCol("sentence")
+
+    val regexMatcher = new RegexMatcher()
+      .setExternalRules(ExternalResource("src/test/resources/regex-matcher/rules.txt", ReadAs.TEXT, Map("delimiter" -> ",")))
+      .setInputCols(Array("sentence"))
+      .setOutputCol("regex")
+      .setStrategy("MATCH_ALL")
+
+    val chunk2Doc = new Chunk2Doc().setInputCols("regex").setOutputCol("doc_chunk")
+
+    val embeddings = BertSentenceEmbeddings.pretrained("sent_small_bert_L2_128")
+      .setInputCols("doc_chunk")
+      .setOutputCol("bert")
+      .setCaseSensitive(false)
+      .setMaxSentenceLength(32)
+
+
+    val pipeline = new Pipeline().setStages(Array(document, sentence, regexMatcher, chunk2Doc, embeddings))
+
+    val pipelineDF = pipeline.fit(testData).transform(testData)
+
+    pipelineDF.select("bert.metadata").show(truncate = false)
+
   }
 
 }


### PR DESCRIPTION
This PR extends the Sentence case class with metadata to be used when necessary to preserve metadata generated by previous annotators. 