### PR TITLE
Fix the wrong name for DistilBertForSequenceClassification in Python

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -15408,7 +15408,7 @@ class DistilBertForSequenceClassification(AnnotatorModel,
     |[pos, pos, pos, pos]|
     +--------------------+
     """
-    name = "BertForSequenceClassification"
+    name = "DistilBertForSequenceClassification"
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
@@ -84,7 +84,7 @@ import java.io.File
  * +--------------------+
  * }}}
  *
- * @see [[DistilBertForTokenClassification]] for token-level classification
+ * @see [[DistilBertForSequenceClassification]] for token-level classification
  * @see [[com.johnsnowlabs.nlp.embeddings.DistilBertEmbeddings DistilBertEmbeddings]] for token embeddings
  * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
  * @param uid required uid for storing annotator to disk


### PR DESCRIPTION
This PR fixes the issue when loading models in DistilBertForSequenceClassification annotator and it fails due to a wrong name.