### PR TITLE
Saving Spark NLP models 50x-60x times

### DIFF
--- a/src/main/scala/com/johnsnowlabs/util/Benchmark.scala
+++ b/src/main/scala/com/johnsnowlabs/util/Benchmark.scala
@@ -20,14 +20,15 @@ object Benchmark {
 
   private var print = true
 
-  def setPrint(v: Boolean) = print = v
+  def setPrint(v: Boolean): Unit = print = v
+
   def getPrint: Boolean = print
 
   def time[R](description: String, forcePrint: Boolean = false)(block: => R): R = {
     val t0 = System.nanoTime()
     val result = block
     val t1 = System.nanoTime()
-    if (print || forcePrint) println(description + ": " + ((t1 - t0)/1000000000.0) + "sec")
+    if (print || forcePrint) println(description + ": " + ((t1 - t0) / 1000000000.0) + "sec")
     result
   }
 
@@ -44,5 +45,6 @@ object Benchmark {
   }
 
   def measure(f: => Any): Double = measure()(f)
+
   def measure(d: String)(f: => Any): Double = measure(description = d)(f)
 }

--- a/src/main/scala/com/johnsnowlabs/util/ConfigLoader.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigLoader.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.johnsnowlabs.util
 
 import org.apache.hadoop.fs.FileSystem
@@ -31,25 +32,25 @@ object ConfigLoader {
   private lazy val configData: Map[String, String] = {
 
     getConfigInfo(ConfigHelper.pretrainedS3BucketKey, "auxdata.johnsnowlabs.com") ++
-    getConfigInfo(ConfigHelper.pretrainedCommunityS3BucketKey, "community.johnsnowlabs.com") ++
-    getConfigInfo(ConfigHelper.pretrainedS3PathKey, "") ++
-    getConfigInfo(ConfigHelper.pretrainedCacheFolder, homeDirectory + "/cache_pretrained") ++
-    getConfigInfo(ConfigHelper.annotatorLogFolder, homeDirectory + "/annotator_logs") ++
-    getConfigInfo(ConfigHelper.accessKeyId, "") ++
-    getConfigInfo(ConfigHelper.secretAccessKey, "") ++
-    getConfigInfo(ConfigHelper.sessionToken, "") ++
-    getConfigInfo(ConfigHelper.awsProfileName, "") ++
-    getConfigInfo(ConfigHelper.awsRegion, "") ++
-    getConfigInfo(ConfigHelper.s3SocketTimeout, "0") ++
-    getConfigInfo(ConfigHelper.storageTmpDir, hadoopTmpDir) ++
-    getConfigInfo(ConfigHelper.serializationMode, "object") ++
-    getConfigInfo(ConfigHelper.useBroadcast, "true") ++
-    getConfigInfo(ConfigHelper.awsExternalAccessKeyId, "") ++
-    getConfigInfo(ConfigHelper.awsExternalSecretAccessKey, "") ++
-    getConfigInfo(ConfigHelper.awsExternalSessionToken, "") ++
-    getConfigInfo(ConfigHelper.awsExternalProfileName, "") ++
-    getConfigInfo(ConfigHelper.awsExternalS3BucketKey, "") ++
-    getConfigInfo(ConfigHelper.awsExternalRegion, "")
+      getConfigInfo(ConfigHelper.pretrainedCommunityS3BucketKey, "community.johnsnowlabs.com") ++
+      getConfigInfo(ConfigHelper.pretrainedS3PathKey, "") ++
+      getConfigInfo(ConfigHelper.pretrainedCacheFolder, homeDirectory + "/cache_pretrained") ++
+      getConfigInfo(ConfigHelper.annotatorLogFolder, homeDirectory + "/annotator_logs") ++
+      getConfigInfo(ConfigHelper.accessKeyId, "") ++
+      getConfigInfo(ConfigHelper.secretAccessKey, "") ++
+      getConfigInfo(ConfigHelper.sessionToken, "") ++
+      getConfigInfo(ConfigHelper.awsProfileName, "") ++
+      getConfigInfo(ConfigHelper.awsRegion, "") ++
+      getConfigInfo(ConfigHelper.s3SocketTimeout, "0") ++
+      getConfigInfo(ConfigHelper.storageTmpDir, hadoopTmpDir) ++
+      getConfigInfo(ConfigHelper.serializationMode, "object") ++
+      getConfigInfo(ConfigHelper.useBroadcast, "true") ++
+      getConfigInfo(ConfigHelper.awsExternalAccessKeyId, "") ++
+      getConfigInfo(ConfigHelper.awsExternalSecretAccessKey, "") ++
+      getConfigInfo(ConfigHelper.awsExternalSessionToken, "") ++
+      getConfigInfo(ConfigHelper.awsExternalProfileName, "") ++
+      getConfigInfo(ConfigHelper.awsExternalS3BucketKey, "") ++
+      getConfigInfo(ConfigHelper.awsExternalRegion, "")
   }
 
   private def getConfigInfo(property: String, defaultValue: String): Map[String, String] = {

--- a/src/main/scala/com/johnsnowlabs/util/FileHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/FileHelper.scala
@@ -23,6 +23,7 @@ import java.security.MessageDigest
 import java.text.DecimalFormat
 
 import org.apache.commons.io.FileUtils
+
 object FileHelper {
   def writeLines(file: String, lines: Seq[String], encoding: String = "UTF-8"): Unit = {
     val writer = Files.newBufferedWriter(Paths.get(file), Charset.forName(encoding))

--- a/src/main/scala/com/johnsnowlabs/util/PipelineModels.scala
+++ b/src/main/scala/com/johnsnowlabs/util/PipelineModels.scala
@@ -18,11 +18,12 @@ package com.johnsnowlabs.util
 
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import org.apache.spark.ml.{Pipeline, PipelineModel, Transformer}
+import org.apache.spark.sql.DataFrame
 
 
 object PipelineModels {
 
-  lazy val dummyDataset = {
+  lazy val dummyDataset: DataFrame = {
     import ResourceHelper.spark.implicits._
     ResourceHelper.spark.createDataset(Seq.empty[String]).toDF("text")
   }

--- a/src/main/scala/com/johnsnowlabs/util/TrainingHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/TrainingHelper.scala
@@ -71,10 +71,10 @@ object TrainingHelper {
       case _: java.io.IOException => //file lock may prevent deletion, ignore and continue
     }
 
-      // 6. Add to metadata.json info about resource
-      val metadataFile = Paths.get(folder, "metadata.json").toString
-      ResourceMetadata.addMetadataToFile(metadataFile, meta)
-    }
+    // 6. Add to metadata.json info about resource
+    val metadataFile = Paths.get(folder, "metadata.json").toString
+    ResourceMetadata.addMetadataToFile(metadataFile, meta)
+  }
 
   def hasColumn(dataSet: Dataset[_], column: String): Boolean = Try(dataSet(column)).isSuccess
 

--- a/src/main/scala/com/johnsnowlabs/util/Version.scala
+++ b/src/main/scala/com/johnsnowlabs/util/Version.scala
@@ -30,7 +30,7 @@ case class Version(parts: List[Int]) {
 object Version {
   def apply(parts: Int*): Version = Version(parts.toList)
 
-  def isInteger(str: String) = str.nonEmpty && str.forall(c => Character.isDigit(c))
+  def isInteger(str: String): Boolean = str.nonEmpty && str.forall(c => Character.isDigit(c))
 
   def parse(str: String): Version = {
     val parts = str.replaceAll("-rc\\d", "").split('.')
@@ -44,18 +44,19 @@ object Version {
   def isCompatible(current: Version, found: Version): Boolean = isCompatible(current, Some(found))
 
   /**
-    * Checks weather found version could be used with current version
-    * @param current Version of current library
-    * @param found Version of library of found resource
-    * @return True ar False
-    *
-    * Examples (current) and (found):
-    * 1.2.3 and 1.2   => True
-    * 1.2   and 1.2.3 => False (found more specific version)    *
-    * 1.2   and None  => True  (found version that could be used with all versions)
-    */
+   * Checks weather found version could be used with current version
+   *
+   * @param current Version of current library
+   * @param found   Version of library of found resource
+   * @return True ar False
+   *
+   *         Examples (current) and (found):
+   *         1.2.3 and 1.2   => True
+   *         1.2   and 1.2.3 => False (found more specific version)    *
+   *         1.2   and None  => True  (found version that could be used with all versions)
+   */
   def isCompatible(current: Version, found: Option[Version]): Boolean = {
-    found.forall{f =>
+    found.forall { f =>
       val cParts = current.parts
       val fParts = f.parts
 
@@ -65,7 +66,7 @@ object Version {
       else {
         // All first digits must be equals:
         var previousWasBigger: Option[Boolean] = None
-        cParts.zip(fParts).forall{case(c, t) =>
+        cParts.zip(fParts).forall { case (c, t) =>
           if (previousWasBigger.exists(v => v) || t == c)
             true
           else if (c > t && previousWasBigger.isEmpty) {

--- a/src/main/scala/com/johnsnowlabs/util/spark/MapAccumulator.scala
+++ b/src/main/scala/com/johnsnowlabs/util/spark/MapAccumulator.scala
@@ -17,7 +17,7 @@
 package com.johnsnowlabs.util.spark
 
 import org.apache.spark.util.AccumulatorV2
-import scala.collection.mutable.{Map=>MMap}
+import scala.collection.mutable.{Map => MMap}
 
 class MapAccumulator(defaultMap: MMap[String, Long] = MMap.empty[String, Long].withDefaultValue(0))
   extends AccumulatorV2[(String, Long), Map[String, Long]] {
@@ -31,7 +31,7 @@ class MapAccumulator(defaultMap: MMap[String, Long] = MMap.empty[String, Long].w
   override def value: Map[String, Long] = _mmap.toMap.withDefaultValue(0)
 
   override def copy(): AccumulatorV2[(String, Long), Map[String, Long]] =
-    new MapAccumulator(MMap[String, Long](value.toSeq:_*).withDefaultValue(0))
+    new MapAccumulator(MMap[String, Long](value.toSeq: _*).withDefaultValue(0))
 
   override def isZero: Boolean = _mmap.isEmpty
 
@@ -39,7 +39,7 @@ class MapAccumulator(defaultMap: MMap[String, Long] = MMap.empty[String, Long].w
 
   override def merge(other: AccumulatorV2[(String, Long), Map[String, Long]]): Unit =
     other match {
-      case o: MapAccumulator => o.mmap.foreach{case (k, v) => _mmap(k) += v}
+      case o: MapAccumulator => o.mmap.foreach { case (k, v) => _mmap(k) += v }
       case _ => throw new UnsupportedOperationException(
         s"Cannot merge ${this.getClass.getName} with ${other.getClass.getName}")
     }


### PR DESCRIPTION
This PR refactors the way Spark NLP annotators based on TensorFlow are being saved. The performance gain with the new refactoring is between 50x to 60x times faster.

Example: Saving XlmRoBertaEmbeddings `large` model takes around 20 minutes, with the new refactorings it will take up to 20 seconds!