### PR TITLE
Fix default language for XlmRoBertaSentenceEmbeddings pretrained model

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -13619,9 +13619,9 @@ class XlmRoBertaSentenceEmbeddings(AnnotatorModel,
         Parameters
         ----------
         name : str, optional
-            Name of the pretrained model, by default "sent_roberta_base"
+            Name of the pretrained model, by default "sent_xlm_roberta_base"
         lang : str, optional
-            Language of the pretrained model, by default "en"
+            Language of the pretrained model, by default "xx"
         remote_loc : str, optional
             Optional remote address of the resource, by default None. Will use
             Spark NLPs repositories otherwise.

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -13613,7 +13613,7 @@ class XlmRoBertaSentenceEmbeddings(AnnotatorModel,
         return XlmRoBertaSentenceEmbeddings(java_model=jModel)
 
     @staticmethod
-    def pretrained(name="sent_xlm_roberta_base", lang="en", remote_loc=None):
+    def pretrained(name="sent_xlm_roberta_base", lang="xx", remote_loc=None):
         """Downloads and loads a pretrained model.
 
         Parameters


### PR DESCRIPTION
This PR fixes the wrong default language for `sent_xlm_roberta_base` model used in `XlmRoBertaSentenceEmbeddings.pretrained()` which should be `xx` and not `en`.