### PR TITLE
GPT2 tests updated

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := getPackageName(is_spark23, is_spark24, is_gpu)
 
 organization := "com.johnsnowlabs.nlp"
 
-version := "3.3.4"
+version := "3.4.0"
 
 scalaVersion in ThisBuild := scalaVer
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -41,7 +41,7 @@ setup(
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
 
-    version='3.3.4',  # Required
+    version='3.4.0',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -2157,7 +2157,7 @@ class GPT2TransformerTextGenerationTestSpec(unittest.TestCase):
             .setOutputCol("documents")
 
         gpt2 = GPT2Transformer \
-            .loadSavedModel("/models/gpt2/gpt2", self.spark) \
+            .pretrained() \
             .setTask("is it true that") \
             .setMaxOutputLength(50) \
             .setDoSample(True) \

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2Transformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2Transformer.scala
@@ -121,7 +121,6 @@ import java.io.File
 
 class GPT2Transformer(override val uid: String)
   extends AnnotatorModel[GPT2Transformer]
-    with HasSimpleAnnotate[GPT2Transformer]
     with HasBatchedAnnotate[GPT2Transformer]
     with ParamsAndFeaturesWritable
     with WriteTensorflowModel {
@@ -389,31 +388,6 @@ class GPT2Transformer(override val uid: String)
     noRepeatNgramSize -> 0,
     ignoreTokenIds -> Array()
   )
-
-  def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
-    val nonEmptySentences = annotations.filter(_.result.nonEmpty)
-
-    if (nonEmptySentences.nonEmpty) {
-      this.getModelIfNotSet.generateSeq2Seq(
-        sentences = nonEmptySentences,
-        batchSize = 1,
-        minOutputLength = $(minOutputLength),
-        maxOutputLength = $(maxOutputLength),
-        doSample = $(doSample),
-        temperature = $(temperature),
-        topK = $(topK),
-        topP = $(topP),
-        repetitionPenalty = $(repetitionPenalty),
-        noRepeatNgramSize = $(noRepeatNgramSize),
-        task = $(task),
-        randomSeed = this.randomSeed,
-        ignoreTokenIds = $(ignoreTokenIds)
-      )
-    } else {
-      Seq.empty[Annotation]
-    }
-  }
-
 
   /**
    * takes a document and annotations and produces new annotations of this annotator's annotation type

--- a/src/main/scala/com/johnsnowlabs/util/Build.scala
+++ b/src/main/scala/com/johnsnowlabs/util/Build.scala
@@ -18,5 +18,5 @@ package com.johnsnowlabs.util
 
 
 object Build {
-  val version: String = "3.3.4"
+  val version: String = "3.4.0"
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2TestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2TestSpec.scala
@@ -19,15 +19,13 @@ class GPT2TestSpec extends AnyFlatSpec {
       .setOutputCol("documents")
 
     val gpt2 = GPT2Transformer
-      .loadSavedModel("/models/gpt2/gpt2", spark = ResourceHelper.spark)
+      .pretrained()
       .setInputCols(Array("documents"))
       .setMaxOutputLength(50)
       .setDoSample(false)
       .setTopK(50)
       .setNoRepeatNgramSize(3)
       .setOutputCol("generation")
-
-    //    gpt2.write.overwrite.save("/tmp/gpt2")
 
     val pipeline = new Pipeline().setStages(Array(documentAssembler, gpt2))
 
@@ -47,7 +45,7 @@ class GPT2TestSpec extends AnyFlatSpec {
       .setOutputCol("documents")
 
     val gpt2 = GPT2Transformer
-      .load("/tmp/gpt2")
+      .pretrained()
       .setTask("Is it true that")
       .setInputCols(Array("documents"))
       .setDoSample(true)
@@ -78,7 +76,7 @@ class GPT2TestSpec extends AnyFlatSpec {
       .setOutputCol("documents")
 
     val gpt2 = GPT2Transformer
-      .load("/tmp/gpt2")
+      .pretrained()
       .setInputCols(Array("documents"))
       .setDoSample(true)
       .setMaxOutputLength(50)


### PR DESCRIPTION
## Description
GPT2 tests updated to use the pretrained models uploaded to the repo. I also updated the sparknlp version to be able to download the models.

## Motivation and Context

This was needed because the tests referred to local copies of the model

## How Has This Been Tested?
I've re-run the Scala and Python gpt2 tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
