### PR TITLE
Optimized Conll Reader

### DIFF
--- a/python/sparknlp/training.py
+++ b/python/sparknlp/training.py
@@ -21,6 +21,7 @@ can be loaded with ``readDataset``.
 from sparknlp.internal import ExtendedJavaWrapper
 from sparknlp.common import ExternalResource, ReadAs
 from pyspark.sql import SparkSession, DataFrame
+import pyspark
 
 
 class CoNLL(ExtendedJavaWrapper):
@@ -136,7 +137,7 @@ class CoNLL(ExtendedJavaWrapper):
         """
         jSession = spark._jsparkSession
 
-        jdf = self._java_obj.readDataset(jSession, path, read_as, partitions, storage_level)
+        jdf = self._java_obj.readDataset(jSession, path, read_as, partitions, spark.sparkContext._getJavaStorageLevel(storage_level))
         return DataFrame(jdf, spark._wrapped)
 
 

--- a/python/sparknlp/training.py
+++ b/python/sparknlp/training.py
@@ -113,7 +113,7 @@ class CoNLL(ExtendedJavaWrapper):
                                     explodeSentences,
                                     delimiter)
 
-    def readDataset(self, spark, path, read_as=ReadAs.TEXT):
+    def readDataset(self, spark, path, read_as=ReadAs.TEXT, partitions=8, storage_level=pyspark.StorageLevel.DISK_ONLY):
         # ToDo Replace with std pyspark
         """Reads the dataset from an external resource.
 
@@ -125,6 +125,9 @@ class CoNLL(ExtendedJavaWrapper):
             Path to the resource
         read_as : str, optional
             How to read the resource, by default ReadAs.TEXT
+        partitions : sets the minimum number of partitions for the case of lifting multiple files in parallel into a single dataframe. Defaults to 8.
+        storage_level : sets the persistence level according to PySpark definitions. Defaults to StorageLevel.DISK_ONLY. Applies only when lifting multiple files.
+        
 
         Returns
         -------
@@ -133,7 +136,7 @@ class CoNLL(ExtendedJavaWrapper):
         """
         jSession = spark._jsparkSession
 
-        jdf = self._java_obj.readDataset(jSession, path, read_as)
+        jdf = self._java_obj.readDataset(jSession, path, read_as, partitions, storage_level)
         return DataFrame(jdf, spark._wrapped)
 
 

--- a/src/main/scala/com/johnsnowlabs/nlp/training/CoNLL.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/training/CoNLL.scala
@@ -319,13 +319,13 @@ case class CoNLL(documentCol: String = "document",
                  ): Dataset[_] = {
     if (path.endsWith("*")) {
       val rdd = spark.sparkContext.wholeTextFiles(path, minPartitions = parallelism).
-        flatMap{ case (fileName, content) =>
+        flatMap{ case (_, content) =>
           val lines = content.split(System.lineSeparator)
-          readLines(lines).map (coreTransformation)
+          readLines(lines).map(doc => coreTransformation(doc))
         }.persist(storageLevel)
 
       spark.createDataFrame(rdd).
-        toDF("fileName", conllTextCol, documentCol, sentenceCol, tokenCol, posCol, labelCol)
+        toDF(conllTextCol, documentCol, sentenceCol, tokenCol, posCol, labelCol)
     } else {
       val er = ExternalResource(path, readAs, Map("format" -> "text"))
       packDocs(readDocs(er), spark)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change adds a new capability to the CoNLL reader, allowing it to read multiple CoNLL files at the same time into a single Dataframe. Example,

```
df = CoNLL().readDataset(spark, './path/to/conlls/*', partitions=12)
```

The difference with previous behavior is the path ending in an `*`. The original mechanism continues to work as before.
Two additional params that work only for the multi file situation,
partitions : minimum number of partitions used to create the Dataframe. Defaults to 8.
storage_level : pyspark.StorageLevel for the Dataframe. Defaults to pyspark.StorageLevel.DISK_ONLY.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
