### PR TITLE
Fix EntityRulerApproach name from import and add the model to ResourceDownloader

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -370,7 +370,7 @@ package object annotator {
 
   object LongformerForTokenClassification extends ReadablePretrainedLongformerForTokenModel with ReadLongformerForTokenTensorflowModel
   
-  type EntityRuler = com.johnsnowlabs.nlp.annotators.er.EntityRulerApproach
+  type EntityRulerApproach = com.johnsnowlabs.nlp.annotators.er.EntityRulerApproach
 
   type EntityRulerModel = com.johnsnowlabs.nlp.annotators.er.EntityRulerModel
 

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -18,6 +18,7 @@ package com.johnsnowlabs.nlp.pretrained
 
 import com.johnsnowlabs.nlp.annotators._
 import com.johnsnowlabs.nlp.annotators.classifier.dl._
+import com.johnsnowlabs.nlp.annotators.er.EntityRulerModel
 import com.johnsnowlabs.nlp.annotators.ld.dl.LanguageDetectorDL
 import com.johnsnowlabs.nlp.annotators.ner.crf.NerCrfModel
 import com.johnsnowlabs.nlp.annotators.ner.dl.NerDLModel
@@ -524,7 +525,8 @@ object PythonResourceDownloader {
     "XlmRoBertaForTokenClassification" -> XlmRoBertaForTokenClassification,
     "AlbertForTokenClassification" -> AlbertForTokenClassification,
     "XlnetForTokenClassification" -> XlnetForTokenClassification,
-    "LongformerForTokenClassification" -> LongformerForTokenClassification
+    "LongformerForTokenClassification" -> LongformerForTokenClassification,
+    "EntityRulerModel" -> EntityRulerModel
   )
 
   def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {


### PR DESCRIPTION
This PR makes sure EntityRulerApproach has the same name from `import com.johnsnowlabs.nlp.annotator._`. It also adds `EntityRulerModel` to ResourceDownloader for future pretrained models.