### PR TITLE
Add new getClasses function to retrieve labels from pretrained models

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -60,6 +60,7 @@ unittest.TextTestRunner().run(LanguageDetectorDLTestSpec())
 unittest.TextTestRunner().run(GraphExtractionTestSpec())
 unittest.TextTestRunner().run(EntityRulerTestSpec())
 unittest.TextTestRunner().run(Doc2VecTestSpec())
+unittest.TextTestRunner().run(AlbertForTokenClassificationTestSpec())
 
 # Should be locally tested
 # print("Running ElmoEmbeddingsTestSpec")
@@ -96,12 +97,12 @@ unittest.TextTestRunner().run(Doc2VecTestSpec())
 # unittest.TextTestRunner().run(RoBertaSentenceEmbeddingsTestSpec())
 # unittest.TextTestRunner().run(RoBertaForTokenClassificationTestSpec())
 # unittest.TextTestRunner().run(XlmRoBertaForTokenClassificationTestSpec())
-# unittest.TextTestRunner().run(AlbertForTokenClassificationTestSpec())
 # unittest.TextTestRunner().run(XlnetForTokenClassificationTestSpec())
 # unittest.TextTestRunner().run(LongformerForTokenClassificationTestSpec())
 # unittest.TextTestRunner().run(DistilBertForSequenceClassificationTestSpec())
 # unittest.TextTestRunner().run(RoBertaForSequenceClassificationTestSpec())
 # unittest.TextTestRunner().run(XlmRoBertaForSequenceClassificationTestSpec())
+# unittest.TextTestRunner().run(GetClassesTestSpec())
 
 # Misc tests
 unittest.TextTestRunner().run(UtilitiesTestSpec())

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -12995,6 +12995,12 @@ class BertForTokenClassification(AnnotatorModel,
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
                              TypeConverters.toListString)
 
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
+
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
 
@@ -13157,6 +13163,12 @@ class DistilBertForTokenClassification(AnnotatorModel,
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
                              TypeConverters.toListString)
+
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
 
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
@@ -13897,6 +13909,12 @@ class RoBertaForTokenClassification(AnnotatorModel,
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
                              TypeConverters.toListString)
 
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
+
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
 
@@ -14057,6 +14075,12 @@ class XlmRoBertaForTokenClassification(AnnotatorModel,
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
                              TypeConverters.toListString)
+
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
 
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
@@ -14225,6 +14249,12 @@ class AlbertForTokenClassification(AnnotatorModel,
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
                              TypeConverters.toListString)
 
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
+
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
 
@@ -14389,6 +14419,12 @@ class XlnetForTokenClassification(AnnotatorModel,
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
                              TypeConverters.toListString)
 
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
+
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
 
@@ -14552,6 +14588,12 @@ class LongformerForTokenClassification(AnnotatorModel,
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
                              TypeConverters.toListString)
+
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
 
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
@@ -14918,6 +14960,12 @@ class BertForSequenceClassification(AnnotatorModel,
     coalesceSentences = Param(Params._dummy(), "coalesceSentences",
                               "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
                               TypeConverters.toBoolean)
+
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
 
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
@@ -15425,6 +15473,12 @@ class DistilBertForSequenceClassification(AnnotatorModel,
                               "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
                               TypeConverters.toBoolean)
 
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
+
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
 
@@ -15608,6 +15662,12 @@ class RoBertaForSequenceClassification(AnnotatorModel,
     coalesceSentences = Param(Params._dummy(), "coalesceSentences",
                               "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
                               TypeConverters.toBoolean)
+
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
 
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
@@ -15793,6 +15853,12 @@ class XlmRoBertaForSequenceClassification(AnnotatorModel,
                               "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
                               TypeConverters.toBoolean)
 
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
+
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
 
@@ -15976,6 +16042,12 @@ class LongformerForSequenceClassification(AnnotatorModel,
     coalesceSentences = Param(Params._dummy(), "coalesceSentences",
                               "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
                               TypeConverters.toBoolean)
+
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
 
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
@@ -16161,6 +16233,12 @@ class AlbertForSequenceClassification(AnnotatorModel,
                               "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
                               TypeConverters.toBoolean)
 
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
+
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
 
@@ -16344,6 +16422,12 @@ class XlnetForSequenceClassification(AnnotatorModel,
     coalesceSentences = Param(Params._dummy(), "coalesceSentences",
                               "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
                               TypeConverters.toBoolean)
+
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
 
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -1933,6 +1933,8 @@ class AlbertForTokenClassificationTestSpec(unittest.TestCase):
 
         model = pipeline.fit(self.data)
         model.transform(self.data).show()
+        print(token_classifier.getClasses())
+        print(token_classifier.getBatchSize())
 
 
 class XlnetForTokenClassificationTestSpec(unittest.TestCase):
@@ -2120,3 +2122,24 @@ class XlmRoBertaForSequenceClassificationTestSpec(unittest.TestCase):
 
         model = pipeline.fit(self.data)
         model.transform(self.data).show()
+
+
+class GetClassesTestSpec(unittest.TestCase):
+
+    def runTest(self):
+        print(AlbertForTokenClassification.pretrained().getClasses())
+        print(XlnetForTokenClassification.pretrained().getClasses())
+        print(BertForTokenClassification.pretrained().getClasses())
+        print(DistilBertForTokenClassification.pretrained().getClasses())
+        print(RoBertaForTokenClassification.pretrained().getClasses())
+        print(XlmRoBertaForTokenClassification.pretrained().getClasses())
+        print(LongformerForTokenClassification.pretrained().getClasses())
+
+        print(AlbertForSequenceClassification.pretrained().getClasses())
+        print(XlnetForSequenceClassification.pretrained().getClasses())
+        print(BertForSequenceClassification.pretrained().getClasses())
+        print(DistilBertForSequenceClassification.pretrained().getClasses())
+        print(RoBertaForSequenceClassification.pretrained().getClasses())
+        print(XlmRoBertaForSequenceClassification.pretrained().getClasses())
+        print(LongformerForSequenceClassification.pretrained().getClasses())
+

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassification.scala
@@ -148,8 +148,12 @@ class AlbertForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /**
    * Holding merges.txt coming from ALBERT model
@@ -232,7 +236,7 @@ class AlbertForSequenceClassification(override val uid: String)
             tensorflowWrapper,
             spp,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures
           )
         )
@@ -282,7 +286,7 @@ class AlbertForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          getLabels
+          $$(labels)
         )
       }
       else {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForTokenClassification.scala
@@ -136,8 +136,12 @@ class AlbertForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /** ConfigProto from tensorflow, serialized into byte array. Get with `config_proto.SerializeToString()`
    *
@@ -196,7 +200,7 @@ class AlbertForTokenClassification(override val uid: String)
             tensorflowWrapper,
             spp,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures
           )
         )
@@ -244,7 +248,7 @@ class AlbertForTokenClassification(override val uid: String)
         $(batchSize),
         $(maxSentenceLength),
         $(caseSensitive),
-        getLabels
+        $$(labels)
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
@@ -156,8 +156,12 @@ class BertForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /** Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
    * Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
@@ -231,7 +235,7 @@ class BertForSequenceClassification(override val uid: String)
             sentenceStartTokenId,
             sentenceEndTokenId,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures,
             $$(vocabulary)
           )
@@ -282,7 +286,7 @@ class BertForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          getLabels
+          $$(labels)
         )
       }
       else {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala
@@ -154,8 +154,12 @@ class BertForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /** ConfigProto from tensorflow, serialized into byte array. Get with `config_proto.SerializeToString()`
    *
@@ -215,7 +219,7 @@ class BertForTokenClassification(override val uid: String)
             sentenceStartTokenId,
             sentenceEndTokenId,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures,
             $$(vocabulary)
           )
@@ -264,7 +268,7 @@ class BertForTokenClassification(override val uid: String)
         $(batchSize),
         $(maxSentenceLength),
         $(caseSensitive),
-        getLabels
+        $$(labels)
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
@@ -155,8 +155,12 @@ class DistilBertForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /** Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
    * Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
@@ -230,7 +234,7 @@ class DistilBertForSequenceClassification(override val uid: String)
             sentenceStartTokenId,
             sentenceEndTokenId,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures,
             $$(vocabulary)
           )
@@ -281,7 +285,7 @@ class DistilBertForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          getLabels
+          $$(labels)
         )
       }
       else {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
@@ -157,8 +157,12 @@ class DistilBertForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /** ConfigProto from tensorflow, serialized into byte array. Get with `config_proto.SerializeToString()`
    *
@@ -218,7 +222,7 @@ class DistilBertForTokenClassification(override val uid: String)
             sentenceStartTokenId,
             sentenceEndTokenId,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures,
             $$(vocabulary)
           )
@@ -267,7 +271,7 @@ class DistilBertForTokenClassification(override val uid: String)
         $(batchSize),
         $(maxSentenceLength),
         $(caseSensitive),
-        getLabels
+        $$(labels)
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassification.scala
@@ -158,8 +158,12 @@ class LongformerForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /**
    * Holding merges.txt coming from Longformer model
@@ -244,7 +248,7 @@ class LongformerForSequenceClassification(override val uid: String)
             sentenceEndTokenId,
             padTokenId,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures,
             $$(merges),
             $$(vocabulary)
@@ -296,7 +300,7 @@ class LongformerForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          getLabels
+          $$(labels)
         )
       }
       else {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForTokenClassification.scala
@@ -158,9 +158,12 @@ class LongformerForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
-
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /**
    * Holding merges.txt coming from RoBERTa model
@@ -231,7 +234,7 @@ class LongformerForTokenClassification(override val uid: String)
             sentenceEndTokenId,
             padTokenId,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures,
             $$(merges),
             $$(vocabulary)
@@ -281,7 +284,7 @@ class LongformerForTokenClassification(override val uid: String)
         $(batchSize),
         $(maxSentenceLength),
         $(caseSensitive),
-        getLabels
+        $$(labels)
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassification.scala
@@ -158,8 +158,12 @@ class RoBertaForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /**
    * Holding merges.txt coming from RoBERTa model
@@ -244,7 +248,7 @@ class RoBertaForSequenceClassification(override val uid: String)
             sentenceEndTokenId,
             padTokenId,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures,
             $$(merges),
             $$(vocabulary)
@@ -296,7 +300,7 @@ class RoBertaForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          getLabels
+          $$(labels)
         )
       }
       else {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForTokenClassification.scala
@@ -158,9 +158,12 @@ class RoBertaForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
-
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /**
    * Holding merges.txt coming from RoBERTa model
@@ -231,7 +234,7 @@ class RoBertaForTokenClassification(override val uid: String)
             sentenceEndTokenId,
             padTokenId,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures,
             $$(merges),
             $$(vocabulary)
@@ -281,7 +284,7 @@ class RoBertaForTokenClassification(override val uid: String)
         $(batchSize),
         $(maxSentenceLength),
         $(caseSensitive),
-        getLabels
+        $$(labels)
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
@@ -160,8 +160,12 @@ class XlmRoBertaForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /**
    * Holding merges.txt coming from XLM-RoBERTa model
@@ -244,7 +248,7 @@ class XlmRoBertaForSequenceClassification(override val uid: String)
             tensorflowWrapper,
             spp,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures
           )
         )
@@ -294,7 +298,7 @@ class XlmRoBertaForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          getLabels
+          $$(labels)
         )
       }
       else {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForTokenClassification.scala
@@ -137,8 +137,12 @@ class XlmRoBertaForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /** ConfigProto from tensorflow, serialized into byte array. Get with `config_proto.SerializeToString()`
    *
@@ -197,7 +201,7 @@ class XlmRoBertaForTokenClassification(override val uid: String)
             tensorflowWrapper,
             spp,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures
           )
         )
@@ -245,7 +249,7 @@ class XlmRoBertaForTokenClassification(override val uid: String)
         $(batchSize),
         $(maxSentenceLength),
         $(caseSensitive),
-        getLabels
+        $$(labels)
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForTokenClassification.scala
@@ -136,8 +136,12 @@ class XlnetForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** @group getParam */
-  def getLabels: Map[String, Int] = $$(labels)
+  /**
+   * Returns labels used to train this model
+   */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
 
   /** ConfigProto from tensorflow, serialized into byte array. Get with `config_proto.SerializeToString()`
    *
@@ -196,7 +200,7 @@ class XlnetForTokenClassification(override val uid: String)
             tensorflowWrapper,
             spp,
             configProtoBytes = getConfigProtoBytes,
-            tags = getLabels,
+            tags = $$(labels),
             signatures = getSignatures
           )
         )
@@ -244,7 +248,7 @@ class XlnetForTokenClassification(override val uid: String)
         $(batchSize),
         $(maxSentenceLength),
         $(caseSensitive),
-        getLabels
+        $$(labels)
       )
     }) else {
       Seq(Seq.empty[Annotation])

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassificationTestSpec.scala
@@ -122,7 +122,7 @@ class AlbertForSequenceClassificationTestSpec extends AnyFlatSpec {
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
     val loadedSequenceModel = AlbertForSequenceClassification.load("./tmp_forsequence_model")
-    loadedSequenceModel.getLabels
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForTokenClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForTokenClassificationTestSpec.scala
@@ -120,7 +120,7 @@ class AlbertForTokenClassificationTestSpec extends AnyFlatSpec {
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
     val loadedDistilBertModel = AlbertForTokenClassification.load("./tmp_albertfortoken_model")
-    loadedDistilBertModel.getLabels
+    println(tokenClassifier.getClasses.mkString("Array(", ", ", ")"))
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassificationTestSpec.scala
@@ -122,8 +122,8 @@ class BertForSequenceClassificationTestSpec extends AnyFlatSpec {
     val loadedPipelineModel = PipelineModel.load("./tmp_bertforsequence_pipeline")
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
-    val loadedDistilBertModel = BertForSequenceClassification.load("./tmp_bertforsequence_model")
-    loadedDistilBertModel.getLabels
+    val loadedSequenceModel = BertForSequenceClassification.load("./tmp_bertforsequence_model")
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassificationTestSpec.scala
@@ -117,8 +117,8 @@ class BertForTokenClassificationTestSpec extends AnyFlatSpec {
     val loadedPipelineModel = PipelineModel.load("./tmp_bertfortoken_pipeline")
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
-    val loadedDistilBertModel = BertForTokenClassification.load("./tmp_bertfortoken_model")
-    loadedDistilBertModel.getLabels
+    val loadedSequenceModel = BertForTokenClassification.load("./tmp_bertfortoken_model")
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassificationTestSpec.scala
@@ -121,8 +121,8 @@ class DistilBertForSequenceClassificationTestSpec extends AnyFlatSpec {
     val loadedPipelineModel = PipelineModel.load("./tmp_distilbertforsequence_pipeline")
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
-    val loadedDistilBertModel = DistilBertForSequenceClassification.load("./tmp_distilbertforsequence_model")
-    loadedDistilBertModel.getLabels
+    val loadedSequenceModel = DistilBertForSequenceClassification.load("./tmp_distilbertforsequence_model")
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassificationTestSpec.scala
@@ -117,8 +117,8 @@ class DistilBertForTokenClassificationTestSpec extends AnyFlatSpec {
     val loadedPipelineModel = PipelineModel.load("./tmp_bertfortoken_pipeline")
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
-    val loadedDistilBertModel = DistilBertForTokenClassification.load("./tmp_bertfortoken_model")
-    loadedDistilBertModel.getLabels
+    val loadedSequenceModel = DistilBertForTokenClassification.load("./tmp_bertfortoken_model")
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassificationTestSpec.scala
@@ -123,7 +123,7 @@ class LongformerForSequenceClassificationTestSpec extends AnyFlatSpec {
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
     val loadedSequenceModel = LongformerForSequenceClassification.load("./tmp_forsequence_model")
-    loadedSequenceModel.getLabels
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForTokenClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForTokenClassificationTestSpec.scala
@@ -116,8 +116,8 @@ class LongformerForTokenClassificationTestSpec extends AnyFlatSpec {
     val loadedPipelineModel = PipelineModel.load("./tmp_longformerfortoken_pipeline")
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
-    val loadedModel = LongformerForTokenClassification.load("./tmp_longformerfortoken_model")
-    loadedModel.getLabels
+    val loadedSequenceModel = LongformerForTokenClassification.load("./tmp_longformerfortoken_model")
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassificationTestSpec.scala
@@ -123,7 +123,7 @@ class RoBertaForSequenceClassificationTestSpec extends AnyFlatSpec {
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
     val loadedSequenceModel = RoBertaForSequenceClassification.load("./tmp_forsequence_model")
-    loadedSequenceModel.getLabels
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForTokenClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForTokenClassificationTestSpec.scala
@@ -117,8 +117,8 @@ class RoBertaForTokenClassificationTestSpec extends AnyFlatSpec {
     val loadedPipelineModel = PipelineModel.load("./tmp_robertafortoken_pipeline")
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
-    val loadedDistilBertModel = RoBertaForTokenClassification.load("./tmp_robertafortoken_model")
-    loadedDistilBertModel.getLabels
+    val loadedSequenceModel = RoBertaForTokenClassification.load("./tmp_robertafortoken_model")
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassificationTestSpec.scala
@@ -122,7 +122,7 @@ class XlmRoBertaForSequenceClassificationTestSpec extends AnyFlatSpec {
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
     val loadedSequenceModel = XlmRoBertaForSequenceClassification.load("./tmp_forsequence_model")
-    loadedSequenceModel.getLabels
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForTokenClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForTokenClassificationTestSpec.scala
@@ -117,8 +117,8 @@ class XlmRoBertaForTokenClassificationTestSpec extends AnyFlatSpec {
     val loadedPipelineModel = PipelineModel.load("./tmp_xlmrobertafortoken_pipeline")
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
-    val loadedDistilBertModel = XlmRoBertaForTokenClassification.load("./tmp_xlmrobertafortoken_model")
-    loadedDistilBertModel.getLabels
+    val loadedSequenceModel = XlmRoBertaForTokenClassification.load("./tmp_xlmrobertafortoken_model")
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForTokenClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForTokenClassificationTestSpec.scala
@@ -119,8 +119,8 @@ class XlnetForTokenClassificationTestSpec extends AnyFlatSpec {
     val loadedPipelineModel = PipelineModel.load("./tmp_xlnetfortoken_pipeline")
     loadedPipelineModel.transform(ddd).select("label.result").show(false)
 
-    val loadedDistilBertModel = XlnetForTokenClassification.load("./tmp_xlnetfortoken_model")
-    loadedDistilBertModel.getLabels
+    val loadedSequenceModel = XlnetForTokenClassification.load("./tmp_xlnetfortoken_model")
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
 
   }
 


### PR DESCRIPTION
This PR introduces a new `.getClasses` function to retrieve labels that model was trained on to all `ForTokenClassification` and `ForSequenceClassification` annotators:

- AlbertForTokenClassification
- XlnetForTokenClassification
- BertForTokenClassification
- DistilBertForTokenClassification
- RoBertaForTokenClassification
- XlmRoBertaForTokenClassification
- LongformerForTokenClassification
- AlbertForSequenceClassification
- XlnetForSequenceClassification
- BertForSequenceClassification
- DistilBertForSequenceClassification
- RoBertaForSequenceClassification
- XlmRoBertaForSequenceClassification
- LongformerForSequenceClassification