### PR TITLE
WIP Add Scala 2.13 support with Apache Spark 3.2.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   val is_spark24: String = System.getProperty("is_spark24", "false")
   val is_spark32: String = System.getProperty("is_spark32", "false")
 
-  val sparkVer: String = getSparkVersion(is_spark23, is_spark24, is_spark32)
+  val sparkVer: String = spark32Ver//getSparkVersion(is_spark23, is_spark24, is_spark32)
 
   /** ------- Spark version end ------- */
 
@@ -56,11 +56,10 @@ object Dependencies {
   }
 
   /** ------- Scala version start ------- */
-  lazy val scala211 = "2.11.12"
-  lazy val scala212 = "2.12.10"
-  lazy val scalaVer: String = if (is_spark23 == "true" | is_spark24 == "true") scala211 else scala212
+  lazy val scala213 = "2.13.6"
+  lazy val scalaVer: String = scala213
 
-  lazy val supportedScalaVersions = List(scala212, scala211)
+  lazy val supportedScalaVersions = List(scala213)
 
   val scalaTestVersion = "3.2.9"
 
@@ -87,7 +86,7 @@ object Dependencies {
 
   val json4sVersion: String = if (is_spark32 == "true") "3.7.0-M11" else "3.5.3"
 
-  val json4s = "org.json4s" %% "json4s-ext" % json4sVersion
+  val json4s = "org.json4s" % "json4s-ext_2.12" % json4sVersion
 
   val trove4jVersion = "3.0.3"
   val trove4j = "net.sf.trove4j" % "trove4j" % trove4jVersion
@@ -95,10 +94,10 @@ object Dependencies {
   val junitVersion = "4.13.2"
   val junit = "junit" % "junit" % junitVersion % Test
 
-  val tensorflowGPUVersion = "0.3.3"
+  val tensorflowGPUVersion = "0.3.4"
   val tensorflowGPU = "com.johnsnowlabs.nlp" %% "tensorflow-gpu" % tensorflowGPUVersion
 
-  val tensorflowCPUVersion = "0.3.3"
+  val tensorflowCPUVersion = "0.3.4"
   val tensorflowCPU = "com.johnsnowlabs.nlp" %% "tensorflow-cpu" % tensorflowCPUVersion
 
   /** ------- Dependencies end  ------- */

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
   }
 
   /** ------- Scala version start ------- */
-  lazy val scala213 = "2.13.6"
+  lazy val scala213 = "2.13.7"
   lazy val scalaVer: String = scala213
 
   lazy val supportedScalaVersions = List(scala213)

--- a/src/main/scala/com/johnsnowlabs/collections/SearchTrie.scala
+++ b/src/main/scala/com/johnsnowlabs/collections/SearchTrie.scala
@@ -46,7 +46,7 @@ case class SearchTrie
     * @param text test to search in
     * @return Iterator with pairs of (begin, end)
     */
-  def search(text: Seq[String]): Seq[(Int, Int)] = {
+  def search(text: collection.Seq[String]): collection.Seq[(Int, Int)] = {
     var nodeId = 0
     val result = new ArrayBuffer[(Int, Int)]()
 

--- a/src/main/scala/com/johnsnowlabs/collections/StorageSearchTrie.scala
+++ b/src/main/scala/com/johnsnowlabs/collections/StorageSearchTrie.scala
@@ -40,7 +40,7 @@ class StorageSearchTrie(
     * @param text test to search in
     * @return Iterator with pairs of (begin, end)
     */
-  def search(text: Seq[String]): Seq[(Int, Int)] = {
+  def search(text: collection.Seq[String]): collection.Seq[(Int, Int)] = {
     var nodeId = 0
     val result = new ArrayBuffer[(Int, Int)]()
 

--- a/src/main/scala/com/johnsnowlabs/ml/crf/CrfDataset.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/crf/CrfDataset.scala
@@ -18,11 +18,11 @@ package com.johnsnowlabs.ml.crf
 
 case class CrfDataset
 (
-  instances: Seq[(InstanceLabels, Instance)],
+  instances: collection.Seq[(InstanceLabels, Instance)],
   metadata: DatasetMetadata
 )
 
-case class InstanceLabels(labels: Seq[Int])
-case class Instance(items: Seq[SparseArray])
+case class InstanceLabels(labels: collection.Seq[Int])
+case class Instance(items: collection.Seq[SparseArray])
 
 

--- a/src/main/scala/com/johnsnowlabs/ml/crf/DatasetEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/crf/DatasetEncoder.scala
@@ -86,8 +86,8 @@ class DatasetEncoder(val startLabel: String = "@#Start") {
 
   def getFeatures(prevLabel: String = startLabel,
                   label: String,
-                  binaryAttrs: Seq[String],
-                  numAttrs: Seq[Float]): (Int, SparseArray) = {
+                  binaryAttrs: collection.Seq[String],
+                  numAttrs: collection.Seq[Float]): (Int, SparseArray) = {
     val labelId = getLabel(label)
 
     val binFeature = binaryAttrs.map{attr =>

--- a/src/main/scala/com/johnsnowlabs/ml/crf/DatasetEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/crf/DatasetEncoder.scala
@@ -132,7 +132,7 @@ class DatasetEncoder(val startLabel: String = "@#Start") {
     )
   }
 
-  private def copy[T : ClassTag](source: IndexedSeq[T]): Array[T] = {
+  private def copy[T : ClassTag](source: ArrayBuffer[T]): Array[T] = {
     if (source.length == 0) {
       Array.empty[T]
     } else {

--- a/src/main/scala/com/johnsnowlabs/ml/crf/DatasetReader.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/crf/DatasetReader.scala
@@ -25,9 +25,9 @@ import scala.collection.mutable.ArrayBuffer
 import scala.io.Source
 
 
-case class TextSentenceLabels(labels: Seq[String])
-case class TextSentenceAttrs(words: Seq[WordAttrs])
-case class WordAttrs(strAttrs: Seq[(String, String)], numAttrs: Array[Float] = Array.empty)
+case class TextSentenceLabels(labels: collection.Seq[String])
+case class TextSentenceAttrs(words: collection.Seq[WordAttrs])
+case class WordAttrs(strAttrs: collection.Seq[(String, String)], numAttrs: Array[Float] = Array.empty)
 
 
 object DatasetReader {


### PR DESCRIPTION
# Scala 2.13 support

This PR is an attempt at providing Scala 2.13 support. It is based off https://github.com/JohnSnowLabs/spark-nlp/pull/6333

This effort is in the very early stages. As you will see, I've commented out portions of the `build.sbt` around handling different versions of Spark and Scala and am initially just focusing on Scala 2.13. Once 2.13 support is figured out, the plan is to fix the `build.sbt`.

At a high-level, I'm planning this work out in the following stages:

## Stage 1 (in-progress): Get it compiling with Scala 2.13

So far, these are the failing files:

- [x] [DatasetEncoder.scala](src/main/scala/com/johnsnowlabs/ml/crf/DatasetEncoder.scala)
- [x] [DatasetReader.scala](src/main/scala/com/johnsnowlabs/ml/crf/DatasetReader.scala)
- [ ] [TensorflowMarian.scala](src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowMarian.scala)
- [ ] [TensorflowMultiClassifier.scala](src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowMultiClassifier.scala)
- [ ] [TensorflowSpell.scala](src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowSpell.scala)
- [ ] [ModelSignatureManager.scala](src/main/scala/com/johnsnowlabs/ml/tensorflow/sign/ModelSignatureManager.scala)
- [ ] [LightPipeline.scala](src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala)
- [ ] [TokenAssembler.scala](src/main/scala/com/johnsnowlabs/nlp/TokenAssembler.scala)
- [ ] [Lemmatizer.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/Lemmatizer.scala)
- [ ] [Normalizer.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/Normalizer.scala)
- [ ] [RecursiveTokenizerModel.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/RecursiveTokenizerModel.scala)
- [ ] [TextMatcherModel.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcherModel.scala)
- [ ] [BigTextMatcherModel.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/btm/BigTextMatcherModel.scala)
- [ ] [YakeKeywordExtraction.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/keyword.yake/YakeKeywordExtraction.scala)
- [ ] [NerCrfModel.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfModel.scala)
- [ ] [Accumulators.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/Accumulators.scala)
- [ ] [PerceptronApproachDistributed.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronApproachDistributed.scala)
- [ ] [PerceptronTrainingUtils.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronTrainingUtils.scala)
- [ ] [SentenceDetectorDLModel.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLModel.scala)
- [ ] [ContextSpellCheckerApproach.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala)
- [ ] [ContextSpellCheckerModel.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala)
- [ ] [WeightedLevenshtein.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/WeightedLevenshtein.scala)
- [ ] [WordSegmenterModel.scala](src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterModel.scala)
- [ ] [functions.scala](src/main/scala/com/johnsnowlabs/nlp/functions.scala)
- [ ] [ResourceHelper.scala](src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala)
- [x] [SearchTrie.scala](src/main/scala/com/johnsnowlabs/collections/SearchTrie.scala)
- [x] [StorageSearchTrie.scala](src/main/scala/com/johnsnowlabs/collections/StorageSearchTrie.scala)

## Stage 2 (blocked by stage 1): Investigate failing tests

Once the language version/compilation issues are resolved, I will investigate failing tests.

## Stage 3 (blocked by stage 2): Run and get reviews

Finally, attempt running and have other eyes on this to review the changes.