### PR TITLE
Fix MarianTransformer crashing on both empty sequence  or longer than 512

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowMarian.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowMarian.scala
@@ -208,9 +208,9 @@ class TensorflowMarian(val tensorflow: TensorflowWrapper,
       }
 
       if (langId > 0)
-        Array(langId) ++ pieceIds.take(maxSeqLength) ++ Array(eosTokenId)
+        Array(langId) ++ pieceIds.take(maxSeqLength - 2) ++ Array(eosTokenId)
       else
-        pieceIds.take(maxSeqLength) ++ Array(eosTokenId)
+        pieceIds.take(maxSeqLength - 1) ++ Array(eosTokenId)
     }
 
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
@@ -278,7 +278,7 @@ class MarianTransformer(override val uid: String) extends
    * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
    */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    val nonEmptySentences = batchedAnnotations.map(x => x.filter(_.result.nonEmpty))
+    val nonEmptySentences = batchedAnnotations.filter(x => x.nonEmpty)
 
     if (nonEmptySentences.nonEmpty) nonEmptySentences.map(tokenizedSentences => {
       this.getModelIfNotSet.generateSeq2Seq(

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
@@ -267,7 +267,7 @@ class MarianTransformer(override val uid: String) extends
   setDefault(
     maxInputLength -> 40,
     maxOutputLength -> 40,
-    batchSize -> 4,
+    batchSize -> 1,
     langId -> ""
   )
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformerTestSpec.scala
@@ -21,6 +21,7 @@ import com.johnsnowlabs.nlp.base._
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.tags.SlowTest
 import com.johnsnowlabs.util.Benchmark
+
 import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -34,7 +35,9 @@ class MarianTransformerTestSpec extends AnyFlatSpec {
       "What is the capital of France?",
       "This should go to French",
       "This is a sentence in English that we want to translate to French",
-      "Despite a Democratic majority in the General Assembly, Nunn was able to enact most of his priorities, including tax increases that funded improvements to the state park system and the construction of a statewide network of mental health centers."
+      "Despite a Democratic majority in the General Assembly, Nunn was able to enact most of his priorities, including tax increases that funded improvements to the state park system and the construction of a statewide network of mental health centers.",
+      "",
+      " "
     ).toDF("text")
 
     val documentAssembler = new DocumentAssembler()
@@ -46,9 +49,10 @@ class MarianTransformerTestSpec extends AnyFlatSpec {
       .setOutputCol("sentence")
 
     val marian = MarianTransformer.pretrained()
-      .setInputCols("sentence")
+      .setInputCols("document")
       .setOutputCol("translation")
-      .setMaxInputLength(30)
+      .setMaxInputLength(512)
+      .setMaxOutputLength(50)
 
     val pipeline = new Pipeline()
       .setStages(Array(
@@ -59,12 +63,22 @@ class MarianTransformerTestSpec extends AnyFlatSpec {
 
     val pipelineModel = pipeline.fit(smallCorpus)
 
-    Benchmark.time("Time to show") {
+    Benchmark.time("Time to save pipeline the first time") {
+      pipelineModel.transform(smallCorpus).select("translation.result").write.mode("overwrite").save("./tmp_marianmt_pipeline")
+    }
+
+    Benchmark.time("Time to save pipeline the second time") {
+      pipelineModel.transform(smallCorpus).select("translation.result").write.mode("overwrite").save("./tmp_marianmt_pipeline")
+    }
+
+    Benchmark.time("Time to first show") {
       pipelineModel.transform(smallCorpus).select("translation").show(false)
     }
+
     Benchmark.time("Time to second show") {
       pipelineModel.transform(smallCorpus).select("translation").show(false)
     }
+
     Benchmark.time("Time to save pipelineMolde") {
       pipelineModel.write.overwrite.save("./tmp_marianmt")
     }
@@ -82,9 +96,7 @@ class MarianTransformerTestSpec extends AnyFlatSpec {
     Benchmark.time("Time to second show") {
       pipelineDF.select("translation").show(false)
     }
-    Benchmark.time("Time to save pipeline") {
-      pipelineModel.transform(smallCorpus).select("translation.result").write.mode("overwrite").save("./tmp_marianmt_pipeline")
-    }
+
   }
 
 }


### PR DESCRIPTION
This PR fixes the following issues in MarianTransformer
- Makes sure the max sequence is 512 even when we add `eos` or sometimes `langId` tokens. It should take the extra token ids into account to not exceed 512 which the MAX_LENGTH of MarianMT models
- Filter empty annotations to avoid exception - the previous filter on `.result` was not a good choice, we should filter on the actual Annotation to filter empty Annotations

