### PR TITLE
Training page update

### DIFF
--- a/docs/_includes/templates/training_anno_template.md
+++ b/docs/_includes/templates/training_anno_template.md
@@ -1,0 +1,54 @@
+
+<div class="h3-box model-content" markdown="1">
+
+### {{include.title}}
+
+{{include.description}}
+
+**Input Annotator Types:** `{{include.input_anno}}`
+
+**Output Annotator Type:** `{{include.output_anno}}`
+
+{% if include.note %}
+
+> **Note:** {{include.note}}
+
+{% endif %}
+
+{% if include.source_link %}
+
+| **Python API:** {{include.python_api_link}} | **Scala API:** {{include.api_link}} | **Source:** {{include.source_link}} |
+
+{% else %}
+
+| **Python API:** {{include.python_api_link}} | **Scala API:** {{include.api_link}} |
+
+
+{% endif %}
+
+
+{% if include.python_example and include.scala_example %}
+
+<details>
+
+<summary class="button"><b>Show Example</b></summary>
+
+<div class="tabs-box" markdown="1">
+
+{% include programmingLanguageSelectScalaPython.html %}
+
+```python
+{{include.python_example}}
+```
+
+```scala
+{{include.scala_example}}
+```
+
+</div>
+
+</details>
+
+{% endif %}
+
+</div>

--- a/docs/_includes/templates/training_dataset_entry.md
+++ b/docs/_includes/templates/training_dataset_entry.md
@@ -1,0 +1,46 @@
+
+<div class="h3-box" markdown="1">
+
+### {{include.title}}
+
+{{include.description}}
+
+**Input File Format:**
+
+```
+{{include.file_format}}
+```
+
+**Constructor Parameters:**
+
+{{include.constructor}}
+
+**Parameters for `readDataset`:**
+
+{{include.read_dataset_params}}
+
+Refer to the documentation for more details on the API:
+
+| **Python API:** {{include.python_api_link}} | **Scala API:** {{include.api_link}} | **Source:** {{include.source_link}} |
+
+<details>
+
+<summary class="button"><b>Show Example</b></summary>
+
+<div class="tabs-box" markdown="1">
+
+{% include programmingLanguageSelectScalaPython.html %}
+
+```python
+{{include.python_example}}
+```
+
+```scala
+{{include.scala_example}}
+```
+
+</div>
+
+</details>
+
+</div>

--- a/docs/en/annotator_entries/ChunkEmbeddings.md
+++ b/docs/en/annotator_entries/ChunkEmbeddings.md
@@ -4,8 +4,8 @@ ChunkEmbeddings
 
 {%- capture description -%}
 This annotator utilizes WordEmbeddings, BertEmbeddings etc. to generate chunk embeddings from either
-[Chunker](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/Chunker), [NGramGenerator](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/NGramGenerator),
-or [NerConverter](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/ner/NerConverter) outputs.
+[Chunker](/docs/en/annotators#chunker), [NGramGenerator](/docs/en/annotators#ngramgenerator),
+or [NerConverter](/docs/en/annotators#nerconverter) outputs.
 
 For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/databricks_notebooks/3.SparkNLP_Pretrained_Models_v3.0.ipynb)
 and the [ChunkEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala).

--- a/docs/en/annotator_entries/ClassifierDL.md
+++ b/docs/en/annotator_entries/ClassifierDL.md
@@ -19,7 +19,7 @@ val classifierDL = ClassifierDLModel.pretrained()
   .setOutputCol("classification")
 ```
 The default model is `"classifierdl_use_trec6"`, if no name is provided. It uses embeddings from the
-[UniversalSentenceEncoder](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder) and is trained on the
+[UniversalSentenceEncoder](/docs/en/transformers#universalsentenceencoder) and is trained on the
 [TREC-6](https://deepai.org/dataset/trec-6#:~:text=The%20TREC%20dataset%20is%20dataset,50%20has%20finer%2Dgrained%20labels) dataset.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Text+Classification).
 

--- a/docs/en/annotator_entries/ClassifierDL.md
+++ b/docs/en/annotator_entries/ClassifierDL.md
@@ -155,12 +155,6 @@ The ClassifierDL annotator uses a deep learning model (DNNs) we have built insid
 
 For instantiated/pretrained models, see ClassifierDLModel.
 
-**Notes**:
-  - This annotator accepts a label column of a single item in either type of String, Int, Float, or Double.
-  - [UniversalSentenceEncoder](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder),
-    [BertSentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings), or
-    [SentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings) can be used for the `inputCol`.
-
 For extended examples of usage, see the Spark NLP Workshop
 [[1] ](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/scala/training/Train%20Multi-Class%20Text%20Classification%20on%20News%20Articles.scala)
 [[2] ](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.Text_Classification_with_ClassifierDL.ipynb)
@@ -176,10 +170,6 @@ CATEGORY
 {%- endcapture -%}
 
 {%- capture approach_python_example -%}
-import sparknlp
-from sparknlp.base import *
-from sparknlp.annotator import *
-from pyspark.ml import Pipeline
 # In this example, the training data `"sentiment.csv"` has the form of
 #
 # text,label
@@ -188,6 +178,11 @@ from pyspark.ml import Pipeline
 # ...
 #
 # Then traning can be done like so:
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
 
 smallCorpus = spark.read.option("header","True").csv("src/test/resources/classifier/sentiment.csv")
 
@@ -230,6 +225,7 @@ pipelineModel = pipeline.fit(smallCorpus)
 // ...
 //
 // Then traning can be done like so:
+
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.embeddings.UniversalSentenceEncoder
 import com.johnsnowlabs.nlp.annotators.classifier.dl.ClassifierDLApproach

--- a/docs/en/annotator_entries/ContextSpellChecker.md
+++ b/docs/en/annotator_entries/ContextSpellChecker.md
@@ -155,12 +155,12 @@ TOKEN
 {%- endcapture -%}
 
 {%- capture approach_python_example -%}
+# For this example, we use the first Sherlock Holmes book as the training dataset.
+
 import sparknlp
 from sparknlp.base import *
 from sparknlp.annotator import *
 from pyspark.ml import Pipeline
-# For this example, we use the first Sherlock Holmes book as the training dataset.
-
 
 documentAssembler = DocumentAssembler() \
     .setInputCol("text") \
@@ -195,6 +195,7 @@ pipelineModel = pipeline.fit(dataset)
 
 {%- capture approach_scala_example -%}
 // For this example, we use the first Sherlock Holmes book as the training dataset.
+
 import spark.implicits._
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.annotators.Tokenizer

--- a/docs/en/annotator_entries/EmbeddingsFinisher.md
+++ b/docs/en/annotator_entries/EmbeddingsFinisher.md
@@ -6,10 +6,10 @@ EmbeddingsFinisher
 Extracts embeddings from Annotations into a more easily usable form.
 
 This is useful for example:
-[WordEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/WordEmbeddings),
-[BertEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/BertEmbeddings),
-[SentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings) and
-[ChunkEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings).
+[WordEmbeddings](/docs/en/annotators#wordembeddings),
+[BertEmbeddings](/docs/en/transformers#bertembeddings),
+[SentenceEmbeddings](/docs/en/annotators#sentenceembeddings) and
+[ChunkEmbeddings](/docs/en/annotators#chunkembeddings).
 
 By using `EmbeddingsFinisher` you can easily transform your embeddings into array of floats or vectors which are
 compatible with Spark ML functions such as LDA, K-mean, Random Forest classifier or any other functions that require

--- a/docs/en/annotator_entries/GraphExtraction.md
+++ b/docs/en/annotator_entries/GraphExtraction.md
@@ -6,13 +6,13 @@ GraphExtraction
 Extracts a dependency graph between entities.
 
 The GraphExtraction class takes e.g. extracted entities from a
-[NerDLModel](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel) and creates a dependency tree which describes how
+[NerDLModel](/docs/en/annotators#nerdl) and creates a dependency tree which describes how
 the entities relate to each other. For that a triple store format is used. Nodes represent the entities and the
 edges represent the relations between those entities. The graph can then be used to find relevant relationships
 between words.
 
-Both the [DependencyParserModel](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserModel) and
-[TypedDependencyParserModel](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/parser/typdep/TypedDependencyParserModel) need to be
+Both the [DependencyParserModel](/docs/en/annotators#dependencyparser) and
+[TypedDependencyParserModel](/docs/en/annotators#typeddependencyparser) need to be
 present in the pipeline. There are two ways to set them:
 
   1. Both Annotators are present in the pipeline already. The dependencies are taken implicitly from these two
@@ -31,7 +31,7 @@ present in the pipeline. There are two ways to set them:
      ```
 
 To transform the resulting graph into a more generic form such as RDF, see the
-[GraphFinisher](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/GraphFinisher).
+[GraphFinisher](/docs/en/annotators#graphfinisher).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/annotator_entries/Lemmatizer.md
+++ b/docs/en/annotator_entries/Lemmatizer.md
@@ -54,8 +54,7 @@ The dictionary can be set as a delimited text file.
 Pretrained models can be loaded with `LemmatizerModel.pretrained`.
 
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Lemmatization).
-For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb)
-and the [LemmatizerTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/LemmatizerTestSpec.scala).
+For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb).
 {%- endcapture -%}
 
 {%- capture approach_input_anno -%}
@@ -67,10 +66,6 @@ TOKEN
 {%- endcapture -%}
 
 {%- capture approach_python_example -%}
-import sparknlp
-from sparknlp.base import *
-from sparknlp.annotator import *
-from pyspark.ml import Pipeline
 # In this example, the lemma dictionary `lemmas_small.txt` has the form of
 #
 # ...
@@ -81,6 +76,11 @@ from pyspark.ml import Pipeline
 # ...
 #
 # where each key is delimited by `->` and values are delimited by `\t`
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
 
 documentAssembler = DocumentAssembler() \
     .setInputCol("text") \

--- a/docs/en/annotator_entries/MultiClassifierDL.md
+++ b/docs/en/annotator_entries/MultiClassifierDL.md
@@ -181,10 +181,6 @@ CATEGORY
 {%- endcapture -%}
 
 {%- capture approach_python_example -%}
-import sparknlp
-from sparknlp.base import *
-from sparknlp.annotator import *
-from pyspark.ml import Pipeline
 # In this example, the training data has the form
 #
 # +----------------+--------------------+--------------------+
@@ -195,6 +191,11 @@ from pyspark.ml import Pipeline
 # |24b0d6c8733c2abe|Thanks  - thanks ...|            [insult]|
 # |8c4478fb239bcfc0|" Gee, 5 minutes ...|[toxic, obscene, ...|
 # +----------------+--------------------+--------------------+
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
 
 # Process training data to create text with associated array of labels
 
@@ -248,6 +249,7 @@ pipelineModel = pipeline.fit(trainDataset)
 // ...
 //
 // It needs some pre-processing first, so the labels are of type `Array[String]`. This can be done like so:
+
 import spark.implicits._
 import com.johnsnowlabs.nlp.annotators.classifier.dl.MultiClassifierDLApproach
 import com.johnsnowlabs.nlp.base.DocumentAssembler

--- a/docs/en/annotator_entries/MultiClassifierDL.md
+++ b/docs/en/annotator_entries/MultiClassifierDL.md
@@ -6,10 +6,10 @@ MultiClassifierDL
 MultiClassifierDL for Multi-label Text Classification.
 
 MultiClassifierDL Bidirectional GRU with Convolution model we have built inside TensorFlow and supports up to 100 classes.
-The input to MultiClassifierDL is Sentence Embeddings such as state-of-the-art
-[UniversalSentenceEncoder](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder),
-[BertSentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings), or
-[SentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings).
+The input to MultiClassifierDL are Sentence Embeddings such as state-of-the-art
+[UniversalSentenceEncoder](/docs/en/transformers#universalsentenceencoder),
+[BertSentenceEmbeddings](/docs/en/transformers#bertsentenceembeddings) or
+[SentenceEmbeddings](/docs/en/annotators#sentenceembeddings).
 
 This is the instantiated model of the MultiClassifierDLApproach.
 For training your own model, please see the documentation of that class.
@@ -21,7 +21,7 @@ val multiClassifier = MultiClassifierDLModel.pretrained()
   .setOutputCol("categories")
 ```
 The default model is `"multiclassifierdl_use_toxic"`, if no name is provided. It uses embeddings from the
-[UniversalSentenceEncoder](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder) and classifies toxic comments.
+[UniversalSentenceEncoder](/docs/en/transformers#universalsentenceencoder) and classifies toxic comments.
 The data is based on the
 [Jigsaw Toxic Comment Classification Challenge](https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/overview).
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Text+Classification).
@@ -150,9 +150,9 @@ up to 100 classes.
 For instantiated/pretrained models, see MultiClassifierDLModel.
 
 The input to `MultiClassifierDL` are Sentence Embeddings such as the state-of-the-art
-[UniversalSentenceEncoder](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder),
-[BertSentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings), or
-[SentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings).
+[UniversalSentenceEncoder](/docs/en/transformers#universalsentenceencoder),
+[BertSentenceEmbeddings](/docs/en/transformers#bertsentenceembeddings) or
+[SentenceEmbeddings](/docs/en/annotators#sentenceembeddings).
 
 In machine learning, multi-label classification and the strongly related problem of multi-output classification are
 variants of the classification problem where multiple labels may be assigned to each instance. Multi-label
@@ -161,12 +161,6 @@ instances into precisely one of more than two classes; in the multi-label proble
 of the classes the instance can be assigned to.
 Formally, multi-label classification is the problem of finding a model that maps inputs x to binary vectors y
 (assigning a value of 0 or 1 for each element (label) in y).
-
-**Notes**:
-  - This annotator requires an array of labels in type of String.
-  - [UniversalSentenceEncoder](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder),
-    [BertSentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings), or
-    [SentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings) can be used for the `inputCol`.
 
 For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb)
 and the [MultiClassifierDLTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MultiClassifierDLTestSpec.scala).
@@ -341,5 +335,5 @@ approach_scala_example=approach_scala_example
 approach_python_api_link=approach_python_api_link
 approach_api_link=approach_api_link
 approach_source_link=approach_source_link
-approach_note="This annotator accepts a label column of a single item in either type of String, Int, Float, or Double. UniversalSentenceEncoder, BertSentenceEmbeddings, or SentenceEmbeddings can be used for the inputCol"
+approach_note="This annotator accepts a label column of a single item in either type of String, Int, Float, or Double. UniversalSentenceEncoder, BertSentenceEmbeddings, SentenceEmbeddings or other sentence based embeddings can be used for the inputCol"
 %}

--- a/docs/en/annotator_entries/NerCrf.md
+++ b/docs/en/annotator_entries/NerCrf.md
@@ -8,9 +8,9 @@ Extracts Named Entities based on a CRF Model.
 This Named Entity recognition annotator allows for a generic model to be trained by utilizing a CRF machine learning
 algorithm. The data should have columns of type `DOCUMENT, TOKEN, POS, WORD_EMBEDDINGS`.
 These can be extracted with for example
-  - a [SentenceDetector](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetector),
-  - a [Tokenizer](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/Tokenizer) and
-  - a [PerceptronModel](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronModel).
+  - a [SentenceDetector](/docs/en/annotators#sentencedetector),
+  - a [Tokenizer](/docs/en/annotators#tokenizer) and
+  - a [PerceptronModel](/docs/en/annotators#postagger-part-of-speech-tagger)
 
 This is the instantiated model of the NerCrfApproach.
 For training your own model, please see the documentation of that class.
@@ -163,14 +163,15 @@ Algorithm for training a Named Entity Recognition Model
 For instantiated/pretrained models, see NerCrfModel.
 
 This Named Entity recognition annotator allows for a generic model to be trained by utilizing a CRF machine learning
-algorithm. The training data should be a labeled Spark Dataset, e.g. [CoNLL](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/training/CoNLL) 2003 IOB with
+algorithm. The training data should be a labeled Spark Dataset, e.g. [CoNLL](/docs/en/training#conll-dataset) 2003 IOB with
 `Annotation` type columns. The data should have columns of type `DOCUMENT, TOKEN, POS, WORD_EMBEDDINGS` and an
 additional label column of annotator type `NAMED_ENTITY`.
 Excluding the label, this can be done with for example
-  - a [SentenceDetector](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetector),
-  - a [Tokenizer](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/Tokenizer),
-  - a [PerceptronModel](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronModel) and
-  - a [WordEmbeddingsModel](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel).
+  - a [SentenceDetector](/docs/en/annotators#sentencedetector),
+  - a [Tokenizer](/docs/en/annotators#tokenizer) and
+  - a [PerceptronModel](/docs/en/annotators#postagger-part-of-speech-tagger) and
+  - a [WordEmbeddingsModel](/docs/en/annotators#wordembeddings)
+  (any word embeddings can be chosen, e.g. [BertEmbeddings](/docs/en/transformers#bertembeddings) for BERT based embeddings).
 
 Optionally the user can provide an entity dictionary file with setExternalFeatures for better accuracy.
 

--- a/docs/en/annotator_entries/NerCrf.md
+++ b/docs/en/annotator_entries/NerCrf.md
@@ -187,13 +187,14 @@ NAMED_ENTITY
 {%- endcapture -%}
 
 {%- capture approach_python_example -%}
+# This CoNLL dataset already includes the sentence, token, pos and label column with their respective annotator types.
+# If a custom dataset is used, these need to be defined.
+
 import sparknlp
 from sparknlp.base import *
 from sparknlp.annotator import *
 from sparknlp.training import *
 from pyspark.ml import Pipeline
-# This CoNLL dataset already includes the sentence, token, pos and label column with their respective annotator types.
-# If a custom dataset is used, these need to be defined.
 
 documentAssembler = DocumentAssembler() \
     .setInputCol("text") \
@@ -230,6 +231,7 @@ pipelineModel = pipeline.fit(trainingData)
 {%- capture approach_scala_example -%}
 // This CoNLL dataset already includes the sentence, token, pos and label column with their respective annotator types.
 // If a custom dataset is used, these need to be defined.
+
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.embeddings.WordEmbeddingsModel
 import com.johnsnowlabs.nlp.annotator.NerCrfApproach

--- a/docs/en/annotator_entries/NerDL.md
+++ b/docs/en/annotator_entries/NerDL.md
@@ -23,7 +23,7 @@ Additionally, pretrained pipelines are available for this module, see [Pipelines
 
 Note that some pretrained models require specific types of embeddings, depending on which they were trained on.
 For example, the default model `"ner_dl"` requires the
-[WordEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel) `"glove_100d"`.
+[WordEmbeddings](/docs/en/annotators#wordembeddings) `"glove_100d"`.
 
 For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/3.SparkNLP_Pretrained_Models.ipynb)
 and the [NerDLSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala).
@@ -155,14 +155,15 @@ The architecture of the neural network is a Char CNNs - BiLSTM - CRF that achiev
 
 For instantiated/pretrained models, see NerDLModel.
 
-The training data should be a labeled Spark Dataset, in the format of [CoNLL](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/training/CoNLL)
+The training data should be a labeled Spark Dataset, in the format of [CoNLL](/docs/en/training#conll-dataset)
 2003 IOB with `Annotation` type columns. The data should have columns of type `DOCUMENT, TOKEN, WORD_EMBEDDINGS` and an
 additional label column of annotator type `NAMED_ENTITY`.
 Excluding the label, this can be done with for example
-  - a [SentenceDetector](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/SentenceDetector),
-  - a [Tokenizer](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/Tokenizer) and
-  - a [WordEmbeddingsModel](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel)
-  (any embeddings can be chosen, e.g. [BertEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/BertEmbeddings) for BERT based embeddings).
+  - a [SentenceDetector](/docs/en/annotators#sentencedetector),
+  - a [Tokenizer](/docs/en/annotators#tokenizer) and
+  - a [PerceptronModel](/docs/en/annotators#postagger-part-of-speech-tagger) and
+  - a [WordEmbeddingsModel](/docs/en/annotators#wordembeddings)
+  (any word embeddings can be chosen, e.g. [BertEmbeddings](/docs/en/transformers#bertembeddings) for BERT based embeddings).
 
 For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/tree/master/jupyter/training/english/dl-ner)
 and the [NerDLSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala).

--- a/docs/en/annotator_entries/NorvigSweeting.md
+++ b/docs/en/annotator_entries/NorvigSweeting.md
@@ -146,10 +146,6 @@ TOKEN
 {%- endcapture -%}
 
 {%- capture approach_python_example -%}
-import sparknlp
-from sparknlp.base import *
-from sparknlp.annotator import *
-from pyspark.ml import Pipeline
 # In this example, the dictionary `"words.txt"` has the form of
 #
 # ...
@@ -161,6 +157,11 @@ from pyspark.ml import Pipeline
 # ...
 #
 # This dictionary is then set to be the basis of the spell checker.
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
 
 documentAssembler = DocumentAssembler() \
     .setInputCol("text") \
@@ -197,6 +198,7 @@ pipelineModel = pipeline.fit(trainingData)
 // ...
 //
 // This dictionary is then set to be the basis of the spell checker.
+
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.annotators.Tokenizer
 import com.johnsnowlabs.nlp.annotators.spell.norvig.NorvigSweetingApproach

--- a/docs/en/annotator_entries/Perceptron.md
+++ b/docs/en/annotator_entries/Perceptron.md
@@ -6,8 +6,7 @@ POSTagger (Part of speech tagger)
 Averaged Perceptron model to tag words part-of-speech.
 Sets a POS tag to each word within a sentence.
 
-This is the instantiated model of the
-[PerceptronApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronApproach).
+This is the instantiated model of the PerceptronApproach.
 For training your own model, please see the documentation of that class.
 
 Pretrained models can be loaded with `pretrained` of the companion object:
@@ -142,7 +141,7 @@ For pretrained models please see the PerceptronModel.
 The training data needs to be in a Spark DataFrame, where the column needs to consist of
 [Annotations](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/Annotation) of type `POS`. The `Annotation` needs to have member `result`
 set to the POS tag and have a `"word"` mapping to its word inside of member `metadata`.
-This DataFrame for training can easily created by the helper class [POS](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/training/POS).
+This DataFrame for training can easily created by the helper class [POS](/docs/en/training#pos-dataset).
 ```
 POS().readDataset(spark, datasetPath).selectExpr("explode(tags) as tags").show(false)
 +---------------------------------------------+

--- a/docs/en/annotator_entries/SentenceDetectorDL.md
+++ b/docs/en/annotator_entries/SentenceDetectorDL.md
@@ -5,7 +5,7 @@ SentenceDetectorDL
 {%- capture model_description -%}
 Annotator that detects sentence boundaries using a deep learning approach.
 
-Instantiated Model of the [SentenceDetectorDLApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLApproach).
+Instantiated Model of the SentenceDetectorDLApproach.
 Detects sentence boundaries using a deep learning approach.
 
 Pretrained models can be loaded with `pretrained` of the companion object:

--- a/docs/en/annotator_entries/SentenceDetectorDL.md
+++ b/docs/en/annotator_entries/SentenceDetectorDL.md
@@ -168,7 +168,7 @@ using a CNN architecture. We also modified the original implementation a little 
 Each extracted sentence can be returned in an Array or exploded to separate rows,
 if `explodeSentences` is set to `true`.
 
-For extended examples of usage, see the [SentenceDetectorDLSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLSpec.scala).
+For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/9.SentenceDetectorDL.ipynb) and the [SentenceDetectorDLSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLSpec.scala).
 {%- endcapture -%}
 
 {%- capture approach_input_anno -%}
@@ -180,10 +180,6 @@ DOCUMENT
 {%- endcapture -%}
 
 {%- capture approach_python_example -%}
-import sparknlp
-from sparknlp.base import *
-from sparknlp.annotator import *
-from pyspark.ml import Pipeline
 # The training process needs data, where each data point is a sentence.
 # In this example the `train.txt` file has the form of
 #
@@ -194,6 +190,11 @@ from pyspark.ml import Pipeline
 #
 # where each line is one sentence.
 # Training can then be started like so:
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
 
 trainingData = spark.read.text("train.txt").toDF("text")
 

--- a/docs/en/annotator_entries/SentimentDL.md
+++ b/docs/en/annotator_entries/SentimentDL.md
@@ -137,11 +137,13 @@ of a text. A common example is if either a product review or tweet can be interp
 For the instantiated/pretrained models, see SentimentDLModel.
 
 **Notes**:
-  - This annotator accepts a label column of a single item in either type of String, Int, Float, or Double.
-    So positive sentiment can be expressed as either `"positive"` or `0`, negative sentiment as `"negative"` or `1`.
-  - [UniversalSentenceEncoder](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder),
-    [BertSentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings), or
-    [SentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings) can be used for the `inputCol`.
+  - This annotator accepts a label column of a single item in either type of
+    String, Int, Float, or Double. So positive sentiment can be expressed as
+    either `"positive"` or `0`, negative sentiment as `"negative"` or `1`.
+  - [UniversalSentenceEncoder](/docs/en/transformers#universalsentenceencoder),
+    [BertSentenceEmbeddings](/docs/en/transformers#bertsentenceembeddings),
+    [SentenceEmbeddings](/docs/en/annotators#sentenceembeddings) or other
+    sentence based embeddings can be used
 
 For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb)
 and the [SentimentDLTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLTestSpec.scala).

--- a/docs/en/annotator_entries/SentimentDetector.md
+++ b/docs/en/annotator_entries/SentimentDetector.md
@@ -62,10 +62,6 @@ SENTIMENT
 {%- endcapture -%}
 
 {%- capture approach_python_example -%}
-import sparknlp
-from sparknlp.base import *
-from sparknlp.annotator import *
-from pyspark.ml import Pipeline
 # In this example, the dictionary `default-sentiment-dict.txt` has the form of
 #
 # ...
@@ -76,6 +72,11 @@ from pyspark.ml import Pipeline
 # ...
 #
 # where each sentiment keyword is delimited by `","`.
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
 
 documentAssembler = DocumentAssembler() \
     .setInputCol("text") \
@@ -129,6 +130,7 @@ result.selectExpr("sentimentScore.result").show(truncate=False)
 // ...
 //
 // where each sentiment keyword is delimited by `","`.
+
 import spark.implicits._
 import com.johnsnowlabs.nlp.DocumentAssembler
 import com.johnsnowlabs.nlp.annotator.Tokenizer

--- a/docs/en/annotator_entries/TypedDependencyParser.md
+++ b/docs/en/annotator_entries/TypedDependencyParser.md
@@ -10,7 +10,7 @@ Dependency parsers provide information about word relationship. For example, dep
 the subjects and objects of a verb are, as well as which words are modifying (describing) the subject. This can help
 you find precise answers to specific questions.
 
-The parser requires the dependant tokens beforehand with e.g. [DependencyParser](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserModel).
+The parser requires the dependant tokens beforehand with e.g. [DependencyParser](/docs/en/annotators#dependencyparser).
 
 Pretrained models can be loaded with `pretrained` of the companion object:
 ```
@@ -185,7 +185,7 @@ Dependency parsers provide information about word relationship. For example, dep
 the subjects and objects of a verb are, as well as which words are modifying (describing) the subject. This can help
 you find precise answers to specific questions.
 
-The parser requires the dependant tokens beforehand with e.g. [DependencyParser](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserModel).
+The parser requires the dependant tokens beforehand with e.g. [DependencyParser](/docs/en/annotators#dependencyparser).
 The required training data can be set in two different ways (only one can be chosen for a particular model):
   - Dataset in the [CoNLL 2009 format](https://ufal.mff.cuni.cz/conll2009-st/trial-data.html) set with `setConll2009`
   - Dataset in the [CoNLL-U format](https://universaldependencies.org/format.html) set with `setConllU`

--- a/docs/en/annotator_entries/ViveknSentiment.md
+++ b/docs/en/annotator_entries/ViveknSentiment.md
@@ -8,7 +8,7 @@ Sentiment analyser inspired by the algorithm by Vivek Narayanan https://github.c
 The algorithm is based on the paper
 ["Fast and accurate sentiment classification using an enhanced Naive Bayes model"](https://arxiv.org/abs/1305.6143).
 
-This is the instantiated model of the [ViveknSentimentApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/sda/vivekn/ViveknSentimentApproach).
+This is the instantiated model of the ViveknSentimentApproach.
 For training your own model, please see the documentation of that class.
 
 The analyzer requires sentence boundaries to give a score in context.

--- a/docs/en/annotator_entries/WordSegmenter.md
+++ b/docs/en/annotator_entries/WordSegmenter.md
@@ -136,16 +136,17 @@ TOKEN
 {%- endcapture -%}
 
 {%- capture approach_python_example -%}
-import sparknlp
-from sparknlp.base import *
-from sparknlp.annotator import *
-from sparknlp.training import *
-from pyspark.ml import Pipeline
 # In this example, `"chinese_train.utf8"` is in the form of
 #
 # 十|LL 四|RR 不|LL 是|RR 四|LL 十|RR
 #
 # and is loaded with the `POS` class to create a dataframe of `"POS"` type Annotations.
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from sparknlp.training import *
+from pyspark.ml import Pipeline
 
 documentAssembler = DocumentAssembler() \
     .setInputCol("text") \
@@ -177,6 +178,7 @@ pipelineModel = pipeline.fit(trainingDataSet)
 // 十|LL 四|RR 不|LL 是|RR 四|LL 十|RR
 //
 // and is loaded with the `POS` class to create a dataframe of `"POS"` type Annotations.
+
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.annotators.ws.WordSegmenterApproach
 import com.johnsnowlabs.nlp.training.POS

--- a/docs/en/annotator_entries/WordSegmenter.md
+++ b/docs/en/annotator_entries/WordSegmenter.md
@@ -121,7 +121,7 @@ To train your own model, a training dataset consisting of
 into a dataframe, where the column is an [Annotation](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/Annotation) of type `"POS"`. This can be
 set with `setPosColumn`.
 
-**Tip**: The helper class [POS](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/training/POS) might be useful to read training data into data frames.
+**Tip**: The helper class [POS](/docs/en/training#pos-dataset) might be useful to read training data into data frames.
 
 For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/tree/master/jupyter/annotation/chinese/word_segmentation)
 and the [WordSegmenterTest](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/WordSegmenterTest.scala).

--- a/docs/en/licensed_annotator_entries/AssertionDL.md
+++ b/docs/en/licensed_annotator_entries/AssertionDL.md
@@ -6,9 +6,9 @@ AssertionDL
 AssertionDL is a deep Learning based approach used to extract Assertion Status
 from extracted entities and text. AssertionDLModel requires DOCUMENT, CHUNK and WORD_EMBEDDINGS type
 annotator inputs, which can be obtained by e.g a
-[DocumentAssembler](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/DocumentAssembler),
-[NerConverter](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/ner/NerConverter)
-and [WordEmbeddingsModel](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel).
+[DocumentAssembler](/docs/en/annotators#documentassembler),
+[NerConverter](/docs/en/annotators#nerconverter)
+and [WordEmbeddingsModel](/docs/en/annotators#wordembeddings).
 The result is an assertion status annotation for each recognized entity.
 Possible values include `“present”, “absent”, “hypothetical”, “conditional”, “associated_with_other_person”` etc.
 

--- a/docs/en/licensed_annotator_entries/AssertionLogReg.md
+++ b/docs/en/licensed_annotator_entries/AssertionLogReg.md
@@ -6,9 +6,9 @@ AssertionLogReg
 This is a main class in AssertionLogReg family. Logarithmic Regression is used to extract Assertion Status
 from extracted entities and text. AssertionLogRegModel requires DOCUMENT, CHUNK and WORD_EMBEDDINGS type
 annotator inputs, which can be obtained by e.g a
-[DocumentAssembler](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/DocumentAssembler),
-[NerConverter](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/ner/NerConverter)
-and [WordEmbeddingsModel](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel).
+[DocumentAssembler](/docs/en/annotators#documentassembler),
+[NerConverter](/docs/en/annotators#nerconverter)
+and [WordEmbeddingsModel](/docs/en/annotators#wordembeddings).
 The result is an assertion status annotation for each recognized entity.
 Possible values are `"Negated", "Affirmed" and "Historical"`.
 

--- a/docs/en/licensed_annotator_entries/DeIdentification.md
+++ b/docs/en/licensed_annotator_entries/DeIdentification.md
@@ -39,11 +39,11 @@ Dr. Gregory House#DOCTOR
 ```
 
 Ideally this annotator works in conjunction with Demographic Named EntityRecognizers that can be trained either using
-[TextMatchers](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/TextMatcher),
-[RegexMatchers](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/RegexMatcher),
-[DateMatchers](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/DateMatcher),
-[NerCRFs](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfApproach) or
-[NerDLs](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach)
+[TextMatchers](/docs/en/annotators#textmatcher),
+[RegexMatchers](/docs/en/annotators#regexmatcher),
+[DateMatchers](/docs/en/annotators#datematcher),
+[NerCRFs](/docs/en/annotators#nercrf) or
+[NerDLs](/docs/en/annotators#nerdl)
 {%- endcapture -%}
 
 {%- capture approach_input_anno -%}

--- a/docs/en/licensed_annotator_entries/IOBTagger.md
+++ b/docs/en/licensed_annotator_entries/IOBTagger.md
@@ -5,8 +5,8 @@ IOBTagger
 {%- capture description -%}
 Merges token tags and NER labels from chunks in the specified format.
 For example output columns as inputs from
-[NerConverter](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/ner/NerConverter.html)
-and [Tokenizer](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/Tokenizer) can be used to merge.
+[NerConverter](/docs/en/annotators#nerconverter)
+and [Tokenizer](/docs/en/annotators#tokenizer) can be used to merge.
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/licensed_annotator_entries/NerDisambiguator.md
+++ b/docs/en/licensed_annotator_entries/NerDisambiguator.md
@@ -29,8 +29,8 @@ Links words of interest, such as names of persons, locations and companies, from
 a corresponding unique entity in a target Knowledge Base (KB). Words of interest are called Named Entities (NEs),
 mentions, or surface forms.
 The model needs extracted CHUNKS and SENTENCE_EMBEDDINGS type input from e.g.
-[SentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddings.html) and
-[NerConverter](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/ner/NerConverter.html).
+[SentenceEmbeddings](/docs/en/annotators#sentenceembeddings) and
+[NerConverter](/docs/en/annotators#nerconverter).
 {%- endcapture -%}
 
 {%- capture approach_input_anno -%}

--- a/docs/en/licensed_annotator_entries/SentenceEntityResolver.md
+++ b/docs/en/licensed_annotator_entries/SentenceEntityResolver.md
@@ -4,7 +4,7 @@ SentenceEntityResolver
 
 {%- capture model_description -%}
 The model transforms a dataset with Input Annotation type SENTENCE_EMBEDDINGS, coming from e.g.
-[BertSentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings.html)
+[BertSentenceEmbeddings](/docs/en/transformers#bertsentenceembeddings)
 and returns the normalized entity for a particular trained ontology / curated dataset.
 (e.g. ICD-10, RxNorm, SNOMED etc.)
 
@@ -177,7 +177,7 @@ val sbert_pipeline_cpt = new Pipeline().setStages(Array(
 {%- capture approach_description -%}
 Contains all the parameters and methods to train a SentenceEntityResolverModel.
 The model transforms a dataset with Input Annotation type SENTENCE_EMBEDDINGS, coming from e.g.
-[BertSentenceEmbeddings](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings.html)
+[BertSentenceEmbeddings](/docs/en/transformers#bertsentenceembeddings)
 and returns the normalized entity for a particular trained ontology / curated dataset.
 (e.g. ICD-10, RxNorm, SNOMED etc.)
 

--- a/docs/en/training.md
+++ b/docs/en/training.md
@@ -10,91 +10,19 @@ use_language_switcher: "Python-Scala"
 ---
 
 ## Training Datasets
+These are classes to load common datasets to train annotators for tasks such as
+part-of-speech tagging, named entity recognition, spell checking and more.
+
+{% include_relative training_entries/pos.md %}
+{% include_relative training_entries/conll.md %}
+{% include_relative training_entries/conllu.md %}
+{% include_relative training_entries/pubtator.md %}
 
 <div class="h3-box" markdown="1">
 
-### POS Dataset
+### Spell Checkers Dataset (Corpus)
 
-In order to train a Part of Speech Tagger annotator, we need to get corpus data as a spark dataframe. There is a component that does this for us: it reads a plain text file and transforms it to a spark dataset.  
-
-**Input File Format:**
-
-```bash
-A|DT few|JJ months|NNS ago|RB you|PRP received|VBD a|DT letter|NN
-```
-
-**Available parameters are:**
-
-- spark: Spark session
-- path(string): Path to file with corpus data for training POS
-- delimiter(string): Delimiter of token and postag. Defaults to `|`
-- outputPosCol(string): Name of the column with POS values. Defaults to "tags".
-
-**Example:**  
-
-Refer to the [POS](https://nlp.johnsnowlabs.com/api/index#com.johnsnowlabs.nlp.training.POS) Scala docs for more details on the API.
-
-<div class="tabs-box" markdown="1">
-
-{% include programmingLanguageSelectScalaPython.html %}
-
-```python
-from sparknlp.training import POS
-train_pos = POS().readDataset(spark, "./src/main/resources/anc-pos-corpus")
-```
-
-```scala
-import com.johnsnowlabs.nlp.training.POS
-val trainPOS = POS().readDataset(spark, "./src/main/resources/anc-pos-corpus")
-```
-
-</div></div><div class="h3-box" markdown="1">
-
-### CoNLL Dataset
-
-In order to train a Named Entity Recognition DL annotator, we need to get CoNLL format data as a spark dataframe. There is a component that does this for us: it reads a plain text file and transforms it to a spark dataset.
-
-**Constructor parameters:**
-
-- documentCol: String = "document",
-- sentenceCol: String = "sentence",
-- tokenCol: String = "token",
-- posCol: String = "pos",
-- conllLabelIndex: Int = 3,
-- conllPosIndex: Int = 1,
-- conllTextCol: String = "text",
-- labelCol: String = "label",
-- explodeSentences: Boolean = false
-
-**Available parameters are:**
-
-- spark: Spark session
-- path(string): Path to a [CoNLL 2003 IOB NER file](https://www.clips.uantwerpen.be/conll2003/ner).
-- readAs(string): Can be LINE_BY_LINE or SPARK_DATASET, with options if latter is used (default LINE_BY_LINE)
-
-**Example:**
-
-Refer to the [CoNLL](https://nlp.johnsnowlabs.com/api/index#com.johnsnowlabs.nlp.training.CoNLL) Scala docs for more details on the API.
-
-<div class="tabs-box" markdown="1">
-
-{% include programmingLanguageSelectScalaPython.html %}
-
-```python
-from sparknlp.training import CoNLL
-training_conll = CoNLL().readDataset(spark, "./src/main/resources/conll2003/eng.train")
-```
-
-```scala
-import com.johnsnowlabs.nlp.training.CoNLL
-val trainingConll = CoNLL().readDataset(spark, "./src/main/resources/conll2003/eng.train")
-```
-
-</div></div><div class="h3-box" markdown="1">
-
-### Spell Checkers Dataset
-
-In order to train a Norvig or Symmetric Spell Checkers, we need to get corpus data as a spark dataframe. We can read a plain text file and transforms it to a spark dataset.  
+In order to train a Norvig or Symmetric Spell Checkers, we need to get corpus data as a spark dataframe. We can read a plain text file and transforms it to a spark dataset.
 
 **Example:**
 
@@ -103,40 +31,62 @@ In order to train a Norvig or Symmetric Spell Checkers, we need to get corpus da
 {% include programmingLanguageSelectScalaPython.html %}
 
 ```python
-train_corpus = spark.read.text("./sherlockholmes.txt")
-                    .withColumnRenamed("value", "text")
+train_corpus = spark.read \
+    .text("./sherlockholmes.txt") \
+    .withColumnRenamed("value", "text")
 ```
 
 ```scala
-val trainCorpus = spark.read.text("./sherlockholmes.txt")
-                       .select(trainCorpus.col("value").as("text"))
+val trainCorpus = spark.read
+    .text("./sherlockholmes.txt")
+    .select(trainCorpus.col("value").as("text"))
 ```
 
-</div></div><div class="h3-box" markdown="1">
+</div></div>
 
-### Vivekn Sentiment Analysis Dataset
+## Text Processing
+These are annotators that can be trained to process text for tasks such as
+dependency parsing, lemmatisation, part-of-speech tagging, sentence detection
+and word segmentation.
 
-To train ViveknSentimentApproach, it is needed to have input columns DOCUMENT and TOKEN, and a String column which is set with `setSentimentCol` stating either `positive` or `negative`
+{% include_relative training_entries/DependencyParser.md %}
+{% include_relative training_entries/Lemmatizer.md %}
+{% include_relative training_entries/Perceptron.md %}
+{% include_relative training_entries/SentenceDetectorDL.md %}
+{% include_relative training_entries/TypedDependencyParser.md %}
+{% include_relative training_entries/WordSegmenter.md %}
 
-</div>
+## Spell Checkers
+These are annotators that can be trained to correct text.
 
-### PubTator Dataset
+{% include_relative training_entries/ContextSpellChecker.md %}
+{% include_relative training_entries/NorvigSweeting.md %}
+{% include_relative training_entries/SymmetricDelete.md %}
 
-The PubTator format includes medical papers' titles, abstracts, and tagged chunks (see [PubTator Docs](http://bioportal.bioontology.org/ontologies/EDAM?p=classes&conceptid=format_3783) and [MedMentions Docs](http://github.com/chanzuckerberg/MedMentions) for more information). We can create a Spark DataFrame from a PubTator text file.
+## Token Classification
+These are annotators that can be trained to recognize named entities in text.
 
-**Available parameters are:**
+{% include_relative training_entries/NerCrf.md %}
+{% include_relative training_entries/NerDL.md %}
 
-- spark: Spark session
-- path(string): Path to a PubTator File
+## Text Classification
+These are annotators that can be trained to classify text into different
+classes, such as sentiment.
 
-**Example:**
+{% include_relative training_entries/ClassifierDL.md %}
+{% include_relative training_entries/MultiClassifierDL.md %}
+{% include_relative training_entries/SentimentDL.md %}
+{% include_relative training_entries/ViveknSentiment.md %}
 
-```scala
-import com.johnsnowlabs.nlp.training.PubTator
-val trainingPubTatorDF = PubTator.readDataset(spark, "./src/test/resources/corpus_pubtator.txt")
-```
+## External Trainable Models
+These are annotators that are trained in an external library, which are then
+loaded into Spark NLP.
 
-### TensorFlow Graphs
+{% include_relative training_entries/BertForTokenClassification.md %}
+{% include_relative training_entries/DistilBertForTokenClassification.md %}
+
+
+## TensorFlow Graphs
 NER DL uses Char CNNs - BiLSTM - CRF Neural Network architecture. Spark NLP defines this architecture through a Tensorflow graph, which requires the following parameters:
 
 - Tags

--- a/docs/en/training_entries/BertForTokenClassification.md
+++ b/docs/en/training_entries/BertForTokenClassification.md
@@ -1,0 +1,177 @@
+{%- capture title -%}
+BertForTokenClassification
+{%- endcapture -%}
+
+{%- capture description -%}
+BertForTokenClassification can load Bert Models with a token classification head
+on top (a linear layer on top of the hidden-states output) e.g. for
+Named-Entity-Recognition (NER) tasks.
+
+Since Spark NLP 3.2.x, this annotator needs to be trained externally using the
+transformers library. After the training process is done, the model checkpoint
+can be loaded by this annotator. This is done with `loadSavedModel` (for loading
+the transformers model) and `load` for the saved Spark NLP model.
+
+For an extended example see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BertForTokenClassification.ipynb).
+
+Example for loading a saved transformers model:
+```python
+# Installing prerequisites
+!pip install -q transformers==4.8.1 tensorflow==2.4.1 spark-nlp>=3.2.0
+
+# Loading the external transformers model
+from transformers import TFBertForTokenClassification, BertTokenizer
+
+MODEL_NAME = 'dslim/bert-base-NER'
+
+tokenizer = BertTokenizer.from_pretrained(MODEL_NAME)
+tokenizer.save_pretrained('./{}_tokenizer/'.format(MODEL_NAME))
+
+model = TFBertForTokenClassification.from_pretrained(MODEL_NAME)
+model.save_pretrained("./{}".format(MODEL_NAME), saved_model=True)
+
+# Extracting the tokenizer resources
+asset_path = '{}/saved_model/1/assets'.format(MODEL_NAME)
+
+!cp {MODEL_NAME}_tokenizer/vocab.txt {asset_path}
+
+# Get label2id dictionary
+labels = model.config.label2id
+# Sort the dictionary based on the id
+labels = sorted(labels, key=labels.get)
+
+with open(asset_path+'/labels.txt', 'w') as f:
+    f.write('\n'.join(labels))
+```
+
+Then the model can be loaded and used into Spark NLP in the following examples:
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+DOCUMENT, TOKEN
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+NAMED_ENTITY
+{%- endcapture -%}
+
+{%- capture python_example -%}
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+tokenizer = Tokenizer() \
+    .setInputCols(["document"]) \
+    .setOutputCol("token")
+
+MODEL_NAME = 'dslim/bert-base-NER'
+tokenClassifier = BertForTokenClassification.loadSavedModel(
+    '{}/saved_model/1'.format(MODEL_NAME),
+    spark) \
+    .setInputCols(["document",'token']) \
+    .setOutputCol("ner") \
+    .setCaseSensitive(True) \
+    .setMaxSentenceLength(128)
+
+# Optionally the classifier can be saved to load it more conveniently into Spark NLP
+tokenClassifier.write().overwrite().save("./{}_spark_nlp".format(MODEL_NAME))
+
+tokenClassifier = BertForTokenClassification.load("./{}_spark_nlp".format(MODEL_NAME))\
+  .setInputCols(["document",'token'])\
+  .setOutputCol("label")
+
+pipeline = Pipeline().setStages([
+    documentAssembler,
+    tokenizer,
+    tokenClassifier
+])
+
+data = spark.createDataFrame([["John Lenon was born in London and lived in Paris. My name is Sarah and I live in London"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+result.select("label.result").show(truncate=False)
++------------------------------------------------------------------------------------+
+|result                                                                              |
++------------------------------------------------------------------------------------+
+|[B-PER, I-PER, O, O, O, B-LOC, O, O, O, B-LOC, O, O, O, O, B-PER, O, O, O, O, B-LOC]|
++------------------------------------------------------------------------------------+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+// The model needs to be trained with the transformers library.
+// Afterwards it can be loaded into the scala version of Spark NLP.
+
+import spark.implicits._
+import com.johnsnowlabs.nlp.base._
+import com.johnsnowlabs.nlp.annotator._
+import org.apache.spark.ml.Pipeline
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val tokenizer = new Tokenizer()
+  .setInputCols("document")
+  .setOutputCol("token")
+
+val modelName = "dslim/bert-base-NER"
+var tokenClassifier = BertForTokenClassification.loadSavedModel(s"$modelName/saved_model/1", spark)
+  .setInputCols("token", "document")
+  .setOutputCol("label")
+  .setCaseSensitive(true)
+  .setMaxSentenceLength(128)
+
+// Optionally the classifier can be saved to load it more conveniently into Spark NLP
+tokenClassifier.write.overwrite.save(s"${modelName}_spark_nlp")
+
+tokenClassifier = BertForTokenClassification.load(s"${modelName}_spark_nlp")
+  .setInputCols("token", "document")
+  .setOutputCol("label")
+  .setCaseSensitive(true)
+
+val pipeline = new Pipeline().setStages(Array(
+  documentAssembler,
+  tokenizer,
+  tokenClassifier
+))
+
+val data = Seq("John Lenon was born in London and lived in Paris. My name is Sarah and I live in London").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+result.select("label.result").show(false)
++------------------------------------------------------------------------------------+
+|result                                                                              |
++------------------------------------------------------------------------------------+
+|[B-PER, I-PER, O, O, O, B-LOC, O, O, O, B-LOC, O, O, O, O, B-PER, O, O, O, O, B-LOC]|
++------------------------------------------------------------------------------------+
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[BertForTokenClassification](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[BertForTokenClassification](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.BertForTokenClassification.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[BertForTokenClassification](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/ClassifierDL.md
+++ b/docs/en/training_entries/ClassifierDL.md
@@ -1,0 +1,142 @@
+{%- capture title -%}
+ClassifierDLApproach
+{%- endcapture -%}
+
+{%- capture description -%}
+Trains a ClassifierDL for generic Multi-class Text Classification.
+
+ClassifierDL uses the state-of-the-art Universal Sentence Encoder as an input for text classifications.
+The ClassifierDL annotator uses a deep learning model (DNNs) we have built inside TensorFlow and supports up to
+100 classes.
+
+For extended examples of usage, see the Spark NLP Workshop
+[[1] ](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/scala/training/Train%20Multi-Class%20Text%20Classification%20on%20News%20Articles.scala)
+[[2] ](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.Text_Classification_with_ClassifierDL.ipynb).
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+SENTENCE_EMBEDDINGS
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+CATEGORY
+{%- endcapture -%}
+
+{%- capture python_example -%}
+# In this example, the training data `"sentiment.csv"` has the form of
+#
+# text,label
+# This movie is the best movie I have wached ever! In my opinion this movie can win an award.,0
+# This was a terrible movie! The acting was bad really bad!,1
+# ...
+#
+# Then traning can be done like so:
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+smallCorpus = spark.read.option("header","True").csv("src/test/resources/classifier/sentiment.csv")
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+useEmbeddings = UniversalSentenceEncoder.pretrained() \
+    .setInputCols("document") \
+    .setOutputCol("sentence_embeddings")
+
+docClassifier = ClassifierDLApproach() \
+    .setInputCols("sentence_embeddings") \
+    .setOutputCol("category") \
+    .setLabelColumn("label") \
+    .setBatchSize(64) \
+    .setMaxEpochs(20) \
+    .setLr(5e-3) \
+    .setDropout(0.5)
+
+pipeline = Pipeline() \
+    .setStages(
+      [
+        documentAssembler,
+        useEmbeddings,
+        docClassifier
+      ]
+    )
+
+pipelineModel = pipeline.fit(smallCorpus)
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+// In this example, the training data `"sentiment.csv"` has the form of
+//
+// text,label
+// This movie is the best movie I have wached ever! In my opinion this movie can win an award.,0
+// This was a terrible movie! The acting was bad really bad!,1
+// ...
+//
+// Then traning can be done like so:
+
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.embeddings.UniversalSentenceEncoder
+import com.johnsnowlabs.nlp.annotators.classifier.dl.ClassifierDLApproach
+import org.apache.spark.ml.Pipeline
+
+val smallCorpus = spark.read.option("header","true").csv("src/test/resources/classifier/sentiment.csv")
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val useEmbeddings = UniversalSentenceEncoder.pretrained()
+  .setInputCols("document")
+  .setOutputCol("sentence_embeddings")
+
+val docClassifier = new ClassifierDLApproach()
+  .setInputCols("sentence_embeddings")
+  .setOutputCol("category")
+  .setLabelColumn("label")
+  .setBatchSize(64)
+  .setMaxEpochs(20)
+  .setLr(5e-3f)
+  .setDropout(0.5f)
+
+val pipeline = new Pipeline()
+  .setStages(
+    Array(
+      documentAssembler,
+      useEmbeddings,
+      docClassifier
+    )
+  )
+
+val pipelineModel = pipeline.fit(smallCorpus)
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[ClassifierDLApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[ClassifierDLApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.ClassifierDLApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[ClassifierDLApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLApproach.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+note="This annotator accepts a label column of a single item in either type of String, Int, Float, or Double. UniversalSentenceEncoder, BertSentenceEmbeddings, or SentenceEmbeddings can be used for the inputCol"
+%}

--- a/docs/en/training_entries/ContextSpellChecker.md
+++ b/docs/en/training_entries/ContextSpellChecker.md
@@ -1,0 +1,131 @@
+{%- capture title -%}
+ContextSpellCheckerApproach
+{%- endcapture -%}
+
+{%- capture description -%}
+Trains a deep-learning based Noisy Channel Model Spell Algorithm.
+Correction candidates are extracted combining context information and word information.
+
+Spell Checking is a sequence to sequence mapping problem. Given an input sequence, potentially containing a
+certain number of errors, `ContextSpellChecker` will rank correction sequences according to three things:
+ 1. Different correction candidates for each word — **word level**.
+ 2. The surrounding text of each word, i.e. it’s context — **sentence level**.
+ 3. The relative cost of different correction candidates according to the edit operations at the character level it requires — **subword level**.
+
+For an in-depth explanation of the module see the article [Applying Context Aware Spell Checking in Spark NLP](https://medium.com/spark-nlp/applying-context-aware-spell-checking-in-spark-nlp-3c29c46963bc).
+
+For extended examples of usage, see the article [Training a Contextual Spell Checker for Italian Language](https://towardsdatascience.com/training-a-contextual-spell-checker-for-italian-language-66dda528e4bf),
+the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/blogposts/5.TrainingContextSpellChecker.ipynb).
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+TOKEN
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+TOKEN
+{%- endcapture -%}
+
+{%- capture python_example -%}
+# For this example, we use the first Sherlock Holmes book as the training dataset.
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+
+tokenizer = Tokenizer() \
+    .setInputCols("document") \
+    .setOutputCol("token")
+
+spellChecker = ContextSpellCheckerApproach() \
+    .setInputCols("token") \
+    .setOutputCol("corrected") \
+    .setWordMaxDistance(3) \
+    .setBatchSize(24) \
+    .setEpochs(8) \
+    .setLanguageModelClasses(1650)  # dependant on vocabulary size
+    # .addVocabClass("_NAME_", names) # Extra classes for correction could be added like this
+
+pipeline = Pipeline().setStages([
+    documentAssembler,
+    tokenizer,
+    spellChecker
+])
+
+path = "sherlockholmes.txt"
+dataset = spark.read.text(path) \
+    .toDF("text")
+pipelineModel = pipeline.fit(dataset)
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+// For this example, we use the first Sherlock Holmes book as the training dataset.
+
+import spark.implicits._
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.annotators.spell.context.ContextSpellCheckerApproach
+
+import org.apache.spark.ml.Pipeline
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+
+val tokenizer = new Tokenizer()
+  .setInputCols("document")
+  .setOutputCol("token")
+
+val spellChecker = new ContextSpellCheckerApproach()
+  .setInputCols("token")
+  .setOutputCol("corrected")
+  .setWordMaxDistance(3)
+  .setBatchSize(24)
+  .setEpochs(8)
+  .setLanguageModelClasses(1650)  // dependant on vocabulary size
+  // .addVocabClass("_NAME_", names) // Extra classes for correction could be added like this
+
+val pipeline = new Pipeline().setStages(Array(
+  documentAssembler,
+  tokenizer,
+  spellChecker
+))
+
+val path = "src/test/resources/spell/sherlockholmes.txt"
+val dataset = spark.sparkContext.textFile(path)
+  .toDF("text")
+val pipelineModel = pipeline.fit(dataset)
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[ContextSpellCheckerApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[ContextSpellCheckerApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.ContextSpellCheckerApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[ContextSpellCheckerApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/DependencyParser.md
+++ b/docs/en/training_entries/DependencyParser.md
@@ -1,0 +1,154 @@
+{%- capture title -%}
+DependencyParserApproach
+{%- endcapture -%}
+
+{%- capture description -%}
+Trains an unlabeled parser that finds a grammatical relations between two words in a sentence.
+
+Dependency parser provides information about word relationship. For example, dependency parsing can tell you what
+the subjects and objects of a verb are, as well as which words are modifying (describing) the subject. This can help
+you find precise answers to specific questions.
+
+The required training data can be set in two different ways (only one can be chosen for a particular model):
+  - Dependency treebank in the [Penn Treebank format](http://www.nltk.org/nltk_data/) set with `setDependencyTreeBank`. Data Format:
+    ```
+    (S
+    (S-TPC-1
+      (NP-SBJ
+        (NP (NP (DT A) (NN form)) (PP (IN of) (NP (NN asbestos))))
+        (RRC ...)...)...)
+    ...
+    (VP (VBD reported) (SBAR (-NONE- 0) (S (-NONE- *T*-1))))
+    (. .))
+    ```
+  - Dataset in the [CoNLL-U format](https://universaldependencies.org/format.html) set with `setConllU`.
+    Data Format:
+    ```
+    -DOCSTART- -X- -X- O
+
+    EU NNP B-NP B-ORG
+    rejects VBZ B-VP O
+    German JJ B-NP B-MISC
+    ```
+
+Apart from that, no additional training data is needed.
+
+See [DependencyParserApproachTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserApproachTestSpec.scala) for further reference on how to use this API.
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+DOCUMENT, POS, TOKEN
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+DEPENDENCY
+{%- endcapture -%}
+
+{%- capture python_example -%}
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+sentence = SentenceDetector() \
+    .setInputCols("document") \
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer() \
+    .setInputCols("sentence") \
+    .setOutputCol("token")
+
+posTagger = PerceptronModel.pretrained() \
+    .setInputCols("sentence", "token") \
+    .setOutputCol("pos")
+
+dependencyParserApproach = DependencyParserApproach() \
+    .setInputCols("sentence", "pos", "token") \
+    .setOutputCol("dependency") \
+    .setDependencyTreeBank("src/test/resources/parser/unlabeled/dependency_treebank")
+
+pipeline = Pipeline().setStages([
+    documentAssembler,
+    sentence,
+    tokenizer,
+    posTagger,
+    dependencyParserApproach
+])
+
+# Additional training data is not needed, the dependency parser relies on the dependency tree bank / CoNLL-U only.
+emptyDataSet = spark.createDataFrame([[""]]).toDF("text")
+pipelineModel = pipeline.fit(emptyDataSet)
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+import spark.implicits._
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.annotators.pos.perceptron.PerceptronModel
+import com.johnsnowlabs.nlp.annotators.parser.dep.DependencyParserApproach
+import org.apache.spark.ml.Pipeline
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val sentence = new SentenceDetector()
+  .setInputCols("document")
+  .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+  .setInputCols("sentence")
+  .setOutputCol("token")
+
+val posTagger = PerceptronModel.pretrained()
+  .setInputCols("sentence", "token")
+  .setOutputCol("pos")
+
+val dependencyParserApproach = new DependencyParserApproach()
+  .setInputCols("sentence", "pos", "token")
+  .setOutputCol("dependency")
+  .setDependencyTreeBank("src/test/resources/parser/unlabeled/dependency_treebank")
+
+val pipeline = new Pipeline().setStages(Array(
+  documentAssembler,
+  sentence,
+  tokenizer,
+  posTagger,
+  dependencyParserApproach
+))
+
+// Additional training data is not needed, the dependency parser relies on the dependency tree bank / CoNLL-U only.
+val emptyDataSet = Seq.empty[String].toDF("text")
+val pipelineModel = pipeline.fit(emptyDataSet)
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[DependencyParserApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[DependencyParserApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.DependencyParserApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[DependencyParserApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserApproach.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/DistilBertForTokenClassification.md
+++ b/docs/en/training_entries/DistilBertForTokenClassification.md
@@ -1,0 +1,181 @@
+{%- capture title -%}
+DistilBertForTokenClassification
+{%- endcapture -%}
+
+{%- capture description -%}
+DistilBertForTokenClassification can load Bert Models with a token classification head on top (a linear layer on top of the hidden-states output)
+e.g. for Named-Entity-Recognition (NER) tasks.
+
+Since Spark NLP 3.2.x, this annotator needs to be trained externally using the
+transformers library. After the training process is done, the model checkpoint
+can be loaded by this annotator. This is done with `loadSavedModel` (for loading
+the transformers model) and `load` for the saved Spark NLP model.
+
+For an extended example see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/transformers/HuggingFace%20in%20Spark%20NLP%20-%20DistilBertForTokenClassification.ipynb).
+
+Example for loading a saved transformers model:
+```python
+# Installing prerequisites
+!pip install -q transformers==4.8.1 tensorflow==2.4.1 spark-nlp>=3.2.0
+
+# Loading the external transformers model
+from transformers import TFDistilBertForTokenClassification, DistilBertTokenizer
+
+MODEL_NAME = 'elastic/distilbert-base-cased-finetuned-conll03-english'
+
+tokenizer = DistilBertTokenizer.from_pretrained(MODEL_NAME)
+tokenizer.save_pretrained('./{}_tokenizer/'.format(MODEL_NAME))
+
+# let's add from_pt=True since there is no TF weights available for this model
+# from_pt=True will convert the pytorch model to tf model
+
+model = TFDistilBertForTokenClassification.from_pretrained(MODEL_NAME, from_pt=True)
+model.save_pretrained("./{}".format(MODEL_NAME), saved_model=True)
+
+# Extracting the tokenizer resources
+asset_path = '{}/saved_model/1/assets'.format(MODEL_NAME)
+
+!cp {MODEL_NAME}_tokenizer/vocab.txt {asset_path}
+
+# Get label2id dictionary
+labels = model.config.label2id
+# Sort the dictionary based on the id
+labels = sorted(labels, key=labels.get)
+
+with open(asset_path+'/labels.txt', 'w') as f:
+    f.write('\n'.join(labels))
+```
+
+Then the model can be loaded and used into Spark NLP in the following examples:
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+DOCUMENT, TOKEN
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+NAMED_ENTITY
+{%- endcapture -%}
+
+{%- capture python_example -%}
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+spark = sparknlp.start()
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+tokenizer = Tokenizer() \
+    .setInputCols(["document"]) \
+    .setOutputCol("token")
+
+MODEL_NAME = 'elastic/distilbert-base-cased-finetuned-conll03-english'
+tokenClassifier = DistilBertForTokenClassification.loadSavedModel(
+    '{}/saved_model/1'.format(MODEL_NAME),
+    spark) \
+    .setInputCols(["document",'token']) \
+    .setOutputCol("label") \
+    .setCaseSensitive(True) \
+    .setMaxSentenceLength(128)
+
+# Optionally the classifier can be saved to load it more conveniently into Spark NLP
+tokenClassifier.write().overwrite().save("./{}_spark_nlp".format(MODEL_NAME))
+
+tokenClassifier = DistilBertForTokenClassification.load("./{}_spark_nlp".format(MODEL_NAME))\
+  .setInputCols(["document",'token'])\
+  .setOutputCol("label")
+
+pipeline = Pipeline().setStages([
+    documentAssembler,
+    tokenizer,
+    tokenClassifier
+])
+
+data = spark.createDataFrame([["John Lenon was born in London and lived in Paris. My name is Sarah and I live in London"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+result.select("label.result").show(truncate=False)
++------------------------------------------------------------------------------------+
+|result                                                                              |
++------------------------------------------------------------------------------------+
+|[B-PER, I-PER, O, O, O, B-LOC, O, O, O, B-LOC, O, O, O, O, B-PER, O, O, O, O, B-LOC]|
++------------------------------------------------------------------------------------+
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+// The model needs to be trained with the transformers library.
+// Afterwards it can be loaded into the scala version of Spark NLP.
+
+import spark.implicits._
+import com.johnsnowlabs.nlp.base._
+import com.johnsnowlabs.nlp.annotator._
+import org.apache.spark.ml.Pipeline
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val tokenizer = new Tokenizer()
+  .setInputCols("document")
+  .setOutputCol("token")
+
+val modelName = "elastic/distilbert-base-cased-finetuned-conll03-english"
+var tokenClassifier = DistilBertForTokenClassification.loadSavedModel(s"$modelName/saved_model/1", spark)
+  .setInputCols("token", "document")
+  .setOutputCol("label")
+  .setCaseSensitive(true)
+  .setMaxSentenceLength(128)
+
+// Optionally the classifier can be saved to load it more conveniently into Spark NLP
+tokenClassifier.write.overwrite.save(s"${modelName}_spark_nlp")
+
+tokenClassifier = DistilBertForTokenClassification.load(s"${modelName}_spark_nlp")
+  .setInputCols("token", "document")
+  .setOutputCol("label")
+  .setCaseSensitive(true)
+
+val pipeline = new Pipeline().setStages(Array(
+  documentAssembler,
+  tokenizer,
+  tokenClassifier
+))
+
+val data = Seq("John Lenon was born in London and lived in Paris. My name is Sarah and I live in London").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+result.select("label.result").show(false)
++------------------------------------------------------------------------------------+
+|result                                                                              |
++------------------------------------------------------------------------------------+
+|[B-PER, I-PER, O, O, O, B-LOC, O, O, O, B-LOC, O, O, O, O, B-PER, O, O, O, O, B-LOC]|
++------------------------------------------------------------------------------------+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[DistilBertForTokenClassification](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[DistilBertForTokenClassification](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.DistilBertForTokenClassification.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[DistilBertForTokenClassification](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/Lemmatizer.md
+++ b/docs/en/training_entries/Lemmatizer.md
@@ -1,0 +1,156 @@
+{%- capture title -%}
+Lemmatizer
+{%- endcapture -%}
+
+{%- capture description -%}
+Class to find lemmas out of words with the objective of returning a base dictionary word.
+Retrieves the significant part of a word. A dictionary of predefined lemmas must be provided with `setDictionary`.
+The dictionary can be set as a delimited text file.
+Pretrained models can be loaded with `LemmatizerModel.pretrained`.
+
+For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/2.Text_Preprocessing_with_SparkNLP_Annotators_Transformers.ipynb).
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+TOKEN
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+TOKEN
+{%- endcapture -%}
+
+{%- capture python_example -%}
+# In this example, the lemma dictionary `lemmas_small.txt` has the form of
+#
+# ...
+# pick	->	pick	picks	picking	picked
+# peck	->	peck	pecking	pecked	pecks
+# pickle	->	pickle	pickles	pickled	pickling
+# pepper	->	pepper	peppers	peppered	peppering
+# ...
+#
+# where each key is delimited by `->` and values are delimited by `\t`
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+sentenceDetector = SentenceDetector() \
+    .setInputCols(["document"]) \
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer() \
+    .setInputCols(["sentence"]) \
+    .setOutputCol("token")
+
+lemmatizer = Lemmatizer() \
+    .setInputCols(["token"]) \
+    .setOutputCol("lemma") \
+    .setDictionary("src/test/resources/lemma-corpus-small/lemmas_small.txt", "->", "\t")
+
+pipeline = Pipeline() \
+    .setStages([
+      documentAssembler,
+      sentenceDetector,
+      tokenizer,
+      lemmatizer
+    ])
+
+data = spark.createDataFrame([["Peter Pipers employees are picking pecks of pickled peppers."]]) \
+    .toDF("text")
+
+result = pipeline.fit(data).transform(data)
+result.selectExpr("lemma.result").show(truncate=False)
++------------------------------------------------------------------+
+|result                                                            |
++------------------------------------------------------------------+
+|[Peter, Pipers, employees, are, pick, peck, of, pickle, pepper, .]|
++------------------------------------------------------------------+
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+// In this example, the lemma dictionary `lemmas_small.txt` has the form of
+//
+// ...
+// pick	->	pick	picks	picking	picked
+// peck	->	peck	pecking	pecked	pecks
+// pickle	->	pickle	pickles	pickled	pickling
+// pepper	->	pepper	peppers	peppered	peppering
+// ...
+//
+// where each key is delimited by `->` and values are delimited by `\t`
+
+import spark.implicits._
+import com.johnsnowlabs.nlp.DocumentAssembler
+import com.johnsnowlabs.nlp.annotator.Tokenizer
+import com.johnsnowlabs.nlp.annotator.SentenceDetector
+import com.johnsnowlabs.nlp.annotators.Lemmatizer
+import org.apache.spark.ml.Pipeline
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetector()
+  .setInputCols(Array("document"))
+  .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+  .setInputCols(Array("sentence"))
+  .setOutputCol("token")
+
+val lemmatizer = new Lemmatizer()
+  .setInputCols(Array("token"))
+  .setOutputCol("lemma")
+  .setDictionary("src/test/resources/lemma-corpus-small/lemmas_small.txt", "->", "\t")
+
+val pipeline = new Pipeline()
+  .setStages(Array(
+    documentAssembler,
+    sentenceDetector,
+    tokenizer,
+    lemmatizer
+  ))
+
+val data = Seq("Peter Pipers employees are picking pecks of pickled peppers.")
+  .toDF("text")
+
+val result = pipeline.fit(data).transform(data)
+result.selectExpr("lemma.result").show(false)
++------------------------------------------------------------------+
+|result                                                            |
++------------------------------------------------------------------+
+|[Peter, Pipers, employees, are, pick, peck, of, pickle, pepper, .]|
++------------------------------------------------------------------+
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[Lemmatizer](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/Lemmatizer)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[Lemmatizer](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.Lemmatizer.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[Lemmatizer](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/Lemmatizer.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/MultiClassifierDL.md
+++ b/docs/en/training_entries/MultiClassifierDL.md
@@ -1,0 +1,187 @@
+{%- capture title -%}
+MultiClassifierDLApproach
+{%- endcapture -%}
+
+{%- capture description -%}
+Trains a MultiClassifierDL for Multi-label Text Classification.
+
+MultiClassifierDL uses a Bidirectional GRU with a convolutional model that we have built inside TensorFlow and supports
+up to 100 classes.
+
+The input to MultiClassifierDL is Sentence Embeddings such as state-of-the-art
+[UniversalSentenceEncoder](docs/en/transformers#universalsentenceencoder),
+[BertSentenceEmbeddings](/docs/en/transformers#bertsentenceembeddings), or
+[SentenceEmbeddings](/docs/en/annotators#sentenceembeddings).
+
+In machine learning, multi-label classification and the strongly related problem of multi-output classification are
+variants of the classification problem where multiple labels may be assigned to each instance. Multi-label
+classification is a generalization of multiclass classification, which is the single-label problem of categorizing
+instances into precisely one of more than two classes; in the multi-label problem there is no constraint on how many
+of the classes the instance can be assigned to.
+Formally, multi-label classification is the problem of finding a model that maps inputs x to binary vectors y
+(assigning a value of 0 or 1 for each element (label) in y).
+
+For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb).
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+SENTENCE_EMBEDDINGS
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+CATEGORY
+{%- endcapture -%}
+
+{%- capture python_example -%}
+# In this example, the training data has the form
+#
+# +----------------+--------------------+--------------------+
+# |              id|                text|              labels|
+# +----------------+--------------------+--------------------+
+# |ed58abb40640f983|PN NewsYou mean ... |             [toxic]|
+# |a1237f726b5f5d89|Dude.  Place the ...|   [obscene, insult]|
+# |24b0d6c8733c2abe|Thanks  - thanks ...|            [insult]|
+# |8c4478fb239bcfc0|" Gee, 5 minutes ...|[toxic, obscene, ...|
+# +----------------+--------------------+--------------------+
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+# Process training data to create text with associated array of labels
+
+trainDataset.printSchema()
+# root
+#  |-- id: string (nullable = true)
+#  |-- text: string (nullable = true)
+#  |-- labels: array (nullable = true)
+#  |    |-- element: string (containsNull = true)
+
+
+# Then create pipeline for training
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document") \
+    .setCleanupMode("shrink")
+
+embeddings = UniversalSentenceEncoder.pretrained() \
+    .setInputCols("document") \
+    .setOutputCol("embeddings")
+
+docClassifier = MultiClassifierDLApproach() \
+    .setInputCols("embeddings") \
+    .setOutputCol("category") \
+    .setLabelColumn("labels") \
+    .setBatchSize(128) \
+    .setMaxEpochs(10) \
+    .setLr(1e-3) \
+    .setThreshold(0.5) \
+    .setValidationSplit(0.1)
+
+pipeline = Pipeline() \
+    .setStages(
+      [
+        documentAssembler,
+        embeddings,
+        docClassifier
+      ]
+    )
+
+pipelineModel = pipeline.fit(trainDataset)
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+// In this example, the training data has the form (Note: labels can be arbitrary)
+//
+// mr,ref
+// "name[Alimentum], area[city centre], familyFriendly[no], near[Burger King]",Alimentum is an adult establish found in the city centre area near Burger King.
+// "name[Alimentum], area[city centre], familyFriendly[yes]",Alimentum is a family-friendly place in the city centre.
+// ...
+//
+// It needs some pre-processing first, so the labels are of type `Array[String]`. This can be done like so:
+
+import spark.implicits._
+import com.johnsnowlabs.nlp.annotators.classifier.dl.MultiClassifierDLApproach
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.embeddings.UniversalSentenceEncoder
+import org.apache.spark.ml.Pipeline
+import org.apache.spark.sql.functions.{col, udf}
+
+// Process training data to create text with associated array of labels
+def splitAndTrim = udf { labels: String =>
+  labels.split(", ").map(x=>x.trim)
+}
+
+val smallCorpus = spark.read
+  .option("header", true)
+  .option("inferSchema", true)
+  .option("mode", "DROPMALFORMED")
+  .csv("src/test/resources/classifier/e2e.csv")
+  .withColumn("labels", splitAndTrim(col("mr")))
+  .withColumn("text", col("ref"))
+  .drop("mr")
+
+smallCorpus.printSchema()
+// root
+// |-- ref: string (nullable = true)
+// |-- labels: array (nullable = true)
+// |    |-- element: string (containsNull = true)
+
+// Then create pipeline for training
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+  .setCleanupMode("shrink")
+
+val embeddings = UniversalSentenceEncoder.pretrained()
+  .setInputCols("document")
+  .setOutputCol("embeddings")
+
+val docClassifier = new MultiClassifierDLApproach()
+  .setInputCols("embeddings")
+  .setOutputCol("category")
+  .setLabelColumn("labels")
+  .setBatchSize(128)
+  .setMaxEpochs(10)
+  .setLr(1e-3f)
+  .setThreshold(0.5f)
+  .setValidationSplit(0.1f)
+
+val pipeline = new Pipeline()
+  .setStages(
+    Array(
+      documentAssembler,
+      embeddings,
+      docClassifier
+    )
+  )
+
+val pipelineModel = pipeline.fit(smallCorpus)
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[MultiClassifierDLApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/classifier/dl/MultiClassifierDLApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[MultiClassifierDLApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.MultiClassifierDLApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[MultiClassifierDLApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MultiClassifierDLApproach.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/NerCrf.md
+++ b/docs/en/training_entries/NerCrf.md
@@ -1,0 +1,138 @@
+{%- capture title -%}
+NerCrfApproach
+{%- endcapture -%}
+
+{%- capture description -%}
+Algorithm for training a Named Entity Recognition Model
+
+This Named Entity recognition annotator allows for a generic model to be trained by utilizing a CRF machine learning
+algorithm. The training data should be a labeled Spark Dataset, e.g. [CoNLL](/docs/en/training#conll-dataset) 2003 IOB with
+`Annotation` type columns. The data should have columns of type `DOCUMENT, TOKEN, POS, WORD_EMBEDDINGS` and an
+additional label column of annotator type `NAMED_ENTITY`.
+Excluding the label, this can be done with for example
+  - a [SentenceDetector](/docs/en/annotators#sentencedetector),
+  - a [Tokenizer](/docs/en/annotators#tokenizer) and
+  - a [PerceptronModel](/docs/en/annotators#postagger-part-of-speech-tagger) and
+  - a [WordEmbeddingsModel](/docs/en/annotators#wordembeddings)
+  (any word embeddings can be chosen, e.g. [BertEmbeddings](/docs/en/transformers#bertembeddings) for BERT based embeddings).
+
+Optionally the user can provide an entity dictionary file with `setExternalFeatures` for better accuracy.
+
+For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/crf-ner/ner_dl_crf.ipynb).
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+DOCUMENT, TOKEN, POS, WORD_EMBEDDINGS
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+NAMED_ENTITY
+{%- endcapture -%}
+
+{%- capture python_example -%}
+# This CoNLL dataset already includes the sentence, token, pos and label column with their respective annotator types.
+# If a custom dataset is used, these need to be defined.
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from sparknlp.training import *
+from pyspark.ml import Pipeline
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+embeddings = WordEmbeddingsModel.pretrained() \
+    .setInputCols(["sentence", "token"]) \
+    .setOutputCol("embeddings") \
+    .setCaseSensitive(False)
+
+nerTagger = NerCrfApproach() \
+    .setInputCols(["sentence", "token", "pos", "embeddings"]) \
+    .setLabelColumn("label") \
+    .setMinEpochs(1) \
+    .setMaxEpochs(3) \
+    .setC0(34) \
+    .setL2(3.0) \
+    .setOutputCol("ner")
+
+pipeline = Pipeline().setStages([
+    documentAssembler,
+    embeddings,
+    nerTagger
+])
+
+
+conll = CoNLL()
+trainingData = conll.readDataset(spark, "src/test/resources/conll2003/eng.train")
+
+pipelineModel = pipeline.fit(trainingData)
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+// This CoNLL dataset already includes the sentence, token, pos and label column with their respective annotator types.
+// If a custom dataset is used, these need to be defined.
+
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.embeddings.WordEmbeddingsModel
+import com.johnsnowlabs.nlp.annotator.NerCrfApproach
+import com.johnsnowlabs.nlp.training.CoNLL
+import org.apache.spark.ml.Pipeline
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val embeddings = WordEmbeddingsModel.pretrained()
+  .setInputCols("sentence", "token")
+  .setOutputCol("embeddings")
+  .setCaseSensitive(false)
+
+val nerTagger = new NerCrfApproach()
+  .setInputCols("sentence", "token", "pos", "embeddings")
+  .setLabelColumn("label")
+  .setMinEpochs(1)
+  .setMaxEpochs(3)
+  .setC0(34)
+  .setL2(3.0)
+  .setOutputCol("ner")
+
+val pipeline = new Pipeline().setStages(Array(
+  documentAssembler,
+  embeddings,
+  nerTagger
+))
+
+
+val conll = CoNLL()
+val trainingData = conll.readDataset(spark, "src/test/resources/conll2003/eng.train")
+
+val pipelineModel = pipeline.fit(trainingData)
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[NerCrfApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[NerCrfApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.NerCrfApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[NerCrfApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfApproach.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/NerDL.md
+++ b/docs/en/training_entries/NerDL.md
@@ -1,0 +1,152 @@
+{%- capture title -%}
+NerDLApproach
+{%- endcapture -%}
+
+{%- capture description -%}
+This Named Entity recognition annotator allows to train generic NER model based on Neural Networks.
+
+The architecture of the neural network is a Char CNNs - BiLSTM - CRF that achieves state-of-the-art in most datasets.
+
+The training data should be a labeled Spark Dataset, in the format of [CoNLL](/docs/en/training#conll-dataset)
+2003 IOB with `Annotation` type columns. The data should have columns of type `DOCUMENT, TOKEN, WORD_EMBEDDINGS` and an
+additional label column of annotator type `NAMED_ENTITY`.
+Excluding the label, this can be done with for example
+  - a [SentenceDetector](/docs/en/annotators#sentencedetector),
+  - a [Tokenizer](/docs/en/annotators#tokenizer) and
+  - a [WordEmbeddingsModel](/docs/en/annotators#wordembeddings)
+  (any word embeddings can be chosen, e.g. [BertEmbeddings](/docs/en/transformers#bertembeddings) for BERT based embeddings).
+
+For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/tree/master/jupyter/training/english/dl-ner).
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+DOCUMENT, TOKEN, WORD_EMBEDDINGS
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+NAMED_ENTITY
+{%- endcapture -%}
+
+{%- capture python_example -%}
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from sparknlp.training import *
+from pyspark.ml import Pipeline
+
+# First extract the prerequisites for the NerDLApproach
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+sentence = SentenceDetector() \
+    .setInputCols(["document"]) \
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer() \
+    .setInputCols(["sentence"]) \
+    .setOutputCol("token")
+
+embeddings = BertEmbeddings.pretrained() \
+    .setInputCols(["sentence", "token"]) \
+    .setOutputCol("embeddings")
+
+# Then the training can start
+nerTagger = NerDLApproach() \
+    .setInputCols(["sentence", "token", "embeddings"]) \
+    .setLabelColumn("label") \
+    .setOutputCol("ner") \
+    .setMaxEpochs(1) \
+    .setRandomSeed(0) \
+    .setVerbose(0)
+
+pipeline = Pipeline().setStages([
+    documentAssembler,
+    sentence,
+    tokenizer,
+    embeddings,
+    nerTagger
+])
+
+# We use the text and labels from the CoNLL dataset
+conll = CoNLL()
+trainingData = conll.readDataset(spark, "src/test/resources/conll2003/eng.train")
+
+pipelineModel = pipeline.fit(trainingData)
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
+import com.johnsnowlabs.nlp.embeddings.BertEmbeddings
+import com.johnsnowlabs.nlp.annotators.ner.dl.NerDLApproach
+import com.johnsnowlabs.nlp.training.CoNLL
+import org.apache.spark.ml.Pipeline
+
+// First extract the prerequisites for the NerDLApproach
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val sentence = new SentenceDetector()
+  .setInputCols("document")
+  .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+  .setInputCols("sentence")
+  .setOutputCol("token")
+
+val embeddings = BertEmbeddings.pretrained()
+  .setInputCols("sentence", "token")
+  .setOutputCol("embeddings")
+
+// Then the training can start
+val nerTagger = new NerDLApproach()
+.setInputCols("sentence", "token", "embeddings")
+.setLabelColumn("label")
+.setOutputCol("ner")
+.setMaxEpochs(1)
+.setRandomSeed(0)
+.setVerbose(0)
+
+val pipeline = new Pipeline().setStages(Array(
+  documentAssembler,
+  sentence,
+  tokenizer,
+  embeddings,
+  nerTagger
+))
+
+// We use the text and labels from the CoNLL dataset
+val conll = CoNLL()
+val trainingData = conll.readDataset(spark, "src/test/resources/conll2003/eng.train")
+
+val pipelineModel = pipeline.fit(trainingData)
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[NerDLApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[NerDLApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.NerDLApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[NerDLApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/NorvigSweeting.md
+++ b/docs/en/training_entries/NorvigSweeting.md
@@ -1,0 +1,121 @@
+{%- capture title -%}
+NorvigSweeting Spellchecker
+{%- endcapture -%}
+
+{%- capture description -%}
+Trains annotator, that retrieves tokens and makes corrections automatically if not found in an English dictionary.
+
+The Symmetric Delete spelling correction algorithm reduces the complexity of edit candidate generation and
+dictionary lookup for a given Damerau-Levenshtein distance. It is six orders of magnitude faster
+(than the standard approach with deletes + transposes + replaces + inserts) and language independent.
+A dictionary of correct spellings must be provided with `setDictionary` as a text file, where each word is parsed by a regex pattern.
+
+For Example a file `"words.txt"`:
+```
+...
+gummy
+gummic
+gummier
+gummiest
+gummiferous
+...
+```
+can be parsed with the regular expression `\S+`, which is the default for `setDictionary`.
+
+This dictionary is then set to be the basis of the spell checker.
+
+Inspired by Norvig model and [SymSpell](https://github.com/wolfgarbe/SymSpell).
+
+For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/vivekn-sentiment/VivekNarayanSentimentApproach.ipynb).
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+TOKEN
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+TOKEN
+{%- endcapture -%}
+
+{%- capture python_example -%}
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+tokenizer = Tokenizer() \
+    .setInputCols(["document"]) \
+    .setOutputCol("token")
+
+spellChecker = NorvigSweetingApproach() \
+    .setInputCols(["token"]) \
+    .setOutputCol("spell") \
+    .setDictionary("src/test/resources/spell/words.txt")
+
+pipeline = Pipeline().setStages([
+    documentAssembler,
+    tokenizer,
+    spellChecker
+])
+
+pipelineModel = pipeline.fit(trainingData)
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.annotators.spell.norvig.NorvigSweetingApproach
+import org.apache.spark.ml.Pipeline
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val tokenizer = new Tokenizer()
+  .setInputCols("document")
+  .setOutputCol("token")
+
+val spellChecker = new NorvigSweetingApproach()
+  .setInputCols("token")
+  .setOutputCol("spell")
+  .setDictionary("src/test/resources/spell/words.txt")
+
+val pipeline = new Pipeline().setStages(Array(
+  documentAssembler,
+  tokenizer,
+  spellChecker
+))
+
+val pipelineModel = pipeline.fit(trainingData)
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[NorvigSweetingApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[NorvigSweetingApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.NorvigSweetingApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[NorvigSweetingApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingApproach.scala)
+{%- endcapture -%}
+
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/Perceptron.md
+++ b/docs/en/training_entries/Perceptron.md
@@ -1,0 +1,161 @@
+{%- capture title -%}
+PerceptronApproach (Part of speech tagger)
+{%- endcapture -%}
+
+{%- capture description -%}
+Trains an averaged Perceptron model to tag words part-of-speech.
+Sets a POS tag to each word within a sentence.
+
+The training data needs to be in a Spark DataFrame, where the column needs to consist of
+[Annotations](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/Annotation) of type `POS`. The `Annotation` needs to have member `result`
+set to the POS tag and have a `"word"` mapping to its word inside of member `metadata`.
+This DataFrame for training can easily created by the helper class [POS](#pos-dataset).
+
+```
+POS().readDataset(spark, datasetPath).selectExpr("explode(tags) as tags").show(false)
++---------------------------------------------+
+|tags                                         |
++---------------------------------------------+
+|[pos, 0, 5, NNP, [word -> Pierre], []]       |
+|[pos, 7, 12, NNP, [word -> Vinken], []]      |
+|[pos, 14, 14, ,, [word -> ,], []]            |
+|[pos, 31, 34, MD, [word -> will], []]        |
+|[pos, 36, 39, VB, [word -> join], []]        |
+|[pos, 41, 43, DT, [word -> the], []]         |
+|[pos, 45, 49, NN, [word -> board], []]       |
+                      ...
+```
+
+For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/french/Train-Perceptron-French.ipynb)
+and [PerceptronApproach tests](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron).
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+TOKEN, DOCUMENT
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+POS
+{%- endcapture -%}
+
+{%- capture python_example -%}
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from sparknlp.training import *
+from pyspark.ml import Pipeline
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+sentence = SentenceDetector() \
+    .setInputCols(["document"]) \
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer() \
+    .setInputCols(["sentence"]) \
+    .setOutputCol("token")
+
+datasetPath = "src/test/resources/anc-pos-corpus-small/test-training.txt"
+trainingPerceptronDF = POS().readDataset(spark, datasetPath)
+
+trainedPos = PerceptronApproach() \
+    .setInputCols(["document", "token"]) \
+    .setOutputCol("pos") \
+    .setPosColumn("tags") \
+    .fit(trainingPerceptronDF)
+
+pipeline = Pipeline().setStages([
+    documentAssembler,
+    sentence,
+    tokenizer,
+    trainedPos
+])
+
+data = spark.createDataFrame([["To be or not to be, is this the question?"]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+
+result.selectExpr("pos.result").show(truncate=False)
++--------------------------------------------------+
+|result                                            |
++--------------------------------------------------+
+|[NNP, NNP, CD, JJ, NNP, NNP, ,, MD, VB, DT, CD, .]|
++--------------------------------------------------+
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+import spark.implicits._
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotator.SentenceDetector
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.training.POS
+import com.johnsnowlabs.nlp.annotators.pos.perceptron.PerceptronApproach
+import org.apache.spark.ml.Pipeline
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val sentence = new SentenceDetector()
+  .setInputCols("document")
+  .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+  .setInputCols("sentence")
+  .setOutputCol("token")
+
+val datasetPath = "src/test/resources/anc-pos-corpus-small/test-training.txt"
+val trainingPerceptronDF = POS().readDataset(spark, datasetPath)
+
+val trainedPos = new PerceptronApproach()
+  .setInputCols("document", "token")
+  .setOutputCol("pos")
+  .setPosColumn("tags")
+  .fit(trainingPerceptronDF)
+
+val pipeline = new Pipeline().setStages(Array(
+  documentAssembler,
+  sentence,
+  tokenizer,
+  trainedPos
+))
+
+val data = Seq("To be or not to be, is this the question?").toDF("text")
+val result = pipeline.fit(data).transform(data)
+
+result.selectExpr("pos.result").show(false)
++--------------------------------------------------+
+|result                                            |
++--------------------------------------------------+
+|[NNP, NNP, CD, JJ, NNP, NNP, ,, MD, VB, DT, CD, .]|
++--------------------------------------------------+
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[PerceptronApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[PerceptronApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.PerceptronApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[PerceptronApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronApproach.scala)
+{%- endcapture -%}
+
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}
+

--- a/docs/en/training_entries/SentenceDetectorDL.md
+++ b/docs/en/training_entries/SentenceDetectorDL.md
@@ -1,0 +1,121 @@
+{%- capture title -%}
+SentenceDetectorDLApproach
+{%- endcapture -%}
+
+{%- capture description -%}
+Trains an annotator that detects sentence boundaries using a deep learning approach.
+
+For pretrained models see SentenceDetectorDLModel.
+
+Currently, only the CNN model is supported for training, but in the future the architecture of the model can
+be set with `setModelArchitecture`.
+
+The default model `"cnn"` is based on the paper
+[Deep-EOS: General-Purpose Neural Networks for Sentence Boundary Detection (2020, Stefan Schweter, Sajawel Ahmed)](https://konvens.org/proceedings/2019/papers/KONVENS2019_paper_41.pdf)
+using a CNN architecture. We also modified the original implementation a little bit to cover broken sentences and some impossible end of line chars.
+
+Each extracted sentence can be returned in an Array or exploded to separate rows,
+if `explodeSentences` is set to `true`.
+
+For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/9.SentenceDetectorDL.ipynb).
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+DOCUMENT
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+DOCUMENT
+{%- endcapture -%}
+
+{%- capture python_example -%}
+# The training process needs data, where each data point is a sentence.
+# In this example the `train.txt` file has the form of
+#
+# ...
+# Slightly more moderate language would make our present situation – namely the lack of progress – a little easier.
+# His political successors now have great responsibilities to history and to the heritage of values bequeathed to them by Nelson Mandela.
+# ...
+#
+# where each line is one sentence.
+# Training can then be started like so:
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+trainingData = spark.read.text("train.txt").toDF("text")
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+sentenceDetector = SentenceDetectorDLApproach() \
+    .setInputCols(["document"]) \
+    .setOutputCol("sentences") \
+    .setEpochsNumber(100)
+
+pipeline = Pipeline().setStages([documentAssembler, sentenceDetector])
+
+model = pipeline.fit(trainingData)
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+// The training process needs data, where each data point is a sentence.
+// In this example the `train.txt` file has the form of
+//
+// ...
+// Slightly more moderate language would make our present situation – namely the lack of progress – a little easier.
+// His political successors now have great responsibilities to history and to the heritage of values bequeathed to them by Nelson Mandela.
+// ...
+//
+// where each line is one sentence.
+// Training can then be started like so:
+
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotators.sentence_detector_dl.SentenceDetectorDLApproach
+import org.apache.spark.ml.Pipeline
+
+val trainingData = spark.read.text("train.txt").toDF("text")
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val sentenceDetector = new SentenceDetectorDLApproach()
+  .setInputCols(Array("document"))
+  .setOutputCol("sentences")
+  .setEpochsNumber(100)
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, sentenceDetector))
+
+val model = pipeline.fit(trainingData)
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[SentenceDetectorDLApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[SentenceDetectorDLApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.SentenceDetectorDLApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[SentenceDetectorDLApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLApproach.scala)
+{%- endcapture -%}
+
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/SentimentDL.md
+++ b/docs/en/training_entries/SentimentDL.md
@@ -1,0 +1,144 @@
+{%- capture title -%}
+SentimentDLApproach
+{%- endcapture -%}
+
+{%- capture approach_description -%}
+Trains a SentimentDL, an annotator for multi-class sentiment analysis.
+
+In natural language processing, sentiment analysis is the task of classifying the affective state or subjective view
+of a text. A common example is if either a product review or tweet can be interpreted positively or negatively.
+
+For the instantiated/pretrained models, see SentimentDLModel.
+
+**Notes**:
+  - This annotator accepts a label column of a single item in either type of String, Int, Float, or Double.
+    So positive sentiment can be expressed as either `"positive"` or `0`, negative sentiment as `"negative"` or `1`.
+  - Any type of sentence embeddings, such as the [UniversalSentenceEncoder](/docs/en/transformers#universalsentenceencoder),
+    [BertSentenceEmbeddings](/docs/en/transformers#bertsentenceembeddings), or
+    [SentenceEmbeddings](docs/en/annotators#sentenceembeddings) can be used for the `inputCol`.
+
+For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb).
+{%- endcapture -%}
+
+{%- capture approach_input_anno -%}
+SENTENCE_EMBEDDINGS
+{%- endcapture -%}
+
+{%- capture approach_output_anno -%}
+CATEGORY
+{%- endcapture -%}
+
+{%- capture approach_python_example -%}
+# In this example, `sentiment.csv` is in the form
+#
+# text,label
+# This movie is the best movie I have watched ever! In my opinion this movie can win an award.,0
+# This was a terrible movie! The acting was bad really bad!,1
+#
+# The model can then be trained with
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+smallCorpus = spark.read.option("header", "True").csv("src/test/resources/classifier/sentiment.csv")
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+useEmbeddings = UniversalSentenceEncoder.pretrained() \
+    .setInputCols(["document"]) \
+    .setOutputCol("sentence_embeddings")
+
+docClassifier = SentimentDLApproach() \
+    .setInputCols(["sentence_embeddings"]) \
+    .setOutputCol("sentiment") \
+    .setLabelColumn("label") \
+    .setBatchSize(32) \
+    .setMaxEpochs(1) \
+    .setLr(5e-3) \
+    .setDropout(0.5)
+
+pipeline = Pipeline() \
+    .setStages(
+      [
+        documentAssembler,
+        useEmbeddings,
+        docClassifier
+      ]
+    )
+
+pipelineModel = pipeline.fit(smallCorpus)
+
+{%- endcapture -%}
+
+{%- capture approach_scala_example -%}
+// In this example, `sentiment.csv` is in the form
+//
+// text,label
+// This movie is the best movie I have watched ever! In my opinion this movie can win an award.,0
+// This was a terrible movie! The acting was bad really bad!,1
+//
+// The model can then be trained with
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotator.UniversalSentenceEncoder
+import com.johnsnowlabs.nlp.annotators.classifier.dl.{SentimentDLApproach, SentimentDLModel}
+import org.apache.spark.ml.Pipeline
+
+val smallCorpus = spark.read.option("header", "true").csv("src/test/resources/classifier/sentiment.csv")
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val useEmbeddings = UniversalSentenceEncoder.pretrained()
+  .setInputCols("document")
+  .setOutputCol("sentence_embeddings")
+
+val docClassifier = new SentimentDLApproach()
+  .setInputCols("sentence_embeddings")
+  .setOutputCol("sentiment")
+  .setLabelColumn("label")
+  .setBatchSize(32)
+  .setMaxEpochs(1)
+  .setLr(5e-3f)
+  .setDropout(0.5f)
+
+val pipeline = new Pipeline()
+  .setStages(
+    Array(
+      documentAssembler,
+      useEmbeddings,
+      docClassifier
+    )
+  )
+
+val pipelineModel = pipeline.fit(smallCorpus)
+
+{%- endcapture -%}
+
+{%- capture approach_api_link -%}
+[SentimentDLApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLApproach)
+{%- endcapture -%}
+
+{%- capture approach_python_api_link -%}
+[SentimentDLApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.SentimentDLApproach.html)
+{%- endcapture -%}
+
+{%- capture approach_source_link -%}
+[SentimentDLApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLApproach.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/SymmetricDelete.md
+++ b/docs/en/training_entries/SymmetricDelete.md
@@ -1,0 +1,120 @@
+{%- capture title -%}
+SymmetricDelete Spellchecker
+{%- endcapture -%}
+
+{%- capture description -%}
+Trains a Symmetric Delete spelling correction algorithm.
+Retrieves tokens and utilizes distance metrics to compute possible derived words.
+
+A dictionary of correct spellings must be provided with `setDictionary` as a text file, where each word is parsed by a regex pattern.
+
+For Example a file `"words.txt"`:
+```
+...
+gummy
+gummic
+gummier
+gummiest
+gummiferous
+...
+```
+can be parsed with the regular expression `\S+`, which is the default for `setDictionary`.
+
+This dictionary is then set to be the basis of the spell checker.
+
+Inspired by [SymSpell](https://github.com/wolfgarbe/SymSpell).
+
+For instantiated/pretrained models, see SymmetricDeleteModel.
+
+See [SymmetricDeleteModelTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModelTestSpec.scala) for further reference.
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+TOKEN
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+TOKEN
+{%- endcapture -%}
+
+{%- capture python_example -%}
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+tokenizer = Tokenizer() \
+    .setInputCols(["document"]) \
+    .setOutputCol("token")
+
+spellChecker = SymmetricDeleteApproach() \
+    .setInputCols(["token"]) \
+    .setOutputCol("spell") \
+    .setDictionary("src/test/resources/spell/words.txt")
+
+pipeline = Pipeline().setStages([
+    documentAssembler,
+    tokenizer,
+    spellChecker
+])
+
+pipelineModel = pipeline.fit(trainingData)
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.annotators.spell.symmetric.SymmetricDeleteApproach
+import org.apache.spark.ml.Pipeline
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val tokenizer = new Tokenizer()
+  .setInputCols("document")
+  .setOutputCol("token")
+
+val spellChecker = new SymmetricDeleteApproach()
+  .setInputCols("token")
+  .setOutputCol("spell")
+  .setDictionary("src/test/resources/spell/words.txt")
+
+val pipeline = new Pipeline().setStages(Array(
+  documentAssembler,
+  tokenizer,
+  spellChecker
+))
+
+val pipelineModel = pipeline.fit(trainingData)
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[SymmetricDeleteApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[SymmetricDeleteApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.SymmetricDeleteApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[SymmetricDeleteApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteApproach.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/TypedDependencyParser.md
+++ b/docs/en/training_entries/TypedDependencyParser.md
@@ -1,0 +1,166 @@
+{%- capture title -%}
+TypedDependencyParser
+{%- endcapture -%}
+
+{%- capture description -%}
+Labeled parser that finds a grammatical relation between two words in a sentence.
+Its input is either a CoNLL2009 or ConllU dataset.
+
+For instantiated/pretrained models, see TypedDependencyParserModel.
+
+Dependency parsers provide information about word relationship. For example, dependency parsing can tell you what
+the subjects and objects of a verb are, as well as which words are modifying (describing) the subject. This can help
+you find precise answers to specific questions.
+
+The parser requires the dependant tokens beforehand with e.g. [DependencyParser](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserModel).
+The required training data can be set in two different ways (only one can be chosen for a particular model):
+  - Dataset in the [CoNLL 2009 format](https://ufal.mff.cuni.cz/conll2009-st/trial-data.html) set with `setConll2009`. Data format:
+    ```
+    1	The	the	the	DT	DT	_	_	4	4	NMOD	NMOD	_	_	_	_
+    2	most	most	most	RBS	RBS	_	_	3	3	AMOD	AMOD	_	_	_	_
+    3	troublesome	troublesome	troublesome	JJ	JJ	_	_	4	4	NMOD	NMOD	_	_	_	_
+    ```
+  - Dataset in the [CoNLL-U format](https://universaldependencies.org/format.html) set with `setConllU`
+    Data format:
+    ```
+    -DOCSTART- -X- -X- O
+
+    EU NNP B-NP B-ORG
+    rejects VBZ B-VP O
+    German JJ B-NP B-MISC
+    ```
+
+Apart from that, no additional training data is needed.
+
+See [TypedDependencyParserApproachTestSpec](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/annotators/parser/typdep/TypedDependencyParserApproachTestSpec.scala) for further reference on this API.
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+TOKEN, POS, DEPENDENCY
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+LABELED_DEPENDENCY
+{%- endcapture -%}
+
+{%- capture python_example -%}
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+sentence = SentenceDetector() \
+    .setInputCols(["document"]) \
+    .setOutputCol("sentence")
+
+tokenizer = Tokenizer() \
+    .setInputCols(["sentence"]) \
+    .setOutputCol("token")
+
+posTagger = PerceptronModel.pretrained() \
+    .setInputCols(["sentence", "token"]) \
+    .setOutputCol("pos")
+
+dependencyParser = DependencyParserModel.pretrained() \
+    .setInputCols(["sentence", "pos", "token"]) \
+    .setOutputCol("dependency")
+
+typedDependencyParser = TypedDependencyParserApproach() \
+    .setInputCols(["dependency", "pos", "token"]) \
+    .setOutputCol("dependency_type") \
+    .setConllU("src/test/resources/parser/labeled/train_small.conllu.txt") \
+    .setNumberOfIterations(1)
+
+pipeline = Pipeline().setStages([
+    documentAssembler,
+    sentence,
+    tokenizer,
+    posTagger,
+    dependencyParser,
+    typedDependencyParser
+])
+
+# Additional training data is not needed, the dependency parser relies on CoNLL-U only.
+emptyDataSet = spark.createDataFrame([[""]]).toDF("text")
+pipelineModel = pipeline.fit(emptyDataSet)
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+import spark.implicits._
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.annotators.pos.perceptron.PerceptronModel
+import com.johnsnowlabs.nlp.annotators.parser.dep.DependencyParserModel
+import com.johnsnowlabs.nlp.annotators.parser.typdep.TypedDependencyParserApproach
+import org.apache.spark.ml.Pipeline
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val sentence = new SentenceDetector()
+  .setInputCols("document")
+  .setOutputCol("sentence")
+
+val tokenizer = new Tokenizer()
+  .setInputCols("sentence")
+  .setOutputCol("token")
+
+val posTagger = PerceptronModel.pretrained()
+  .setInputCols("sentence", "token")
+  .setOutputCol("pos")
+
+val dependencyParser = DependencyParserModel.pretrained()
+  .setInputCols("sentence", "pos", "token")
+  .setOutputCol("dependency")
+
+val typedDependencyParser = new TypedDependencyParserApproach()
+  .setInputCols("dependency", "pos", "token")
+  .setOutputCol("dependency_type")
+  .setConllU("src/test/resources/parser/labeled/train_small.conllu.txt")
+  .setNumberOfIterations(1)
+
+val pipeline = new Pipeline().setStages(Array(
+  documentAssembler,
+  sentence,
+  tokenizer,
+  posTagger,
+  dependencyParser,
+  typedDependencyParser
+))
+
+// Additional training data is not needed, the dependency parser relies on CoNLL-U only.
+val emptyDataSet = Seq.empty[String].toDF("text")
+val pipelineModel = pipeline.fit(emptyDataSet)
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[TypedDependencyParserApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/parser/typdep/TypedDependencyParserApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[TypedDependencyParserApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.TypedDependencyParserApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[TypedDependencyParserApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/parser/typdep/TypedDependencyParserApproach.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/TypedDependencyParser.md
+++ b/docs/en/training_entries/TypedDependencyParser.md
@@ -12,7 +12,7 @@ Dependency parsers provide information about word relationship. For example, dep
 the subjects and objects of a verb are, as well as which words are modifying (describing) the subject. This can help
 you find precise answers to specific questions.
 
-The parser requires the dependant tokens beforehand with e.g. [DependencyParser](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserModel).
+The parser requires the dependant tokens beforehand with e.g. [DependencyParser](/docs/en/annotators#dependencyparser).
 The required training data can be set in two different ways (only one can be chosen for a particular model):
   - Dataset in the [CoNLL 2009 format](https://ufal.mff.cuni.cz/conll2009-st/trial-data.html) set with `setConll2009`. Data format:
     ```

--- a/docs/en/training_entries/ViveknSentiment.md
+++ b/docs/en/training_entries/ViveknSentiment.md
@@ -1,0 +1,162 @@
+{%- capture title -%}
+ViveknSentimentAproach
+{%- endcapture -%}
+
+{%- capture description -%}
+Trains a sentiment analyser inspired by the algorithm by Vivek Narayanan https://github.com/vivekn/sentiment/.
+
+The algorithm is based on the paper
+["Fast and accurate sentiment classification using an enhanced Naive Bayes model"](https://arxiv.org/abs/1305.6143).
+
+The analyzer requires sentence boundaries to give a score in context.
+Tokenization is needed to make sure tokens are within bounds. Transitivity requirements are also required.
+
+The training data needs to consist of a column for normalized text and a label column (either `"positive"` or `"negative"`).
+
+For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/vivekn-sentiment/VivekNarayanSentimentApproach.ipynb).
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+TOKEN, DOCUMENT
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+SENTIMENT
+{%- endcapture -%}
+
+{%- capture python_example -%}
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+
+document = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+token = Tokenizer() \
+    .setInputCols(["document"]) \
+    .setOutputCol("token")
+
+normalizer = Normalizer() \
+    .setInputCols(["token"]) \
+    .setOutputCol("normal")
+
+vivekn = ViveknSentimentApproach() \
+    .setInputCols(["document", "normal"]) \
+    .setSentimentCol("train_sentiment") \
+    .setOutputCol("result_sentiment")
+
+finisher = Finisher() \
+    .setInputCols(["result_sentiment"]) \
+    .setOutputCols("final_sentiment")
+
+pipeline = Pipeline().setStages([document, token, normalizer, vivekn, finisher])
+
+training = spark.createDataFrame([
+    ("I really liked this movie!", "positive"),
+    ("The cast was horrible", "negative"),
+    ("Never going to watch this again or recommend it to anyone", "negative"),
+    ("It's a waste of time", "negative"),
+    ("I loved the protagonist", "positive"),
+    ("The music was really really good", "positive")
+]).toDF("text", "train_sentiment")
+pipelineModel = pipeline.fit(training)
+
+data = spark.createDataFrame([
+    ["I recommend this movie"],
+    ["Dont waste your time!!!"]
+]).toDF("text")
+result = pipelineModel.transform(data)
+
+result.select("final_sentiment").show(truncate=False)
++---------------+
+|final_sentiment|
++---------------+
+|[positive]     |
+|[negative]     |
++---------------+
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+import spark.implicits._
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.annotators.Normalizer
+import com.johnsnowlabs.nlp.annotators.sda.vivekn.ViveknSentimentApproach
+import com.johnsnowlabs.nlp.Finisher
+import org.apache.spark.ml.Pipeline
+
+val document = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val token = new Tokenizer()
+  .setInputCols("document")
+  .setOutputCol("token")
+
+val normalizer = new Normalizer()
+  .setInputCols("token")
+  .setOutputCol("normal")
+
+val vivekn = new ViveknSentimentApproach()
+  .setInputCols("document", "normal")
+  .setSentimentCol("train_sentiment")
+  .setOutputCol("result_sentiment")
+
+val finisher = new Finisher()
+  .setInputCols("result_sentiment")
+  .setOutputCols("final_sentiment")
+
+val pipeline = new Pipeline().setStages(Array(document, token, normalizer, vivekn, finisher))
+
+val training = Seq(
+  ("I really liked this movie!", "positive"),
+  ("The cast was horrible", "negative"),
+  ("Never going to watch this again or recommend it to anyone", "negative"),
+  ("It's a waste of time", "negative"),
+  ("I loved the protagonist", "positive"),
+  ("The music was really really good", "positive")
+).toDF("text", "train_sentiment")
+val pipelineModel = pipeline.fit(training)
+
+val data = Seq(
+  "I recommend this movie",
+  "Dont waste your time!!!"
+).toDF("text")
+val result = pipelineModel.transform(data)
+
+result.select("final_sentiment").show(false)
++---------------+
+|final_sentiment|
++---------------+
+|[positive]     |
+|[negative]     |
++---------------+
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[ViveknSentimentApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/sda/vivekn/ViveknSentimentApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[ViveknSentimentApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.ViveknSentimentApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[ViveknSentimentApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/sda/vivekn/ViveknSentimentApproach.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/WordSegmenter.md
+++ b/docs/en/training_entries/WordSegmenter.md
@@ -1,0 +1,126 @@
+{%- capture title -%}
+WordSegmenterApproach
+{%- endcapture -%}
+
+{%- capture description -%}
+Trains a WordSegmenter which tokenizes non-english or non-whitespace separated texts.
+
+Many languages are not whitespace separated and their sentences are a concatenation of many symbols, like Korean,
+Japanese or Chinese. Without understanding the language, splitting the words into their corresponding tokens is
+impossible. The WordSegmenter is trained to understand these languages and split them into semantically correct parts.
+
+To train your own model, a training dataset consisting of
+[Part-Of-Speech tags](https://en.wikipedia.org/wiki/Part-of-speech_tagging) is required. The data has to be loaded
+into a dataframe, where the column is an [Annotation](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/Annotation) of type `"POS"`. This can be
+set with `setPosColumn`.
+
+**Tip**: The helper class [POS](#pos-dataset) might be useful to read training data into data frames.
+
+For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/tree/master/jupyter/annotation/chinese/word_segmentation).
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+DOCUMENT
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+TOKEN
+{%- endcapture -%}
+
+{%- capture python_example -%}
+# In this example, `"chinese_train.utf8"` is in the form of
+#
+# 十|LL 四|RR 不|LL 是|RR 四|LL 十|RR
+#
+# and is loaded with the `POS` class to create a dataframe of `"POS"` type Annotations.
+
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from sparknlp.training import *
+from pyspark.ml import Pipeline
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+wordSegmenter = WordSegmenterApproach() \
+    .setInputCols(["document"]) \
+    .setOutputCol("token") \
+    .setPosColumn("tags") \
+    .setNIterations(5)
+
+pipeline = Pipeline().setStages([
+    documentAssembler,
+    wordSegmenter
+])
+
+trainingDataSet = POS().readDataset(
+    spark,
+    "src/test/resources/word-segmenter/chinese_train.utf8"
+)
+
+pipelineModel = pipeline.fit(trainingDataSet)
+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+// In this example, `"chinese_train.utf8"` is in the form of
+//
+// 十|LL 四|RR 不|LL 是|RR 四|LL 十|RR
+//
+// and is loaded with the `POS` class to create a dataframe of `"POS"` type Annotations.
+
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotators.ws.WordSegmenterApproach
+import com.johnsnowlabs.nlp.training.POS
+import org.apache.spark.ml.Pipeline
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val wordSegmenter = new WordSegmenterApproach()
+  .setInputCols("document")
+  .setOutputCol("token")
+  .setPosColumn("tags")
+  .setNIterations(5)
+
+val pipeline = new Pipeline().setStages(Array(
+  documentAssembler,
+  wordSegmenter
+))
+
+val trainingDataSet = POS().readDataset(
+  ResourceHelper.spark,
+  "src/test/resources/word-segmenter/chinese_train.utf8"
+)
+
+val pipelineModel = pipeline.fit(trainingDataSet)
+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[WordSegmenterApproach](https://nlp.johnsnowlabs.com/api/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterApproach)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[WordSegmenterApproach](https://nlp.johnsnowlabs.com/api/python/reference/autosummary/sparknlp.annotator.WordSegmenterApproach.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[WordSegmenterApproach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterApproach.scala)
+{%- endcapture -%}
+
+{% include templates/training_anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}
+

--- a/docs/en/training_entries/conll.md
+++ b/docs/en/training_entries/conll.md
@@ -1,0 +1,99 @@
+{%- capture title -%}
+CoNLL Dataset
+{%- endcapture -%}
+
+{%- capture description -%}
+In order to train a Named Entity Recognition DL annotator, we need to get CoNLL format data as a spark dataframe. There is a component that does this for us: it reads a plain text file and transforms it to a spark dataset.
+
+The dataset should be in the format of [CoNLL 2003](https://www.clips.uantwerpen.be/conll2003/ner/) and needs to be specified with `readDataset()`, which will create a dataframe with the data.
+{%- endcapture -%}
+
+{%- capture file_format -%}
+-DOCSTART- -X- -X- O
+
+EU NNP B-NP B-ORG
+rejects VBZ B-VP O
+German JJ B-NP B-MISC
+call NN I-NP O
+to TO B-VP O
+boycott VB I-VP O
+British JJ B-NP B-MISC
+lamb NN I-NP O
+. . O O
+{%- endcapture -%}
+
+
+{%- capture constructor -%}
+- **documentCol:** Name of the DocumentAssembler column, by default ‘document’
+- **sentenceCol:** Name of the SentenceDetector column, by default ‘sentence’
+- **tokenCol:** Name of the Tokenizer column, by default ‘token’
+- **posCol:** Name of the PerceptronModel column, by default ‘pos’
+- **conllLabelIndex:** Index of the label column in the dataset, by default 3
+- **conllPosIndex:** Index of the POS tags in the dataset, by default 1
+- **textCol:** Index of the text column in the dataset, by default ‘text’
+- **labelCol:** Name of the label column, by default ‘label’
+- **explodeSentences:** Whether to explode sentences to separate rows, by default True
+- **delimiter:** Delimiter used to separate columns inside CoNLL file
+{%- endcapture -%}
+
+{%- capture read_dataset_params -%}
+- **spark**: Initiated Spark Session with Spark NLP
+- **path**: Path to the resource
+- **read_as**: How to read the resource, by default ReadAs.TEXT
+{%- endcapture -%}
+
+{%- capture python_example -%}
+from sparknlp.training import CoNLL
+trainingData = CoNLL().readDataset(spark, "src/test/resources/conll2003/eng.train")
+trainingData.selectExpr(
+    "text",
+    "token.result as tokens",
+    "pos.result as pos",
+    "label.result as label"
+).show(3, False)
++------------------------------------------------+----------------------------------------------------------+-------------------------------------+-----------------------------------------+
+|text                                            |tokens                                                    |pos                                  |label                                    |
++------------------------------------------------+----------------------------------------------------------+-------------------------------------+-----------------------------------------+
+|EU rejects German call to boycott British lamb .|[EU, rejects, German, call, to, boycott, British, lamb, .]|[NNP, VBZ, JJ, NN, TO, VB, JJ, NN, .]|[B-ORG, O, B-MISC, O, O, O, B-MISC, O, O]|
+|Peter Blackburn                                 |[Peter, Blackburn]                                        |[NNP, NNP]                           |[B-PER, I-PER]                           |
+|BRUSSELS 1996-08-22                             |[BRUSSELS, 1996-08-22]                                    |[NNP, CD]                            |[B-LOC, O]                               |
++------------------------------------------------+----------------------------------------------------------+-------------------------------------+-----------------------------------------+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+val trainingData = CoNLL().readDataset(spark, "src/test/resources/conll2003/eng.train")
+trainingData.selectExpr("text", "token.result as tokens", "pos.result as pos", "label.result as label")
+  .show(3, false)
++------------------------------------------------+----------------------------------------------------------+-------------------------------------+-----------------------------------------+
+|text                                            |tokens                                                    |pos                                  |label                                    |
++------------------------------------------------+----------------------------------------------------------+-------------------------------------+-----------------------------------------+
+|EU rejects German call to boycott British lamb .|[EU, rejects, German, call, to, boycott, British, lamb, .]|[NNP, VBZ, JJ, NN, TO, VB, JJ, NN, .]|[B-ORG, O, B-MISC, O, O, O, B-MISC, O, O]|
+|Peter Blackburn                                 |[Peter, Blackburn]                                        |[NNP, NNP]                           |[B-PER, I-PER]                           |
+|BRUSSELS 1996-08-22                             |[BRUSSELS, 1996-08-22]                                    |[NNP, CD]                            |[B-LOC, O]                               |
++------------------------------------------------+----------------------------------------------------------+-------------------------------------+-----------------------------------------+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[CoNLL](/api/com/johnsnowlabs/nlp/training/CoNLL.html)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[CoNLL](/api/python/reference/autosummary/sparknlp.training.CoNLL.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[CoNLL.scala](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/training/CoNLL.scala)
+{%- endcapture -%}
+
+{% include templates/training_dataset_entry.md
+title=title
+description=description
+file_format=file_format
+constructor=constructor
+read_dataset_params=read_dataset_params
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/conllu.md
+++ b/docs/en/training_entries/conllu.md
@@ -1,0 +1,90 @@
+{%- capture title -%}
+CoNLL-U Dataset
+{%- endcapture -%}
+
+{%- capture description -%}
+In order to train a DependencyParserApproach annotator, we need to get CoNLL-U format data as a spark dataframe. There is a component that does this for us: it reads a plain text file and transforms it to a spark dataset.
+
+The dataset should be in the format of [CoNLL-U](https://universaldependencies.org/format.html) and needs to be specified with `readDataset()`, which will create a dataframe with the data.
+{%- endcapture -%}
+
+{%- capture file_format -%}
+-DOCSTART- -X- -X- O
+
+EU NNP B-NP B-ORG
+rejects VBZ B-VP O
+German JJ B-NP B-MISC
+call NN I-NP O
+to TO B-VP O
+boycott VB I-VP O
+British JJ B-NP B-MISC
+lamb NN I-NP O
+. . O O
+{%- endcapture -%}
+
+{%- capture constructor -%}
+- **explodeSentences**: Whether to explode each sentence to a separate row
+{%- endcapture -%}
+
+{%- capture read_dataset_params -%}
+- **spark**: Initiated Spark Session with Spark NLP
+- **path**: Path to the resource
+- **read_as**: How to read the resource, by default ReadAs.TEXT
+{%- endcapture -%}
+
+{%- capture python_example -%}
+from sparknlp.training import CoNLLU
+conlluFile = "src/test/resources/conllu/en.test.conllu"
+conllDataSet = CoNLLU(False).readDataset(spark, conlluFile)
+conllDataSet.selectExpr(
+    "text",
+    "form.result as form",
+    "upos.result as upos",
+    "xpos.result as xpos",
+    "lemma.result as lemma"
+).show(1, False)
++---------------------------------------+----------------------------------------------+---------------------------------------------+------------------------------+--------------------------------------------+
+|text                                   |form                                          |upos                                         |xpos                          |lemma                                       |
++---------------------------------------+----------------------------------------------+---------------------------------------------+------------------------------+--------------------------------------------+
+|What if Google Morphed Into GoogleOS?  |[What, if, Google, Morphed, Into, GoogleOS, ?]|[PRON, SCONJ, PROPN, VERB, ADP, PROPN, PUNCT]|[WP, IN, NNP, VBD, IN, NNP, .]|[what, if, Google, morph, into, GoogleOS, ?]|
++---------------------------------------+----------------------------------------------+---------------------------------------------+------------------------------+--------------------------------------------+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+import com.johnsnowlabs.nlp.training.CoNLLU
+
+val conlluFile = "src/test/resources/conllu/en.test.conllu"
+val conllDataSet = CoNLLU(false).readDataset(ResourceHelper.spark, conlluFile)
+conllDataSet.selectExpr("text", "form.result as form", "upos.result as upos", "xpos.result as xpos", "lemma.result as lemma")
+  .show(1, false)
++---------------------------------------+----------------------------------------------+---------------------------------------------+------------------------------+--------------------------------------------+
+|text                                   |form                                          |upos                                         |xpos                          |lemma                                       |
++---------------------------------------+----------------------------------------------+---------------------------------------------+------------------------------+--------------------------------------------+
+|What if Google Morphed Into GoogleOS?  |[What, if, Google, Morphed, Into, GoogleOS, ?]|[PRON, SCONJ, PROPN, VERB, ADP, PROPN, PUNCT]|[WP, IN, NNP, VBD, IN, NNP, .]|[what, if, Google, morph, into, GoogleOS, ?]|
++---------------------------------------+----------------------------------------------+---------------------------------------------+------------------------------+--------------------------------------------+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[CoNLLU](/api/com/johnsnowlabs/nlp/training/CoNLLU.html)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[CoNLLU](/api/python/reference/autosummary/sparknlp.training.CoNLLU.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[CoNLLU.scala](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/training/CoNLLU.scala)
+{%- endcapture -%}
+
+{% include templates/training_dataset_entry.md
+title=title
+description=description
+file_format=file_format
+constructor=constructor
+read_dataset_params=read_dataset_params
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/pos.md
+++ b/docs/en/training_entries/pos.md
@@ -1,0 +1,111 @@
+{%- capture title -%}
+POS Dataset
+{%- endcapture -%}
+
+{%- capture description -%}
+In order to train a Part of Speech Tagger annotator, we need to get corpus data as a Spark dataframe. There is a component that does this for us: it reads a plain text file and transforms it to a Spark dataset.
+{%- endcapture -%}
+
+{%- capture file_format -%}
+A|DT few|JJ months|NNS ago|RB you|PRP received|VBD a|DT letter|NN
+{%- endcapture -%}
+
+{%- capture constructor -%}
+None
+{%- endcapture -%}
+
+{%- capture read_dataset_params -%}
+- **spark**: Initiated Spark Session with Spark NLP
+- **path**: Path to the resource
+- **delimiter**: Delimiter of word and POS, by default "\|"
+- **outputPosCol**: Name of the output POS column, by default “tags”
+- **outputDocumentCol**: Name of the output document column, by default “document”
+- **outputTextCol**: Name of the output text column, by default “text”
+{%- endcapture -%}
+
+{%- capture python_example -%}
+from sparknlp.training import POS
+pos = POS()
+path = "src/test/resources/anc-pos-corpus-small/test-training.txt"
+posDf = pos.readDataset(spark, path, "|", "tags")
+posDf.selectExpr("explode(tags) as tags").show(truncate=False)
++---------------------------------------------+
+|tags                                         |
++---------------------------------------------+
+|[pos, 0, 5, NNP, [word -> Pierre], []]       |
+|[pos, 7, 12, NNP, [word -> Vinken], []]      |
+|[pos, 14, 14, ,, [word -> ,], []]            |
+|[pos, 16, 17, CD, [word -> 61], []]          |
+|[pos, 19, 23, NNS, [word -> years], []]      |
+|[pos, 25, 27, JJ, [word -> old], []]         |
+|[pos, 29, 29, ,, [word -> ,], []]            |
+|[pos, 31, 34, MD, [word -> will], []]        |
+|[pos, 36, 39, VB, [word -> join], []]        |
+|[pos, 41, 43, DT, [word -> the], []]         |
+|[pos, 45, 49, NN, [word -> board], []]       |
+|[pos, 51, 52, IN, [word -> as], []]          |
+|[pos, 47, 47, DT, [word -> a], []]           |
+|[pos, 56, 67, JJ, [word -> nonexecutive], []]|
+|[pos, 69, 76, NN, [word -> director], []]    |
+|[pos, 78, 81, NNP, [word -> Nov.], []]       |
+|[pos, 83, 84, CD, [word -> 29], []]          |
+|[pos, 81, 81, ., [word -> .], []]            |
++---------------------------------------------+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+import com.johnsnowlabs.nlp.training.POS
+
+val pos = POS()
+val path = "src/test/resources/anc-pos-corpus-small/test-training.txt"
+val posDf = pos.readDataset(spark, path, "|", "tags")
+
+posDf.selectExpr("explode(tags) as tags").show(false)
++---------------------------------------------+
+|tags                                         |
++---------------------------------------------+
+|[pos, 0, 5, NNP, [word -> Pierre], []]       |
+|[pos, 7, 12, NNP, [word -> Vinken], []]      |
+|[pos, 14, 14, ,, [word -> ,], []]            |
+|[pos, 16, 17, CD, [word -> 61], []]          |
+|[pos, 19, 23, NNS, [word -> years], []]      |
+|[pos, 25, 27, JJ, [word -> old], []]         |
+|[pos, 29, 29, ,, [word -> ,], []]            |
+|[pos, 31, 34, MD, [word -> will], []]        |
+|[pos, 36, 39, VB, [word -> join], []]        |
+|[pos, 41, 43, DT, [word -> the], []]         |
+|[pos, 45, 49, NN, [word -> board], []]       |
+|[pos, 51, 52, IN, [word -> as], []]          |
+|[pos, 47, 47, DT, [word -> a], []]           |
+|[pos, 56, 67, JJ, [word -> nonexecutive], []]|
+|[pos, 69, 76, NN, [word -> director], []]    |
+|[pos, 78, 81, NNP, [word -> Nov.], []]       |
+|[pos, 83, 84, CD, [word -> 29], []]          |
+|[pos, 81, 81, ., [word -> .], []]            |
++---------------------------------------------+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[POS](/api/com/johnsnowlabs/nlp/training/POS.html)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[POS](/api/python/reference/autosummary/sparknlp.training.POS.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[POS.scala](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/training/POS.scala)
+{%- endcapture -%}
+
+{% include templates/training_dataset_entry.md
+title=title
+description=description
+file_format=file_format
+constructor=constructor
+read_dataset_params=read_dataset_params
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/training_entries/pubtator.md
+++ b/docs/en/training_entries/pubtator.md
@@ -1,0 +1,75 @@
+{%- capture title -%}
+PubTator Dataset
+{%- endcapture -%}
+
+{%- capture description -%}
+The PubTator format includes medical papers' titles, abstracts, and tagged chunks (see [PubTator Docs](http://bioportal.bioontology.org/ontologies/EDAM?p=classes&conceptid=format_3783) and [MedMentions Docs](http://github.com/chanzuckerberg/MedMentions) for more information). We can create a Spark DataFrame from a PubTator text file.
+{%- endcapture -%}
+
+{%- capture file_format -%}
+25763772        0       5       DCTN4   T116,T123       C4308010
+25763772        23      63      chronic Pseudomonas aeruginosa infection        T047    C0854135
+25763772        67      82      cystic fibrosis T047    C0010674
+25763772        83      120     Pseudomonas aeruginosa (Pa) infection   T047    C0854135
+25763772        124     139     cystic fibrosis T047    C0010674
+{%- endcapture -%}
+
+{%- capture constructor -%}
+None
+{%- endcapture -%}
+
+{%- capture read_dataset_params -%}
+- **spark**: Initiated Spark Session with Spark NLP
+- **path**: Path to the resource
+- **isPaddedToken**: Whether tokens are padded
+{%- endcapture -%}
+
+{%- capture python_example -%}
+from sparknlp.training import PubTator
+pubTatorFile = "./src/test/resources/corpus_pubtator_sample.txt"
+pubTatorDataSet = PubTator().readDataset(spark, pubTatorFile)
+pubTatorDataSet.show(1)
++--------+--------------------+--------------------+--------------------+-----------------------+---------------------+-----------------------+
+|  doc_id|      finished_token|        finished_pos|        finished_ner|finished_token_metadata|finished_pos_metadata|finished_label_metadata|
++--------+--------------------+--------------------+--------------------+-----------------------+---------------------+-----------------------+
+|25763772|[DCTN4, as, a, mo...|[NNP, IN, DT, NN,...|[B-T116, O, O, O,...|   [[sentence, 0], [...| [[word, DCTN4], [...|   [[word, DCTN4], [...|
++--------+--------------------+--------------------+--------------------+-----------------------+---------------------+-----------------------+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+import com.johnsnowlabs.nlp.training.PubTator
+
+val pubTatorFile = "./src/test/resources/corpus_pubtator_sample.txt"
+val pubTatorDataSet = PubTator().readDataset(ResourceHelper.spark, pubTatorFile)
+pubTatorDataSet.show(1)
++--------+--------------------+--------------------+--------------------+-----------------------+---------------------+-----------------------+
+|  doc_id|      finished_token|        finished_pos|        finished_ner|finished_token_metadata|finished_pos_metadata|finished_label_metadata|
++--------+--------------------+--------------------+--------------------+-----------------------+---------------------+-----------------------+
+|25763772|[DCTN4, as, a, mo...|[NNP, IN, DT, NN,...|[B-T116, O, O, O,...|   [[sentence, 0], [...| [[word, DCTN4], [...|   [[word, DCTN4], [...|
++--------+--------------------+--------------------+--------------------+-----------------------+---------------------+-----------------------+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[PubTator](/api/com/johnsnowlabs/nlp/training/PubTator.html)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[PubTator](/api/python/reference/autosummary/sparknlp.training.PubTator.html)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[PubTator.scala](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/training/PubTator.scala)
+{%- endcapture -%}
+
+{% include templates/training_dataset_entry.md
+title=title
+description=description
+file_format=file_format
+constructor=constructor
+read_dataset_params=read_dataset_params
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/transformer_entries/AlbertEmbeddings.md
+++ b/docs/en/transformer_entries/AlbertEmbeddings.md
@@ -170,7 +170,7 @@ result.select("ner.result").show(false)
 {%- endcapture -%}
 
 {%- capture training_python_example -%}
-import sparknlp1
+import sparknlp
 from sparknlp.base import *
 from sparknlp.annotator import *
 from sparknlp.training import *

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLApproach.scala
@@ -48,7 +48,9 @@ import scala.collection.mutable.WrappedArray
   * Each extracted sentence can be returned in an Array or exploded to separate rows,
   * if `explodeSentences` is set to `true`.
   *
-  * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLSpec.scala SentenceDetectorDLSpec]].
+  * For extended examples of usage, see the
+  * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/9.SentenceDetectorDL.ipynb Spark NLP Workshop]]
+  * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLSpec.scala SentenceDetectorDLSpec]].
   *
   * ==Example==
   * The training process needs data, where each data point is a sentence.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is an update to the Training page.

It includes the trainable annotators, sorted by tasks. In total these were overhauled and added:
- Training Datasets
    - POS Dataset
    - CoNLL Dataset
    - CoNLL-U Dataset
    - PubTator Dataset
    - Spell Checkers Dataset (Corpus)
- Text Processing
    - DependencyParserApproach
    - Lemmatizer
    - PerceptronApproach (Part of speech tagger)
    - SentenceDetectorDLApproach
    - TypedDependencyParser
    - WordSegmenterApproach
- Spell Checkers
    - ContextSpellCheckerApproach
    - NorvigSweeting Spellchecker
    - SymmetricDelete Spellchecker
- Token Classification
    - NerCrfApproach
    - NerDLApproach
- Text Classification
    - ClassifierDLApproach
    - MultiClassifierDLApproach
    - SentimentDLApproach
    - ViveknSentimentAproach
- External Trainable Models
    - BertForTokenClassification
    - DistilBertForTokenClassification

This PR also contains minor polishes to the doc pages.

- links to annotators on the page now refer to the entries on the doc pages, rather than the scala docs
- adjusted some python examples

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No Code Changes