### PR TITLE
Optimized batch processing for Bert sentence and word embeddings

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -324,25 +324,7 @@ class BertEmbeddings(override val uid: String)
       else
         Seq.empty[Annotation]
     })
-//
-//    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations.map(annotations =>
-//      TokenizedWithSentence.unpack(annotations).toArray
-//    ).toArray
-//    /*Return empty if the real tokens are empty*/
-//    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
-//      val tokenized = tokenizeWithAlignment(tokenizedSentences)
-//
-//      val withEmbeddings = getModelIfNotSet.calculateEmbeddings(
-//        tokenized,
-//        tokenizedSentences,
-//        $(batchSize),
-//        $(maxSentenceLength),
-//        $(caseSensitive)
-//      )
-//      WordpieceEmbeddingsSentence.pack(withEmbeddings)
-//    }) else {
-//      Seq(Seq.empty[Annotation])
-//    }
+
   }
 
   override protected def afterAnnotate(dataset: DataFrame): DataFrame = {

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings.scala
@@ -32,104 +32,104 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import scala.collection.mutable.ArrayBuffer
 
 /**
-  * Sentence-level embeddings using BERT. BERT (Bidirectional Encoder Representations from Transformers) provides dense
-  * vector representations for natural language by using a deep, pre-trained neural network with the Transformer architecture.
-  *
-  * Pretrained models can be loaded with `pretrained` of the companion object:
-  * {{{
-  * val embeddings = BertSentenceEmbeddings.pretrained()
-  *   .setInputCols("sentence")
-  *   .setOutputCol("sentence_bert_embeddings")
-  * }}}
-  * The default model is `"sent_small_bert_L2_768"`, if no name is provided.
-  *
-  * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models?task=Embeddings Models Hub]].
-  *
-  * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BERT%20Sentence.ipynb Spark NLP Workshop]]
-  * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddingsTestSpec.scala BertSentenceEmbeddingsTestSpec]].
-  *
-  * '''Sources''' :
-  *
-  * [[https://arxiv.org/abs/1810.04805 BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding]]
-  *
-  * [[https://github.com/google-research/bert]]
-  *
-  * ''' Paper abstract '''
-  *
-  * ''We introduce a new language representation model called BERT, which stands for Bidirectional Encoder Representations
-  * from Transformers. Unlike recent language representation models, BERT is designed to pre-train deep bidirectional
-  * representations from unlabeled text by jointly conditioning on both left and right context in all layers. As a
-  * result, the pre-trained BERT model can be fine-tuned with just one additional output layer to create
-  * state-of-the-art models for a wide range of tasks, such as question answering and language inference, without
-  * substantial task-specific architecture modifications. BERT is conceptually simple and empirically powerful. It
-  * obtains new state-of-the-art results on eleven natural language processing tasks, including pushing the GLUE score
-  * to 80.5% (7.7% point absolute improvement), MultiNLI accuracy to 86.7% (4.6% absolute improvement), SQuAD v1.1
-  * question answering Test F1 to 93.2 (1.5 point absolute improvement) and SQuAD v2.0 Test F1 to 83.1 (5.1 point
-  * absolute improvement).''
-  *
-  * ==Example==
-  * {{{
-  * import spark.implicits._
-  * import com.johnsnowlabs.nlp.base.DocumentAssembler
-  * import com.johnsnowlabs.nlp.annotator.SentenceDetector
-  * import com.johnsnowlabs.nlp.embeddings.BertSentenceEmbeddings
-  * import com.johnsnowlabs.nlp.EmbeddingsFinisher
-  * import org.apache.spark.ml.Pipeline
-  *
-  * val documentAssembler = new DocumentAssembler()
-  *   .setInputCol("text")
-  *   .setOutputCol("document")
-  *
-  * val sentence = new SentenceDetector()
-  *   .setInputCols("document")
-  *   .setOutputCol("sentence")
-  *
-  * val embeddings = BertSentenceEmbeddings.pretrained("sent_small_bert_L2_128")
-  *   .setInputCols("sentence")
-  *   .setOutputCol("sentence_bert_embeddings")
-  *
-  * val embeddingsFinisher = new EmbeddingsFinisher()
-  *   .setInputCols("sentence_bert_embeddings")
-  *   .setOutputCols("finished_embeddings")
-  *   .setOutputAsVector(true)
-  *
-  * val pipeline = new Pipeline().setStages(Array(
-  *   documentAssembler,
-  *   sentence,
-  *   embeddings,
-  *   embeddingsFinisher
-  * ))
-  *
-  * val data = Seq("John loves apples. Mary loves oranges. John loves Mary.").toDF("text")
-  * val result = pipeline.fit(data).transform(data)
-  *
-  * result.selectExpr("explode(finished_embeddings) as result").show(5, 80)
-  * +--------------------------------------------------------------------------------+
-  * |                                                                          result|
-  * +--------------------------------------------------------------------------------+
-  * |[-0.8951074481010437,0.13753940165042877,0.3108254075050354,-1.65693199634552...|
-  * |[-0.6180210709571838,-0.12179657071828842,-0.191165953874588,-1.4497021436691...|
-  * |[-0.822715163230896,0.7568016648292542,-0.1165061742067337,-1.59048593044281,...|
-  * +--------------------------------------------------------------------------------+
-  * }}}
-  *
-  * @see [[BertEmbeddings]] for token-level embeddings
-  * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based embeddings
-  * @param uid required uid for storing annotator to disk
-  * @groupname anno Annotator types
-  * @groupdesc anno Required input and expected output annotator types
-  * @groupname Ungrouped Members
-  * @groupname param Parameters
-  * @groupname setParam Parameter setters
-  * @groupname getParam Parameter getters
-  * @groupname Ungrouped Members
-  * @groupprio param  1
-  * @groupprio anno  2
-  * @groupprio Ungrouped 3
-  * @groupprio setParam  4
-  * @groupprio getParam  5
-  * @groupdesc param A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
-  * */
+ * Sentence-level embeddings using BERT. BERT (Bidirectional Encoder Representations from Transformers) provides dense
+ * vector representations for natural language by using a deep, pre-trained neural network with the Transformer architecture.
+ *
+ * Pretrained models can be loaded with `pretrained` of the companion object:
+ * {{{
+ * val embeddings = BertSentenceEmbeddings.pretrained()
+ *   .setInputCols("sentence")
+ *   .setOutputCol("sentence_bert_embeddings")
+ * }}}
+ * The default model is `"sent_small_bert_L2_768"`, if no name is provided.
+ *
+ * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models?task=Embeddings Models Hub]].
+ *
+ * For extended examples of usage, see the [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BERT%20Sentence.ipynb Spark NLP Workshop]]
+ * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddingsTestSpec.scala BertSentenceEmbeddingsTestSpec]].
+ *
+ * '''Sources''' :
+ *
+ * [[https://arxiv.org/abs/1810.04805 BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding]]
+ *
+ * [[https://github.com/google-research/bert]]
+ *
+ * ''' Paper abstract '''
+ *
+ * ''We introduce a new language representation model called BERT, which stands for Bidirectional Encoder Representations
+ * from Transformers. Unlike recent language representation models, BERT is designed to pre-train deep bidirectional
+ * representations from unlabeled text by jointly conditioning on both left and right context in all layers. As a
+ * result, the pre-trained BERT model can be fine-tuned with just one additional output layer to create
+ * state-of-the-art models for a wide range of tasks, such as question answering and language inference, without
+ * substantial task-specific architecture modifications. BERT is conceptually simple and empirically powerful. It
+ * obtains new state-of-the-art results on eleven natural language processing tasks, including pushing the GLUE score
+ * to 80.5% (7.7% point absolute improvement), MultiNLI accuracy to 86.7% (4.6% absolute improvement), SQuAD v1.1
+ * question answering Test F1 to 93.2 (1.5 point absolute improvement) and SQuAD v2.0 Test F1 to 83.1 (5.1 point
+ * absolute improvement).''
+ *
+ * ==Example==
+ * {{{
+ * import spark.implicits._
+ * import com.johnsnowlabs.nlp.base.DocumentAssembler
+ * import com.johnsnowlabs.nlp.annotator.SentenceDetector
+ * import com.johnsnowlabs.nlp.embeddings.BertSentenceEmbeddings
+ * import com.johnsnowlabs.nlp.EmbeddingsFinisher
+ * import org.apache.spark.ml.Pipeline
+ *
+ * val documentAssembler = new DocumentAssembler()
+ *   .setInputCol("text")
+ *   .setOutputCol("document")
+ *
+ * val sentence = new SentenceDetector()
+ *   .setInputCols("document")
+ *   .setOutputCol("sentence")
+ *
+ * val embeddings = BertSentenceEmbeddings.pretrained("sent_small_bert_L2_128")
+ *   .setInputCols("sentence")
+ *   .setOutputCol("sentence_bert_embeddings")
+ *
+ * val embeddingsFinisher = new EmbeddingsFinisher()
+ *   .setInputCols("sentence_bert_embeddings")
+ *   .setOutputCols("finished_embeddings")
+ *   .setOutputAsVector(true)
+ *
+ * val pipeline = new Pipeline().setStages(Array(
+ *   documentAssembler,
+ *   sentence,
+ *   embeddings,
+ *   embeddingsFinisher
+ * ))
+ *
+ * val data = Seq("John loves apples. Mary loves oranges. John loves Mary.").toDF("text")
+ * val result = pipeline.fit(data).transform(data)
+ *
+ * result.selectExpr("explode(finished_embeddings) as result").show(5, 80)
+ * +--------------------------------------------------------------------------------+
+ * |                                                                          result|
+ * +--------------------------------------------------------------------------------+
+ * |[-0.8951074481010437,0.13753940165042877,0.3108254075050354,-1.65693199634552...|
+ * |[-0.6180210709571838,-0.12179657071828842,-0.191165953874588,-1.4497021436691...|
+ * |[-0.822715163230896,0.7568016648292542,-0.1165061742067337,-1.59048593044281,...|
+ * +--------------------------------------------------------------------------------+
+ * }}}
+ *
+ * @see [[BertEmbeddings]] for token-level embeddings
+ * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based embeddings
+ * @param uid required uid for storing annotator to disk
+ * @groupname anno Annotator types
+ * @groupdesc anno Required input and expected output annotator types
+ * @groupname Ungrouped Members
+ * @groupname param Parameters
+ * @groupname setParam Parameter setters
+ * @groupname getParam Parameter getters
+ * @groupname Ungrouped Members
+ * @groupprio param  1
+ * @groupprio anno  2
+ * @groupprio Ungrouped 3
+ * @groupprio setParam  4
+ * @groupprio getParam  5
+ * @groupdesc param A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
+ * */
 class BertSentenceEmbeddings(override val uid: String)
   extends AnnotatorModel[BertSentenceEmbeddings]
     with HasBatchedAnnotate[BertSentenceEmbeddings]
@@ -316,7 +316,6 @@ class BertSentenceEmbeddings(override val uid: String)
    * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
    */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    /*Return empty if the real sentences are empty*/
 
     //Unpack annotations and zip each sentence to the index or the row it belongs to
     val sentencesWithRow = batchedAnnotations
@@ -350,6 +349,7 @@ class BertSentenceEmbeddings(override val uid: String)
       else
         Seq.empty[Annotation]
     })
+
   }
 
   override protected def afterAnnotate(dataset: DataFrame): DataFrame = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This is an optimization of batch processing in BertSentenceEmbeddings and BertEmbeddings model which improves performance of single machine setups where there are few/single sentence per row.

## Description

The HasBatchedAnnotate trait lets models process several rows at once. The idea is to enable batching annotations across rows which can significantly speed up processing, especially on GPU hardware. However, the current implementation of batchAnnotate method in BertSentenceEmbeddings and BertEmbeddings doesn't actually allows this as they process rows one by one therefore and can therefore batch only annotations within a single row.  This PR solves the problem by adding all annotations which are passed to batchAnnotate, regardless of which row they belong to, to a single collection and then passing this collection to TensorflowBert to process them using the given batch size. 
The change leads to significant performance gain on single machine setup when there is a single or a few annotations per row. Below are the results of the BertEmbeddings benchmark test on the conll2004 dataset:

![image](https://user-images.githubusercontent.com/6031570/141941731-c429d004-1e1c-4826-bc20-6a24254cbd06.png)

The test is run on a single machine with a GPU. GPU performance is significantly improved when sentence are exploded (i.e. a single sentence per row).

Additional tests revealed that the changes make little to no impact on performance in a cluster setup with multiple GPUs. Apparently such a Spark setup is capable of utilizing the GPUs even when each call of batchAnnotate is feeding the input tensors one by one. 

<!--- Describe your changes in detail -->

I've re-implemented batchAnnotate method of  BertSentenceEmbeddings and BertEmbeddings. Instead of processing the annotations separately for each row, I collect put all the annotations in a single collection and make sure the allocation of annotations per rows is preserved by zipping annotations to their row index. The all annotations are tokenized and passed to the TF graph to compute their (sentence or word) embeddings. At the end embeddings are again distributed across rows.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

It lets BertSentenceEmbeddings and BertEmbeddings processes sentences in batches when there are a few annotations per row. In such cases, the change significantly improves performance on single machine setups.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I've made sure the results of the improved batch processing are identical to the ones produced by the current implementation. This test uses different JAR files so it is not included in the current commit.
I've also tested performance in order to demonstrate the changes indeed improve performance (see table above).
Test were run on a local SparkNLP installation.
Changes don't have any impact on functionality and shouldn't affect or break any existing code 

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/6031570/141941731-c429d004-1e1c-4826-bc20-6a24254cbd06.png)

![image](https://user-images.githubusercontent.com/6031570/141644662-0fa5ca86-d102-4782-abfe-7dfabada689f.png)

![image](https://user-images.githubusercontent.com/6031570/141943372-9627e3e7-fce0-4a07-b81b-628dc7edf49b.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

It is actually neither of the above, we need one more option 'code optimization with no functional implications but significant impact on performance'

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
