### PR TITLE
Fix a bug in NerDLModel that degrades GPU performance

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -25,7 +25,7 @@ import org.apache.spark.ml.util.Identifiable
 import scala.collection.Map
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-
+import scala.collection.JavaConverters._
 
 class TensorflowNer(val tensorflow: TensorflowWrapper,
                     val encoder: NerDatasetEncoder,
@@ -54,7 +54,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
               configProtoBytes: Option[Array[Byte]] = None,
               includeConfidence: Boolean = false,
               includeAllConfidenceScores: Boolean,
-              batchSize: Int = 8): Array[Array[(String, Option[Array[Map[String, String]]])]] = {
+              batchSize: Int): Array[Array[(String, Option[Array[Map[String, String]]])]] = {
 
     val result = ArrayBuffer[Array[(String, Option[Array[Map[String, String]]])]]()
 
@@ -78,20 +78,17 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
 
         val calculatorInc = if (includeConfidence) calculator.fetch(scoresKey) else calculator
 
-        val calculated = calculatorInc.run()
-
-        tensors.clearTensors()
+        val calculated = calculatorInc.run().asScala
 
         val allTags = encoder.tags
-        val tagIds = TensorResources.extractInts(calculated.get(0))
+        val tagIds = TensorResources.extractInts(calculated.head)
 
         val confidence: Option[Seq[Array[Float]]] = {
           try {
             if (includeConfidence) {
-              val scores = TensorResources.extractFloats(calculated.get(1))
+              val scores = TensorResources.extractFloats(calculated(1))
               require(scores.length % tagIds.length == 0, "tag size mismatch against feed size. please report an issue.")
               val exp = scores.map(s => math.exp(s.toDouble)).grouped(scores.length / tagIds.length).toSeq
-              // val probs = exp.map(g => try{BigDecimal(g.map(_ / g.sum).max).setScale(4, BigDecimal.RoundingMode.HALF_UP).toDouble}catch{case _: Exception => 0.0d})
               val probs = if (includeAllConfidenceScores) {
                 //Only include the score of the predicted tag
                 exp.map(d => d.map(_ / d.sum).map(p => try {
@@ -127,6 +124,10 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
           batchInput.sentenceLengths,
           confidence,
           includeAllConfidenceScores = includeAllConfidenceScores)
+
+        calculated.foreach(_.close())
+        tensors.clearSession(calculated)
+        tensors.clearTensors()
 
         result.appendAll(sentenceTags)
       }
@@ -209,20 +210,20 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
         val calculated = tensorflow.getSession(configProtoBytes = configProtoBytes).runner
           .feed(sentenceLengthsKey, tensors.createTensor(batchInput.sentenceLengths))
           .feed(wordEmbeddingsKey, tensors.createTensor(batchInput.wordEmbeddings))
-
           .feed(wordLengthsKey, tensors.createTensor(batchInput.wordLengths))
           .feed(charIdsKey, tensors.createTensor(batchInput.charIds))
           .feed(labelsKey, tensors.createTensor(batchTags))
-
           .feed(dropoutKey, tensors.createTensor(dropout))
           .feed(learningRateKey, tensors.createTensor(learningRate))
-
           .fetch(lossKey)
           .addTarget(trainingKey)
-          .run()
+          .run().asScala
 
-        loss += TensorResources.extractFloats(calculated.get(0)).head
+        loss += TensorResources.extractFloats(calculated.head).head
 
+        calculated.foreach(_.close())
+        tensors.clearSession(calculated)
+        tensors.clearTensors()
         tensors.clearTensors()
         batches += 1
       }
@@ -232,13 +233,11 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
       outputLog("\n", uuid, enableOutputLogs, outputLogsPath)
       outputLog(f"Epoch ${epoch + 1}/$endEpoch - $endTime%.2fs - loss: $loss - batches: $batches", uuid, enableOutputLogs, outputLogsPath)
 
-
       if (validationSplit > 0.0) {
         println(s"Quality on validation dataset (${validationSplit * 100}%), validation examples = $validLength")
         outputLog(s"Quality on validation dataset (${validationSplit * 100}%), validation examples = $validLength", uuid, enableOutputLogs, outputLogsPath)
         measure(validDataset, extended = evaluationLogExtended, includeConfidence = includeConfidence, enableOutputLogs = enableOutputLogs, outputLogsPath = outputLogsPath, batchSize = batchSize, uuid = uuid)
       }
-
 
       if (test.nonEmpty) {
         println("Quality on test dataset: ")
@@ -311,7 +310,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
       val sentenceLabels = batch.map(pair => pair._1.labels.toArray).toList
 
       (sentenceTokens, sentenceLabels, sentenceTokenTags).zipped.foreach {
-        case (tokens, labels, tags) =>
+        case (_, labels, tags) =>
           for (i <- labels.indices) {
 
             val label = labels(i)

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -53,7 +53,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
   def predict(dataset: Array[WordpieceEmbeddingsSentence],
               configProtoBytes: Option[Array[Byte]] = None,
               includeConfidence: Boolean = false,
-              includeAllConfidenceScores: Boolean,
+              includeAllConfidenceScores: Boolean = false,
               batchSize: Int): Array[Array[(String, Option[Array[Map[String, String]]])]] = {
 
     val result = ArrayBuffer[Array[(String, Option[Array[Map[String, String]]])]]()
@@ -224,7 +224,6 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
         calculated.foreach(_.close())
         tensors.clearSession(calculated)
         tensors.clearTensors()
-        tensors.clearTensors()
         batches += 1
       }
 
@@ -298,7 +297,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
 
     for (batch <- labeled) {
 
-      val sentencePredictedTags = predict(batch.map(_._2), includeConfidence = includeConfidence, includeAllConfidenceScores = includeAllConfidenceScores, batchSize = batchSize)
+      val sentencePredictedTags = predict(batch.map(_._2), batchSize = batchSize)
 
       val sentenceTokenTags = tagsForTokens(sentencePredictedTags, batch.map(_._2))
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -516,6 +516,7 @@ class NerDLApproach(override val uid: String)
       .setDatasetParams(ner.encoder.params)
       .setModelIfNotSet(dataset.sparkSession, newWrapper)
       .setIncludeConfidence($(includeConfidence))
+      .setIncludeAllConfidenceScores($(includeAllConfidenceScores))
       .setStorageRef(embeddingsRef)
 
     if (get(configProtoBytes).isDefined)
@@ -527,8 +528,8 @@ class NerDLApproach(override val uid: String)
 
   def getDataSetParams(dsIt: Iterator[Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]]): (mutable.Set[String], mutable.Set[Char], Int, Long) = {
 
-    var labels = scala.collection.mutable.Set[String]()
-    var chars = scala.collection.mutable.Set[Char]()
+    val labels = scala.collection.mutable.Set[String]()
+    val chars = scala.collection.mutable.Set[Char]()
     var embeddingsDim = 1
     var dsLen = 0L
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLModel.scala
@@ -267,7 +267,7 @@ class NerDLModel(override val uid: String)
   setDefault(
     includeConfidence -> false,
     includeAllConfidenceScores -> false,
-    batchSize -> 8
+    batchSize -> 32
   )
 
   private case class RowIdentifiedSentence(rowIndex: Int, rowSentence: WordpieceEmbeddingsSentence)
@@ -279,7 +279,8 @@ class NerDLModel(override val uid: String)
       batch.map(_.rowSentence),
       getConfigProtoBytes,
       includeConfidence = $(includeConfidence),
-      includeAllConfidenceScores = $(includeAllConfidenceScores)
+      includeAllConfidenceScores = $(includeAllConfidenceScores),
+      $(batchSize)
     )
 
     val outputBatches = Array.fill[Array[NerTaggedSentence]](tokenized.length)(Array.empty)


### PR DESCRIPTION
This PR fixes a bug that was introduced in Spark NLP 3.1.2 that doesn't pass batchSize param value to the predict function. Therefore, the value of batchSize stayed always at 8. Although, batchSize of 8 can be fine for CPU, is very low for GPU. This resulted in bad performance when NerDLModel was used on GPU after Spark NLP 3.1.2 releases.