### PR TITLE
Introducing ALBERT, XLNet, RoBERTa, XLM-RoBERTa, and Longformer ForSequenceClassification annotators

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -100,6 +100,7 @@ unittest.TextTestRunner().run(Doc2VecTestSpec())
 # unittest.TextTestRunner().run(XlnetForTokenClassificationTestSpec())
 # unittest.TextTestRunner().run(LongformerForTokenClassificationTestSpec())
 # unittest.TextTestRunner().run(DistilBertForSequenceClassificationTestSpec())
+# unittest.TextTestRunner().run(RoBertaForSequenceClassificationTestSpec())
 
 # Misc tests
 

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -101,9 +101,9 @@ unittest.TextTestRunner().run(Doc2VecTestSpec())
 # unittest.TextTestRunner().run(LongformerForTokenClassificationTestSpec())
 # unittest.TextTestRunner().run(DistilBertForSequenceClassificationTestSpec())
 # unittest.TextTestRunner().run(RoBertaForSequenceClassificationTestSpec())
+# unittest.TextTestRunner().run(XlmRoBertaForSequenceClassificationTestSpec())
 
 # Misc tests
-
 unittest.TextTestRunner().run(UtilitiesTestSpec())
 unittest.TextTestRunner().run(SerializersTestSpec())
 unittest.TextTestRunner().run(ResourceDownloaderShowTestSpec())

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -15694,3 +15694,186 @@ class RoBertaForSequenceClassification(AnnotatorModel,
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(RoBertaForSequenceClassification, name, lang, remote_loc)
+
+
+class XlmRoBertaForSequenceClassification(AnnotatorModel,
+                                          HasCaseSensitiveProperties,
+                                          HasBatchedAnnotate):
+    """XlmRoBertaForSequenceClassification can load XLM-RoBERTa Models with sequence classification/regression head on
+    top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
+
+    Pretrained models can be loaded with :meth:`.pretrained` of the companion
+    object:
+
+    >>> sequenceClassifier = XlmRoBertaForSequenceClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label")
+
+    The default model is ``"xlm_roberta_base_sequence_classifier_imdb"``, if no name is
+    provided.
+
+    For available pretrained models please see the `Models Hub
+    <https://nlp.johnsnowlabs.com/models?task=Text+Classification>`__.
+
+    Models from the HuggingFace 🤗 Transformers library are also compatible with
+    Spark NLP 🚀. To see which models are compatible and how to import them see
+    `Import Transformers into Spark NLP 🚀
+    <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT, TOKEN``    ``CATEGORY``
+    ====================== ======================
+
+    Parameters
+    ----------
+    batchSize
+        Batch size. Large values allows faster processing but requires more
+        memory, by default 8
+    caseSensitive
+        Whether to ignore case in tokens for embeddings matching, by default
+        True
+    configProtoBytes
+        ConfigProto from tensorflow, serialized into byte array.
+    maxSentenceLength
+        Max sentence length to process, by default 128
+    coalesceSentences
+        Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging
+        probabilities in all sentences.
+
+    Examples
+    --------
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("token")
+    >>> sequenceClassifier = XlmRoBertaForSequenceClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label") \\
+    ...     .setCaseSensitive(True)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     tokenizer,
+    ...     sequenceClassifier
+    ... ])
+    >>> data = spark.createDataFrame([[\"\"\"John Lenon was born in London and lived
+    ... in Paris. My name is Sarah and I live in London\"\"\"]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.select("label.result").show(truncate=False)
+    +--------------------+
+    |result              |
+    +--------------------+
+    |[neg, neg]          |
+    |[pos, pos, pos, pos]|
+    +--------------------+
+    """
+    name = "XlmRoBertaForSequenceClassification"
+
+    maxSentenceLength = Param(Params._dummy(),
+                              "maxSentenceLength",
+                              "Max sentence length to process",
+                              typeConverter=TypeConverters.toInt)
+
+    configProtoBytes = Param(Params._dummy(),
+                             "configProtoBytes",
+                             "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
+                             TypeConverters.toListString)
+
+    coalesceSentences = Param(Params._dummy(), "coalesceSentences",
+                              "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
+                              TypeConverters.toBoolean)
+
+    def setConfigProtoBytes(self, b):
+        """Sets configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
+        return self._set(configProtoBytes=b)
+
+    def setMaxSentenceLength(self, value):
+        """Sets max sentence length to process, by default 128.
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
+        return self._set(maxSentenceLength=value)
+
+    def setCoalesceSentences(self, value):
+        """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
+        Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
+        into the model and averaging all the probabilities for the entire document instead of probabilities per sentence. (Default: true)
+
+        Parameters
+        ----------
+        value : bool
+            If the output of all sentences will be averaged to one output
+        """
+        return self._set(coalesceSentences=value)
+
+    @keyword_only
+    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.XlmRoBertaForSequenceClassification",
+                 java_model=None):
+        super(XlmRoBertaForSequenceClassification, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        self._setDefault(
+            batchSize=8,
+            maxSentenceLength=128,
+            caseSensitive=True
+        )
+
+    @staticmethod
+    def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        XlmRoBertaForSequenceClassification
+            The restored model
+        """
+        from sparknlp.internal import _XlmRoBertaSequenceClassifierLoader
+        jModel = _XlmRoBertaSequenceClassifierLoader(folder, spark_session._jsparkSession)._java_obj
+        return XlmRoBertaForSequenceClassification(java_model=jModel)
+
+    @staticmethod
+    def pretrained(name="xlm_roberta_base_sequence_classifier_imdb", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default
+            "xlm_roberta_base_sequence_classifier_imdb"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None. Will use
+            Spark NLPs repositories otherwise.
+
+        Returns
+        -------
+        XlmRoBertaForSequenceClassification
+            The restored model
+        """
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(XlmRoBertaForSequenceClassification, name, lang, remote_loc)

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -15511,3 +15511,186 @@ class DistilBertForSequenceClassification(AnnotatorModel,
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(DistilBertForSequenceClassification, name, lang, remote_loc)
+
+
+class RoBertaForSequenceClassification(AnnotatorModel,
+                                       HasCaseSensitiveProperties,
+                                       HasBatchedAnnotate):
+    """RoBertaForSequenceClassification can load RoBERTa Models with sequence classification/regression head on
+    top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
+
+    Pretrained models can be loaded with :meth:`.pretrained` of the companion
+    object:
+
+    >>> sequenceClassifier = RoBertaForSequenceClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label")
+
+    The default model is ``"roberta_base_sequence_classifier_imdb"``, if no name is
+    provided.
+
+    For available pretrained models please see the `Models Hub
+    <https://nlp.johnsnowlabs.com/models?task=Text+Classification>`__.
+
+    Models from the HuggingFace 🤗 Transformers library are also compatible with
+    Spark NLP 🚀. To see which models are compatible and how to import them see
+    `Import Transformers into Spark NLP 🚀
+    <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT, TOKEN``    ``CATEGORY``
+    ====================== ======================
+
+    Parameters
+    ----------
+    batchSize
+        Batch size. Large values allows faster processing but requires more
+        memory, by default 8
+    caseSensitive
+        Whether to ignore case in tokens for embeddings matching, by default
+        True
+    configProtoBytes
+        ConfigProto from tensorflow, serialized into byte array.
+    maxSentenceLength
+        Max sentence length to process, by default 128
+    coalesceSentences
+        Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging
+        probabilities in all sentences.
+
+    Examples
+    --------
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("token")
+    >>> sequenceClassifier = RoBertaForSequenceClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label") \\
+    ...     .setCaseSensitive(True)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     tokenizer,
+    ...     sequenceClassifier
+    ... ])
+    >>> data = spark.createDataFrame([[\"\"\"John Lenon was born in London and lived
+    ... in Paris. My name is Sarah and I live in London\"\"\"]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.select("label.result").show(truncate=False)
+    +--------------------+
+    |result              |
+    +--------------------+
+    |[neg, neg]          |
+    |[pos, pos, pos, pos]|
+    +--------------------+
+    """
+    name = "RoBertaForSequenceClassification"
+
+    maxSentenceLength = Param(Params._dummy(),
+                              "maxSentenceLength",
+                              "Max sentence length to process",
+                              typeConverter=TypeConverters.toInt)
+
+    configProtoBytes = Param(Params._dummy(),
+                             "configProtoBytes",
+                             "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
+                             TypeConverters.toListString)
+
+    coalesceSentences = Param(Params._dummy(), "coalesceSentences",
+                              "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
+                              TypeConverters.toBoolean)
+
+    def setConfigProtoBytes(self, b):
+        """Sets configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
+        return self._set(configProtoBytes=b)
+
+    def setMaxSentenceLength(self, value):
+        """Sets max sentence length to process, by default 128.
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
+        return self._set(maxSentenceLength=value)
+
+    def setCoalesceSentences(self, value):
+        """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
+        Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
+        into the model and averaging all the probabilities for the entire document instead of probabilities per sentence. (Default: true)
+
+        Parameters
+        ----------
+        value : bool
+            If the output of all sentences will be averaged to one output
+        """
+        return self._set(coalesceSentences=value)
+
+    @keyword_only
+    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.RoBertaForSequenceClassification",
+                 java_model=None):
+        super(RoBertaForSequenceClassification, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        self._setDefault(
+            batchSize=8,
+            maxSentenceLength=128,
+            caseSensitive=True
+        )
+
+    @staticmethod
+    def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        RoBertaForSequenceClassification
+            The restored model
+        """
+        from sparknlp.internal import _RoBertaSequenceClassifierLoader
+        jModel = _RoBertaSequenceClassifierLoader(folder, spark_session._jsparkSession)._java_obj
+        return RoBertaForSequenceClassification(java_model=jModel)
+
+    @staticmethod
+    def pretrained(name="roberta_base_sequence_classifier_imdb", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default
+            "roberta_base_sequence_classifier_imdb"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None. Will use
+            Spark NLPs repositories otherwise.
+
+        Returns
+        -------
+        RoBertaForSequenceClassification
+            The restored model
+        """
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(RoBertaForSequenceClassification, name, lang, remote_loc)

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -14961,7 +14961,8 @@ class BertForSequenceClassification(AnnotatorModel,
         self._setDefault(
             batchSize=8,
             maxSentenceLength=128,
-            caseSensitive=True
+            caseSensitive=True,
+            coalesceSentences=False
         )
 
     @staticmethod
@@ -15466,7 +15467,8 @@ class DistilBertForSequenceClassification(AnnotatorModel,
         self._setDefault(
             batchSize=8,
             maxSentenceLength=128,
-            caseSensitive=True
+            caseSensitive=True,
+            coalesceSentences=False
         )
 
     @staticmethod
@@ -15649,7 +15651,8 @@ class RoBertaForSequenceClassification(AnnotatorModel,
         self._setDefault(
             batchSize=8,
             maxSentenceLength=128,
-            caseSensitive=True
+            caseSensitive=True,
+            coalesceSentences=False
         )
 
     @staticmethod
@@ -15832,7 +15835,8 @@ class XlmRoBertaForSequenceClassification(AnnotatorModel,
         self._setDefault(
             batchSize=8,
             maxSentenceLength=128,
-            caseSensitive=True
+            caseSensitive=True,
+            coalesceSentences=False
         )
 
     @staticmethod
@@ -16015,7 +16019,8 @@ class LongformerForSequenceClassification(AnnotatorModel,
         self._setDefault(
             batchSize=8,
             maxSentenceLength=4096,
-            caseSensitive=True
+            caseSensitive=True,
+            coalesceSentences=False
         )
 
     @staticmethod
@@ -16060,3 +16065,187 @@ class LongformerForSequenceClassification(AnnotatorModel,
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(LongformerForSequenceClassification, name, lang, remote_loc)
+
+
+class AlbertForSequenceClassification(AnnotatorModel,
+                                      HasCaseSensitiveProperties,
+                                      HasBatchedAnnotate):
+    """AlbertForSequenceClassification can load Albert Models with sequence classification/regression head on
+    top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
+
+    Pretrained models can be loaded with :meth:`.pretrained` of the companion
+    object:
+
+    >>> sequenceClassifier = AlbertForSequenceClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label")
+
+    The default model is ``"albert_base_sequence_classifier_imdb"``, if no name is
+    provided.
+
+    For available pretrained models please see the `Models Hub
+    <https://nlp.johnsnowlabs.com/models?task=Text+Classification>`__.
+
+    Models from the HuggingFace 🤗 Transformers library are also compatible with
+    Spark NLP 🚀. To see which models are compatible and how to import them see
+    `Import Transformers into Spark NLP 🚀
+    <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT, TOKEN``    ``CATEGORY``
+    ====================== ======================
+
+    Parameters
+    ----------
+    batchSize
+        Batch size. Large values allows faster processing but requires more
+        memory, by default 8
+    caseSensitive
+        Whether to ignore case in tokens for embeddings matching, by default
+        True
+    configProtoBytes
+        ConfigProto from tensorflow, serialized into byte array.
+    maxSentenceLength
+        Max sentence length to process, by default 128
+    coalesceSentences
+        Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging
+        probabilities in all sentences.
+
+    Examples
+    --------
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("token")
+    >>> sequenceClassifier = AlbertForSequenceClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label") \\
+    ...     .setCaseSensitive(True)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     tokenizer,
+    ...     sequenceClassifier
+    ... ])
+    >>> data = spark.createDataFrame([[\"\"\"John Lenon was born in London and lived
+    ... in Paris. My name is Sarah and I live in London\"\"\"]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.select("label.result").show(truncate=False)
+    +--------------------+
+    |result              |
+    +--------------------+
+    |[neg, neg]          |
+    |[pos, pos, pos, pos]|
+    +--------------------+
+    """
+    name = "AlbertForSequenceClassification"
+
+    maxSentenceLength = Param(Params._dummy(),
+                              "maxSentenceLength",
+                              "Max sentence length to process",
+                              typeConverter=TypeConverters.toInt)
+
+    configProtoBytes = Param(Params._dummy(),
+                             "configProtoBytes",
+                             "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
+                             TypeConverters.toListInt)
+
+    coalesceSentences = Param(Params._dummy(), "coalesceSentences",
+                              "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
+                              TypeConverters.toBoolean)
+
+    def setConfigProtoBytes(self, b):
+        """Sets configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
+        return self._set(configProtoBytes=b)
+
+    def setMaxSentenceLength(self, value):
+        """Sets max sentence length to process, by default 128.
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
+        return self._set(maxSentenceLength=value)
+
+    def setCoalesceSentences(self, value):
+        """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
+        Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
+        into the model and averaging all the probabilities for the entire document instead of probabilities per sentence. (Default: true)
+
+        Parameters
+        ----------
+        value : bool
+            If the output of all sentences will be averaged to one output
+        """
+        return self._set(coalesceSentences=value)
+
+    @keyword_only
+    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.AlbertForSequenceClassification",
+                 java_model=None):
+        super(AlbertForSequenceClassification, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        self._setDefault(
+            batchSize=8,
+            maxSentenceLength=128,
+            caseSensitive=False,
+            coalesceSentences=False
+        )
+
+    @staticmethod
+    def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        AlbertForSequenceClassification
+            The restored model
+        """
+        from sparknlp.internal import _AlbertSequenceClassifierLoader
+        jModel = _AlbertSequenceClassifierLoader(folder, spark_session._jsparkSession)._java_obj
+        return AlbertForSequenceClassification(java_model=jModel)
+
+    @staticmethod
+    def pretrained(name="albert_base_sequence_classifier_imdb", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default
+            "albert_base_sequence_classifier_imdb"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None. Will use
+            Spark NLPs repositories otherwise.
+
+        Returns
+        -------
+        AlbertForSequenceClassification
+            The restored model
+        """
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(AlbertForSequenceClassification, name, lang, remote_loc)

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -15877,3 +15877,186 @@ class XlmRoBertaForSequenceClassification(AnnotatorModel,
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(XlmRoBertaForSequenceClassification, name, lang, remote_loc)
+
+
+class LongformerForSequenceClassification(AnnotatorModel,
+                                          HasCaseSensitiveProperties,
+                                          HasBatchedAnnotate):
+    """LongformerForSequenceClassification can load Longformer Models with sequence classification/regression head on
+    top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
+
+    Pretrained models can be loaded with :meth:`.pretrained` of the companion
+    object:
+
+    >>> sequenceClassifier = LongformerForSequenceClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label")
+
+    The default model is ``"longformer_base_sequence_classifier_imdb"``, if no name is
+    provided.
+
+    For available pretrained models please see the `Models Hub
+    <https://nlp.johnsnowlabs.com/models?task=Text+Classification>`__.
+
+    Models from the HuggingFace 🤗 Transformers library are also compatible with
+    Spark NLP 🚀. To see which models are compatible and how to import them see
+    `Import Transformers into Spark NLP 🚀
+    <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT, TOKEN``    ``CATEGORY``
+    ====================== ======================
+
+    Parameters
+    ----------
+    batchSize
+        Batch size. Large values allows faster processing but requires more
+        memory, by default 8
+    caseSensitive
+        Whether to ignore case in tokens for embeddings matching, by default
+        True
+    configProtoBytes
+        ConfigProto from tensorflow, serialized into byte array.
+    maxSentenceLength
+        Max sentence length to process, by default 128
+    coalesceSentences
+        Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging
+        probabilities in all sentences.
+
+    Examples
+    --------
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("token")
+    >>> sequenceClassifier = LongformerForSequenceClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label") \\
+    ...     .setCaseSensitive(True)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     tokenizer,
+    ...     sequenceClassifier
+    ... ])
+    >>> data = spark.createDataFrame([[\"\"\"John Lenon was born in London and lived
+    ... in Paris. My name is Sarah and I live in London\"\"\"]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.select("label.result").show(truncate=False)
+    +--------------------+
+    |result              |
+    +--------------------+
+    |[neg, neg]          |
+    |[pos, pos, pos, pos]|
+    +--------------------+
+    """
+    name = "LongformerForSequenceClassification"
+
+    maxSentenceLength = Param(Params._dummy(),
+                              "maxSentenceLength",
+                              "Max sentence length to process",
+                              typeConverter=TypeConverters.toInt)
+
+    configProtoBytes = Param(Params._dummy(),
+                             "configProtoBytes",
+                             "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
+                             TypeConverters.toListInt)
+
+    coalesceSentences = Param(Params._dummy(), "coalesceSentences",
+                              "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
+                              TypeConverters.toBoolean)
+
+    def setConfigProtoBytes(self, b):
+        """Sets configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
+        return self._set(configProtoBytes=b)
+
+    def setMaxSentenceLength(self, value):
+        """Sets max sentence length to process, by default 128.
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
+        return self._set(maxSentenceLength=value)
+
+    def setCoalesceSentences(self, value):
+        """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
+        Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
+        into the model and averaging all the probabilities for the entire document instead of probabilities per sentence. (Default: true)
+
+        Parameters
+        ----------
+        value : bool
+            If the output of all sentences will be averaged to one output
+        """
+        return self._set(coalesceSentences=value)
+
+    @keyword_only
+    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.LongformerForSequenceClassification",
+                 java_model=None):
+        super(LongformerForSequenceClassification, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        self._setDefault(
+            batchSize=8,
+            maxSentenceLength=4096,
+            caseSensitive=True
+        )
+
+    @staticmethod
+    def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        LongformerForSequenceClassification
+            The restored model
+        """
+        from sparknlp.internal import _LongformerSequenceClassifierLoader
+        jModel = _LongformerSequenceClassifierLoader(folder, spark_session._jsparkSession)._java_obj
+        return LongformerForSequenceClassification(java_model=jModel)
+
+    @staticmethod
+    def pretrained(name="longformer_base_sequence_classifier_imdb", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default
+            "longformer_base_sequence_classifier_imdb"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None. Will use
+            Spark NLPs repositories otherwise.
+
+        Returns
+        -------
+        LongformerForSequenceClassification
+            The restored model
+        """
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(LongformerForSequenceClassification, name, lang, remote_loc)

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -16249,3 +16249,187 @@ class AlbertForSequenceClassification(AnnotatorModel,
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(AlbertForSequenceClassification, name, lang, remote_loc)
+
+
+class XlnetForSequenceClassification(AnnotatorModel,
+                                     HasCaseSensitiveProperties,
+                                     HasBatchedAnnotate):
+    """XlnetForSequenceClassification can load XLNet Models with sequence classification/regression head on
+    top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
+
+    Pretrained models can be loaded with :meth:`.pretrained` of the companion
+    object:
+
+    >>> sequenceClassifier = XlnetForSequenceClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label")
+
+    The default model is ``"xlnet_base_sequence_classifier_imdb"``, if no name is
+    provided.
+
+    For available pretrained models please see the `Models Hub
+    <https://nlp.johnsnowlabs.com/models?task=Text+Classification>`__.
+
+    Models from the HuggingFace 🤗 Transformers library are also compatible with
+    Spark NLP 🚀. To see which models are compatible and how to import them see
+    `Import Transformers into Spark NLP 🚀
+    <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT, TOKEN``    ``CATEGORY``
+    ====================== ======================
+
+    Parameters
+    ----------
+    batchSize
+        Batch size. Large values allows faster processing but requires more
+        memory, by default 8
+    caseSensitive
+        Whether to ignore case in tokens for embeddings matching, by default
+        True
+    configProtoBytes
+        ConfigProto from tensorflow, serialized into byte array.
+    maxSentenceLength
+        Max sentence length to process, by default 128
+    coalesceSentences
+        Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging
+        probabilities in all sentences.
+
+    Examples
+    --------
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("token")
+    >>> sequenceClassifier = XlnetForSequenceClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label") \\
+    ...     .setCaseSensitive(True)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     tokenizer,
+    ...     sequenceClassifier
+    ... ])
+    >>> data = spark.createDataFrame([[\"\"\"John Lenon was born in London and lived
+    ... in Paris. My name is Sarah and I live in London\"\"\"]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.select("label.result").show(truncate=False)
+    +--------------------+
+    |result              |
+    +--------------------+
+    |[neg, neg]          |
+    |[pos, pos, pos, pos]|
+    +--------------------+
+    """
+    name = "XlnetForSequenceClassification"
+
+    maxSentenceLength = Param(Params._dummy(),
+                              "maxSentenceLength",
+                              "Max sentence length to process",
+                              typeConverter=TypeConverters.toInt)
+
+    configProtoBytes = Param(Params._dummy(),
+                             "configProtoBytes",
+                             "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
+                             TypeConverters.toListInt)
+
+    coalesceSentences = Param(Params._dummy(), "coalesceSentences",
+                              "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
+                              TypeConverters.toBoolean)
+
+    def setConfigProtoBytes(self, b):
+        """Sets configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[str]
+            ConfigProto from tensorflow, serialized into byte array
+        """
+        return self._set(configProtoBytes=b)
+
+    def setMaxSentenceLength(self, value):
+        """Sets max sentence length to process, by default 128.
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
+        return self._set(maxSentenceLength=value)
+
+    def setCoalesceSentences(self, value):
+        """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
+        Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
+        into the model and averaging all the probabilities for the entire document instead of probabilities per sentence. (Default: true)
+
+        Parameters
+        ----------
+        value : bool
+            If the output of all sentences will be averaged to one output
+        """
+        return self._set(coalesceSentences=value)
+
+    @keyword_only
+    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.XlnetForSequenceClassification",
+                 java_model=None):
+        super(XlnetForSequenceClassification, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        self._setDefault(
+            batchSize=8,
+            maxSentenceLength=128,
+            caseSensitive=True,
+            coalesceSentences=False
+        )
+
+    @staticmethod
+    def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        XlnetForSequenceClassification
+            The restored model
+        """
+        from sparknlp.internal import _XlnetSequenceClassifierLoader
+        jModel = _XlnetSequenceClassifierLoader(folder, spark_session._jsparkSession)._java_obj
+        return XlnetForSequenceClassification(java_model=jModel)
+
+    @staticmethod
+    def pretrained(name="xlnet_base_sequence_classifier_imdb", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default
+            "xlnet_base_sequence_classifier_imdb"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None. Will use
+            Spark NLPs repositories otherwise.
+
+        Returns
+        -------
+        XlnetForSequenceClassification
+            The restored model
+        """
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(XlnetForSequenceClassification, name, lang, remote_loc)

--- a/python/sparknlp/internal.py
+++ b/python/sparknlp/internal.py
@@ -481,3 +481,10 @@ class _AlbertSequenceClassifierLoader(ExtendedJavaWrapper):
         super(_AlbertSequenceClassifierLoader, self).__init__(
             "com.johnsnowlabs.nlp.annotators.classifier.dl.AlbertForSequenceClassification.loadSavedModel", path,
             jspark)
+
+
+class _XlnetSequenceClassifierLoader(ExtendedJavaWrapper):
+    def __init__(self, path, jspark):
+        super(_XlnetSequenceClassifierLoader, self).__init__(
+            "com.johnsnowlabs.nlp.annotators.classifier.dl.XlnetForSequenceClassification.loadSavedModel", path,
+            jspark)

--- a/python/sparknlp/internal.py
+++ b/python/sparknlp/internal.py
@@ -453,3 +453,10 @@ class _DistilBertSequenceClassifierLoader(ExtendedJavaWrapper):
         super(_DistilBertSequenceClassifierLoader, self).__init__(
             "com.johnsnowlabs.nlp.annotators.classifier.dl.DistilBertForSequenceClassification.loadSavedModel", path,
             jspark)
+
+
+class _RoBertaSequenceClassifierLoader(ExtendedJavaWrapper):
+    def __init__(self, path, jspark):
+        super(_RoBertaSequenceClassifierLoader, self).__init__(
+            "com.johnsnowlabs.nlp.annotators.classifier.dl.RoBertaForSequenceClassification.loadSavedModel", path,
+            jspark)

--- a/python/sparknlp/internal.py
+++ b/python/sparknlp/internal.py
@@ -474,3 +474,10 @@ class _LongformerSequenceClassifierLoader(ExtendedJavaWrapper):
         super(_LongformerSequenceClassifierLoader, self).__init__(
             "com.johnsnowlabs.nlp.annotators.classifier.dl.LongformerForSequenceClassification.loadSavedModel", path,
             jspark)
+
+
+class _AlbertSequenceClassifierLoader(ExtendedJavaWrapper):
+    def __init__(self, path, jspark):
+        super(_AlbertSequenceClassifierLoader, self).__init__(
+            "com.johnsnowlabs.nlp.annotators.classifier.dl.AlbertForSequenceClassification.loadSavedModel", path,
+            jspark)

--- a/python/sparknlp/internal.py
+++ b/python/sparknlp/internal.py
@@ -467,3 +467,10 @@ class _XlmRoBertaSequenceClassifierLoader(ExtendedJavaWrapper):
         super(_XlmRoBertaSequenceClassifierLoader, self).__init__(
             "com.johnsnowlabs.nlp.annotators.classifier.dl.XlmRoBertaForSequenceClassification.loadSavedModel", path,
             jspark)
+
+
+class _LongformerSequenceClassifierLoader(ExtendedJavaWrapper):
+    def __init__(self, path, jspark):
+        super(_LongformerSequenceClassifierLoader, self).__init__(
+            "com.johnsnowlabs.nlp.annotators.classifier.dl.LongformerForSequenceClassification.loadSavedModel", path,
+            jspark)

--- a/python/sparknlp/internal.py
+++ b/python/sparknlp/internal.py
@@ -460,3 +460,10 @@ class _RoBertaSequenceClassifierLoader(ExtendedJavaWrapper):
         super(_RoBertaSequenceClassifierLoader, self).__init__(
             "com.johnsnowlabs.nlp.annotators.classifier.dl.RoBertaForSequenceClassification.loadSavedModel", path,
             jspark)
+
+
+class _XlmRoBertaSequenceClassifierLoader(ExtendedJavaWrapper):
+    def __init__(self, path, jspark):
+        super(_XlmRoBertaSequenceClassifierLoader, self).__init__(
+            "com.johnsnowlabs.nlp.annotators.classifier.dl.XlmRoBertaForSequenceClassification.loadSavedModel", path,
+            jspark)

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -2055,14 +2055,14 @@ class DistilBertForSequenceClassificationTestSpec(unittest.TestCase):
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        token_classifier = DistilBertForSequenceClassification.pretrained() \
+        doc_classifier = DistilBertForSequenceClassification.pretrained() \
             .setInputCols(["document", "token"]) \
             .setOutputCol("ner")
 
         pipeline = Pipeline(stages=[
             document_assembler,
             tokenizer,
-            token_classifier
+            doc_classifier
         ])
 
         model = pipeline.fit(self.data)
@@ -2081,14 +2081,14 @@ class RoBertaForSequenceClassificationTestSpec(unittest.TestCase):
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        token_classifier = RoBertaForSequenceClassification.pretrained() \
+        doc_classifier = RoBertaForSequenceClassification.pretrained() \
             .setInputCols(["document", "token"]) \
             .setOutputCol("ner")
 
         pipeline = Pipeline(stages=[
             document_assembler,
             tokenizer,
-            token_classifier
+            doc_classifier
         ])
 
         model = pipeline.fit(self.data)

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -2067,3 +2067,29 @@ class DistilBertForSequenceClassificationTestSpec(unittest.TestCase):
 
         model = pipeline.fit(self.data)
         model.transform(self.data).show()
+
+
+class RoBertaForSequenceClassificationTestSpec(unittest.TestCase):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+    def runTest(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        token_classifier = RoBertaForSequenceClassification.pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("ner")
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            token_classifier
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -2057,7 +2057,7 @@ class DistilBertForSequenceClassificationTestSpec(unittest.TestCase):
 
         doc_classifier = DistilBertForSequenceClassification.pretrained() \
             .setInputCols(["document", "token"]) \
-            .setOutputCol("ner")
+            .setOutputCol("class")
 
         pipeline = Pipeline(stages=[
             document_assembler,
@@ -2083,7 +2083,34 @@ class RoBertaForSequenceClassificationTestSpec(unittest.TestCase):
 
         doc_classifier = RoBertaForSequenceClassification.pretrained() \
             .setInputCols(["document", "token"]) \
-            .setOutputCol("ner")
+            .setOutputCol("class")
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            doc_classifier
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()
+
+
+class XlmRoBertaForSequenceClassificationTestSpec(unittest.TestCase):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+    def runTest(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        doc_classifier = XlmRoBertaForSequenceClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("class")
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowAlbertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowAlbertClassification.scala
@@ -18,7 +18,6 @@ package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{SentencePieceWrapper, SentencepieceEncoder}
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import com.johnsnowlabs.nlp.annotators.common._
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
@@ -108,7 +107,6 @@ class TensorflowAlbertClassification(val tensorflowWrapper: TensorflowWrapper,
     batchScores
   }
 
-  //TODO: create an abstract in TensorflowForClassification
   def tagSequence(batch: Seq[Array[Int]]): Array[Array[Float]] = {
     val tensors = new TensorResources()
 
@@ -154,48 +152,6 @@ class TensorflowAlbertClassification(val tensorflowWrapper: TensorflowWrapper,
       calculateSoftmax(scores)).toArray
 
     batchScores
-  }
-
-  //TODO: move me to TensorflowForClassification
-  def predictSequence(tokenizedSentences: Seq[TokenizedSentence], sentences: Seq[Sentence], batchSize: Int, maxSentenceLength: Int,
-                      caseSensitive: Boolean, coalesceSentences: Boolean = false, tags: Map[String, Int]): Seq[Annotation] = {
-
-    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
-
-    /*Run calculation by batches*/
-    wordPieceTokenizedSentences.zip(sentences).zipWithIndex.grouped(batchSize).flatMap { batch =>
-      val tokensBatch = batch.map(x => (x._1._1, x._2))
-      val encoded = encode(tokensBatch, maxSentenceLength)
-      val logits = tagSequence(encoded)
-
-      if (coalesceSentences) {
-        val scores = logits.transpose.map(_.sum / logits.length)
-        val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-        val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-        Array(
-          Annotation(
-            annotatorType = AnnotatorType.CATEGORY,
-            begin = sentences.head.start,
-            end = sentences.head.end,
-            result = label,
-            metadata = Map("sentence" -> sentences.head.index.toString) ++ meta
-          )
-        )
-      } else {
-        sentences.zip(logits).map { case (sentence, scores) =>
-          val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-          val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-          Annotation(
-            annotatorType = AnnotatorType.CATEGORY,
-            begin = sentence.start,
-            end = sentence.end,
-            result = label,
-            metadata = Map("sentence" -> sentence.index.toString) ++ meta
-          )
-        }
-      }
-    }.toSeq
-
   }
 
   def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowAlbertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowAlbertClassification.scala
@@ -18,6 +18,7 @@ package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{SentencePieceWrapper, SentencepieceEncoder}
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import com.johnsnowlabs.nlp.annotators.common._
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
@@ -105,6 +106,96 @@ class TensorflowAlbertClassification(val tensorflowWrapper: TensorflowWrapper,
       calculateSoftmax(scores)).toArray.grouped(maxSentenceLength).toArray
 
     batchScores
+  }
+
+  //TODO: create an abstract in TensorflowForClassification
+  def tagSequence(batch: Seq[Array[Int]]): Array[Array[Float]] = {
+    val tensors = new TensorResources()
+
+    val maxSentenceLength = batch.map(encodedSentence => encodedSentence.length).max
+    val batchLength = batch.length
+
+    val tokenBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+    val maskBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+    val segmentBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+
+    // [nb of encoded sentences , maxSentenceLength]
+    val shape = Array(batch.length.toLong, maxSentenceLength)
+
+    batch.zipWithIndex
+      .foreach { case (sentence, idx) =>
+        val offset = idx * maxSentenceLength
+        tokenBuffers.offset(offset).write(sentence)
+        maskBuffers.offset(offset).write(sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
+        segmentBuffers.offset(offset).write(Array.fill(maxSentenceLength)(0))
+      }
+
+    val runner = tensorflowWrapper.getTFHubSession(configProtoBytes = configProtoBytes, initAllTables = false).runner
+
+    val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
+    val maskTensors = tensors.createIntBufferTensor(shape, maskBuffers)
+    val segmentTensors = tensors.createIntBufferTensor(shape, segmentBuffers)
+
+    runner
+      .feed(_tfAlbertSignatures.getOrElse(ModelSignatureConstants.InputIds.key, "missing_input_id_key"), tokenTensors)
+      .feed(_tfAlbertSignatures.getOrElse(ModelSignatureConstants.AttentionMask.key, "missing_input_mask_key"), maskTensors)
+      .feed(_tfAlbertSignatures.getOrElse(ModelSignatureConstants.TokenTypeIds.key, "missing_segment_ids_key"), segmentTensors)
+      .fetch(_tfAlbertSignatures.getOrElse(ModelSignatureConstants.LogitsOutput.key, "missing_logits_key"))
+
+    val outs = runner.run().asScala
+    val rawScores = TensorResources.extractFloats(outs.head)
+
+    outs.foreach(_.close())
+    tensors.clearSession(outs)
+    tensors.clearTensors()
+
+    val dim = rawScores.length / batchLength
+    val batchScores: Array[Array[Float]] = rawScores.grouped(dim).map(scores =>
+      calculateSoftmax(scores)).toArray
+
+    batchScores
+  }
+
+  //TODO: move me to TensorflowForClassification
+  def predictSequence(tokenizedSentences: Seq[TokenizedSentence], sentences: Seq[Sentence], batchSize: Int, maxSentenceLength: Int,
+                      caseSensitive: Boolean, coalesceSentences: Boolean = false, tags: Map[String, Int]): Seq[Annotation] = {
+
+    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
+
+    /*Run calculation by batches*/
+    wordPieceTokenizedSentences.zip(sentences).zipWithIndex.grouped(batchSize).flatMap { batch =>
+      val tokensBatch = batch.map(x => (x._1._1, x._2))
+      val encoded = encode(tokensBatch, maxSentenceLength)
+      val logits = tagSequence(encoded)
+
+      if (coalesceSentences) {
+        val scores = logits.transpose.map(_.sum / logits.length)
+        val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
+        val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
+        Array(
+          Annotation(
+            annotatorType = AnnotatorType.CATEGORY,
+            begin = sentences.head.start,
+            end = sentences.head.end,
+            result = label,
+            metadata = Map("sentence" -> sentences.head.index.toString) ++ meta
+          )
+        )
+      } else {
+        sentences.zip(logits).map { case (sentence, scores) =>
+          val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
+          val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
+          Annotation(
+            annotatorType = AnnotatorType.CATEGORY,
+            begin = sentence.start,
+            end = sentence.end,
+            result = label,
+            metadata = Map("sentence" -> sentence.index.toString) ++ meta
+          )
+        }
+      }
+    }.toSeq
+
   }
 
   def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowBertClassification.scala
@@ -17,7 +17,6 @@
 package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.annotators.tokenizer.wordpiece.{BasicTokenizer, WordpieceEncoder}
 import org.tensorflow.ndarray.buffer.IntDataBuffer
@@ -115,7 +114,6 @@ class TensorflowBertClassification(val tensorflowWrapper: TensorflowWrapper,
     batchScores
   }
 
-  //TODO: create an abstract in TensorflowForClassification
   def tagSequence(batch: Seq[Array[Int]]): Array[Array[Float]] = {
     val tensors = new TensorResources()
 
@@ -162,48 +160,6 @@ class TensorflowBertClassification(val tensorflowWrapper: TensorflowWrapper,
       calculateSoftmax(scores)).toArray
 
     batchScores
-  }
-
-  //TODO: move me to TensorflowForClassification
-  def predictSequence(tokenizedSentences: Seq[TokenizedSentence], sentences: Seq[Sentence], batchSize: Int, maxSentenceLength: Int,
-                      caseSensitive: Boolean, coalesceSentences: Boolean = false, tags: Map[String, Int]): Seq[Annotation] = {
-
-    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
-
-    /*Run calculation by batches*/
-    wordPieceTokenizedSentences.zip(sentences).zipWithIndex.grouped(batchSize).flatMap { batch =>
-      val tokensBatch = batch.map(x => (x._1._1, x._2))
-      val encoded = encode(tokensBatch, maxSentenceLength)
-      val logits = tagSequence(encoded)
-
-      if (coalesceSentences) {
-        val scores = logits.transpose.map(_.sum / logits.length)
-        val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-        val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-        Array(
-          Annotation(
-            annotatorType = AnnotatorType.CATEGORY,
-            begin = sentences.head.start,
-            end = sentences.head.end,
-            result = label,
-            metadata = Map("sentence" -> sentences.head.index.toString) ++ meta
-          )
-        )
-      } else {
-        sentences.zip(logits).map { case (sentence, scores) =>
-          val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-          val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-          Annotation(
-            annotatorType = AnnotatorType.CATEGORY,
-            begin = sentence.start,
-            end = sentence.end,
-            result = label,
-            metadata = Map("sentence" -> sentence.index.toString) ++ meta
-          )
-        }
-      }
-    }.toSeq
-
   }
 
   def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowDistilBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowDistilBertClassification.scala
@@ -17,7 +17,6 @@
 package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.annotators.tokenizer.wordpiece.{BasicTokenizer, WordpieceEncoder}
 import org.tensorflow.ndarray.buffer.IntDataBuffer
@@ -113,7 +112,6 @@ class TensorflowDistilBertClassification(val tensorflowWrapper: TensorflowWrappe
     batchScores
   }
 
-  //TODO: create an abstract in TensorflowForClassification
   def tagSequence(batch: Seq[Array[Int]]): Array[Array[Float]] = {
     val tensors = new TensorResources()
 
@@ -140,7 +138,6 @@ class TensorflowDistilBertClassification(val tensorflowWrapper: TensorflowWrappe
 
     val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
     val maskTensors = tensors.createIntBufferTensor(shape, maskBuffers)
-    val segmentTensors = tensors.createIntBufferTensor(shape, segmentBuffers)
 
     runner
       .feed(_tfDistilBertSignatures.getOrElse(ModelSignatureConstants.InputIds.key, "missing_input_id_key"), tokenTensors)
@@ -159,48 +156,6 @@ class TensorflowDistilBertClassification(val tensorflowWrapper: TensorflowWrappe
       calculateSoftmax(scores)).toArray
 
     batchScores
-  }
-
-  //TODO: move me to TensorflowForClassification
-  def predictSequence(tokenizedSentences: Seq[TokenizedSentence], sentences: Seq[Sentence], batchSize: Int, maxSentenceLength: Int,
-                      caseSensitive: Boolean, coalesceSentences: Boolean = false, tags: Map[String, Int]): Seq[Annotation] = {
-
-    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
-
-    /*Run calculation by batches*/
-    wordPieceTokenizedSentences.zip(sentences).zipWithIndex.grouped(batchSize).flatMap { batch =>
-      val tokensBatch = batch.map(x => (x._1._1, x._2))
-      val encoded = encode(tokensBatch, maxSentenceLength)
-      val logits = tagSequence(encoded)
-
-      if (coalesceSentences) {
-        val scores = logits.transpose.map(_.sum / logits.length)
-        val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-        val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-        Array(
-          Annotation(
-            annotatorType = AnnotatorType.CATEGORY,
-            begin = sentences.head.start,
-            end = sentences.head.end,
-            result = label,
-            metadata = Map("sentence" -> sentences.head.index.toString) ++ meta
-          )
-        )
-      } else {
-        sentences.zip(logits).map { case (sentence, scores) =>
-          val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-          val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-          Annotation(
-            annotatorType = AnnotatorType.CATEGORY,
-            begin = sentence.start,
-            end = sentence.end,
-            result = label,
-            metadata = Map("sentence" -> sentence.index.toString) ++ meta
-          )
-        }
-      }
-    }.toSeq
-
   }
 
   def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowRoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowRoBertaClassification.scala
@@ -17,7 +17,6 @@
 package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.annotators.tokenizer.bpe.BpeTokenizer
 import org.tensorflow.ndarray.buffer.IntDataBuffer
@@ -109,7 +108,6 @@ class TensorflowRoBertaClassification(val tensorflowWrapper: TensorflowWrapper,
     batchScores
   }
 
-  //TODO: create an abstract in TensorflowForClassification
   def tagSequence(batch: Seq[Array[Int]]): Array[Array[Float]] = {
     val tensors = new TensorResources()
 
@@ -154,50 +152,8 @@ class TensorflowRoBertaClassification(val tensorflowWrapper: TensorflowWrapper,
     batchScores
   }
 
-  //TODO: move me to TensorflowForClassification
-  def predictSequence(tokenizedSentences: Seq[TokenizedSentence], sentences: Seq[Sentence], batchSize: Int, maxSentenceLength: Int,
-                      caseSensitive: Boolean, coalesceSentences: Boolean = false, tags: Map[String, Int]): Seq[Annotation] = {
-
-    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
-
-    /*Run calculation by batches*/
-    wordPieceTokenizedSentences.zip(sentences).zipWithIndex.grouped(batchSize).flatMap { batch =>
-      val tokensBatch = batch.map(x => (x._1._1, x._2))
-      val encoded = encode(tokensBatch, maxSentenceLength)
-      val logits = tagSequence(encoded)
-
-      if (coalesceSentences) {
-        val scores = logits.transpose.map(_.sum / logits.length)
-        val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-        val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-        Array(
-          Annotation(
-            annotatorType = AnnotatorType.CATEGORY,
-            begin = sentences.head.start,
-            end = sentences.head.end,
-            result = label,
-            metadata = Map("sentence" -> sentences.head.index.toString) ++ meta
-          )
-        )
-      } else {
-        sentences.zip(logits).map { case (sentence, scores) =>
-          val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-          val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-          Annotation(
-            annotatorType = AnnotatorType.CATEGORY,
-            begin = sentence.start,
-            end = sentence.end,
-            result = label,
-            metadata = Map("sentence" -> sentence.index.toString) ++ meta
-          )
-        }
-      }
-    }.toSeq
-
-  }
-
   def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),
-                                tokenPiece: TokenPiece): Option[IndexedToken] = {
+                       tokenPiece: TokenPiece): Option[IndexedToken] = {
     tokenizedSentences(sentence._2).indexedTokens.find(p => p.begin == tokenPiece.begin)
   }
 

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlmRoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlmRoBertaClassification.scala
@@ -18,6 +18,7 @@ package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{SentencePieceWrapper, SentencepieceEncoder}
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import com.johnsnowlabs.nlp.annotators.common._
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
@@ -102,11 +103,95 @@ class TensorflowXlmRoBertaClassification(val tensorflowWrapper: TensorflowWrappe
     batchScores
   }
 
+  //TODO: create an abstract in TensorflowForClassification
+  def tagSequence(batch: Seq[Array[Int]]): Array[Array[Float]] = {
+    val tensors = new TensorResources()
+
+    val maxSentenceLength = batch.map(encodedSentence => encodedSentence.length).max
+    val batchLength = batch.length
+
+    val tokenBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+    val maskBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+
+    // [nb of encoded sentences , maxSentenceLength]
+    val shape = Array(batch.length.toLong, maxSentenceLength)
+
+    batch.zipWithIndex
+      .foreach { case (sentence, idx) =>
+        val offset = idx * maxSentenceLength
+        tokenBuffers.offset(offset).write(sentence)
+        maskBuffers.offset(offset).write(sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
+      }
+
+    val runner = tensorflowWrapper.getTFHubSession(configProtoBytes = configProtoBytes, initAllTables = false).runner
+
+    val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
+    val maskTensors = tensors.createIntBufferTensor(shape, maskBuffers)
+
+    runner
+      .feed(_tfXlmRoBertaSignatures.getOrElse(ModelSignatureConstants.InputIds.key, "missing_input_id_key"), tokenTensors)
+      .feed(_tfXlmRoBertaSignatures.getOrElse(ModelSignatureConstants.AttentionMask.key, "missing_input_mask_key"), maskTensors)
+      .fetch(_tfXlmRoBertaSignatures.getOrElse(ModelSignatureConstants.LogitsOutput.key, "missing_logits_key"))
+
+    val outs = runner.run().asScala
+    val rawScores = TensorResources.extractFloats(outs.head)
+
+    outs.foreach(_.close())
+    tensors.clearSession(outs)
+    tensors.clearTensors()
+
+    val dim = rawScores.length / batchLength
+    val batchScores: Array[Array[Float]] = rawScores.grouped(dim).map(scores =>
+      calculateSoftmax(scores)).toArray
+
+    batchScores
+  }
+
+  //TODO: move me to TensorflowForClassification
+  def predictSequence(tokenizedSentences: Seq[TokenizedSentence], sentences: Seq[Sentence], batchSize: Int, maxSentenceLength: Int,
+                      caseSensitive: Boolean, coalesceSentences: Boolean = false, tags: Map[String, Int]): Seq[Annotation] = {
+
+    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
+
+    /*Run calculation by batches*/
+    wordPieceTokenizedSentences.zip(sentences).zipWithIndex.grouped(batchSize).flatMap { batch =>
+      val tokensBatch = batch.map(x => (x._1._1, x._2))
+      val encoded = encode(tokensBatch, maxSentenceLength)
+      val logits = tagSequence(encoded)
+
+      if (coalesceSentences) {
+        val scores = logits.transpose.map(_.sum / logits.length)
+        val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
+        val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
+        Array(
+          Annotation(
+            annotatorType = AnnotatorType.CATEGORY,
+            begin = sentences.head.start,
+            end = sentences.head.end,
+            result = label,
+            metadata = Map("sentence" -> sentences.head.index.toString) ++ meta
+          )
+        )
+      } else {
+        sentences.zip(logits).map { case (sentence, scores) =>
+          val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
+          val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
+          Annotation(
+            annotatorType = AnnotatorType.CATEGORY,
+            begin = sentence.start,
+            end = sentence.end,
+            result = label,
+            metadata = Map("sentence" -> sentence.index.toString) ++ meta
+          )
+        }
+      }
+    }.toSeq
+
+  }
+
   def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),
-                                tokenPiece: TokenPiece): Option[IndexedToken] = {
+                       tokenPiece: TokenPiece): Option[IndexedToken] = {
     tokenizedSentences(sentence._2).indexedTokens.find(p => p.begin == tokenPiece.begin && tokenPiece.isWordStart)
   }
 
 }
-
-

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlmRoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlmRoBertaClassification.scala
@@ -18,7 +18,6 @@ package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{SentencePieceWrapper, SentencepieceEncoder}
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import com.johnsnowlabs.nlp.annotators.common._
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
@@ -103,7 +102,6 @@ class TensorflowXlmRoBertaClassification(val tensorflowWrapper: TensorflowWrappe
     batchScores
   }
 
-  //TODO: create an abstract in TensorflowForClassification
   def tagSequence(batch: Seq[Array[Int]]): Array[Array[Float]] = {
     val tensors = new TensorResources()
 
@@ -145,48 +143,6 @@ class TensorflowXlmRoBertaClassification(val tensorflowWrapper: TensorflowWrappe
       calculateSoftmax(scores)).toArray
 
     batchScores
-  }
-
-  //TODO: move me to TensorflowForClassification
-  def predictSequence(tokenizedSentences: Seq[TokenizedSentence], sentences: Seq[Sentence], batchSize: Int, maxSentenceLength: Int,
-                      caseSensitive: Boolean, coalesceSentences: Boolean = false, tags: Map[String, Int]): Seq[Annotation] = {
-
-    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
-
-    /*Run calculation by batches*/
-    wordPieceTokenizedSentences.zip(sentences).zipWithIndex.grouped(batchSize).flatMap { batch =>
-      val tokensBatch = batch.map(x => (x._1._1, x._2))
-      val encoded = encode(tokensBatch, maxSentenceLength)
-      val logits = tagSequence(encoded)
-
-      if (coalesceSentences) {
-        val scores = logits.transpose.map(_.sum / logits.length)
-        val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-        val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-        Array(
-          Annotation(
-            annotatorType = AnnotatorType.CATEGORY,
-            begin = sentences.head.start,
-            end = sentences.head.end,
-            result = label,
-            metadata = Map("sentence" -> sentences.head.index.toString) ++ meta
-          )
-        )
-      } else {
-        sentences.zip(logits).map { case (sentence, scores) =>
-          val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-          val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-          Annotation(
-            annotatorType = AnnotatorType.CATEGORY,
-            begin = sentence.start,
-            end = sentence.end,
-            result = label,
-            metadata = Map("sentence" -> sentence.index.toString) ++ meta
-          )
-        }
-      }
-    }.toSeq
-
   }
 
   def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlnetClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlnetClassification.scala
@@ -18,6 +18,7 @@ package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{SentencePieceWrapper, SentencepieceEncoder}
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import com.johnsnowlabs.nlp.annotators.common._
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
@@ -110,8 +111,102 @@ class TensorflowXlnetClassification(val tensorflowWrapper: TensorflowWrapper,
     batchScores
   }
 
+
+  //TODO: create an abstract in TensorflowForClassification
+  def tagSequence(batch: Seq[Array[Int]]): Array[Array[Float]] = {
+    val tensors = new TensorResources()
+
+    val maxSentenceLength = batch.map(encodedSentence => encodedSentence.length).max
+    val batchLength = batch.length
+
+    val tokenBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+    val maskBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+    val segmentBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+
+    // [nb of encoded sentences , maxSentenceLength]
+    val shape = Array(batch.length.toLong, maxSentenceLength)
+
+    batch.zipWithIndex
+      .foreach { case (sentence, idx) =>
+        val offset = idx * maxSentenceLength
+        tokenBuffers.offset(offset).write(sentence)
+        maskBuffers.offset(offset).write(sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
+        segmentBuffers.offset(offset).write(Array.fill(maxSentenceLength)(0))
+      }
+
+    val runner = tensorflowWrapper.getTFHubSession(configProtoBytes = configProtoBytes, initAllTables = false).runner
+
+    val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
+    val maskTensors = tensors.createIntBufferTensor(shape, maskBuffers)
+    val segmentTensors = tensors.createIntBufferTensor(shape, segmentBuffers)
+
+    runner
+      .feed(_tfXlnetSignatures.getOrElse(ModelSignatureConstants.InputIds.key, "missing_input_id_key"), tokenTensors)
+      .feed(_tfXlnetSignatures.getOrElse(ModelSignatureConstants.AttentionMask.key, "missing_input_mask_key"), maskTensors)
+      .feed(_tfXlnetSignatures.getOrElse(ModelSignatureConstants.TokenTypeIds.key, "missing_segment_ids_key"), segmentTensors)
+      .fetch(_tfXlnetSignatures.getOrElse(ModelSignatureConstants.LogitsOutput.key, "missing_logits_key"))
+
+    val outs = runner.run().asScala
+    val rawScores = TensorResources.extractFloats(outs.head)
+
+    outs.foreach(_.close())
+    tensors.clearSession(outs)
+    tensors.clearTensors()
+    tokenTensors.close()
+    maskTensors.close()
+    segmentTensors.close()
+
+    val dim = rawScores.length / batchLength
+    val batchScores: Array[Array[Float]] = rawScores.grouped(dim).map(scores =>
+      calculateSoftmax(scores)).toArray
+
+    batchScores
+  }
+
+  //TODO: move me to TensorflowForClassification
+  def predictSequence(tokenizedSentences: Seq[TokenizedSentence], sentences: Seq[Sentence], batchSize: Int, maxSentenceLength: Int,
+                      caseSensitive: Boolean, coalesceSentences: Boolean = false, tags: Map[String, Int]): Seq[Annotation] = {
+
+    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
+
+    /*Run calculation by batches*/
+    wordPieceTokenizedSentences.zip(sentences).zipWithIndex.grouped(batchSize).flatMap { batch =>
+      val tokensBatch = batch.map(x => (x._1._1, x._2))
+      val encoded = encode(tokensBatch, maxSentenceLength)
+      val logits = tagSequence(encoded)
+
+      if (coalesceSentences) {
+        val scores = logits.transpose.map(_.sum / logits.length)
+        val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
+        val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
+        Array(
+          Annotation(
+            annotatorType = AnnotatorType.CATEGORY,
+            begin = sentences.head.start,
+            end = sentences.head.end,
+            result = label,
+            metadata = Map("sentence" -> sentences.head.index.toString) ++ meta
+          )
+        )
+      } else {
+        sentences.zip(logits).map { case (sentence, scores) =>
+          val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
+          val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
+          Annotation(
+            annotatorType = AnnotatorType.CATEGORY,
+            begin = sentence.start,
+            end = sentence.end,
+            result = label,
+            metadata = Map("sentence" -> sentence.index.toString) ++ meta
+          )
+        }
+      }
+    }.toSeq
+
+  }
+
   def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),
-                                tokenPiece: TokenPiece): Option[IndexedToken] = {
+                       tokenPiece: TokenPiece): Option[IndexedToken] = {
     tokenizedSentences(sentence._2).indexedTokens.find(p => p.begin == tokenPiece.begin && tokenPiece.isWordStart)
   }
 }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlnetClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlnetClassification.scala
@@ -18,7 +18,6 @@ package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{SentencePieceWrapper, SentencepieceEncoder}
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import com.johnsnowlabs.nlp.annotators.common._
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
@@ -111,8 +110,6 @@ class TensorflowXlnetClassification(val tensorflowWrapper: TensorflowWrapper,
     batchScores
   }
 
-
-  //TODO: create an abstract in TensorflowForClassification
   def tagSequence(batch: Seq[Array[Int]]): Array[Array[Float]] = {
     val tensors = new TensorResources()
 
@@ -161,48 +158,6 @@ class TensorflowXlnetClassification(val tensorflowWrapper: TensorflowWrapper,
       calculateSoftmax(scores)).toArray
 
     batchScores
-  }
-
-  //TODO: move me to TensorflowForClassification
-  def predictSequence(tokenizedSentences: Seq[TokenizedSentence], sentences: Seq[Sentence], batchSize: Int, maxSentenceLength: Int,
-                      caseSensitive: Boolean, coalesceSentences: Boolean = false, tags: Map[String, Int]): Seq[Annotation] = {
-
-    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
-
-    /*Run calculation by batches*/
-    wordPieceTokenizedSentences.zip(sentences).zipWithIndex.grouped(batchSize).flatMap { batch =>
-      val tokensBatch = batch.map(x => (x._1._1, x._2))
-      val encoded = encode(tokensBatch, maxSentenceLength)
-      val logits = tagSequence(encoded)
-
-      if (coalesceSentences) {
-        val scores = logits.transpose.map(_.sum / logits.length)
-        val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-        val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-        Array(
-          Annotation(
-            annotatorType = AnnotatorType.CATEGORY,
-            begin = sentences.head.start,
-            end = sentences.head.end,
-            result = label,
-            metadata = Map("sentence" -> sentences.head.index.toString) ++ meta
-          )
-        )
-      } else {
-        sentences.zip(logits).map { case (sentence, scores) =>
-          val label = tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-          val meta = scores.zipWithIndex.flatMap(x => Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-          Annotation(
-            annotatorType = AnnotatorType.CATEGORY,
-            begin = sentence.start,
-            end = sentence.end,
-            result = label,
-            metadata = Map("sentence" -> sentence.index.toString) ++ meta
-          )
-        }
-      }
-    }.toSeq
-
   }
 
   def findIndexedToken(tokenizedSentences: Seq[TokenizedSentence], sentence: (WordpieceTokenizedSentence, Int),

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -408,4 +408,8 @@ package object annotator {
 
   object AlbertForSequenceClassification extends ReadablePretrainedAlbertForSequenceModel with ReadAlbertForSequenceTensorflowModel
 
+  type XlnetForSequenceClassification = com.johnsnowlabs.nlp.annotators.classifier.dl.XlnetForSequenceClassification
+
+  object XlnetForSequenceClassification extends ReadablePretrainedXlnetForSequenceModel with ReadXlnetForSequenceTensorflowModel
+
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -392,4 +392,8 @@ package object annotator {
 
   object DistilBertForSequenceClassification extends ReadablePretrainedDistilBertForSequenceModel with ReadDistilBertForSequenceTensorflowModel
 
+  type RoBertaForSequenceClassification = com.johnsnowlabs.nlp.annotators.classifier.dl.RoBertaForSequenceClassification
+
+  object RoBertaForSequenceClassification extends ReadablePretrainedRoBertaForSequenceModel with ReadRoBertaForSequenceTensorflowModel
+
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -404,4 +404,8 @@ package object annotator {
 
   object LongformerForSequenceClassification extends ReadablePretrainedLongformerForSequenceModel with ReadLongformerForSequenceTensorflowModel
 
+  type AlbertForSequenceClassification = com.johnsnowlabs.nlp.annotators.classifier.dl.AlbertForSequenceClassification
+
+  object AlbertForSequenceClassification extends ReadablePretrainedAlbertForSequenceModel with ReadAlbertForSequenceTensorflowModel
+
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -396,4 +396,8 @@ package object annotator {
 
   object RoBertaForSequenceClassification extends ReadablePretrainedRoBertaForSequenceModel with ReadRoBertaForSequenceTensorflowModel
 
+  type XlmRoBertaForSequenceClassification = com.johnsnowlabs.nlp.annotators.classifier.dl.XlmRoBertaForSequenceClassification
+
+  object XlmRoBertaForSequenceClassification extends ReadablePretrainedXlmRoBertaForSequenceModel with ReadXlmRoBertaForSequenceTensorflowModel
+
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -400,4 +400,8 @@ package object annotator {
 
   object XlmRoBertaForSequenceClassification extends ReadablePretrainedXlmRoBertaForSequenceModel with ReadXlmRoBertaForSequenceTensorflowModel
 
+  type LongformerForSequenceClassification = com.johnsnowlabs.nlp.annotators.classifier.dl.LongformerForSequenceClassification
+
+  object LongformerForSequenceClassification extends ReadablePretrainedLongformerForSequenceModel with ReadLongformerForSequenceTensorflowModel
+
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassification.scala
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2017-2021 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.ml.tensorflow._
+import com.johnsnowlabs.ml.tensorflow.sentencepiece.{ReadSentencePieceModel, SentencePieceWrapper, WriteSentencePieceModel}
+import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.serialization.MapFeature
+import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
+
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.param.{BooleanParam, IntArrayParam, IntParam}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.SparkSession
+
+import java.io.File
+
+/**
+ * AlbertForSequenceClassification can load ALBERT Models with sequence classification/regression head on top
+ * (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
+ *
+ * Pretrained models can be loaded with `pretrained` of the companion object:
+ * {{{
+ * val sequenceClassifier = AlbertForSequenceClassification.pretrained()
+ *   .setInputCols("token", "document")
+ *   .setOutputCol("label")
+ * }}}
+ * The default model is `"albert_base_sequence_classifier_imdb"`, if no name is provided.
+ *
+ * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models?task=Text+Classification Models Hub]].
+ *
+ * Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. The Spark NLP Workshop
+ * example shows how to import them [[https://github.com/JohnSnowLabs/spark-nlp/discussions/5669]].
+ * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassificationTestSpec.scala AlbertForSequenceClassification]].
+ *
+ * ==Example==
+ * {{{
+ * import spark.implicits._
+ * import com.johnsnowlabs.nlp.base._
+ * import com.johnsnowlabs.nlp.annotator._
+ * import org.apache.spark.ml.Pipeline
+ *
+ * val documentAssembler = new DocumentAssembler()
+ *   .setInputCol("text")
+ *   .setOutputCol("document")
+ *
+ * val tokenizer = new Tokenizer()
+ *   .setInputCols("document")
+ *   .setOutputCol("token")
+ *
+ * val sequenceClassifier = AlbertForSequenceClassification.pretrained()
+ *   .setInputCols("token", "document")
+ *   .setOutputCol("label")
+ *   .setCaseSensitive(true)
+ *
+ * val pipeline = new Pipeline().setStages(Array(
+ *   documentAssembler,
+ *   tokenizer,
+ *   sequenceClassifier
+ * ))
+ *
+ * val data = Seq("John Lenon was born in London and lived in Paris. My name is Sarah and I live in London").toDF("text")
+ * val result = pipeline.fit(data).transform(data)
+ *
+ * result.select("label.result").show(false)
+ * +--------------------+
+ * |result              |
+ * +--------------------+
+ * |[neg, neg]          |
+ * |[pos, pos, pos, pos]|
+ * +--------------------+
+ * }}}
+ *
+ * @see [[AlbertForSequenceClassification]] for sequence-level classification
+ * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
+ * @param uid required uid for storing annotator to disk
+ * @groupname anno Annotator types
+ * @groupdesc anno Required input and expected output annotator types
+ * @groupname Ungrouped Members
+ * @groupname param Parameters
+ * @groupname setParam Parameter setters
+ * @groupname getParam Parameter getters
+ * @groupname Ungrouped Members
+ * @groupprio param  1
+ * @groupprio anno  2
+ * @groupprio Ungrouped 3
+ * @groupprio setParam  4
+ * @groupprio getParam  5
+ * @groupdesc param A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
+ * */
+class AlbertForSequenceClassification(override val uid: String)
+  extends AnnotatorModel[AlbertForSequenceClassification]
+    with HasBatchedAnnotate[AlbertForSequenceClassification]
+    with WriteTensorflowModel
+    with WriteSentencePieceModel
+    with HasCaseSensitiveProperties {
+
+  /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */
+  def this() = this(Identifiable.randomUID("AlbertForSequenceClassification"))
+
+  /**
+   * Input Annotator Types: DOCUMENT, TOKEN
+   *
+   * @group anno
+   */
+  override val inputAnnotatorTypes: Array[String] = Array(AnnotatorType.DOCUMENT, AnnotatorType.TOKEN)
+
+  /**
+   * Output Annotator Types: CATEGORY
+   *
+   * @group anno
+   */
+  override val outputAnnotatorType: AnnotatorType = AnnotatorType.CATEGORY
+
+  def sentenceStartTokenId: Int = {
+    $$(vocabulary)("<s>")
+  }
+
+  def sentenceEndTokenId: Int = {
+    $$(vocabulary)("</s>")
+  }
+
+  def padTokenId: Int = {
+    $$(vocabulary)("<pad>")
+  }
+
+
+  /**
+   * Vocabulary used to encode the words to ids with WordPieceEncoder
+   *
+   * @group param
+   * */
+  val vocabulary: MapFeature[String, Int] = new MapFeature(this, "vocabulary")
+
+  /** @group setParam */
+  def setVocabulary(value: Map[String, Int]): this.type = set(vocabulary, value)
+
+
+  /**
+   * Labels used to decode predicted IDs back to string tags
+   *
+   * @group param
+   * */
+  val labels: MapFeature[String, Int] = new MapFeature(this, "labels")
+
+  /** @group setParam */
+  def setLabels(value: Map[String, Int]): this.type = set(labels, value)
+
+  /** @group getParam */
+  def getLabels: Map[String, Int] = $$(labels)
+
+  /**
+   * Holding merges.txt coming from ALBERT model
+   *
+   * @group param
+   */
+  val merges: MapFeature[(String, String), Int] = new MapFeature(this, "merges")
+
+  /** @group setParam */
+  def setMerges(value: Map[(String, String), Int]): this.type = set(merges, value)
+
+  /** Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
+   * Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
+   * into the model and averaging all the probabilities for the entire document instead of probabilities per sentence. (Default: true)
+   *
+   * @group param
+   * */
+  val coalesceSentences = new BooleanParam(this, "coalesceSentences", "If sets to true the output of all sentences will be averaged to one output instead of one output per sentence. Default to true.")
+
+  /** @group setParam */
+  def setCoalesceSentences(value: Boolean): this.type = set(coalesceSentences, value)
+
+  /** @group getParam */
+  def getCoalesceSentences: Boolean = $(coalesceSentences)
+
+  /** ConfigProto from tensorflow, serialized into byte array. Get with `config_proto.SerializeToString()`
+   *
+   * @group param
+   * */
+  val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
+
+  /** @group setParam */
+  def setConfigProtoBytes(bytes: Array[Int]): AlbertForSequenceClassification.this.type = set(this.configProtoBytes, bytes)
+
+  /** @group getParam */
+  def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
+
+  /** Max sentence length to process (Default: `128`)
+   *
+   * @group param
+   * */
+  val maxSentenceLength = new IntParam(this, "maxSentenceLength", "Max sentence length to process")
+
+  /** @group setParam */
+  def setMaxSentenceLength(value: Int): this.type = {
+    require(value <= 512, "ALBERT models do not support sequences longer than 512 because of trainable positional embeddings.")
+    require(value >= 1, "The maxSentenceLength must be at least 1")
+    set(maxSentenceLength, value)
+    this
+  }
+
+  /** @group getParam */
+  def getMaxSentenceLength: Int = $(maxSentenceLength)
+
+  /**
+   * It contains TF model signatures for the laded saved model
+   *
+   * @group param
+   * */
+  val signatures = new MapFeature[String, String](model = this, name = "signatures")
+
+  /** @group setParam */
+  def setSignatures(value: Map[String, String]): this.type = {
+    if (get(signatures).isEmpty)
+      set(signatures, value)
+    this
+  }
+
+  /** @group getParam */
+  def getSignatures: Option[Map[String, String]] = get(this.signatures)
+
+  private var _model: Option[Broadcast[TensorflowAlbertClassification]] = None
+
+  /** @group setParam */
+  def setModelIfNotSet(spark: SparkSession, tensorflowWrapper: TensorflowWrapper, spp: SentencePieceWrapper): AlbertForSequenceClassification = {
+    if (_model.isEmpty) {
+      _model = Some(
+        spark.sparkContext.broadcast(
+          new TensorflowAlbertClassification(
+            tensorflowWrapper,
+            spp,
+            configProtoBytes = getConfigProtoBytes,
+            tags = getLabels,
+            signatures = getSignatures
+          )
+        )
+      )
+    }
+
+    this
+  }
+
+  /** @group getParam */
+  def getModelIfNotSet: TensorflowAlbertClassification = _model.get.value
+
+
+  /** Whether to lowercase tokens or not
+   *
+   * @group setParam
+   * */
+  override def setCaseSensitive(value: Boolean): this.type = {
+    if (get(caseSensitive).isEmpty)
+      set(this.caseSensitive, value)
+    this
+  }
+
+  setDefault(
+    batchSize -> 8,
+    maxSentenceLength -> 128,
+    caseSensitive -> false,
+    coalesceSentences -> false
+  )
+
+  /**
+   * takes a document and annotations and produces new annotations of this annotator's annotation type
+   *
+   * @param batchedAnnotations Annotations that correspond to inputAnnotationCols generated by previous annotators if any
+   * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
+   */
+  override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
+    batchedAnnotations.map(annotations => {
+      val sentences = SentenceSplit.unpack(annotations).toArray
+      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+
+      if (tokenizedSentences.nonEmpty) {
+        getModelIfNotSet.predictSequence(
+          tokenizedSentences,
+          sentences,
+          $(batchSize),
+          $(maxSentenceLength),
+          $(caseSensitive),
+          $(coalesceSentences),
+          getLabels
+        )
+      }
+      else {
+        Seq.empty[Annotation]
+      }
+    }
+
+    )
+  }
+
+
+  override def onWrite(path: String, spark: SparkSession): Unit = {
+    super.onWrite(path, spark)
+    writeTensorflowModelV2(path, spark, getModelIfNotSet.tensorflowWrapper, "_albert_classification", AlbertForSequenceClassification.tfFile, configProtoBytes = getConfigProtoBytes)
+    writeSentencePieceModel(path, spark, getModelIfNotSet.spp, "_albert", AlbertForSequenceClassification.sppFile)
+  }
+}
+
+trait ReadablePretrainedAlbertForSequenceModel extends ParamsAndFeaturesReadable[AlbertForSequenceClassification] with HasPretrained[AlbertForSequenceClassification] {
+  override val defaultModelName: Some[String] = Some("albert_base_sequence_classifier_imdb")
+
+  /** Java compliant-overrides */
+  override def pretrained(): AlbertForSequenceClassification = super.pretrained()
+
+  override def pretrained(name: String): AlbertForSequenceClassification = super.pretrained(name)
+
+  override def pretrained(name: String, lang: String): AlbertForSequenceClassification = super.pretrained(name, lang)
+
+  override def pretrained(name: String, lang: String, remoteLoc: String): AlbertForSequenceClassification = super.pretrained(name, lang, remoteLoc)
+}
+
+trait ReadAlbertForSequenceTensorflowModel extends ReadTensorflowModel with ReadSentencePieceModel {
+  this: ParamsAndFeaturesReadable[AlbertForSequenceClassification] =>
+
+  override val tfFile: String = "albert_classification_tensorflow"
+  override val sppFile: String = "albert_spp"
+
+  def readTensorflow(instance: AlbertForSequenceClassification, path: String, spark: SparkSession): Unit = {
+
+    val tf = readTensorflowModel(path, spark, "_albert_classification_tf", initAllTables = false)
+    val spp = readSentencePieceModel(path, spark, "_albert_spp", sppFile)
+    instance.setModelIfNotSet(spark, tf, spp)
+  }
+
+  addReader(readTensorflow)
+
+  def loadSavedModel(tfModelPath: String, spark: SparkSession): AlbertForSequenceClassification = {
+    val f = new File(tfModelPath)
+    val savedModel = new File(tfModelPath, "saved_model.pb")
+    require(f.exists, s"Folder $tfModelPath not found")
+    require(f.isDirectory, s"File $tfModelPath is not folder")
+    require(
+      savedModel.exists(),
+      s"savedModel file saved_model.pb not found in folder $tfModelPath"
+    )
+    val sppModelPath = tfModelPath + "/assets"
+    val sppModel = new File(sppModelPath, "spiece.model")
+    require(sppModel.exists(), s"SentencePiece model spiece.model not found in folder $sppModelPath")
+
+    val labelsPath = new File(tfModelPath + "/assets", "labels.txt")
+    require(labelsPath.exists(), s"Labels file labels.txt not found in folder $tfModelPath/assets/")
+
+    val labelsResource = new ExternalResource(labelsPath.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
+    val labels = ResourceHelper.parseLines(labelsResource).zipWithIndex.toMap
+
+    val (wrapper, signatures) = TensorflowWrapper.read(tfModelPath, zipped = false, useBundle = true)
+    val spp = SentencePieceWrapper.read(sppModel.toString)
+
+    val _signatures = signatures match {
+      case Some(s) => s
+      case None => throw new Exception("Cannot load signature definitions from model!")
+    }
+
+    /** the order of setSignatures is important if we use getSignatures inside setModelIfNotSet */
+    new AlbertForSequenceClassification()
+      .setLabels(labels)
+      .setSignatures(_signatures)
+      .setModelIfNotSet(spark, wrapper, spp)
+  }
+}
+
+/**
+ * This is the companion object of [[AlbertForSequenceClassification]]. Please refer to that class for the documentation.
+ */
+object AlbertForSequenceClassification extends ReadablePretrainedAlbertForSequenceModel with ReadAlbertForSequenceTensorflowModel

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForTokenClassification.scala
@@ -85,7 +85,7 @@ import java.io.File
  * +------------------------------------------------------------------------------------+
  * }}}
  *
- * @see [[com.johnsnowlabs.nlp.embeddings.AlbertEmbeddings AlbertEmbeddings]] for token-level embeddings
+ * @see [[AlbertForTokenClassification]] for token-level classification
  * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
  * @param uid required uid for storing annotator to disk
  * @groupname anno Annotator types

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
@@ -85,9 +85,7 @@ import java.io.File
  * +--------------------+
  * }}}
  *
- * @see [[BertForTokenClassification]] for token-level classification
- * @see [[com.johnsnowlabs.nlp.embeddings.BertSentenceEmbeddings BertSentenceEmbeddings]] for sentence-level embeddings
- * @see [[com.johnsnowlabs.nlp.embeddings.BertEmbeddings BertEmbeddings]] for token-level embeddings
+ * @see [[BertForSequenceClassification]] for sequnece-level classification
  * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
  * @param uid required uid for storing annotator to disk
  * @groupname anno Annotator types

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala
@@ -83,9 +83,7 @@ import java.io.File
  * +------------------------------------------------------------------------------------+
  * }}}
  *
- * @see [[BertForSequenceClassification]] for sentence-level classification
- * @see [[com.johnsnowlabs.nlp.embeddings.BertEmbeddings BertEmbeddings]] for token-level embeddings
- * @see [[com.johnsnowlabs.nlp.annotator.BertSentenceEmbeddings BertSentenceEmbeddings]] for sentence-level embeddings
+ * @see [[BertForTokenClassification]] for token-level classification
  * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
  * @param uid required uid for storing annotator to disk
  * @groupname anno Annotator types

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
@@ -84,8 +84,7 @@ import java.io.File
  * +--------------------+
  * }}}
  *
- * @see [[DistilBertForSequenceClassification]] for token-level classification
- * @see [[com.johnsnowlabs.nlp.embeddings.DistilBertEmbeddings DistilBertEmbeddings]] for token embeddings
+ * @see [[DistilBertForSequenceClassification]] for sequence-level classification
  * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
  * @param uid required uid for storing annotator to disk
  * @groupname anno Annotator types

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
@@ -85,8 +85,7 @@ import java.io.File
  * +------------------------------------------------------------------------------------+
  * }}}
  *
- * @see [[DistilBertForSequenceClassification]] for sentence-level classification
- * @see [[com.johnsnowlabs.nlp.embeddings.DistilBertEmbeddings DistilBertEmbeddings]] for token level embeddings
+ * @see [[DistilBertForTokenClassification]] for token-level classification
  * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
  * @param uid required uid for storing annotator to disk
  * @groupname anno Annotator types

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassification.scala
@@ -1,0 +1,403 @@
+/*
+ * Copyright 2017-2021 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.ml.tensorflow._
+import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.serialization.MapFeature
+import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.param.{BooleanParam, IntArrayParam, IntParam}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.SparkSession
+
+import java.io.File
+
+/**
+ * LongformerForSequenceClassification can load Longformer Models with sequence classification/regression head on top
+ * (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
+ *
+ * Pretrained models can be loaded with `pretrained` of the companion object:
+ * {{{
+ * val sequenceClassifier = LongformerForSequenceClassification.pretrained()
+ *   .setInputCols("token", "document")
+ *   .setOutputCol("label")
+ * }}}
+ * The default model is `"longformer_base_sequence_classifier_imdb"`, if no name is provided.
+ *
+ * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models?task=Text+Classification Models Hub]].
+ *
+ * Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. The Spark NLP Workshop
+ * example shows how to import them [[https://github.com/JohnSnowLabs/spark-nlp/discussions/5669]].
+ * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassificationTestSpec.scala LongformerForSequenceClassification]].
+ *
+ * ==Example==
+ * {{{
+ * import spark.implicits._
+ * import com.johnsnowlabs.nlp.base._
+ * import com.johnsnowlabs.nlp.annotator._
+ * import org.apache.spark.ml.Pipeline
+ *
+ * val documentAssembler = new DocumentAssembler()
+ *   .setInputCol("text")
+ *   .setOutputCol("document")
+ *
+ * val tokenizer = new Tokenizer()
+ *   .setInputCols("document")
+ *   .setOutputCol("token")
+ *
+ * val sequenceClassifier = LongformerForSequenceClassification.pretrained()
+ *   .setInputCols("token", "document")
+ *   .setOutputCol("label")
+ *   .setCaseSensitive(true)
+ *
+ * val pipeline = new Pipeline().setStages(Array(
+ *   documentAssembler,
+ *   tokenizer,
+ *   sequenceClassifier
+ * ))
+ *
+ * val data = Seq("John Lenon was born in London and lived in Paris. My name is Sarah and I live in London").toDF("text")
+ * val result = pipeline.fit(data).transform(data)
+ *
+ * result.select("label.result").show(false)
+ * +--------------------+
+ * |result              |
+ * +--------------------+
+ * |[neg, neg]          |
+ * |[pos, pos, pos, pos]|
+ * +--------------------+
+ * }}}
+ *
+ * @see [[LongformerForSequenceClassification]] for sequence-level classification
+ * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
+ * @param uid required uid for storing annotator to disk
+ * @groupname anno Annotator types
+ * @groupdesc anno Required input and expected output annotator types
+ * @groupname Ungrouped Members
+ * @groupname param Parameters
+ * @groupname setParam Parameter setters
+ * @groupname getParam Parameter getters
+ * @groupname Ungrouped Members
+ * @groupprio param  1
+ * @groupprio anno  2
+ * @groupprio Ungrouped 3
+ * @groupprio setParam  4
+ * @groupprio getParam  5
+ * @groupdesc param A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
+ * */
+class LongformerForSequenceClassification(override val uid: String)
+  extends AnnotatorModel[LongformerForSequenceClassification]
+    with HasBatchedAnnotate[LongformerForSequenceClassification]
+    with WriteTensorflowModel
+    with HasCaseSensitiveProperties {
+
+  /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */
+  def this() = this(Identifiable.randomUID("LongformerForSequenceClassification"))
+
+  /**
+   * Input Annotator Types: DOCUMENT, TOKEN
+   *
+   * @group anno
+   */
+  override val inputAnnotatorTypes: Array[String] = Array(AnnotatorType.DOCUMENT, AnnotatorType.TOKEN)
+
+  /**
+   * Output Annotator Types: CATEGORY
+   *
+   * @group anno
+   */
+  override val outputAnnotatorType: AnnotatorType = AnnotatorType.CATEGORY
+
+  def sentenceStartTokenId: Int = {
+    $$(vocabulary)("<s>")
+  }
+
+  def sentenceEndTokenId: Int = {
+    $$(vocabulary)("</s>")
+  }
+
+  def padTokenId: Int = {
+    $$(vocabulary)("<pad>")
+  }
+
+
+  /**
+   * Vocabulary used to encode the words to ids with WordPieceEncoder
+   *
+   * @group param
+   * */
+  val vocabulary: MapFeature[String, Int] = new MapFeature(this, "vocabulary")
+
+  /** @group setParam */
+  def setVocabulary(value: Map[String, Int]): this.type = set(vocabulary, value)
+
+
+  /**
+   * Labels used to decode predicted IDs back to string tags
+   *
+   * @group param
+   * */
+  val labels: MapFeature[String, Int] = new MapFeature(this, "labels")
+
+  /** @group setParam */
+  def setLabels(value: Map[String, Int]): this.type = set(labels, value)
+
+  /** @group getParam */
+  def getLabels: Map[String, Int] = $$(labels)
+
+  /**
+   * Holding merges.txt coming from Longformer model
+   *
+   * @group param
+   */
+  val merges: MapFeature[(String, String), Int] = new MapFeature(this, "merges")
+
+  /** @group setParam */
+  def setMerges(value: Map[(String, String), Int]): this.type = set(merges, value)
+
+  /** Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
+   * Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
+   * into the model and averaging all the probabilities for the entire document instead of probabilities per sentence. (Default: true)
+   *
+   * @group param
+   * */
+  val coalesceSentences = new BooleanParam(this, "coalesceSentences", "If sets to true the output of all sentences will be averaged to one output instead of one output per sentence. Default to true.")
+
+  /** @group setParam */
+  def setCoalesceSentences(value: Boolean): this.type = set(coalesceSentences, value)
+
+  /** @group getParam */
+  def getCoalesceSentences: Boolean = $(coalesceSentences)
+
+  /** ConfigProto from tensorflow, serialized into byte array. Get with `config_proto.SerializeToString()`
+   *
+   * @group param
+   * */
+  val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
+
+  /** @group setParam */
+  def setConfigProtoBytes(bytes: Array[Int]): LongformerForSequenceClassification.this.type = set(this.configProtoBytes, bytes)
+
+  /** @group getParam */
+  def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
+
+  /** Max sentence length to process (Default: `128`)
+   *
+   * @group param
+   * */
+  val maxSentenceLength = new IntParam(this, "maxSentenceLength", "Max sentence length to process")
+
+  /** @group setParam */
+  def setMaxSentenceLength(value: Int): this.type = {
+    require(value <= 4096, "Longformer models do not support sequences longer than 4096 because of trainable positional embeddings.")
+    require(value >= 1, "The maxSentenceLength must be at least 1")
+    set(maxSentenceLength, value)
+    this
+  }
+
+  /** @group getParam */
+  def getMaxSentenceLength: Int = $(maxSentenceLength)
+
+  /**
+   * It contains TF model signatures for the laded saved model
+   *
+   * @group param
+   * */
+  val signatures = new MapFeature[String, String](model = this, name = "signatures")
+
+  /** @group setParam */
+  def setSignatures(value: Map[String, String]): this.type = {
+    if (get(signatures).isEmpty)
+      set(signatures, value)
+    this
+  }
+
+  /** @group getParam */
+  def getSignatures: Option[Map[String, String]] = get(this.signatures)
+
+  private var _model: Option[Broadcast[TensorflowRoBertaClassification]] = None
+
+  /** @group setParam */
+  def setModelIfNotSet(spark: SparkSession, tensorflowWrapper: TensorflowWrapper): LongformerForSequenceClassification = {
+    if (_model.isEmpty) {
+      _model = Some(
+        spark.sparkContext.broadcast(
+          new TensorflowRoBertaClassification(
+            tensorflowWrapper,
+            sentenceStartTokenId,
+            sentenceEndTokenId,
+            padTokenId,
+            configProtoBytes = getConfigProtoBytes,
+            tags = getLabels,
+            signatures = getSignatures,
+            $$(merges),
+            $$(vocabulary)
+          )
+        )
+      )
+    }
+
+    this
+  }
+
+  /** @group getParam */
+  def getModelIfNotSet: TensorflowRoBertaClassification = _model.get.value
+
+
+  /** Whether to lowercase tokens or not
+   *
+   * @group setParam
+   * */
+  override def setCaseSensitive(value: Boolean): this.type = {
+    if (get(caseSensitive).isEmpty)
+      set(this.caseSensitive, value)
+    this
+  }
+
+  setDefault(
+    batchSize -> 8,
+    maxSentenceLength -> 4096,
+    caseSensitive -> true,
+    coalesceSentences -> false
+  )
+
+  /**
+   * takes a document and annotations and produces new annotations of this annotator's annotation type
+   *
+   * @param batchedAnnotations Annotations that correspond to inputAnnotationCols generated by previous annotators if any
+   * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
+   */
+  override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
+    batchedAnnotations.map(annotations => {
+      val sentences = SentenceSplit.unpack(annotations).toArray
+      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+
+      if (tokenizedSentences.nonEmpty) {
+        getModelIfNotSet.predictSequence(
+          tokenizedSentences,
+          sentences,
+          $(batchSize),
+          $(maxSentenceLength),
+          $(caseSensitive),
+          $(coalesceSentences),
+          getLabels
+        )
+      }
+      else {
+        Seq.empty[Annotation]
+      }
+    }
+
+    )
+  }
+
+
+  override def onWrite(path: String, spark: SparkSession): Unit = {
+    super.onWrite(path, spark)
+    writeTensorflowModelV2(path, spark, getModelIfNotSet.tensorflowWrapper, "_longformer_classification", LongformerForSequenceClassification.tfFile, configProtoBytes = getConfigProtoBytes)
+  }
+
+}
+
+trait ReadablePretrainedLongformerForSequenceModel extends ParamsAndFeaturesReadable[LongformerForSequenceClassification] with HasPretrained[LongformerForSequenceClassification] {
+  override val defaultModelName: Some[String] = Some("longformer_base_sequence_classifier_imdb")
+
+  /** Java compliant-overrides */
+  override def pretrained(): LongformerForSequenceClassification = super.pretrained()
+
+  override def pretrained(name: String): LongformerForSequenceClassification = super.pretrained(name)
+
+  override def pretrained(name: String, lang: String): LongformerForSequenceClassification = super.pretrained(name, lang)
+
+  override def pretrained(name: String, lang: String, remoteLoc: String): LongformerForSequenceClassification = super.pretrained(name, lang, remoteLoc)
+}
+
+trait ReadLongformerForSequenceTensorflowModel extends ReadTensorflowModel {
+  this: ParamsAndFeaturesReadable[LongformerForSequenceClassification] =>
+
+  override val tfFile: String = "longformer_classification_tensorflow"
+
+  def readTensorflow(instance: LongformerForSequenceClassification, path: String, spark: SparkSession): Unit = {
+
+    val tf = readTensorflowModel(path, spark, "_longformer_classification_tf", initAllTables = false)
+    instance.setModelIfNotSet(spark, tf)
+  }
+
+  addReader(readTensorflow)
+
+  def loadSavedModel(tfModelPath: String, spark: SparkSession): LongformerForSequenceClassification = {
+
+    val f = new File(tfModelPath)
+    val savedModel = new File(tfModelPath, "saved_model.pb")
+
+    require(f.exists, s"Folder $tfModelPath not found")
+    require(f.isDirectory, s"File $tfModelPath is not folder")
+    require(
+      savedModel.exists(),
+      s"savedModel file saved_model.pb not found in folder $tfModelPath"
+    )
+
+    val vocabFile = new File(tfModelPath + "/assets", "vocab.txt")
+    require(f.exists, s"Folder $tfModelPath not found")
+    require(f.isDirectory, s"File $tfModelPath is not folder")
+    require(vocabFile.exists(), s"Vocabulary file vocab.txt not found in folder $tfModelPath")
+
+    val mergesFile = new File(tfModelPath + "/assets", "merges.txt")
+    require(f.exists, s"Folder $tfModelPath not found")
+    require(f.isDirectory, s"File $tfModelPath is not folder")
+    require(mergesFile.exists(), s"merges file merges.txt not found in folder $tfModelPath")
+
+    val vocabResource = new ExternalResource(vocabFile.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
+    val words = ResourceHelper.parseLines(vocabResource).zipWithIndex.toMap
+
+    val mergesResource = new ExternalResource(mergesFile.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
+    val merges = ResourceHelper.parseLines(mergesResource)
+
+    val bytePairs: Map[(String, String), Int] = merges.map(_.split(" "))
+      .filter(w => w.length == 2)
+      .map { case Array(c1, c2) => (c1, c2) }
+      .zipWithIndex.toMap
+
+    val labelsPath = new File(tfModelPath + "/assets", "labels.txt")
+    require(labelsPath.exists(), s"Labels file labels.txt not found in folder $tfModelPath/assets/")
+
+    val labelsResource = new ExternalResource(labelsPath.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
+    val labels = ResourceHelper.parseLines(labelsResource).zipWithIndex.toMap
+
+    val (wrapper, signatures) = TensorflowWrapper.read(tfModelPath, zipped = false, useBundle = true)
+
+    val _signatures = signatures match {
+      case Some(s) => s
+      case None => throw new Exception("Cannot load signature definitions from model!")
+    }
+
+    /** the order of setSignatures is important if we use getSignatures inside setModelIfNotSet */
+    new LongformerForSequenceClassification()
+      .setVocabulary(words)
+      .setMerges(bytePairs)
+      .setLabels(labels)
+      .setSignatures(_signatures)
+      .setModelIfNotSet(spark, wrapper)
+  }
+}
+
+/**
+ * This is the companion object of [[LongformerForSequenceClassification]]. Please refer to that class for the documentation.
+ */
+object LongformerForSequenceClassification extends ReadablePretrainedLongformerForSequenceModel with ReadLongformerForSequenceTensorflowModel

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForTokenClassification.scala
@@ -84,7 +84,7 @@ import java.io.File
  * +------------------------------------------------------------------------------------+
  * }}}
  *
- * @see [[com.johnsnowlabs.nlp.embeddings.LongformerEmbeddings LongformerEmbeddings]] for token-level embeddings
+ * @see [[LongformerForTokenClassification]] for token-level classification
  * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
  * @param uid required uid for storing annotator to disk
  * @groupname anno Annotator types

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassification.scala
@@ -1,0 +1,403 @@
+/*
+ * Copyright 2017-2021 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.ml.tensorflow._
+import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.serialization.MapFeature
+import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.param.{BooleanParam, IntArrayParam, IntParam}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.SparkSession
+
+import java.io.File
+
+/**
+ * RoBertaForSequenceClassification can load RoBERTa Models with sequence classification/regression head on top
+ * (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
+ *
+ * Pretrained models can be loaded with `pretrained` of the companion object:
+ * {{{
+ * val sequenceClassifier = RoBertaForSequenceClassification.pretrained()
+ *   .setInputCols("token", "document")
+ *   .setOutputCol("label")
+ * }}}
+ * The default model is `"roberta_base_sequence_classifier_imdb"`, if no name is provided.
+ *
+ * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models?task=Text+Classification Models Hub]].
+ *
+ * Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. The Spark NLP Workshop
+ * example shows how to import them [[https://github.com/JohnSnowLabs/spark-nlp/discussions/5669]].
+ * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassificationTestSpec.scala RoBertaForSequenceClassification]].
+ *
+ * ==Example==
+ * {{{
+ * import spark.implicits._
+ * import com.johnsnowlabs.nlp.base._
+ * import com.johnsnowlabs.nlp.annotator._
+ * import org.apache.spark.ml.Pipeline
+ *
+ * val documentAssembler = new DocumentAssembler()
+ *   .setInputCol("text")
+ *   .setOutputCol("document")
+ *
+ * val tokenizer = new Tokenizer()
+ *   .setInputCols("document")
+ *   .setOutputCol("token")
+ *
+ * val sequenceClassifier = RoBertaForSequenceClassification.pretrained()
+ *   .setInputCols("token", "document")
+ *   .setOutputCol("label")
+ *   .setCaseSensitive(true)
+ *
+ * val pipeline = new Pipeline().setStages(Array(
+ *   documentAssembler,
+ *   tokenizer,
+ *   sequenceClassifier
+ * ))
+ *
+ * val data = Seq("John Lenon was born in London and lived in Paris. My name is Sarah and I live in London").toDF("text")
+ * val result = pipeline.fit(data).transform(data)
+ *
+ * result.select("label.result").show(false)
+ * +--------------------+
+ * |result              |
+ * +--------------------+
+ * |[neg, neg]          |
+ * |[pos, pos, pos, pos]|
+ * +--------------------+
+ * }}}
+ *
+ * @see [[RoBertaForSequenceClassification]] for sequence-level classification
+ * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
+ * @param uid required uid for storing annotator to disk
+ * @groupname anno Annotator types
+ * @groupdesc anno Required input and expected output annotator types
+ * @groupname Ungrouped Members
+ * @groupname param Parameters
+ * @groupname setParam Parameter setters
+ * @groupname getParam Parameter getters
+ * @groupname Ungrouped Members
+ * @groupprio param  1
+ * @groupprio anno  2
+ * @groupprio Ungrouped 3
+ * @groupprio setParam  4
+ * @groupprio getParam  5
+ * @groupdesc param A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
+ * */
+class RoBertaForSequenceClassification(override val uid: String)
+  extends AnnotatorModel[RoBertaForSequenceClassification]
+    with HasBatchedAnnotate[RoBertaForSequenceClassification]
+    with WriteTensorflowModel
+    with HasCaseSensitiveProperties {
+
+  /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */
+  def this() = this(Identifiable.randomUID("RoBertaForSequenceClassification"))
+
+  /**
+   * Input Annotator Types: DOCUMENT, TOKEN
+   *
+   * @group anno
+   */
+  override val inputAnnotatorTypes: Array[String] = Array(AnnotatorType.DOCUMENT, AnnotatorType.TOKEN)
+
+  /**
+   * Output Annotator Types: CATEGORY
+   *
+   * @group anno
+   */
+  override val outputAnnotatorType: AnnotatorType = AnnotatorType.CATEGORY
+
+  def sentenceStartTokenId: Int = {
+    $$(vocabulary)("<s>")
+  }
+
+  def sentenceEndTokenId: Int = {
+    $$(vocabulary)("</s>")
+  }
+
+  def padTokenId: Int = {
+    $$(vocabulary)("<pad>")
+  }
+
+
+  /**
+   * Vocabulary used to encode the words to ids with WordPieceEncoder
+   *
+   * @group param
+   * */
+  val vocabulary: MapFeature[String, Int] = new MapFeature(this, "vocabulary")
+
+  /** @group setParam */
+  def setVocabulary(value: Map[String, Int]): this.type = set(vocabulary, value)
+
+
+  /**
+   * Labels used to decode predicted IDs back to string tags
+   *
+   * @group param
+   * */
+  val labels: MapFeature[String, Int] = new MapFeature(this, "labels")
+
+  /** @group setParam */
+  def setLabels(value: Map[String, Int]): this.type = set(labels, value)
+
+  /** @group getParam */
+  def getLabels: Map[String, Int] = $$(labels)
+
+  /**
+   * Holding merges.txt coming from RoBERTa model
+   *
+   * @group param
+   */
+  val merges: MapFeature[(String, String), Int] = new MapFeature(this, "merges")
+
+  /** @group setParam */
+  def setMerges(value: Map[(String, String), Int]): this.type = set(merges, value)
+
+  /** Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
+   * Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
+   * into the model and averaging all the probabilities for the entire document instead of probabilities per sentence. (Default: true)
+   *
+   * @group param
+   * */
+  val coalesceSentences = new BooleanParam(this, "coalesceSentences", "If sets to true the output of all sentences will be averaged to one output instead of one output per sentence. Default to true.")
+
+  /** @group setParam */
+  def setCoalesceSentences(value: Boolean): this.type = set(coalesceSentences, value)
+
+  /** @group getParam */
+  def getCoalesceSentences: Boolean = $(coalesceSentences)
+
+  /** ConfigProto from tensorflow, serialized into byte array. Get with `config_proto.SerializeToString()`
+   *
+   * @group param
+   * */
+  val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
+
+  /** @group setParam */
+  def setConfigProtoBytes(bytes: Array[Int]): RoBertaForSequenceClassification.this.type = set(this.configProtoBytes, bytes)
+
+  /** @group getParam */
+  def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
+
+  /** Max sentence length to process (Default: `128`)
+   *
+   * @group param
+   * */
+  val maxSentenceLength = new IntParam(this, "maxSentenceLength", "Max sentence length to process")
+
+  /** @group setParam */
+  def setMaxSentenceLength(value: Int): this.type = {
+    require(value <= 512, "RoBERTa models do not support sequences longer than 512 because of trainable positional embeddings.")
+    require(value >= 1, "The maxSentenceLength must be at least 1")
+    set(maxSentenceLength, value)
+    this
+  }
+
+  /** @group getParam */
+  def getMaxSentenceLength: Int = $(maxSentenceLength)
+
+  /**
+   * It contains TF model signatures for the laded saved model
+   *
+   * @group param
+   * */
+  val signatures = new MapFeature[String, String](model = this, name = "signatures")
+
+  /** @group setParam */
+  def setSignatures(value: Map[String, String]): this.type = {
+    if (get(signatures).isEmpty)
+      set(signatures, value)
+    this
+  }
+
+  /** @group getParam */
+  def getSignatures: Option[Map[String, String]] = get(this.signatures)
+
+  private var _model: Option[Broadcast[TensorflowRoBertaClassification]] = None
+
+  /** @group setParam */
+  def setModelIfNotSet(spark: SparkSession, tensorflowWrapper: TensorflowWrapper): RoBertaForSequenceClassification = {
+    if (_model.isEmpty) {
+      _model = Some(
+        spark.sparkContext.broadcast(
+          new TensorflowRoBertaClassification(
+            tensorflowWrapper,
+            sentenceStartTokenId,
+            sentenceEndTokenId,
+            padTokenId,
+            configProtoBytes = getConfigProtoBytes,
+            tags = getLabels,
+            signatures = getSignatures,
+            $$(merges),
+            $$(vocabulary)
+          )
+        )
+      )
+    }
+
+    this
+  }
+
+  /** @group getParam */
+  def getModelIfNotSet: TensorflowRoBertaClassification = _model.get.value
+
+
+  /** Whether to lowercase tokens or not
+   *
+   * @group setParam
+   * */
+  override def setCaseSensitive(value: Boolean): this.type = {
+    if (get(caseSensitive).isEmpty)
+      set(this.caseSensitive, value)
+    this
+  }
+
+  setDefault(
+    batchSize -> 8,
+    maxSentenceLength -> 128,
+    caseSensitive -> true,
+    coalesceSentences -> false
+  )
+
+  /**
+   * takes a document and annotations and produces new annotations of this annotator's annotation type
+   *
+   * @param batchedAnnotations Annotations that correspond to inputAnnotationCols generated by previous annotators if any
+   * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
+   */
+  override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
+    batchedAnnotations.map(annotations => {
+      val sentences = SentenceSplit.unpack(annotations).toArray
+      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+
+      if (tokenizedSentences.nonEmpty) {
+        getModelIfNotSet.predictSequence(
+          tokenizedSentences,
+          sentences,
+          $(batchSize),
+          $(maxSentenceLength),
+          $(caseSensitive),
+          $(coalesceSentences),
+          getLabels
+        )
+      }
+      else {
+        Seq.empty[Annotation]
+      }
+    }
+
+    )
+  }
+
+
+  override def onWrite(path: String, spark: SparkSession): Unit = {
+    super.onWrite(path, spark)
+    writeTensorflowModelV2(path, spark, getModelIfNotSet.tensorflowWrapper, "_roberta_classification", RoBertaForSequenceClassification.tfFile, configProtoBytes = getConfigProtoBytes)
+  }
+
+}
+
+trait ReadablePretrainedRoBertaForSequenceModel extends ParamsAndFeaturesReadable[RoBertaForSequenceClassification] with HasPretrained[RoBertaForSequenceClassification] {
+  override val defaultModelName: Some[String] = Some("roberta_base_sequence_classifier_imdb")
+
+  /** Java compliant-overrides */
+  override def pretrained(): RoBertaForSequenceClassification = super.pretrained()
+
+  override def pretrained(name: String): RoBertaForSequenceClassification = super.pretrained(name)
+
+  override def pretrained(name: String, lang: String): RoBertaForSequenceClassification = super.pretrained(name, lang)
+
+  override def pretrained(name: String, lang: String, remoteLoc: String): RoBertaForSequenceClassification = super.pretrained(name, lang, remoteLoc)
+}
+
+trait ReadRoBertaForSequenceTensorflowModel extends ReadTensorflowModel {
+  this: ParamsAndFeaturesReadable[RoBertaForSequenceClassification] =>
+
+  override val tfFile: String = "roberta_classification_tensorflow"
+
+  def readTensorflow(instance: RoBertaForSequenceClassification, path: String, spark: SparkSession): Unit = {
+
+    val tf = readTensorflowModel(path, spark, "_roberta_classification_tf", initAllTables = false)
+    instance.setModelIfNotSet(spark, tf)
+  }
+
+  addReader(readTensorflow)
+
+  def loadSavedModel(tfModelPath: String, spark: SparkSession): RoBertaForSequenceClassification = {
+
+    val f = new File(tfModelPath)
+    val savedModel = new File(tfModelPath, "saved_model.pb")
+
+    require(f.exists, s"Folder $tfModelPath not found")
+    require(f.isDirectory, s"File $tfModelPath is not folder")
+    require(
+      savedModel.exists(),
+      s"savedModel file saved_model.pb not found in folder $tfModelPath"
+    )
+
+    val vocabFile = new File(tfModelPath + "/assets", "vocab.txt")
+    require(f.exists, s"Folder $tfModelPath not found")
+    require(f.isDirectory, s"File $tfModelPath is not folder")
+    require(vocabFile.exists(), s"Vocabulary file vocab.txt not found in folder $tfModelPath")
+
+    val mergesFile = new File(tfModelPath + "/assets", "merges.txt")
+    require(f.exists, s"Folder $tfModelPath not found")
+    require(f.isDirectory, s"File $tfModelPath is not folder")
+    require(mergesFile.exists(), s"merges file merges.txt not found in folder $tfModelPath")
+
+    val vocabResource = new ExternalResource(vocabFile.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
+    val words = ResourceHelper.parseLines(vocabResource).zipWithIndex.toMap
+
+    val mergesResource = new ExternalResource(mergesFile.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
+    val merges = ResourceHelper.parseLines(mergesResource)
+
+    val bytePairs: Map[(String, String), Int] = merges.map(_.split(" "))
+      .filter(w => w.length == 2)
+      .map { case Array(c1, c2) => (c1, c2) }
+      .zipWithIndex.toMap
+
+    val labelsPath = new File(tfModelPath + "/assets", "labels.txt")
+    require(labelsPath.exists(), s"Labels file labels.txt not found in folder $tfModelPath/assets/")
+
+    val labelsResource = new ExternalResource(labelsPath.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
+    val labels = ResourceHelper.parseLines(labelsResource).zipWithIndex.toMap
+
+    val (wrapper, signatures) = TensorflowWrapper.read(tfModelPath, zipped = false, useBundle = true)
+
+    val _signatures = signatures match {
+      case Some(s) => s
+      case None => throw new Exception("Cannot load signature definitions from model!")
+    }
+
+    /** the order of setSignatures is important if we use getSignatures inside setModelIfNotSet */
+    new RoBertaForSequenceClassification()
+      .setVocabulary(words)
+      .setMerges(bytePairs)
+      .setLabels(labels)
+      .setSignatures(_signatures)
+      .setModelIfNotSet(spark, wrapper)
+  }
+}
+
+/**
+ * This is the companion object of [[RoBertaForSequenceClassification]]. Please refer to that class for the documentation.
+ */
+object RoBertaForSequenceClassification extends ReadablePretrainedRoBertaForSequenceModel with ReadRoBertaForSequenceTensorflowModel

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForTokenClassification.scala
@@ -84,9 +84,7 @@ import java.io.File
  * +------------------------------------------------------------------------------------+
  * }}}
  *
- * @see [[com.johnsnowlabs.nlp.embeddings.RoBertaEmbeddings RoBertaEmbeddings]] for token-level embeddings
- * @see [[com.johnsnowlabs.nlp.annotator.RoBertaSentenceEmbeddings RoBertaSentenceEmbeddings]] for sentence-level
- *      embeddings
+ * @see [[RoBertaForTokenClassification]] for token-level classification
  * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
  * @param uid required uid for storing annotator to disk
  * @groupname anno Annotator types

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2017-2021 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.ml.tensorflow._
+import com.johnsnowlabs.ml.tensorflow.sentencepiece.{ReadSentencePieceModel, SentencePieceWrapper, WriteSentencePieceModel}
+import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.serialization.MapFeature
+import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.param.{BooleanParam, IntArrayParam, IntParam}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.SparkSession
+
+import java.io.File
+
+/**
+ * XlmRoBertaForSequenceClassification can load XLM-RoBERTa Models with sequence classification/regression head on top
+ * (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
+ *
+ * Pretrained models can be loaded with `pretrained` of the companion object:
+ * {{{
+ * val sequenceClassifier = XlmRoBertaForSequenceClassification.pretrained()
+ *   .setInputCols("token", "document")
+ *   .setOutputCol("label")
+ * }}}
+ * The default model is `"xlm_roberta_base_sequence_classifier_imdb"`, if no name is provided.
+ *
+ * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models?task=Text+Classification Models Hub]].
+ *
+ * Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. The Spark NLP Workshop
+ * example shows how to import them [[https://github.com/JohnSnowLabs/spark-nlp/discussions/5669]].
+ * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassificationTestSpec.scala XlmRoBertaForSequenceClassification]].
+ *
+ * ==Example==
+ * {{{
+ * import spark.implicits._
+ * import com.johnsnowlabs.nlp.base._
+ * import com.johnsnowlabs.nlp.annotator._
+ * import org.apache.spark.ml.Pipeline
+ *
+ * val documentAssembler = new DocumentAssembler()
+ *   .setInputCol("text")
+ *   .setOutputCol("document")
+ *
+ * val tokenizer = new Tokenizer()
+ *   .setInputCols("document")
+ *   .setOutputCol("token")
+ *
+ * val sequenceClassifier = XlmRoBertaForSequenceClassification.pretrained()
+ *   .setInputCols("token", "document")
+ *   .setOutputCol("label")
+ *   .setCaseSensitive(true)
+ *
+ * val pipeline = new Pipeline().setStages(Array(
+ *   documentAssembler,
+ *   tokenizer,
+ *   sequenceClassifier
+ * ))
+ *
+ * val data = Seq("John Lenon was born in London and lived in Paris. My name is Sarah and I live in London").toDF("text")
+ * val result = pipeline.fit(data).transform(data)
+ *
+ * result.select("label.result").show(false)
+ * +--------------------+
+ * |result              |
+ * +--------------------+
+ * |[neg, neg]          |
+ * |[pos, pos, pos, pos]|
+ * +--------------------+
+ * }}}
+ *
+ * @see [[XlmRoBertaForSequenceClassification]] for sequence-level classification
+ * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
+ * @param uid required uid for storing annotator to disk
+ * @groupname anno Annotator types
+ * @groupdesc anno Required input and expected output annotator types
+ * @groupname Ungrouped Members
+ * @groupname param Parameters
+ * @groupname setParam Parameter setters
+ * @groupname getParam Parameter getters
+ * @groupname Ungrouped Members
+ * @groupprio param  1
+ * @groupprio anno  2
+ * @groupprio Ungrouped 3
+ * @groupprio setParam  4
+ * @groupprio getParam  5
+ * @groupdesc param A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
+ * */
+class XlmRoBertaForSequenceClassification(override val uid: String)
+  extends AnnotatorModel[XlmRoBertaForSequenceClassification]
+    with HasBatchedAnnotate[XlmRoBertaForSequenceClassification]
+    with WriteTensorflowModel
+    with WriteSentencePieceModel
+    with HasCaseSensitiveProperties {
+
+  /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */
+  def this() = this(Identifiable.randomUID("XlmRoBertaForSequenceClassification"))
+
+  /**
+   * Input Annotator Types: DOCUMENT, TOKEN
+   *
+   * @group anno
+   */
+  override val inputAnnotatorTypes: Array[String] = Array(AnnotatorType.DOCUMENT, AnnotatorType.TOKEN)
+
+  /**
+   * Output Annotator Types: CATEGORY
+   *
+   * @group anno
+   */
+  override val outputAnnotatorType: AnnotatorType = AnnotatorType.CATEGORY
+
+  def sentenceStartTokenId: Int = {
+    $$(vocabulary)("<s>")
+  }
+
+  def sentenceEndTokenId: Int = {
+    $$(vocabulary)("</s>")
+  }
+
+  def padTokenId: Int = {
+    $$(vocabulary)("<pad>")
+  }
+
+
+  /**
+   * Vocabulary used to encode the words to ids with WordPieceEncoder
+   *
+   * @group param
+   * */
+  val vocabulary: MapFeature[String, Int] = new MapFeature(this, "vocabulary")
+
+  /** @group setParam */
+  def setVocabulary(value: Map[String, Int]): this.type = set(vocabulary, value)
+
+
+  /**
+   * Labels used to decode predicted IDs back to string tags
+   *
+   * @group param
+   * */
+  val labels: MapFeature[String, Int] = new MapFeature(this, "labels")
+
+  /** @group setParam */
+  def setLabels(value: Map[String, Int]): this.type = set(labels, value)
+
+  /** @group getParam */
+  def getLabels: Map[String, Int] = $$(labels)
+
+  /**
+   * Holding merges.txt coming from XLM-RoBERTa model
+   *
+   * @group param
+   */
+  val merges: MapFeature[(String, String), Int] = new MapFeature(this, "merges")
+
+  /** @group setParam */
+  def setMerges(value: Map[(String, String), Int]): this.type = set(merges, value)
+
+  /** Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
+   * Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
+   * into the model and averaging all the probabilities for the entire document instead of probabilities per sentence. (Default: true)
+   *
+   * @group param
+   * */
+  val coalesceSentences = new BooleanParam(this, "coalesceSentences", "If sets to true the output of all sentences will be averaged to one output instead of one output per sentence. Default to true.")
+
+  /** @group setParam */
+  def setCoalesceSentences(value: Boolean): this.type = set(coalesceSentences, value)
+
+  /** @group getParam */
+  def getCoalesceSentences: Boolean = $(coalesceSentences)
+
+  /** ConfigProto from tensorflow, serialized into byte array. Get with `config_proto.SerializeToString()`
+   *
+   * @group param
+   * */
+  val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
+
+  /** @group setParam */
+  def setConfigProtoBytes(bytes: Array[Int]): XlmRoBertaForSequenceClassification.this.type = set(this.configProtoBytes, bytes)
+
+  /** @group getParam */
+  def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
+
+  /** Max sentence length to process (Default: `128`)
+   *
+   * @group param
+   * */
+  val maxSentenceLength = new IntParam(this, "maxSentenceLength", "Max sentence length to process")
+
+  /** @group setParam */
+  def setMaxSentenceLength(value: Int): this.type = {
+    require(value <= 512, "XLM-RoBERTa models do not support sequences longer than 512 because of trainable positional embeddings.")
+    require(value >= 1, "The maxSentenceLength must be at least 1")
+    set(maxSentenceLength, value)
+    this
+  }
+
+  /** @group getParam */
+  def getMaxSentenceLength: Int = $(maxSentenceLength)
+
+  /**
+   * It contains TF model signatures for the laded saved model
+   *
+   * @group param
+   * */
+  val signatures = new MapFeature[String, String](model = this, name = "signatures")
+
+  /** @group setParam */
+  def setSignatures(value: Map[String, String]): this.type = {
+    if (get(signatures).isEmpty)
+      set(signatures, value)
+    this
+  }
+
+  /** @group getParam */
+  def getSignatures: Option[Map[String, String]] = get(this.signatures)
+
+  private var _model: Option[Broadcast[TensorflowXlmRoBertaClassification]] = None
+
+  /** @group setParam */
+  def setModelIfNotSet(spark: SparkSession, tensorflowWrapper: TensorflowWrapper, spp: SentencePieceWrapper): XlmRoBertaForSequenceClassification = {
+    if (_model.isEmpty) {
+      _model = Some(
+        spark.sparkContext.broadcast(
+          new TensorflowXlmRoBertaClassification(
+            tensorflowWrapper,
+            spp,
+            configProtoBytes = getConfigProtoBytes,
+            tags = getLabels,
+            signatures = getSignatures
+          )
+        )
+      )
+    }
+
+    this
+  }
+
+  /** @group getParam */
+  def getModelIfNotSet: TensorflowXlmRoBertaClassification = _model.get.value
+
+
+  /** Whether to lowercase tokens or not
+   *
+   * @group setParam
+   * */
+  override def setCaseSensitive(value: Boolean): this.type = {
+    if (get(caseSensitive).isEmpty)
+      set(this.caseSensitive, value)
+    this
+  }
+
+  setDefault(
+    batchSize -> 8,
+    maxSentenceLength -> 128,
+    caseSensitive -> true,
+    coalesceSentences -> false
+  )
+
+  /**
+   * takes a document and annotations and produces new annotations of this annotator's annotation type
+   *
+   * @param batchedAnnotations Annotations that correspond to inputAnnotationCols generated by previous annotators if any
+   * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
+   */
+  override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
+    batchedAnnotations.map(annotations => {
+      val sentences = SentenceSplit.unpack(annotations).toArray
+      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+
+      if (tokenizedSentences.nonEmpty) {
+        getModelIfNotSet.predictSequence(
+          tokenizedSentences,
+          sentences,
+          $(batchSize),
+          $(maxSentenceLength),
+          $(caseSensitive),
+          $(coalesceSentences),
+          getLabels
+        )
+      }
+      else {
+        Seq.empty[Annotation]
+      }
+    }
+
+    )
+  }
+
+
+  override def onWrite(path: String, spark: SparkSession): Unit = {
+    super.onWrite(path, spark)
+    writeTensorflowModelV2(path, spark, getModelIfNotSet.tensorflowWrapper, "_xlm_roberta_classification", XlmRoBertaForTokenClassification.tfFile, configProtoBytes = getConfigProtoBytes)
+    writeSentencePieceModel(path, spark, getModelIfNotSet.spp, "_xlmroberta", XlmRoBertaForTokenClassification.sppFile)
+  }
+}
+
+trait ReadablePretrainedXlmRoBertaForSequenceModel extends ParamsAndFeaturesReadable[XlmRoBertaForSequenceClassification] with HasPretrained[XlmRoBertaForSequenceClassification] {
+  override val defaultModelName: Some[String] = Some("xlm_roberta_base_sequence_classifier_imdb")
+
+  /** Java compliant-overrides */
+  override def pretrained(): XlmRoBertaForSequenceClassification = super.pretrained()
+
+  override def pretrained(name: String): XlmRoBertaForSequenceClassification = super.pretrained(name)
+
+  override def pretrained(name: String, lang: String): XlmRoBertaForSequenceClassification = super.pretrained(name, lang)
+
+  override def pretrained(name: String, lang: String, remoteLoc: String): XlmRoBertaForSequenceClassification = super.pretrained(name, lang, remoteLoc)
+}
+
+trait ReadXlmRoBertaForSequenceTensorflowModel extends ReadTensorflowModel with ReadSentencePieceModel {
+  this: ParamsAndFeaturesReadable[XlmRoBertaForSequenceClassification] =>
+
+  override val tfFile: String = "xlm_roberta_classification_tensorflow"
+  override val sppFile: String = "xlmroberta_spp"
+
+  def readTensorflow(instance: XlmRoBertaForSequenceClassification, path: String, spark: SparkSession): Unit = {
+
+    val tf = readTensorflowModel(path, spark, "_xlm_roberta_classification_tf", initAllTables = false)
+    val spp = readSentencePieceModel(path, spark, "_xlmroberta_spp", sppFile)
+    instance.setModelIfNotSet(spark, tf, spp)
+  }
+
+  addReader(readTensorflow)
+
+  def loadSavedModel(tfModelPath: String, spark: SparkSession): XlmRoBertaForSequenceClassification = {
+
+    val f = new File(tfModelPath)
+    val savedModel = new File(tfModelPath, "saved_model.pb")
+    require(f.exists, s"Folder $tfModelPath not found")
+    require(f.isDirectory, s"File $tfModelPath is not folder")
+    require(
+      savedModel.exists(),
+      s"savedModel file saved_model.pb not found in folder $tfModelPath"
+    )
+    val sppModelPath = tfModelPath + "/assets"
+    val sppModel = new File(sppModelPath, "sentencepiece.bpe.model")
+    require(sppModel.exists(), s"SentencePiece model sentencepiece.bpe.model not found in folder $sppModelPath")
+
+    val labelsPath = new File(tfModelPath + "/assets", "labels.txt")
+    require(labelsPath.exists(), s"Labels file labels.txt not found in folder $tfModelPath/assets/")
+
+    val labelsResource = new ExternalResource(labelsPath.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
+    val labels = ResourceHelper.parseLines(labelsResource).zipWithIndex.toMap
+
+    val (wrapper, signatures) = TensorflowWrapper.read(tfModelPath, zipped = false, useBundle = true)
+    val spp = SentencePieceWrapper.read(sppModel.toString)
+
+    val _signatures = signatures match {
+      case Some(s) => s
+      case None => throw new Exception("Cannot load signature definitions from model!")
+    }
+
+
+    /** the order of setSignatures is important if we use getSignatures inside setModelIfNotSet */
+    new XlmRoBertaForSequenceClassification()
+      .setLabels(labels)
+      .setSignatures(_signatures)
+      .setModelIfNotSet(spark, wrapper, spp)
+  }
+}
+
+/**
+ * This is the companion object of [[XlmRoBertaForSequenceClassification]]. Please refer to that class for the documentation.
+ */
+object XlmRoBertaForSequenceClassification extends ReadablePretrainedXlmRoBertaForSequenceModel with ReadXlmRoBertaForSequenceTensorflowModel

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForTokenClassification.scala
@@ -85,8 +85,7 @@ import java.io.File
  * +------------------------------------------------------------------------------------+
  * }}}
  *
- * @see [[com.johnsnowlabs.nlp.embeddings.XlmRoBertaEmbeddings XlmRoBertaEmbeddings]] for token-level embeddings
- * @see [[com.johnsnowlabs.nlp.embeddings.XlmRoBertaSentenceEmbeddings XlmRoBertaSentenceEmbeddings]] for sentence-level embeddings
+ * @see [[XlmRoBertaForTokenClassification]] for token-level classification
  * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
  * @param uid required uid for storing annotator to disk
  * @groupname anno Annotator types

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassification.scala
@@ -31,22 +31,22 @@ import org.apache.spark.sql.SparkSession
 import java.io.File
 
 /**
- * AlbertForSequenceClassification can load ALBERT Models with sequence classification/regression head on top
+ * XlnetForSequenceClassification can load XLNet Models with sequence classification/regression head on top
  * (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
  *
  * Pretrained models can be loaded with `pretrained` of the companion object:
  * {{{
- * val sequenceClassifier = AlbertForSequenceClassification.pretrained()
+ * val sequenceClassifier = XlnetForSequenceClassification.pretrained()
  *   .setInputCols("token", "document")
  *   .setOutputCol("label")
  * }}}
- * The default model is `"albert_base_sequence_classifier_imdb"`, if no name is provided.
+ * The default model is `"xlnet_base_sequence_classifier_imdb"`, if no name is provided.
  *
  * For available pretrained models please see the [[https://nlp.johnsnowlabs.com/models?task=Text+Classification Models Hub]].
  *
  * Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. The Spark NLP Workshop
  * example shows how to import them [[https://github.com/JohnSnowLabs/spark-nlp/discussions/5669]].
- * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassificationTestSpec.scala AlbertForSequenceClassification]].
+ * and the [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassificationTestSpec.scala XlnetForSequenceClassification]].
  *
  * ==Example==
  * {{{
@@ -63,7 +63,7 @@ import java.io.File
  *   .setInputCols("document")
  *   .setOutputCol("token")
  *
- * val sequenceClassifier = AlbertForSequenceClassification.pretrained()
+ * val sequenceClassifier = XlnetForSequenceClassification.pretrained()
  *   .setInputCols("token", "document")
  *   .setOutputCol("label")
  *   .setCaseSensitive(true)
@@ -86,7 +86,7 @@ import java.io.File
  * +--------------------+
  * }}}
  *
- * @see [[AlbertForSequenceClassification]] for sequence-level classification
+ * @see [[XlnetForSequenceClassification]] for sequence-level classification
  * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
  * @param uid required uid for storing annotator to disk
  * @groupname anno Annotator types
@@ -103,15 +103,15 @@ import java.io.File
  * @groupprio getParam  5
  * @groupdesc param A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
  * */
-class AlbertForSequenceClassification(override val uid: String)
-  extends AnnotatorModel[AlbertForSequenceClassification]
-    with HasBatchedAnnotate[AlbertForSequenceClassification]
+class XlnetForSequenceClassification(override val uid: String)
+  extends AnnotatorModel[XlnetForSequenceClassification]
+    with HasBatchedAnnotate[XlnetForSequenceClassification]
     with WriteTensorflowModel
     with WriteSentencePieceModel
     with HasCaseSensitiveProperties {
 
   /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */
-  def this() = this(Identifiable.randomUID("AlbertForSequenceClassification"))
+  def this() = this(Identifiable.randomUID("XlnetForSequenceClassification"))
 
   /**
    * Input Annotator Types: DOCUMENT, TOKEN
@@ -152,7 +152,7 @@ class AlbertForSequenceClassification(override val uid: String)
   def getLabels: Map[String, Int] = $$(labels)
 
   /**
-   * Holding merges.txt coming from ALBERT model
+   * Holding merges.txt coming from XLNet model
    *
    * @group param
    */
@@ -182,7 +182,7 @@ class AlbertForSequenceClassification(override val uid: String)
   val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
 
   /** @group setParam */
-  def setConfigProtoBytes(bytes: Array[Int]): AlbertForSequenceClassification.this.type = set(this.configProtoBytes, bytes)
+  def setConfigProtoBytes(bytes: Array[Int]): XlnetForSequenceClassification.this.type = set(this.configProtoBytes, bytes)
 
   /** @group getParam */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
@@ -195,7 +195,7 @@ class AlbertForSequenceClassification(override val uid: String)
 
   /** @group setParam */
   def setMaxSentenceLength(value: Int): this.type = {
-    require(value <= 512, "ALBERT models do not support sequences longer than 512 because of trainable positional embeddings.")
+    require(value <= 512, "XLNet models do not support sequences longer than 512 because of trainable positional embeddings.")
     require(value >= 1, "The maxSentenceLength must be at least 1")
     set(maxSentenceLength, value)
     this
@@ -221,14 +221,14 @@ class AlbertForSequenceClassification(override val uid: String)
   /** @group getParam */
   def getSignatures: Option[Map[String, String]] = get(this.signatures)
 
-  private var _model: Option[Broadcast[TensorflowAlbertClassification]] = None
+  private var _model: Option[Broadcast[TensorflowXlnetClassification]] = None
 
   /** @group setParam */
-  def setModelIfNotSet(spark: SparkSession, tensorflowWrapper: TensorflowWrapper, spp: SentencePieceWrapper): AlbertForSequenceClassification = {
+  def setModelIfNotSet(spark: SparkSession, tensorflowWrapper: TensorflowWrapper, spp: SentencePieceWrapper): XlnetForSequenceClassification = {
     if (_model.isEmpty) {
       _model = Some(
         spark.sparkContext.broadcast(
-          new TensorflowAlbertClassification(
+          new TensorflowXlnetClassification(
             tensorflowWrapper,
             spp,
             configProtoBytes = getConfigProtoBytes,
@@ -243,7 +243,7 @@ class AlbertForSequenceClassification(override val uid: String)
   }
 
   /** @group getParam */
-  def getModelIfNotSet: TensorflowAlbertClassification = _model.get.value
+  def getModelIfNotSet: TensorflowXlnetClassification = _model.get.value
 
 
   /** Whether to lowercase tokens or not
@@ -259,7 +259,7 @@ class AlbertForSequenceClassification(override val uid: String)
   setDefault(
     batchSize -> 8,
     maxSentenceLength -> 128,
-    caseSensitive -> false,
+    caseSensitive -> true,
     coalesceSentences -> false
   )
 
@@ -296,40 +296,40 @@ class AlbertForSequenceClassification(override val uid: String)
 
   override def onWrite(path: String, spark: SparkSession): Unit = {
     super.onWrite(path, spark)
-    writeTensorflowModelV2(path, spark, getModelIfNotSet.tensorflowWrapper, "_albert_classification", AlbertForSequenceClassification.tfFile, configProtoBytes = getConfigProtoBytes)
-    writeSentencePieceModel(path, spark, getModelIfNotSet.spp, "_albert", AlbertForSequenceClassification.sppFile)
+    writeTensorflowModelV2(path, spark, getModelIfNotSet.tensorflowWrapper, "_xlnet_classification", XlnetForSequenceClassification.tfFile, configProtoBytes = getConfigProtoBytes)
+    writeSentencePieceModel(path, spark, getModelIfNotSet.spp, "_xlnet", XlnetForSequenceClassification.sppFile)
   }
 }
 
-trait ReadablePretrainedAlbertForSequenceModel extends ParamsAndFeaturesReadable[AlbertForSequenceClassification] with HasPretrained[AlbertForSequenceClassification] {
-  override val defaultModelName: Some[String] = Some("albert_base_sequence_classifier_imdb")
+trait ReadablePretrainedXlnetForSequenceModel extends ParamsAndFeaturesReadable[XlnetForSequenceClassification] with HasPretrained[XlnetForSequenceClassification] {
+  override val defaultModelName: Some[String] = Some("xlnet_base_sequence_classifier_imdb")
 
   /** Java compliant-overrides */
-  override def pretrained(): AlbertForSequenceClassification = super.pretrained()
+  override def pretrained(): XlnetForSequenceClassification = super.pretrained()
 
-  override def pretrained(name: String): AlbertForSequenceClassification = super.pretrained(name)
+  override def pretrained(name: String): XlnetForSequenceClassification = super.pretrained(name)
 
-  override def pretrained(name: String, lang: String): AlbertForSequenceClassification = super.pretrained(name, lang)
+  override def pretrained(name: String, lang: String): XlnetForSequenceClassification = super.pretrained(name, lang)
 
-  override def pretrained(name: String, lang: String, remoteLoc: String): AlbertForSequenceClassification = super.pretrained(name, lang, remoteLoc)
+  override def pretrained(name: String, lang: String, remoteLoc: String): XlnetForSequenceClassification = super.pretrained(name, lang, remoteLoc)
 }
 
-trait ReadAlbertForSequenceTensorflowModel extends ReadTensorflowModel with ReadSentencePieceModel {
-  this: ParamsAndFeaturesReadable[AlbertForSequenceClassification] =>
+trait ReadXlnetForSequenceTensorflowModel extends ReadTensorflowModel with ReadSentencePieceModel {
+  this: ParamsAndFeaturesReadable[XlnetForSequenceClassification] =>
 
-  override val tfFile: String = "albert_classification_tensorflow"
-  override val sppFile: String = "albert_spp"
+  override val tfFile: String = "xlnet_classification_tensorflow"
+  override val sppFile: String = "xlnet_spp"
 
-  def readTensorflow(instance: AlbertForSequenceClassification, path: String, spark: SparkSession): Unit = {
+  def readTensorflow(instance: XlnetForSequenceClassification, path: String, spark: SparkSession): Unit = {
 
-    val tf = readTensorflowModel(path, spark, "_albert_classification_tf", initAllTables = false)
-    val spp = readSentencePieceModel(path, spark, "_albert_spp", sppFile)
+    val tf = readTensorflowModel(path, spark, "_xlnet_classification_tf", initAllTables = false)
+    val spp = readSentencePieceModel(path, spark, "_xlnet_spp", sppFile)
     instance.setModelIfNotSet(spark, tf, spp)
   }
 
   addReader(readTensorflow)
 
-  def loadSavedModel(tfModelPath: String, spark: SparkSession): AlbertForSequenceClassification = {
+  def loadSavedModel(tfModelPath: String, spark: SparkSession): XlnetForSequenceClassification = {
     val f = new File(tfModelPath)
     val savedModel = new File(tfModelPath, "saved_model.pb")
     require(f.exists, s"Folder $tfModelPath not found")
@@ -357,7 +357,7 @@ trait ReadAlbertForSequenceTensorflowModel extends ReadTensorflowModel with Read
     }
 
     /** the order of setSignatures is important if we use getSignatures inside setModelIfNotSet */
-    new AlbertForSequenceClassification()
+    new XlnetForSequenceClassification()
       .setLabels(labels)
       .setSignatures(_signatures)
       .setModelIfNotSet(spark, wrapper, spp)
@@ -365,6 +365,6 @@ trait ReadAlbertForSequenceTensorflowModel extends ReadTensorflowModel with Read
 }
 
 /**
- * This is the companion object of [[AlbertForSequenceClassification]]. Please refer to that class for the documentation.
+ * This is the companion object of [[XlnetForSequenceClassification]]. Please refer to that class for the documentation.
  */
-object AlbertForSequenceClassification extends ReadablePretrainedAlbertForSequenceModel with ReadAlbertForSequenceTensorflowModel
+object XlnetForSequenceClassification extends ReadablePretrainedXlnetForSequenceModel with ReadXlnetForSequenceTensorflowModel

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForTokenClassification.scala
@@ -85,7 +85,7 @@ import java.io.File
  * +------------------------------------------------------------------------------------+
  * }}}
  *
- * @see [[com.johnsnowlabs.nlp.embeddings.XlnetEmbeddings XlnetEmbeddings]] for token-level embeddings
+ * @see [[XlnetForTokenClassification]] for token-level classification
  * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based classifiers
  * @param uid required uid for storing annotator to disk
  * @groupname anno Annotator types

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -530,7 +530,8 @@ object PythonResourceDownloader {
     "EntityRulerModel" -> EntityRulerModel,
     "Doc2VecModel" -> Doc2VecModel,
     "DistilBertForSequenceClassification" -> DistilBertForSequenceClassification,
-    "RoBertaForSequenceClassification" -> RoBertaForSequenceClassification
+    "RoBertaForSequenceClassification" -> RoBertaForSequenceClassification,
+    "XlmRoBertaForSequenceClassification" -> XlmRoBertaForSequenceClassification
   )
 
   def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -531,7 +531,8 @@ object PythonResourceDownloader {
     "Doc2VecModel" -> Doc2VecModel,
     "DistilBertForSequenceClassification" -> DistilBertForSequenceClassification,
     "RoBertaForSequenceClassification" -> RoBertaForSequenceClassification,
-    "XlmRoBertaForSequenceClassification" -> XlmRoBertaForSequenceClassification
+    "XlmRoBertaForSequenceClassification" -> XlmRoBertaForSequenceClassification,
+    "LongformerForSequenceClassification" -> LongformerForSequenceClassification
   )
 
   def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -532,7 +532,8 @@ object PythonResourceDownloader {
     "DistilBertForSequenceClassification" -> DistilBertForSequenceClassification,
     "RoBertaForSequenceClassification" -> RoBertaForSequenceClassification,
     "XlmRoBertaForSequenceClassification" -> XlmRoBertaForSequenceClassification,
-    "LongformerForSequenceClassification" -> LongformerForSequenceClassification
+    "LongformerForSequenceClassification" -> LongformerForSequenceClassification,
+    "AlbertForSequenceClassification" -> AlbertForSequenceClassification
   )
 
   def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -529,7 +529,8 @@ object PythonResourceDownloader {
     "BertForSequenceClassification" -> BertForSequenceClassification,
     "EntityRulerModel" -> EntityRulerModel,
     "Doc2VecModel" -> Doc2VecModel,
-    "DistilBertForSequenceClassification" -> DistilBertForSequenceClassification
+    "DistilBertForSequenceClassification" -> DistilBertForSequenceClassification,
+    "RoBertaForSequenceClassification" -> RoBertaForSequenceClassification
   )
 
   def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -533,7 +533,8 @@ object PythonResourceDownloader {
     "RoBertaForSequenceClassification" -> RoBertaForSequenceClassification,
     "XlmRoBertaForSequenceClassification" -> XlmRoBertaForSequenceClassification,
     "LongformerForSequenceClassification" -> LongformerForSequenceClassification,
-    "AlbertForSequenceClassification" -> AlbertForSequenceClassification
+    "AlbertForSequenceClassification" -> AlbertForSequenceClassification,
+    "XlnetForSequenceClassification" -> XlnetForSequenceClassification
   )
 
   def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassificationTestSpec.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017-2021 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.training.CoNLL
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.SlowTest
+import com.johnsnowlabs.util.Benchmark
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.functions.{col, explode, size}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class AlbertForSequenceClassificationTestSpec extends AnyFlatSpec {
+
+  import ResourceHelper.spark.implicits._
+
+  "AlbertForSequenceClassification" should "correctly load custom model with extracted signatures" taggedAs SlowTest in {
+
+    val ddd = Seq(
+      "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London.",
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21",
+      " carbon emissions have come down without impinging on our growth. .  . .",
+      "\\u2009.carbon emissions have come down without impinging on our growth .\\u2009.\\u2009."
+    ).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val classifier = AlbertForSequenceClassification
+      .pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(false)
+      .setCoalesceSentences(false)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, classifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("label").show(20, truncate = false)
+    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF
+      .withColumn("doc_size", size(col("document")))
+      .withColumn("label_size", size(col("label")))
+      .where(col("doc_size") =!= col("label_size"))
+      .select("doc_size", "label_size", "document.result", "label.result")
+      .show(20, truncate = false)
+
+    val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+
+    println(s"total tokens: $totalDocs")
+    println(s"total embeddings: $totalLabels")
+
+    assert(totalDocs == totalLabels)
+  }
+
+  "AlbertForSequenceClassification" should "be saved and loaded correctly" taggedAs SlowTest in {
+
+    import ResourceHelper.spark.implicits._
+
+    val ddd = Seq(
+      "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London",
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21"
+    ).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val classifier = AlbertForSequenceClassification.pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, classifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("label.result").show(false)
+
+    Benchmark.time("Time to save AlbertForSequenceClassification pipeline model") {
+      pipelineModel.write.overwrite().save("./tmp_forsequence_pipeline")
+    }
+
+    Benchmark.time("Time to save AlbertForSequenceClassification model") {
+      pipelineModel.stages.last.asInstanceOf[AlbertForSequenceClassification].write.overwrite().save("./tmp_forsequence_model")
+    }
+
+    val loadedPipelineModel = PipelineModel.load("./tmp_forsequence_pipeline")
+    loadedPipelineModel.transform(ddd).select("label.result").show(false)
+
+    val loadedSequenceModel = AlbertForSequenceClassification.load("./tmp_forsequence_model")
+    loadedSequenceModel.getLabels
+
+  }
+
+  "AlbertForSequenceClassification" should "benchmark test" taggedAs SlowTest in {
+
+    val conll = CoNLL()
+    val training_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.train")
+
+    val classifier = AlbertForSequenceClassification.pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("class")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        classifier
+      ))
+
+    val pipelineDF = pipeline.fit(training_data).transform(training_data)
+    Benchmark.time("Time to save AlbertForSequenceClassification results") {
+      pipelineDF.write.mode("overwrite").parquet("./tmp_sequence_classifier")
+    }
+
+    pipelineDF.select("label").show(20, truncate = false)
+    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF
+      .withColumn("doc_size", size(col("document")))
+      .withColumn("label_size", size(col("label")))
+      .where(col("doc_size") =!= col("label_size"))
+      .select("doc_size", "label_size", "document.result", "label.result")
+      .show(20, truncate = false)
+
+    val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+
+    println(s"total tokens: $totalDocs")
+    println(s"total embeddings: $totalLabels")
+
+    assert(totalDocs == totalLabels)
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassificationTestSpec.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2017-2021 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.training.CoNLL
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.SlowTest
+import com.johnsnowlabs.util.Benchmark
+
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.functions.{col, explode, size}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class LongformerForSequenceClassificationTestSpec extends AnyFlatSpec {
+
+  import ResourceHelper.spark.implicits._
+
+  "LongformerForSequenceClassification" should "correctly load custom model with extracted signatures" taggedAs SlowTest in {
+
+    val ddd = Seq(
+      "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London.",
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21",
+      " carbon emissions have come down without impinging on our growth. .  . .",
+      "\\u2009.carbon emissions have come down without impinging on our growth .\\u2009.\\u2009."
+    ).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val classifier = LongformerForSequenceClassification
+      .pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(false)
+      .setCoalesceSentences(false)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, classifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("label").show(20, truncate = false)
+    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF
+      .withColumn("doc_size", size(col("document")))
+      .withColumn("label_size", size(col("label")))
+      .where(col("doc_size") =!= col("label_size"))
+      .select("doc_size", "label_size", "document.result", "label.result")
+      .show(20, truncate = false)
+
+    val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+
+    println(s"total tokens: $totalDocs")
+    println(s"total embeddings: $totalLabels")
+
+    assert(totalDocs == totalLabels)
+  }
+
+  "LongformerForSequenceClassification" should "be saved and loaded correctly" taggedAs SlowTest in {
+
+    import ResourceHelper.spark.implicits._
+
+    val ddd = Seq(
+      "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London",
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21"
+    ).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val classifier = LongformerForSequenceClassification.pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, classifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("label.result").show(false)
+
+    Benchmark.time("Time to save LongformerForSequenceClassification pipeline model") {
+      pipelineModel.write.overwrite().save("./tmp_forsequence_pipeline")
+    }
+
+    Benchmark.time("Time to save LongformerForSequenceClassification model") {
+      pipelineModel.stages.last.asInstanceOf[LongformerForSequenceClassification].write.overwrite().save("./tmp_forsequence_model")
+    }
+
+    val loadedPipelineModel = PipelineModel.load("./tmp_forsequence_pipeline")
+    loadedPipelineModel.transform(ddd).select("label.result").show(false)
+
+    val loadedSequenceModel = LongformerForSequenceClassification.load("./tmp_forsequence_model")
+    loadedSequenceModel.getLabels
+
+  }
+
+  "LongformerForSequenceClassification" should "benchmark test" taggedAs SlowTest in {
+
+    val conll = CoNLL()
+    val training_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.train")
+
+    val classifier = LongformerForSequenceClassification.pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("class")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        classifier
+      ))
+
+    val pipelineDF = pipeline.fit(training_data).transform(training_data)
+    Benchmark.time("Time to save LongformerForSequenceClassification results") {
+      pipelineDF.write.mode("overwrite").parquet("./tmp_sequence_classifier")
+    }
+
+    pipelineDF.select("label").show(20, truncate = false)
+    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF
+      .withColumn("doc_size", size(col("document")))
+      .withColumn("label_size", size(col("label")))
+      .where(col("doc_size") =!= col("label_size"))
+      .select("doc_size", "label_size", "document.result", "label.result")
+      .show(20, truncate = false)
+
+    val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+
+    println(s"total tokens: $totalDocs")
+    println(s"total embeddings: $totalLabels")
+
+    assert(totalDocs == totalLabels)
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassificationTestSpec.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2017-2021 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.training.CoNLL
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.SlowTest
+import com.johnsnowlabs.util.Benchmark
+
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.functions.{col, explode, size}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class RoBertaForSequenceClassificationTestSpec extends AnyFlatSpec {
+
+  import ResourceHelper.spark.implicits._
+
+  "RoBertaForSequenceClassification" should "correctly load custom model with extracted signatures" taggedAs SlowTest in {
+
+    val ddd = Seq(
+      "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London.",
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21",
+      " carbon emissions have come down without impinging on our growth. .  . .",
+      "\\u2009.carbon emissions have come down without impinging on our growth .\\u2009.\\u2009."
+    ).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val tokenClassifier = RoBertaForSequenceClassification
+      .pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(false)
+      .setCoalesceSentences(false)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, tokenClassifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("label").show(20, truncate = false)
+    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF
+      .withColumn("doc_size", size(col("document")))
+      .withColumn("label_size", size(col("label")))
+      .where(col("doc_size") =!= col("label_size"))
+      .select("doc_size", "label_size", "document.result", "label.result")
+      .show(20, truncate = false)
+
+    val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+
+    println(s"total tokens: $totalDocs")
+    println(s"total embeddings: $totalLabels")
+
+    assert(totalDocs == totalLabels)
+  }
+
+  "RoBertaForSequenceClassification" should "be saved and loaded correctly" taggedAs SlowTest in {
+
+    import ResourceHelper.spark.implicits._
+
+    val ddd = Seq(
+      "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London",
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21"
+    ).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val tokenClassifier = RoBertaForSequenceClassification.pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, tokenClassifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("label.result").show(false)
+
+    Benchmark.time("Time to save RoBertaForSequenceClassification pipeline model") {
+      pipelineModel.write.overwrite().save("./tmp_forsequence_pipeline")
+    }
+
+    Benchmark.time("Time to save RoBertaForSequenceClassification model") {
+      pipelineModel.stages.last.asInstanceOf[RoBertaForSequenceClassification].write.overwrite().save("./tmp_forsequence_model")
+    }
+
+    val loadedPipelineModel = PipelineModel.load("./tmp_forsequence_pipeline")
+    loadedPipelineModel.transform(ddd).select("label.result").show(false)
+
+    val loadedSequenceModel = RoBertaForSequenceClassification.load("./tmp_forsequence_model")
+    loadedSequenceModel.getLabels
+
+  }
+
+  "RoBertaForSequenceClassification" should "benchmark test" taggedAs SlowTest in {
+
+    val conll = CoNLL()
+    val training_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.train")
+
+    val tokenClassifier = RoBertaForSequenceClassification.pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("class")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        tokenClassifier
+      ))
+
+    val pipelineDF = pipeline.fit(training_data).transform(training_data)
+    Benchmark.time("Time to save RoBertaForSequenceClassification results") {
+      pipelineDF.write.mode("overwrite").parquet("./tmp_sequence_classifier")
+    }
+
+    pipelineDF.select("label").show(20, truncate = false)
+    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF
+      .withColumn("doc_size", size(col("document")))
+      .withColumn("label_size", size(col("label")))
+      .where(col("doc_size") =!= col("label_size"))
+      .select("doc_size", "label_size", "document.result", "label.result")
+      .show(20, truncate = false)
+
+    val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+
+    println(s"total tokens: $totalDocs")
+    println(s"total embeddings: $totalLabels")
+
+    assert(totalDocs == totalLabels)
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassificationTestSpec.scala
@@ -22,16 +22,15 @@ import com.johnsnowlabs.nlp.training.CoNLL
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.tags.SlowTest
 import com.johnsnowlabs.util.Benchmark
-
 import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.apache.spark.sql.functions.{col, explode, size}
 import org.scalatest.flatspec.AnyFlatSpec
 
-class RoBertaForSequenceClassificationTestSpec extends AnyFlatSpec {
+class XlmRoBertaForSequenceClassificationTestSpec extends AnyFlatSpec {
 
   import ResourceHelper.spark.implicits._
 
-  "RoBertaForSequenceClassification" should "correctly load custom model with extracted signatures" taggedAs SlowTest in {
+  "XlmRoBertaForSequenceClassification" should "correctly load custom model with extracted signatures" taggedAs SlowTest in {
 
     val ddd = Seq(
       "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London.",
@@ -50,7 +49,7 @@ class RoBertaForSequenceClassificationTestSpec extends AnyFlatSpec {
       .setInputCols(Array("document"))
       .setOutputCol("token")
 
-    val classifier = RoBertaForSequenceClassification
+    val classifier = XlmRoBertaForSequenceClassification
       .pretrained()
       .setInputCols(Array("token", "document"))
       .setOutputCol("label")
@@ -80,7 +79,7 @@ class RoBertaForSequenceClassificationTestSpec extends AnyFlatSpec {
     assert(totalDocs == totalLabels)
   }
 
-  "RoBertaForSequenceClassification" should "be saved and loaded correctly" taggedAs SlowTest in {
+  "XlmRoBertaForSequenceClassification" should "be saved and loaded correctly" taggedAs SlowTest in {
 
     import ResourceHelper.spark.implicits._
 
@@ -99,7 +98,7 @@ class RoBertaForSequenceClassificationTestSpec extends AnyFlatSpec {
       .setInputCols(Array("document"))
       .setOutputCol("token")
 
-    val classifier = RoBertaForSequenceClassification.pretrained()
+    val classifier = XlmRoBertaForSequenceClassification.pretrained()
       .setInputCols(Array("token", "document"))
       .setOutputCol("label")
       .setCaseSensitive(true)
@@ -111,28 +110,28 @@ class RoBertaForSequenceClassificationTestSpec extends AnyFlatSpec {
 
     pipelineDF.select("label.result").show(false)
 
-    Benchmark.time("Time to save RoBertaForSequenceClassification pipeline model") {
+    Benchmark.time("Time to save XlmRoBertaForSequenceClassification pipeline model") {
       pipelineModel.write.overwrite().save("./tmp_forsequence_pipeline")
     }
 
-    Benchmark.time("Time to save RoBertaForSequenceClassification model") {
-      pipelineModel.stages.last.asInstanceOf[RoBertaForSequenceClassification].write.overwrite().save("./tmp_forsequence_model")
+    Benchmark.time("Time to save XlmRoBertaForSequenceClassification model") {
+      pipelineModel.stages.last.asInstanceOf[XlmRoBertaForSequenceClassification].write.overwrite().save("./tmp_forsequence_model")
     }
 
     val loadedPipelineModel = PipelineModel.load("./tmp_forsequence_pipeline")
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
-    val loadedSequenceModel = RoBertaForSequenceClassification.load("./tmp_forsequence_model")
+    val loadedSequenceModel = XlmRoBertaForSequenceClassification.load("./tmp_forsequence_model")
     loadedSequenceModel.getLabels
 
   }
 
-  "RoBertaForSequenceClassification" should "benchmark test" taggedAs SlowTest in {
+  "XlmRoBertaForSequenceClassification" should "benchmark test" taggedAs SlowTest in {
 
     val conll = CoNLL()
     val training_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.train")
 
-    val classifier = RoBertaForSequenceClassification.pretrained()
+    val classifier = XlmRoBertaForSequenceClassification.pretrained()
       .setInputCols(Array("token", "document"))
       .setOutputCol("class")
       .setCaseSensitive(true)
@@ -143,7 +142,7 @@ class RoBertaForSequenceClassificationTestSpec extends AnyFlatSpec {
       ))
 
     val pipelineDF = pipeline.fit(training_data).transform(training_data)
-    Benchmark.time("Time to save RoBertaForSequenceClassification results") {
+    Benchmark.time("Time to save XlmRoBertaForSequenceClassification results") {
       pipelineDF.write.mode("overwrite").parquet("./tmp_sequence_classifier")
     }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassificationTestSpec.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017-2021 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.training.CoNLL
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.SlowTest
+import com.johnsnowlabs.util.Benchmark
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.functions.{col, explode, size}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class XlnetForSequenceClassificationTestSpec extends AnyFlatSpec {
+
+  import ResourceHelper.spark.implicits._
+
+  "XlnetForSequenceClassification" should "correctly load custom model with extracted signatures" taggedAs SlowTest in {
+
+    val ddd = Seq(
+      "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London.",
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21",
+      " carbon emissions have come down without impinging on our growth. .  . .",
+      "\\u2009.carbon emissions have come down without impinging on our growth .\\u2009.\\u2009."
+    ).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val classifier = XlnetForSequenceClassification
+      .pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(false)
+      .setCoalesceSentences(false)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, classifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("label").show(20, truncate = false)
+    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF
+      .withColumn("doc_size", size(col("document")))
+      .withColumn("label_size", size(col("label")))
+      .where(col("doc_size") =!= col("label_size"))
+      .select("doc_size", "label_size", "document.result", "label.result")
+      .show(20, truncate = false)
+
+    val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+
+    println(s"total tokens: $totalDocs")
+    println(s"total embeddings: $totalLabels")
+
+    assert(totalDocs == totalLabels)
+  }
+
+  "XlnetForSequenceClassification" should "be saved and loaded correctly" taggedAs SlowTest in {
+
+    import ResourceHelper.spark.implicits._
+
+    val ddd = Seq(
+      "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London",
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21"
+    ).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val classifier = XlnetForSequenceClassification.pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, classifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("label.result").show(false)
+
+    Benchmark.time("Time to save XlnetForSequenceClassification pipeline model") {
+      pipelineModel.write.overwrite().save("./tmp_forsequence_pipeline")
+    }
+
+    Benchmark.time("Time to save XlnetForSequenceClassification model") {
+      pipelineModel.stages.last.asInstanceOf[XlnetForSequenceClassification].write.overwrite().save("./tmp_forsequence_model")
+    }
+
+    val loadedPipelineModel = PipelineModel.load("./tmp_forsequence_pipeline")
+    loadedPipelineModel.transform(ddd).select("label.result").show(false)
+
+    val loadedSequenceModel = XlnetForSequenceClassification.load("./tmp_forsequence_model")
+    loadedSequenceModel.getLabels
+
+  }
+
+  "XlnetForSequenceClassification" should "benchmark test" taggedAs SlowTest in {
+
+    val conll = CoNLL()
+    val training_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.train")
+
+    val classifier = XlnetForSequenceClassification.pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("class")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        classifier
+      ))
+
+    val pipelineDF = pipeline.fit(training_data).transform(training_data)
+    Benchmark.time("Time to save XlnetForSequenceClassification results") {
+      pipelineDF.write.mode("overwrite").parquet("./tmp_sequence_classifier")
+    }
+
+    pipelineDF.select("label").show(20, truncate = false)
+    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF
+      .withColumn("doc_size", size(col("document")))
+      .withColumn("label_size", size(col("label")))
+      .where(col("doc_size") =!= col("label_size"))
+      .select("doc_size", "label_size", "document.result", "label.result")
+      .show(20, truncate = false)
+
+    val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+
+    println(s"total tokens: $totalDocs")
+    println(s"total embeddings: $totalLabels")
+
+    assert(totalDocs == totalLabels)
+  }
+}


### PR DESCRIPTION
This PR introduces new annotators for the following transformer architectures for sequence classification:
- AlbertForSequenceClassification
- XlnetForSequenceClassification
- RoBertaForSequenceClassification
- XlmRoBertaForSequenceClassification
- LongformerForSequenceClassification
