### PR TITLE
Redesign ForTokenClassification Annotators

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowAlbertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowAlbertClassification.scala
@@ -19,7 +19,6 @@ package com.johnsnowlabs.ml.tensorflow
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{SentencePieceWrapper, SentencepieceEncoder}
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
 import com.johnsnowlabs.nlp.annotators.common._
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
 import scala.collection.JavaConverters._
@@ -37,35 +36,28 @@ class TensorflowAlbertClassification(val tensorflowWrapper: TensorflowWrapper,
                                      configProtoBytes: Option[Array[Byte]] = None,
                                      tags: Map[String, Int],
                                      signatures: Option[Map[String, String]] = None
-                                    ) extends Serializable {
+                                    ) extends Serializable with TensorflowTokenClassification {
 
   val _tfAlbertSignatures: Map[String, String] = signatures.getOrElse(ModelSignatureManager.apply())
 
   // keys representing the input and output tensors of the ALBERT model
-  private val SentenceStartTokenId = spp.getSppModel.pieceToId("[CLS]")
-  private val SentenceEndTokenId = spp.getSppModel.pieceToId("[SEP]")
-  private val SentencePadTokenId = spp.getSppModel.pieceToId("[pad]")
-  private val SentencePieceDelimiterId = spp.getSppModel.pieceToId("▁")
+  protected val sentencePadTokenId: Int = spp.getSppModel.pieceToId("[pad]")
+  protected val sentenceStartTokenId: Int = spp.getSppModel.pieceToId("[CLS]")
+  protected val sentenceEndTokenId: Int = spp.getSppModel.pieceToId("[SEP]")
 
-  /** Encode the input sequence to indexes IDs adding padding where necessary */
-  def prepareBatchInputs(sentences: Seq[(WordpieceTokenizedSentence, Int)], maxSequenceLength: Int): Seq[Array[Int]] = {
-    val maxSentenceLength =
-      Array(
-        maxSequenceLength - 2,
-        sentences.map { case (wpTokSentence, _) => wpTokSentence.tokens.length }.max).min
+  private val sentencePieceDelimiterId: Int = spp.getSppModel.pieceToId("▁")
 
-    sentences
-      .map { case (wpTokSentence, _) =>
-        val tokenPieceIds = wpTokSentence.tokens.map(t => t.pieceId)
-        val padding = Array.fill(maxSentenceLength - tokenPieceIds.length)(SentencePadTokenId)
+  def tokenizeWithAlignment(sentences: Seq[TokenizedSentence], maxSeqLength: Int, caseSensitive: Boolean):
+  Seq[WordpieceTokenizedSentence] = {
 
-        Array(SentenceStartTokenId) ++ tokenPieceIds.take(maxSentenceLength) ++ Array(SentenceEndTokenId) ++ padding
-      }
-  }
+    val encoder = new SentencepieceEncoder(spp, caseSensitive, sentencePieceDelimiterId)
 
-  def calcluateSoftmax(scores: Array[Float]): Array[Float] = {
-    val exp = scores.map(x => math.exp(x))
-    exp.map(x => x / exp.sum).map(_.toFloat)
+    val sentecneTokenPieces = sentences.map { s =>
+      val shrinkedSentence = s.indexedTokens.take(maxSeqLength - 2)
+      val wordpieceTokens = shrinkedSentence.flatMap(token => encoder.encode(token)).take(maxSeqLength)
+      WordpieceTokenizedSentence(wordpieceTokens)
+    }
+    sentecneTokenPieces
   }
 
   def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
@@ -85,7 +77,7 @@ class TensorflowAlbertClassification(val tensorflowWrapper: TensorflowWrapper,
       .foreach { case (sentence, idx) =>
         val offset = idx * maxSentenceLength
         tokenBuffers.offset(offset).write(sentence)
-        maskBuffers.offset(offset).write(sentence.map(x => if (x == SentencePadTokenId) 0 else 1))
+        maskBuffers.offset(offset).write(sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
         segmentBuffers.offset(offset).write(Array.fill(maxSentenceLength)(0))
       }
 
@@ -110,72 +102,17 @@ class TensorflowAlbertClassification(val tensorflowWrapper: TensorflowWrapper,
 
     val dim = rawScores.length / (batchLength * maxSentenceLength)
     val batchScores: Array[Array[Array[Float]]] = rawScores.grouped(dim).map(scores =>
-      calcluateSoftmax(scores)).toArray.grouped(maxSentenceLength).toArray
+      calculateSoftmax(scores)).toArray.grouped(maxSentenceLength).toArray
 
     batchScores
   }
 
-  def predict(tokenizedSentences: Seq[TokenizedSentence],
-              batchSize: Int,
-              maxSentenceLength: Int,
-              caseSensitive: Boolean
-             ): Seq[Annotation] = {
+  def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),
+                                tokenPiece: TokenPiece): Option[IndexedToken] = {
 
-    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
-
-    /*Run calculation by batches*/
-    wordPieceTokenizedSentences.zipWithIndex.grouped(batchSize).flatMap { batch =>
-      val encoded = prepareBatchInputs(batch, maxSentenceLength)
-      val logits = tag(encoded)
-
-      /*Combine tokens and calculated logits*/
-      batch.zip(logits).flatMap { case (sentence, tokenVectors) =>
-        val tokenLength = sentence._1.tokens.length
-
-        /*All wordpiece logits*/
-        val tokenLogits = tokenVectors.slice(1, tokenLength + 1)
-
-        /*Word-level and span-level alignment with Tokenizer
-        https://github.com/google-research/bert#tokenization
-
-        ### Input
-        orig_tokens = ["John", "Johanson", "'s",  "house"]
-        labels      = ["NNP",  "NNP",      "POS", "NN"]
-
-        # bert_tokens == ["[CLS]", "john", "johan", "##son", "'", "s", "house", "[SEP]"]
-        # orig_to_tok_map == [1, 2, 4, 6]*/
-
-        val labelsWithScores = sentence._1.tokens.zip(tokenLogits).flatMap {
-          case (token, scores) =>
-            tokenizedSentences(sentence._2).indexedTokens.find(
-              p => p.begin == token.begin && token.isWordStart).map {
-              token =>
-                val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-                val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-                Annotation(
-                  annotatorType = AnnotatorType.NAMED_ENTITY,
-                  begin = token.begin,
-                  end = token.end,
-                  result = label,
-                  metadata = Map("sentence" -> sentence._2.toString) ++ meta
-                )
-            }
-        }
-        labelsWithScores.toSeq
-      }
-    }.toSeq
+    tokenizedSentences(sentence._2).indexedTokens.find(p => p.begin == tokenPiece.begin && tokenPiece.isWordStart)
   }
 
-  def tokenizeWithAlignment(sentences: Seq[TokenizedSentence], maxSeqLength: Int, caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = {
-    val encoder = new SentencepieceEncoder(spp, caseSensitive, SentencePieceDelimiterId)
-
-    val sentecneTokenPieces = sentences.map { s =>
-      val shrinkedSentence = s.indexedTokens.take(maxSeqLength - 2)
-      val wordpieceTokens = shrinkedSentence.flatMap(token => encoder.encode(token)).take(maxSeqLength)
-      WordpieceTokenizedSentence(wordpieceTokens)
-    }
-    sentecneTokenPieces
-  }
 }
 
 

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBertClassification.scala
@@ -18,7 +18,7 @@ package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
 import com.johnsnowlabs.nlp.annotators.common._
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
+import com.johnsnowlabs.nlp.annotators.tokenizer.wordpiece.{BasicTokenizer, WordpieceEncoder}
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
 import scala.collection.JavaConverters._
@@ -33,34 +33,37 @@ import scala.collection.JavaConverters._
  * @param signatures           TF v2 signatures in Spark NLP
  * */
 class TensorflowBertClassification(val tensorflowWrapper: TensorflowWrapper,
-                                   sentenceStartTokenId: Int,
-                                   sentenceEndTokenId: Int,
+                                   val sentenceStartTokenId: Int,
+                                   val sentenceEndTokenId: Int,
                                    configProtoBytes: Option[Array[Byte]] = None,
                                    tags: Map[String, Int],
-                                   signatures: Option[Map[String, String]] = None
-                                  ) extends Serializable {
+                                   signatures: Option[Map[String, String]] = None,
+                                   vocabulary: Map[String, Int]
+                                  ) extends Serializable with TensorflowTokenClassification {
 
   val _tfBertSignatures: Map[String, String] = signatures.getOrElse(ModelSignatureManager.apply())
 
-  /** Encode the input sequence to indexes IDs adding padding where necessary */
-  def encode(sentences: Seq[(WordpieceTokenizedSentence, Int)], maxSequenceLength: Int): Seq[Array[Int]] = {
-    val maxSentenceLength =
-      Array(
-        maxSequenceLength - 2,
-        sentences.map { case (wpTokSentence, _) => wpTokSentence.tokens.length }.max).min
+  protected val sentencePadTokenId = 0
 
-    sentences
-      .map { case (wpTokSentence, _) =>
-        val tokenPieceIds = wpTokSentence.tokens.map(t => t.pieceId)
-        val padding = Array.fill(maxSentenceLength - tokenPieceIds.length)(0)
+  def tokenizeWithAlignment(sentences: Seq[TokenizedSentence], maxSeqLength: Int, caseSensitive: Boolean):
+  Seq[WordpieceTokenizedSentence] = {
 
-        Array(sentenceStartTokenId) ++ tokenPieceIds.take(maxSentenceLength) ++ Array(sentenceEndTokenId) ++ padding
+    val basicTokenizer = new BasicTokenizer(caseSensitive)
+    val encoder = new WordpieceEncoder(vocabulary)
+
+    sentences.map { tokenIndex =>
+      // filter empty and only whitespace tokens
+      val bertTokens = tokenIndex.indexedTokens.filter(x => x.token.nonEmpty && !x.token.equals(" ")).map { token =>
+        val content = if (caseSensitive) token.token else token.token.toLowerCase()
+        val sentenceBegin = token.begin
+        val sentenceEnd = token.end
+        val sentenceInedx = tokenIndex.sentenceIndex
+        val result = basicTokenizer.tokenize(Sentence(content, sentenceBegin, sentenceEnd, sentenceInedx))
+        if (result.nonEmpty) result.head else IndexedToken("")
       }
-  }
-
-  def calcluateSoftmax(scores: Array[Float]): Array[Float] = {
-    val exp = scores.map(x => math.exp(x))
-    exp.map(x => x / exp.sum).map(_.toFloat)
+      val wordpieceTokens = bertTokens.flatMap(token => encoder.encode(token)).take(maxSeqLength)
+      WordpieceTokenizedSentence(wordpieceTokens)
+    }
   }
 
   def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
@@ -106,58 +109,14 @@ class TensorflowBertClassification(val tensorflowWrapper: TensorflowWrapper,
 
     val dim = rawScores.length / (batchLength * maxSentenceLength)
     val batchScores: Array[Array[Array[Float]]] = rawScores.grouped(dim).map(scores =>
-      calcluateSoftmax(scores)).toArray.grouped(maxSentenceLength).toArray
+      calculateSoftmax(scores)).toArray.grouped(maxSentenceLength).toArray
 
     batchScores
   }
 
-  def predict(sentences: Seq[WordpieceTokenizedSentence],
-              originalTokenSentences: Seq[TokenizedSentence],
-              batchSize: Int,
-              maxSentenceLength: Int
-             ): Seq[Annotation] = {
-
-    /*Run calculation by batches*/
-    sentences.zipWithIndex.grouped(batchSize).flatMap { batch =>
-      val encoded = encode(batch, maxSentenceLength)
-      val logits = tag(encoded)
-
-      /*Combine tokens and calculated logits*/
-      batch.zip(logits).flatMap { case (sentence, tokenVectors) =>
-        val tokenLength = sentence._1.tokens.length
-
-        /*All wordpiece logits*/
-        val tokenLogits = tokenVectors.slice(1, tokenLength + 1)
-
-        /*Word-level and span-level alignment with Tokenizer
-        https://github.com/google-research/bert#tokenization
-
-        ### Input
-        orig_tokens = ["John", "Johanson", "'s",  "house"]
-        labels      = ["NNP",  "NNP",      "POS", "NN"]
-
-        # bert_tokens == ["[CLS]", "john", "johan", "##son", "'", "s", "house", "[SEP]"]
-        # orig_to_tok_map == [1, 2, 4, 6]*/
-
-        val labelsWithScores = sentence._1.tokens.zip(tokenLogits).flatMap {
-          case (token, scores) =>
-            originalTokenSentences(sentence._2).indexedTokens.find(
-              p => p.begin == token.begin).map {
-              token =>
-                val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-                val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-                Annotation(
-                  annotatorType = AnnotatorType.NAMED_ENTITY,
-                  begin = token.begin,
-                  end = token.end,
-                  result = label,
-                  metadata = Map("sentence" -> sentence._2.toString) ++ meta
-                )
-            }
-        }
-        labelsWithScores.toSeq
-      }
-    }.toSeq
+  def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),
+                       tokenPiece: TokenPiece): Option[IndexedToken] = {
+    tokenizedSentences(sentence._2).indexedTokens.find(p => p.begin == tokenPiece.begin)
   }
 
 }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowDistilBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowDistilBertClassification.scala
@@ -18,8 +18,7 @@ package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
 import com.johnsnowlabs.nlp.annotators.common._
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
-
+import com.johnsnowlabs.nlp.annotators.tokenizer.wordpiece.{BasicTokenizer, WordpieceEncoder}
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
 import scala.collection.JavaConverters._
@@ -34,34 +33,37 @@ import scala.collection.JavaConverters._
  * @param signatures           TF v2 signatures in Spark NLP
  * */
 class TensorflowDistilBertClassification(val tensorflowWrapper: TensorflowWrapper,
-                                         sentenceStartTokenId: Int,
-                                         sentenceEndTokenId: Int,
+                                         val sentenceStartTokenId: Int,
+                                         val sentenceEndTokenId: Int,
                                          configProtoBytes: Option[Array[Byte]] = None,
                                          tags: Map[String, Int],
-                                         signatures: Option[Map[String, String]] = None
-                                        ) extends Serializable {
+                                         signatures: Option[Map[String, String]] = None,
+                                         vocabulary: Map[String, Int]
+                                        ) extends Serializable with TensorflowTokenClassification {
 
   val _tfDistilBertSignatures: Map[String, String] = signatures.getOrElse(ModelSignatureManager.apply())
 
-  /** Encode the input sequence to indexes IDs adding padding where necessary */
-  def encode(sentences: Seq[(WordpieceTokenizedSentence, Int)], maxSequenceLength: Int): Seq[Array[Int]] = {
-    val maxSentenceLength =
-      Array(
-        maxSequenceLength - 2,
-        sentences.map { case (wpTokSentence, _) => wpTokSentence.tokens.length }.max).min
+  protected val sentencePadTokenId = 0
 
-    sentences
-      .map { case (wpTokSentence, _) =>
-        val tokenPieceIds = wpTokSentence.tokens.map(t => t.pieceId)
-        val padding = Array.fill(maxSentenceLength - tokenPieceIds.length)(0)
+  def tokenizeWithAlignment(sentences: Seq[TokenizedSentence], maxSeqLength: Int, caseSensitive: Boolean):
+  Seq[WordpieceTokenizedSentence] = {
 
-        Array(sentenceStartTokenId) ++ tokenPieceIds.take(maxSentenceLength) ++ Array(sentenceEndTokenId) ++ padding
+    val basicTokenizer = new BasicTokenizer(caseSensitive)
+    val encoder = new WordpieceEncoder(vocabulary)
+
+    sentences.map { tokenIndex =>
+      // filter empty and only whitespace tokens
+      val bertTokens = tokenIndex.indexedTokens.filter(x => x.token.nonEmpty && !x.token.equals(" ")).map { token =>
+        val content = if (caseSensitive) token.token else token.token.toLowerCase()
+        val sentenceBegin = token.begin
+        val sentenceEnd = token.end
+        val sentenceInedx = tokenIndex.sentenceIndex
+        val result = basicTokenizer.tokenize(Sentence(content, sentenceBegin, sentenceEnd, sentenceInedx))
+        if (result.nonEmpty) result.head else IndexedToken("")
       }
-  }
-
-  def calcluateSoftmax(scores: Array[Float]): Array[Float] = {
-    val exp = scores.map(x => math.exp(x))
-    exp.map(x => x / exp.sum).map(_.toFloat)
+      val wordpieceTokens = bertTokens.flatMap(token => encoder.encode(token)).take(maxSeqLength)
+      WordpieceTokenizedSentence(wordpieceTokens)
+    }
   }
 
   def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
@@ -106,58 +108,14 @@ class TensorflowDistilBertClassification(val tensorflowWrapper: TensorflowWrappe
 
     val dim = rawScores.length / (batchLength * maxSentenceLength)
     val batchScores: Array[Array[Array[Float]]] = rawScores.grouped(dim).map(scores =>
-      calcluateSoftmax(scores)).toArray.grouped(maxSentenceLength).toArray
+      calculateSoftmax(scores)).toArray.grouped(maxSentenceLength).toArray
 
     batchScores
   }
 
-  def predict(sentences: Seq[WordpieceTokenizedSentence],
-              originalTokenSentences: Seq[TokenizedSentence],
-              batchSize: Int,
-              maxSentenceLength: Int
-             ): Seq[Annotation] = {
-
-    /*Run calculation by batches*/
-    sentences.zipWithIndex.grouped(batchSize).flatMap { batch =>
-      val encoded = encode(batch, maxSentenceLength)
-      val logits = tag(encoded)
-
-      /*Combine tokens and calculated logits*/
-      batch.zip(logits).flatMap { case (sentence, tokenVectors) =>
-        val tokenLength = sentence._1.tokens.length
-
-        /*All wordpiece logits*/
-        val tokenLogits = tokenVectors.slice(1, tokenLength + 1)
-
-        /*Word-level and span-level alignment with Tokenizer
-        https://github.com/google-research/bert#tokenization
-
-        ### Input
-        orig_tokens = ["John", "Johanson", "'s",  "house"]
-        labels      = ["NNP",  "NNP",      "POS", "NN"]
-
-        # bert_tokens == ["[CLS]", "john", "johan", "##son", "'", "s", "house", "[SEP]"]
-        # orig_to_tok_map == [1, 2, 4, 6]*/
-
-        val labelsWithScores = sentence._1.tokens.zip(tokenLogits).flatMap {
-          case (token, scores) =>
-            originalTokenSentences(sentence._2).indexedTokens.find(
-              p => p.begin == token.begin).map {
-              token =>
-                val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-                val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-                Annotation(
-                  annotatorType = AnnotatorType.NAMED_ENTITY,
-                  begin = token.begin,
-                  end = token.end,
-                  result = label,
-                  metadata = Map("sentence" -> sentence._2.toString) ++ meta
-                )
-            }
-        }
-        labelsWithScores.toSeq
-      }
-    }.toSeq
+  def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),
+                       tokenPiece: TokenPiece): Option[IndexedToken] = {
+    tokenizedSentences(sentence._2).indexedTokens.find(p => p.begin == tokenPiece.begin)
   }
 
 }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowRoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowRoBertaClassification.scala
@@ -18,6 +18,7 @@ package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
 import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.annotators.tokenizer.bpe.BpeTokenizer
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
@@ -33,35 +34,36 @@ import scala.collection.JavaConverters._
  * @param signatures           TF v2 signatures in Spark NLP
  * */
 class TensorflowRoBertaClassification(val tensorflowWrapper: TensorflowWrapper,
-                                      sentenceStartTokenId: Int,
-                                      sentenceEndTokenId: Int,
-                                      padTokenId: Int,
+                                      val sentenceStartTokenId: Int,
+                                      val sentenceEndTokenId: Int,
+                                      val sentencePadTokenId: Int,
                                       configProtoBytes: Option[Array[Byte]] = None,
                                       tags: Map[String, Int],
-                                      signatures: Option[Map[String, String]] = None
-                                     ) extends Serializable {
+                                      signatures: Option[Map[String, String]] = None,
+                                      merges: Map[(String, String), Int],
+                                      vocabulary: Map[String, Int]
+                                     ) extends Serializable with TensorflowTokenClassification {
 
   val _tfRoBertaSignatures: Map[String, String] = signatures.getOrElse(ModelSignatureManager.apply())
 
-  /** Encode the input sequence to indexes IDs adding padding where necessary */
-  def encode(sentences: Seq[(WordpieceTokenizedSentence, Int)], maxSequenceLength: Int): Seq[Array[Int]] = {
-    val maxSentenceLength =
-      Array(
-        maxSequenceLength - 2,
-        sentences.map { case (wpTokSentence, _) => wpTokSentence.tokens.length }.max).min
+  def tokenizeWithAlignment(sentences: Seq[TokenizedSentence], maxSeqLength: Int, caseSensitive: Boolean):
+  Seq[WordpieceTokenizedSentence] = {
 
-    sentences
-      .map { case (wpTokSentence, _) =>
-        val tokenPieceIds = wpTokSentence.tokens.map(t => t.pieceId)
-        val padding = Array.fill(maxSentenceLength - tokenPieceIds.length)(padTokenId)
+    val bpeTokenizer = BpeTokenizer.forModel("roberta", merges, vocabulary)
 
-        Array(sentenceStartTokenId) ++ tokenPieceIds.take(maxSentenceLength) ++ Array(sentenceEndTokenId) ++ padding
+    sentences.map { tokenIndex =>
+      // filter empty and only whitespace tokens
+      val bertTokens = tokenIndex.indexedTokens.filter(x => x.token.nonEmpty && !x.token.equals(" ")).map { token =>
+        val content = if (caseSensitive) token.token else token.token.toLowerCase()
+        val sentenceBegin = token.begin
+        val sentenceEnd = token.end
+        val sentenceInedx = tokenIndex.sentenceIndex
+        val result = bpeTokenizer.tokenize(Sentence(content, sentenceBegin, sentenceEnd, sentenceInedx))
+        if (result.nonEmpty) result.head else IndexedToken("")
       }
-  }
-
-  def calcluateSoftmax(scores: Array[Float]): Array[Float] = {
-    val exp = scores.map(x => math.exp(x))
-    exp.map(x => x / exp.sum).map(_.toFloat)
+      val wordpieceTokens = bertTokens.flatMap(token => bpeTokenizer.encode(token)).take(maxSeqLength)
+      WordpieceTokenizedSentence(wordpieceTokens)
+    }
   }
 
   def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
@@ -80,7 +82,7 @@ class TensorflowRoBertaClassification(val tensorflowWrapper: TensorflowWrapper,
       .foreach { case (sentence, idx) =>
         val offset = idx * maxSentenceLength
         tokenBuffers.offset(offset).write(sentence)
-        maskBuffers.offset(offset).write(sentence.map(x => if (x == padTokenId) 0 else 1))
+        maskBuffers.offset(offset).write(sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
       }
 
     val runner = tensorflowWrapper.getTFHubSession(configProtoBytes = configProtoBytes, initAllTables = false).runner
@@ -102,60 +104,14 @@ class TensorflowRoBertaClassification(val tensorflowWrapper: TensorflowWrapper,
 
     val dim = rawScores.length / (batchLength * maxSentenceLength)
     val batchScores: Array[Array[Array[Float]]] = rawScores.grouped(dim).map(scores =>
-      calcluateSoftmax(scores)).toArray.grouped(maxSentenceLength).toArray
+      calculateSoftmax(scores)).toArray.grouped(maxSentenceLength).toArray
 
     batchScores
   }
 
-  def predict(sentences: Seq[WordpieceTokenizedSentence],
-              originalTokenSentences: Seq[TokenizedSentence],
-              batchSize: Int,
-              maxSentenceLength: Int
-             ): Seq[Annotation] = {
-
-    /*Run calculation by batches*/
-    sentences.zipWithIndex.grouped(batchSize).flatMap { batch =>
-      val encoded = encode(batch, maxSentenceLength)
-      val logits = tag(encoded)
-
-      /*Combine tokens and calculated logits*/
-      batch.zip(logits).flatMap { case (sentence, tokenVectors) =>
-        val tokenLength = sentence._1.tokens.length
-
-        /*All wordpiece logits*/
-        val tokenLogits = tokenVectors.slice(1, tokenLength + 1)
-
-        /*Word-level and span-level alignment with Tokenizer
-        https://github.com/google-research/bert#tokenization
-
-        ### Input
-        orig_tokens = ["John", "Johanson", "'s",  "house"]
-        labels      = ["NNP",  "NNP",      "POS", "NN"]
-
-        # bert_tokens == ["[CLS]", "john", "johan", "##son", "'", "s", "house", "[SEP]"]
-        # orig_to_tok_map == [1, 2, 4, 6]*/
-
-        val labelsWithScores = sentence._1.tokens.zip(tokenLogits).flatMap {
-          case (token, scores) =>
-            originalTokenSentences(sentence._2).indexedTokens.find(
-              p => p.begin == token.begin).map {
-              token =>
-                val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-                val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-                Annotation(
-                  annotatorType = AnnotatorType.NAMED_ENTITY,
-                  begin = token.begin,
-                  end = token.end,
-                  result = label,
-                  metadata = Map("sentence" -> sentence._2.toString) ++ meta
-                )
-            }
-        }
-        labelsWithScores.toSeq
-      }
-    }.toSeq
+  def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),
+                                tokenPiece: TokenPiece): Option[IndexedToken] = {
+    tokenizedSentences(sentence._2).indexedTokens.find(p => p.begin == tokenPiece.begin)
   }
 
 }
-
-

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowTokenClassification.scala
@@ -1,0 +1,98 @@
+package com.johnsnowlabs.ml.tensorflow
+
+import com.johnsnowlabs.nlp.annotators.common.{IndexedToken, TokenPiece, TokenizedSentence, WordpieceTokenizedSentence}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
+
+trait TensorflowTokenClassification {
+
+  protected val sentencePadTokenId: Int
+  protected val sentenceStartTokenId: Int
+  protected val sentenceEndTokenId: Int
+
+  def predict(tokenizedSentences: Seq[TokenizedSentence], batchSize: Int, maxSentenceLength: Int,
+              caseSensitive: Boolean, tags: Map[String, Int]): Seq[Annotation] = {
+
+    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
+
+    /*Run calculation by batches*/
+    wordPieceTokenizedSentences.zipWithIndex.grouped(batchSize).flatMap { batch =>
+      val encoded = encode(batch, maxSentenceLength)
+      val logits = tag(encoded)
+
+      /*Combine tokens and calculated logits*/
+      batch.zip(logits).flatMap { case (sentence, tokenVectors) =>
+        val tokenLength = sentence._1.tokens.length
+
+        /*All wordpiece logits*/
+        val tokenLogits: Array[Array[Float]] = tokenVectors.slice(1, tokenLength + 1)
+
+        val labelsWithScores = wordAndSpanLevelAlignmentWithTokenizer(tokenLogits, tokenizedSentences, sentence, tags)
+        labelsWithScores
+      }
+    }.toSeq
+
+  }
+
+  def tokenizeWithAlignment(sentences: Seq[TokenizedSentence], maxSeqLength: Int, caseSensitive: Boolean): Seq[WordpieceTokenizedSentence]
+
+  /** Encode the input sequence to indexes IDs adding padding where necessary
+   * */
+  def encode(sentences: Seq[(WordpieceTokenizedSentence, Int)], maxSequenceLength: Int): Seq[Array[Int]] = {
+    //aka prepareBatchInputs
+    val maxSentenceLength =
+      Array(
+        maxSequenceLength - 2,
+        sentences.map { case (wpTokSentence, _) => wpTokSentence.tokens.length }.max).min
+
+    sentences
+      .map { case (wpTokSentence, _) =>
+        val tokenPieceIds = wpTokSentence.tokens.map(t => t.pieceId)
+        val padding = Array.fill(maxSentenceLength - tokenPieceIds.length)(sentencePadTokenId)
+
+        Array(sentenceStartTokenId) ++ tokenPieceIds.take(maxSentenceLength) ++ Array(sentenceEndTokenId) ++ padding
+      }
+  }
+
+  def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]]
+
+  def calculateSoftmax(scores: Array[Float]): Array[Float] = {
+    val exp = scores.map(x => math.exp(x))
+    exp.map(x => x / exp.sum).map(_.toFloat)
+  }
+
+  /** Word-level and span-level alignment with Tokenizer
+    https://github.com/google-research/bert#tokenization
+
+    ### Input
+    orig_tokens = ["John", "Johanson", "'s",  "house"]
+    labels      = ["NNP",  "NNP",      "POS", "NN"]
+
+    # bert_tokens == ["[CLS]", "john", "johan", "##son", "'", "s", "house", "[SEP]"]
+    # orig_to_tok_map == [1, 2, 4, 6]
+   */
+  def wordAndSpanLevelAlignmentWithTokenizer(tokenLogits: Array[Array[Float]], tokenizedSentences: Seq[TokenizedSentence],
+                                             sentence: (WordpieceTokenizedSentence, Int), tags: Map[String, Int]): Seq[Annotation] = {
+
+    val labelsWithScores = sentence._1.tokens.zip(tokenLogits).flatMap {
+      case (tokenPiece, scores) =>
+        val indexedToken = findIndexedToken(tokenizedSentences, sentence, tokenPiece)
+        indexedToken.map {
+          token =>
+            val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
+            val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
+            Annotation(
+              annotatorType = AnnotatorType.NAMED_ENTITY,
+              begin = token.begin,
+              end = token.end,
+              result = label,
+              metadata = Map("sentence" -> sentence._2.toString, "word" -> token.token) ++ meta
+            )
+        }
+    }
+    labelsWithScores.toSeq
+  }
+
+  def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),
+                       tokenPiece: TokenPiece): Option[IndexedToken]
+
+}

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlnetClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlnetClassification.scala
@@ -19,7 +19,6 @@ package com.johnsnowlabs.ml.tensorflow
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{SentencePieceWrapper, SentencepieceEncoder}
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
 import com.johnsnowlabs.nlp.annotators.common._
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
 import scala.collection.JavaConverters._
@@ -37,35 +36,28 @@ class TensorflowXlnetClassification(val tensorflowWrapper: TensorflowWrapper,
                                     configProtoBytes: Option[Array[Byte]] = None,
                                     tags: Map[String, Int],
                                     signatures: Option[Map[String, String]] = None
-                                   ) extends Serializable {
+                                   ) extends Serializable with TensorflowTokenClassification {
 
   val _tfXlnetSignatures: Map[String, String] = signatures.getOrElse(ModelSignatureManager.apply())
 
   // keys representing the input and output tensors of the XLNet model
-  private val SentenceStartTokenId = spp.getSppModel.pieceToId("<cls>")
-  private val SentenceEndTokenId = spp.getSppModel.pieceToId("<sep>")
-  private val SentencePadTokenId = spp.getSppModel.pieceToId("<pad>")
-  private val SentencePieceDelimiterId = spp.getSppModel.pieceToId("▁")
+  override protected val sentenceStartTokenId: Int = spp.getSppModel.pieceToId("<cls>")
+  override protected val sentenceEndTokenId: Int = spp.getSppModel.pieceToId("<sep>")
+  override protected val sentencePadTokenId: Int = spp.getSppModel.pieceToId("<pad>")
 
-  /** Encode the input sequence to indexes IDs adding padding where necessary */
-  def prepareBatchInputs(sentences: Seq[(WordpieceTokenizedSentence, Int)], maxSequenceLength: Int): Seq[Array[Int]] = {
-    val maxSentenceLength =
-      Array(
-        maxSequenceLength - 2,
-        sentences.map { case (wpTokSentence, _) => wpTokSentence.tokens.length }.max).min
+  private val sentencePieceDelimiterId = spp.getSppModel.pieceToId("▁")
 
-    sentences
-      .map { case (wpTokSentence, _) =>
-        val tokenPieceIds = wpTokSentence.tokens.map(t => t.pieceId)
-        val padding = Array.fill(maxSentenceLength - tokenPieceIds.length)(SentencePadTokenId)
+  def tokenizeWithAlignment(sentences: Seq[TokenizedSentence], maxSeqLength: Int, caseSensitive: Boolean):
+  Seq[WordpieceTokenizedSentence] = {
 
-        Array(SentenceStartTokenId) ++ tokenPieceIds.take(maxSentenceLength) ++ Array(SentenceEndTokenId) ++ padding
-      }
-  }
+    val encoder = new SentencepieceEncoder(spp, caseSensitive, delimiterId = sentencePieceDelimiterId)
 
-  def calcluateSoftmax(scores: Array[Float]): Array[Float] = {
-    val exp = scores.map(x => math.exp(x))
-    exp.map(x => x / exp.sum).map(_.toFloat)
+    val sentecneTokenPieces = sentences.map { s =>
+      val shrinkedSentence = s.indexedTokens.take(maxSeqLength - 2)
+      val wordpieceTokens = shrinkedSentence.flatMap(token => encoder.encode(token)).take(maxSeqLength)
+      WordpieceTokenizedSentence(wordpieceTokens)
+    }
+    sentecneTokenPieces
   }
 
   def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
@@ -85,7 +77,7 @@ class TensorflowXlnetClassification(val tensorflowWrapper: TensorflowWrapper,
       .foreach { case (sentence, idx) =>
         val offset = idx * maxSentenceLength
         tokenBuffers.offset(offset).write(sentence)
-        maskBuffers.offset(offset).write(sentence.map(x => if (x == SentencePadTokenId) 0 else 1))
+        maskBuffers.offset(offset).write(sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
         segmentBuffers.offset(offset).write(Array.fill(maxSentenceLength)(0))
       }
 
@@ -113,71 +105,14 @@ class TensorflowXlnetClassification(val tensorflowWrapper: TensorflowWrapper,
 
     val dim = rawScores.length / (batchLength * maxSentenceLength)
     val batchScores: Array[Array[Array[Float]]] = rawScores.grouped(dim).map(scores =>
-      calcluateSoftmax(scores)).toArray.grouped(maxSentenceLength).toArray
+      calculateSoftmax(scores)).toArray.grouped(maxSentenceLength).toArray
 
     batchScores
   }
 
-  def predict(tokenizedSentences: Seq[TokenizedSentence],
-              batchSize: Int,
-              maxSentenceLength: Int,
-              caseSensitive: Boolean
-             ): Seq[Annotation] = {
-
-    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
-
-    /*Run calculation by batches*/
-    wordPieceTokenizedSentences.zipWithIndex.grouped(batchSize).flatMap { batch =>
-      val encoded = prepareBatchInputs(batch, maxSentenceLength)
-      val logits = tag(encoded)
-
-      /*Combine tokens and calculated logits*/
-      batch.zip(logits).flatMap { case (sentence, tokenVectors) =>
-        val tokenLength = sentence._1.tokens.length
-
-        /*All wordpiece logits*/
-        val tokenLogits = tokenVectors.slice(1, tokenLength + 1)
-
-        /*Word-level and span-level alignment with Tokenizer
-        https://github.com/google-research/bert#tokenization
-
-        ### Input
-        orig_tokens = ["John", "Johanson", "'s",  "house"]
-        labels      = ["NNP",  "NNP",      "POS", "NN"]
-
-        # bert_tokens == ["[CLS]", "john", "johan", "##son", "'", "s", "house", "[SEP]"]
-        # orig_to_tok_map == [1, 2, 4, 6]*/
-
-        val labelsWithScores = sentence._1.tokens.zip(tokenLogits).flatMap {
-          case (token, scores) =>
-            tokenizedSentences(sentence._2).indexedTokens.find(
-              p => p.begin == token.begin && token.isWordStart).map {
-              token =>
-                val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-                val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-                Annotation(
-                  annotatorType = AnnotatorType.NAMED_ENTITY,
-                  begin = token.begin,
-                  end = token.end,
-                  result = label,
-                  metadata = Map("sentence" -> sentence._2.toString) ++ meta
-                )
-            }
-        }
-        labelsWithScores.toSeq
-      }
-    }.toSeq
-  }
-
-  def tokenizeWithAlignment(sentences: Seq[TokenizedSentence], maxSeqLength: Int, caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = {
-    val encoder = new SentencepieceEncoder(spp, caseSensitive, delimiterId = SentencePieceDelimiterId)
-
-    val sentecneTokenPieces = sentences.map { s =>
-      val shrinkedSentence = s.indexedTokens.take(maxSeqLength - 2)
-      val wordpieceTokens = shrinkedSentence.flatMap(token => encoder.encode(token)).take(maxSeqLength)
-      WordpieceTokenizedSentence(wordpieceTokens)
-    }
-    sentecneTokenPieces
+  def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),
+                                tokenPiece: TokenPiece): Option[IndexedToken] = {
+    tokenizedSentences(sentence._2).indexedTokens.find(p => p.begin == tokenPiece.begin && tokenPiece.isWordStart)
   }
 }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForTokenClassification.scala
@@ -243,7 +243,8 @@ class AlbertForTokenClassification(override val uid: String)
         tokenizedSentences,
         $(batchSize),
         $(maxSentenceLength),
-        $(caseSensitive)
+        $(caseSensitive),
+        getLabels
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala
@@ -218,7 +218,8 @@ class BertForTokenClassification(override val uid: String)
             sentenceEndTokenId,
             configProtoBytes = getConfigProtoBytes,
             tags = getLabels,
-            signatures = getSignatures
+            signatures = getSignatures,
+            $$(vocabulary)
           )
         )
       )
@@ -247,25 +248,6 @@ class BertForTokenClassification(override val uid: String)
     caseSensitive -> true
   )
 
-  def tokenizeWithAlignment(tokens: Seq[TokenizedSentence]): Seq[WordpieceTokenizedSentence] = {
-    val basicTokenizer = new BasicTokenizer($(caseSensitive))
-    val encoder = new WordpieceEncoder($$(vocabulary))
-
-    tokens.map { tokenIndex =>
-      // filter empty and only whitespace tokens
-      val bertTokens = tokenIndex.indexedTokens.filter(x => x.token.nonEmpty && !x.token.equals(" ")).map { token =>
-        val content = if ($(caseSensitive)) token.token else token.token.toLowerCase()
-        val sentenceBegin = token.begin
-        val sentenceEnd = token.end
-        val sentenceInedx = tokenIndex.sentenceIndex
-        val result = basicTokenizer.tokenize(Sentence(content, sentenceBegin, sentenceEnd, sentenceInedx))
-        if (result.nonEmpty) result.head else IndexedToken("")
-      }
-      val wordpieceTokens = bertTokens.flatMap(token => encoder.encode(token)).take($(maxSentenceLength))
-      WordpieceTokenizedSentence(wordpieceTokens)
-    }
-  }
-
   /**
    * takes a document and annotations and produces new annotations of this annotator's annotation type
    *
@@ -278,13 +260,13 @@ class BertForTokenClassification(override val uid: String)
     ).toArray
     /*Return empty if the real tokens are empty*/
     if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
-      val tokenized = tokenizeWithAlignment(tokenizedSentences)
 
       getModelIfNotSet.predict(
-        tokenized,
         tokenizedSentences,
         $(batchSize),
-        $(maxSentenceLength)
+        $(maxSentenceLength),
+        $(caseSensitive),
+        getLabels
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
@@ -219,7 +219,8 @@ class DistilBertForTokenClassification(override val uid: String)
             sentenceEndTokenId,
             configProtoBytes = getConfigProtoBytes,
             tags = getLabels,
-            signatures = getSignatures
+            signatures = getSignatures,
+            $$(vocabulary)
           )
         )
       )
@@ -248,25 +249,6 @@ class DistilBertForTokenClassification(override val uid: String)
     caseSensitive -> true
   )
 
-  def tokenizeWithAlignment(tokens: Seq[TokenizedSentence]): Seq[WordpieceTokenizedSentence] = {
-    val basicTokenizer = new BasicTokenizer($(caseSensitive))
-    val encoder = new WordpieceEncoder($$(vocabulary))
-
-    tokens.map { tokenIndex =>
-      // filter empty and only whitespace tokens
-      val bertTokens = tokenIndex.indexedTokens.filter(x => x.token.nonEmpty && !x.token.equals(" ")).map { token =>
-        val content = if ($(caseSensitive)) token.token else token.token.toLowerCase()
-        val sentenceBegin = token.begin
-        val sentenceEnd = token.end
-        val sentenceInedx = tokenIndex.sentenceIndex
-        val result = basicTokenizer.tokenize(Sentence(content, sentenceBegin, sentenceEnd, sentenceInedx))
-        if (result.nonEmpty) result.head else IndexedToken("")
-      }
-      val wordpieceTokens = bertTokens.flatMap(token => encoder.encode(token)).take($(maxSentenceLength))
-      WordpieceTokenizedSentence(wordpieceTokens)
-    }
-  }
-
   /**
    * takes a document and annotations and produces new annotations of this annotator's annotation type
    *
@@ -279,13 +261,13 @@ class DistilBertForTokenClassification(override val uid: String)
     ).toArray
     /*Return empty if the real tokens are empty*/
     if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
-      val tokenized = tokenizeWithAlignment(tokenizedSentences)
 
       getModelIfNotSet.predict(
-        tokenized,
         tokenizedSentences,
         $(batchSize),
-        $(maxSentenceLength)
+        $(maxSentenceLength),
+        $(caseSensitive),
+        getLabels
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForTokenClassification.scala
@@ -233,7 +233,9 @@ class RoBertaForTokenClassification(override val uid: String)
             padTokenId,
             configProtoBytes = getConfigProtoBytes,
             tags = getLabels,
-            signatures = getSignatures
+            signatures = getSignatures,
+            $$(merges),
+            $$(vocabulary)
           )
         )
       )
@@ -262,29 +264,6 @@ class RoBertaForTokenClassification(override val uid: String)
     caseSensitive -> true
   )
 
-  def tokenizeWithAlignment(tokens: Seq[TokenizedSentence]): Seq[WordpieceTokenizedSentence] = {
-    val bpeTokenizer = BpeTokenizer.forModel(
-      "roberta",
-      merges = $$(merges),
-      vocab = $$(vocabulary),
-      padWithSentenceTokens = false
-    )
-
-    tokens.map { tokenIndex =>
-      // filter empty and only whitespace tokens
-      val bertTokens = tokenIndex.indexedTokens.filter(x => x.token.nonEmpty && !x.token.equals(" ")).map { token =>
-        val content = if ($(caseSensitive)) token.token else token.token.toLowerCase()
-        val sentenceBegin = token.begin
-        val sentenceEnd = token.end
-        val sentenceInedx = tokenIndex.sentenceIndex
-        val result = bpeTokenizer.tokenize(Sentence(content, sentenceBegin, sentenceEnd, sentenceInedx))
-        if (result.nonEmpty) result.head else IndexedToken("")
-      }
-      val wordpieceTokens = bertTokens.flatMap(token => bpeTokenizer.encode(token)).take($(maxSentenceLength))
-      WordpieceTokenizedSentence(wordpieceTokens)
-    }
-  }
-
   /**
    * takes a document and annotations and produces new annotations of this annotator's annotation type
    *
@@ -297,13 +276,13 @@ class RoBertaForTokenClassification(override val uid: String)
     ).toArray
     /*Return empty if the real tokens are empty*/
     if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
-      val tokenized = tokenizeWithAlignment(tokenizedSentences)
 
       getModelIfNotSet.predict(
-        tokenized,
         tokenizedSentences,
         $(batchSize),
-        $(maxSentenceLength)
+        $(maxSentenceLength),
+        $(caseSensitive),
+        getLabels
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForTokenClassification.scala
@@ -244,7 +244,8 @@ class XlmRoBertaForTokenClassification(override val uid: String)
         tokenizedSentences,
         $(batchSize),
         $(maxSentenceLength),
-        $(caseSensitive)
+        $(caseSensitive),
+        getLabels
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForTokenClassification.scala
@@ -243,7 +243,8 @@ class XlnetForTokenClassification(override val uid: String)
         tokenizedSentences,
         $(batchSize),
         $(maxSentenceLength),
-        $(caseSensitive)
+        $(caseSensitive),
+        getLabels
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/wordpiece/BasicTokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/wordpiece/BasicTokenizer.scala
@@ -21,7 +21,7 @@ import com.johnsnowlabs.nlp.annotators.common.{IndexedToken, Sentence}
 import scala.collection.mutable
 
 
-private [nlp] class BasicTokenizer(caseSensitive: Boolean = false) {
+private [johnsnowlabs] class BasicTokenizer(caseSensitive: Boolean = false) {
 
   def isWhitespace(char: Char): Boolean = {
     char == ' ' || char == '\t' || char == '\n' || char == '\r' || Character.isWhitespace(char)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/wordpiece/WordpieceEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/wordpiece/WordpieceEncoder.scala
@@ -20,7 +20,7 @@ import com.johnsnowlabs.nlp.annotators.common.{IndexedToken, TokenPiece}
 import scala.collection.mutable.ArrayBuffer
 
 
-private[nlp] class WordpieceEncoder
+private[johnsnowlabs] class WordpieceEncoder
 (
   vocabulary: Map[String, Int],
   unkToken: String = "[UNK]",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change consisted of two modifications:

1. Creating a trait `TensorflowTokenClassification` that shares all similar logic that all other ForTokenClassification annotators.
2. Adding word information on metadata for all ForTokenClassification annotators 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- To make the code more flexible and maintainable
- To fix [issue 943](https://github.com/JohnSnowLabs/spark-nlp-internal/issues/943) with NerOverwriter 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running unit tests locally and with Databricks and Google Colab [notebooks](https://colab.research.google.com/drive/1DWUIyJzFhL9dhzu6b4LKtucC-3-81Q31?usp=sharing)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
