### PR TITLE
Adding timestamp in logging file's name

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/Logging.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/Logging.scala
@@ -20,6 +20,8 @@ import com.johnsnowlabs.nlp.annotators.ner.Verbose
 import com.johnsnowlabs.nlp.util.io.OutputHelper
 import org.slf4j.LoggerFactory
 
+import java.time.Instant
+
 /* Logging for the TensorFlow Models, probably can be used in other places */
 trait Logging {
 
@@ -27,6 +29,8 @@ trait Logging {
 
   protected val logger = LoggerFactory.getLogger(getLogName)
   val verboseLevel: Verbose.Value
+
+  private val unixTimeStamp: Long = Instant.now().getEpochSecond
 
   protected def log(value: => String, minLevel: Verbose.Level): Unit = {
     if (minLevel.id >= verboseLevel.id) {
@@ -36,7 +40,7 @@ trait Logging {
 
   protected def outputLog(value: => String, uuid: String, shouldLog: Boolean, outputLogsPath: String): Unit = {
     if (shouldLog) {
-      OutputHelper.writeAppend(uuid, value, outputLogsPath)
+      OutputHelper.writeAppend(uuid, value, outputLogsPath, unixTimeStamp.toString)
     }
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/OutputHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/OutputHelper.scala
@@ -23,6 +23,8 @@ import org.apache.spark.SparkFiles
 
 import java.io.{File, FileWriter, PrintWriter}
 import java.nio.charset.StandardCharsets
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import scala.language.existentials
 
 
@@ -38,10 +40,11 @@ object OutputHelper {
 
   var historyLog: Array[String] = Array()
 
-  def writeAppend(uuid: String, content: String, outputLogsPath: String): Unit = {
+  def writeAppend(uuid: String, content: String, outputLogsPath: String, timeStamp: String): Unit = {
 
     val targetFolder = getTargetFolder(outputLogsPath)
-    targetPath = new Path(targetFolder, uuid + ".log")
+    val fileName = f"${uuid}_$timeStamp.log"
+    targetPath = new Path(targetFolder, fileName)
 
     if (isDBFS) {
       historyLog = historyLog ++ Array(content)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Modifies naming convention to save the logs on disk for training annotators (e.g NerDLApproach, ClassifierDL, etc)
The current naming format is: `annotator_uid.log`
This change will make the format: `annotator_uid_timestamp.log`
An example for NerDLApproach: `NerDL_bfab02716caf_1636467507.log`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When there are many classifiers trained, it is difficult to match the name of log files. By adding the timestamp, it would be easier to identify and match log files with trained models.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
