### PR TITLE
Change KEYWORD to CHUNK output type in YakeModel

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -10401,7 +10401,7 @@ class YakeModel(AnnotatorModel):
     ====================== ======================
     Input Annotation types Output Annotation type
     ====================== ======================
-    ``TOKEN``              ``KEYWORD``
+    ``TOKEN``              ``CHUNK``
     ====================== ======================
 
     Parameters

--- a/src/main/scala/com/johnsnowlabs/nlp/AnnotatorType.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/AnnotatorType.scala
@@ -33,7 +33,6 @@ object AnnotatorType {
   val DEPENDENCY = "dependency"
   val LABELED_DEPENDENCY = "labeled_dependency"
   val LANGUAGE = "language"
-  val KEYWORD = "keyword"
   val NODE = "node"
   val DUMMY = "dummy"
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/keyword.yake/YakeModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/keyword.yake/YakeModel.scala
@@ -17,7 +17,7 @@
 package com.johnsnowlabs.nlp.annotators.keyword.yake
 
 import com.johnsnowlabs.nlp.annotators.keyword.yake.util.Utilities.{getTag, medianCalculator}
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, ParamsAndFeaturesReadable, HasSimpleAnnotate}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasSimpleAnnotate, ParamsAndFeaturesReadable}
 import org.apache.spark.ml.feature.StopWordsRemover
 import org.apache.spark.ml.util.Identifiable
 import org.slf4j.LoggerFactory
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory
 import scala.collection.immutable.ListMap
 import scala.collection.{immutable, mutable}
 import scala.collection.mutable.ListBuffer
-import com.johnsnowlabs.nlp.AnnotatorType.{TOKEN, KEYWORD}
+import com.johnsnowlabs.nlp.AnnotatorType.{CHUNK, TOKEN}
 import com.johnsnowlabs.nlp.annotators.keyword.yake.util.Token
 
 import scala.math.sqrt
@@ -53,7 +53,7 @@ import scala.math.sqrt
  * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/8.Keyword_Extraction_YAKE.ipynb Spark NLP Workshop]]
  * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/keyword/yake/YakeTestSpec.scala YakeTestSpec]].
  *
- *  '''Sources''' :
+ * '''Sources''' :
  *
  * [[https://www.sciencedirect.com/science/article/pii/S0020025519308588 Campos, R., Mangaravite, V., Pasquali, A., Jatowt, A., Jorge, A., Nunes, C. and Jatowt, A. (2020). YAKE! Keyword Extraction from Single Documents using Multiple Local Features. In Information Sciences Journal. Elsevier, Vol 509, pp 257-289]]
  *
@@ -153,7 +153,7 @@ class YakeModel(override val uid: String) extends AnnotatorModel[YakeModel] with
    *
    * @group anno
    */
-  override val outputAnnotatorType: AnnotatorType = KEYWORD
+  override val outputAnnotatorType: AnnotatorType = CHUNK
   /** Input Annotator Types: TOKEN
    *
    * @group anno

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/keyword.yake/YakeParams.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/keyword.yake/YakeParams.scala
@@ -16,7 +16,7 @@
 
 package com.johnsnowlabs.nlp.annotators.keyword.yake
 
-import org.apache.spark.ml.param.{BooleanParam, FloatParam, IntParam, Params, StringArrayParam}
+import org.apache.spark.ml.param.{FloatParam, IntParam, Params, StringArrayParam}
 
 trait YakeParams extends Params {
 
@@ -66,17 +66,22 @@ trait YakeParams extends Params {
 
   /** @group setParam */
   def setStopWords(value: Array[String]): this.type = set(stopWords, value)
+
   /** @group getParam */
   def getStopWords: Array[String] = $(stopWords)
 
   /** @group setParam */
-  def setWindowSize(value: Int): this.type = set(windowSize, value+1)
+  def setWindowSize(value: Int): this.type = set(windowSize, value + 1)
+
   /** @group setParam */
   def setMaxNGrams(value: Int): this.type = set(maxNGrams, value)
+
   /** @group setParam */
   def setMinNGrams(value: Int): this.type = set(minNGrams, value)
+
   /** @group setParam */
   def setNKeywords(value: Int): this.type = set(nKeywords, value)
+
   /** @group setParam */
-  def setThreshold(value: Float): this.type = set(threshold,value)
+  def setThreshold(value: Float): this.type = set(threshold, value)
 }


### PR DESCRIPTION
In order to have more available features after the YakeModel annotator such as Chunk2Doc or ChunkEmbeddings, I have changed the output type from KEYWORD to CHUNK. 