### PR TITLE
PyDoc: fix escaping for EntityRuler annotator

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -14530,7 +14530,7 @@ class EntityRulerApproach(AnnotatorApproach, HasStorage):
         ...     .setPatternsResource(
         ...       "patterns.csv",
         ...       ReadAs.TEXT,
-        ...       {"format": "csv", "delimiter": "\\|"}
+        ...       {"format": "csv", "delimiter": "\\\\|"}
         ...     ) \\
         ...     .setEnablePatternRegex(True)
         >>> pipeline = Pipeline().setStages([


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
PyDoc needs extra escaping, so it is equivalent to the other docs.