### PR TITLE
Enable batch processing for GPT2 and T5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := getPackageName(is_spark23, is_spark24, is_gpu)
 
 organization := "com.johnsnowlabs.nlp"
 
-version := "3.3.4"
+version := "3.4.0"
 
 scalaVersion in ThisBuild := scalaVer
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -41,7 +41,7 @@ setup(
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
 
-    version='3.3.4',  # Required
+    version='3.4.0',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the "Summary" metadata field:

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -11634,7 +11634,7 @@ class T5Transformer(AnnotatorModel, HasBatchedAnnotate):
             repetitionPenalty=1.0,
             noRepeatNgramSize=0,
             ignoreTokenIds=[],
-            batchSize=1
+            batchSize=8
         )
 
     @staticmethod
@@ -11863,7 +11863,7 @@ class MarianTransformer(AnnotatorModel, HasBatchedAnnotate):
             java_model=java_model
         )
         self._setDefault(
-            batchSize=1,
+            batchSize=8,
             maxInputLength=40,
             maxOutputLength=40,
             langId="",
@@ -16807,7 +16807,7 @@ class GPT2Transformer(AnnotatorModel, HasBatchedAnnotate):
             repetitionPenalty=1.0,
             noRepeatNgramSize=0,
             ignoreTokenIds=[],
-            batchSize=1
+            batchSize=8
         )
 
     @staticmethod

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -16668,6 +16668,8 @@ class GPT2Transformer(AnnotatorModel):
                            "A list of token ids which are ignored in the decoder's output",
                            typeConverter=TypeConverters.toListInt)
 
+    batchSize = Param(Params._dummy(), "batchSize", "Batch size", TypeConverters.toInt)
+
     def setTask(self, value):
         """Sets the transformer's task, e.g. ``summarize:``.
 
@@ -16789,6 +16791,17 @@ class GPT2Transformer(AnnotatorModel):
         """
         return self._set(noRepeatNgramSize=value)
 
+    def setBatchSize(self, v):
+        """Sets batch size, by default 64.
+
+        Parameters
+        ----------
+        v : int
+            Batch size
+        """
+        self._set(batchSize=v)
+        return self
+
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.seq2seq.GPT2Transformer", java_model=None):
         super(GPT2Transformer, self).__init__(
@@ -16805,7 +16818,8 @@ class GPT2Transformer(AnnotatorModel):
             topP=1.0,
             repetitionPenalty=1.0,
             noRepeatNgramSize=0,
-            ignoreTokenIds=[]
+            ignoreTokenIds=[],
+            batchSize=8
         )
 
     @staticmethod

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -11332,7 +11332,7 @@ class WordSegmenterModel(AnnotatorModel):
         return ResourceDownloader.downloadModel(WordSegmenterModel, name, lang, remote_loc)
 
 
-class T5Transformer(AnnotatorModel):
+class T5Transformer(AnnotatorModel, HasBatchedAnnotate):
     """T5: the Text-To-Text Transfer Transformer
 
     T5 reconsiders all NLP tasks into a unified text-to-text-format where the
@@ -11633,7 +11633,8 @@ class T5Transformer(AnnotatorModel):
             topP=1.0,
             repetitionPenalty=1.0,
             noRepeatNgramSize=0,
-            ignoreTokenIds=[]
+            ignoreTokenIds=[],
+            batchSize=1
         )
 
     @staticmethod
@@ -16519,7 +16520,7 @@ class XlnetForSequenceClassification(AnnotatorModel,
         return ResourceDownloader.downloadModel(XlnetForSequenceClassification, name, lang, remote_loc)
 
 
-class GPT2Transformer(AnnotatorModel):
+class GPT2Transformer(AnnotatorModel, HasBatchedAnnotate):
     """GPT2: the OpenAI Text-To-Text Transformer
 
     GPT-2 is a large transformer-based language model with 1.5 billion parameters, trained on a dataset of 8 million
@@ -16668,8 +16669,6 @@ class GPT2Transformer(AnnotatorModel):
                            "A list of token ids which are ignored in the decoder's output",
                            typeConverter=TypeConverters.toListInt)
 
-    batchSize = Param(Params._dummy(), "batchSize", "Batch size", TypeConverters.toInt)
-
     def setTask(self, value):
         """Sets the transformer's task, e.g. ``summarize:``.
 
@@ -16791,17 +16790,6 @@ class GPT2Transformer(AnnotatorModel):
         """
         return self._set(noRepeatNgramSize=value)
 
-    def setBatchSize(self, v):
-        """Sets batch size, by default 64.
-
-        Parameters
-        ----------
-        v : int
-            Batch size
-        """
-        self._set(batchSize=v)
-        return self
-
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.seq2seq.GPT2Transformer", java_model=None):
         super(GPT2Transformer, self).__init__(
@@ -16819,7 +16807,7 @@ class GPT2Transformer(AnnotatorModel):
             repetitionPenalty=1.0,
             noRepeatNgramSize=0,
             ignoreTokenIds=[],
-            batchSize=8
+            batchSize=1
         )
 
     @staticmethod

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -2157,7 +2157,7 @@ class GPT2TransformerTextGenerationTestSpec(unittest.TestCase):
             .setOutputCol("documents")
 
         gpt2 = GPT2Transformer \
-            .loadSavedModel("/models/gpt2/gpt2", self.spark) \
+            .pretrained() \
             .setTask("is it true that") \
             .setMaxOutputLength(50) \
             .setDoSample(True) \

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2Transformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2Transformer.scala
@@ -387,7 +387,7 @@ class GPT2Transformer(override val uid: String)
     repetitionPenalty -> 1.0,
     noRepeatNgramSize -> 0,
     ignoreTokenIds -> Array(),
-    batchSize -> 8
+    batchSize -> 1
   )
 
   /**

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2Transformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2Transformer.scala
@@ -387,7 +387,7 @@ class GPT2Transformer(override val uid: String)
     repetitionPenalty -> 1.0,
     noRepeatNgramSize -> 0,
     ignoreTokenIds -> Array(),
-    batchSize -> 1
+    batchSize -> 8
   )
 
   /**

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2Transformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2Transformer.scala
@@ -121,7 +121,6 @@ import java.io.File
 
 class GPT2Transformer(override val uid: String)
   extends AnnotatorModel[GPT2Transformer]
-    with HasSimpleAnnotate[GPT2Transformer]
     with HasBatchedAnnotate[GPT2Transformer]
     with ParamsAndFeaturesWritable
     with WriteTensorflowModel {
@@ -387,33 +386,9 @@ class GPT2Transformer(override val uid: String)
     topP -> 1.0,
     repetitionPenalty -> 1.0,
     noRepeatNgramSize -> 0,
-    ignoreTokenIds -> Array()
+    ignoreTokenIds -> Array(),
+    batchSize -> 8
   )
-
-  def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
-    val nonEmptySentences = annotations.filter(_.result.nonEmpty)
-
-    if (nonEmptySentences.nonEmpty) {
-      this.getModelIfNotSet.generateSeq2Seq(
-        sentences = nonEmptySentences,
-        batchSize = 1,
-        minOutputLength = $(minOutputLength),
-        maxOutputLength = $(maxOutputLength),
-        doSample = $(doSample),
-        temperature = $(temperature),
-        topK = $(topK),
-        topP = $(topP),
-        repetitionPenalty = $(repetitionPenalty),
-        noRepeatNgramSize = $(noRepeatNgramSize),
-        task = $(task),
-        randomSeed = this.randomSeed,
-        ignoreTokenIds = $(ignoreTokenIds)
-      )
-    } else {
-      Seq.empty[Annotation]
-    }
-  }
-
 
   /**
    * takes a document and annotations and produces new annotations of this annotator's annotation type

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
@@ -284,7 +284,7 @@ class MarianTransformer(override val uid: String) extends
   setDefault(
     maxInputLength -> 40,
     maxOutputLength -> 40,
-    batchSize -> 1,
+    batchSize -> 8,
     langId -> "",
     ignoreTokenIds -> Array()
   )

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/T5Transformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/T5Transformer.scala
@@ -19,8 +19,7 @@ package com.johnsnowlabs.nlp.annotators.seq2seq
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{ReadSentencePieceModel, SentencePieceWrapper, WriteSentencePieceModel}
 import com.johnsnowlabs.ml.tensorflow.{ReadTensorflowModel, TensorflowT5, TensorflowWrapper, WriteTensorflowModel}
 import com.johnsnowlabs.nlp.AnnotatorType.DOCUMENT
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasPretrained, HasSimpleAnnotate, ParamsAndFeaturesReadable, ParamsAndFeaturesWritable}
-
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasBatchedAnnotate, HasPretrained, HasSimpleAnnotate, ParamsAndFeaturesReadable, ParamsAndFeaturesWritable}
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.param.{BooleanParam, DoubleParam, IntArrayParam, IntParam, Param}
 import org.apache.spark.ml.util.Identifiable
@@ -131,7 +130,7 @@ import java.io.File
  */
 class T5Transformer(override val uid: String)
   extends AnnotatorModel[T5Transformer]
-    with HasSimpleAnnotate[T5Transformer]
+    with HasBatchedAnnotate[T5Transformer]
     with ParamsAndFeaturesWritable
     with WriteTensorflowModel
     with WriteSentencePieceModel {
@@ -367,32 +366,38 @@ class T5Transformer(override val uid: String)
     topP -> 1.0,
     repetitionPenalty -> 1.0,
     noRepeatNgramSize -> 0,
-    ignoreTokenIds -> Array()
+    ignoreTokenIds -> Array(),
+    batchSize -> 1
   )
 
+  override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
+    val nonEmptyBatch = batchedAnnotations.filter(_.nonEmpty)
 
-  override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
-
-    val nonEmptySentences = annotations.filter(_.result.nonEmpty)
-
-    if (nonEmptySentences.nonEmpty) {
-      this.getModelIfNotSet.generateSeq2Seq(
-        sentences = nonEmptySentences,
-        batchSize = 1,
-        minOutputLength = $(minOutputLength),
-        maxOutputLength = $(maxOutputLength),
-        doSample = $(doSample),
-        temperature = $(temperature),
-        topK = $(topK),
-        topP = $(topP),
-        repetitionPenalty = $(repetitionPenalty),
-        noRepeatNgramSize = $(noRepeatNgramSize),
-        task = $(task),
-        randomSeed = this.randomSeed,
-        $(ignoreTokenIds)
-      )
+    if (nonEmptyBatch.nonEmpty) {
+      nonEmptyBatch.map(batch => {
+        val nonEmptyAnnotations = batch.filter(_.result.nonEmpty)
+        if (nonEmptyAnnotations.nonEmpty) {
+          this.getModelIfNotSet.generateSeq2Seq(
+            sentences = nonEmptyAnnotations,
+            batchSize = 1,
+            minOutputLength = $(minOutputLength),
+            maxOutputLength = $(maxOutputLength),
+            doSample = $(doSample),
+            temperature = $(temperature),
+            topK = $(topK),
+            topP = $(topP),
+            repetitionPenalty = $(repetitionPenalty),
+            noRepeatNgramSize = $(noRepeatNgramSize),
+            task = $(task),
+            randomSeed = this.randomSeed,
+            $(ignoreTokenIds)
+          )
+        } else {
+          Seq()
+        }
+      })
     } else {
-      Seq.empty[Annotation]
+      Seq()
     }
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/T5Transformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/T5Transformer.scala
@@ -367,7 +367,7 @@ class T5Transformer(override val uid: String)
     repetitionPenalty -> 1.0,
     noRepeatNgramSize -> 0,
     ignoreTokenIds -> Array(),
-    batchSize -> 1
+    batchSize -> 8
   )
 
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {

--- a/src/main/scala/com/johnsnowlabs/util/Build.scala
+++ b/src/main/scala/com/johnsnowlabs/util/Build.scala
@@ -18,5 +18,5 @@ package com.johnsnowlabs.util
 
 
 object Build {
-  val version: String = "3.3.4"
+  val version: String = "3.4.0"
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2TestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2TestSpec.scala
@@ -19,15 +19,13 @@ class GPT2TestSpec extends AnyFlatSpec {
       .setOutputCol("documents")
 
     val gpt2 = GPT2Transformer
-      .loadSavedModel("/models/gpt2/gpt2", spark = ResourceHelper.spark)
+      .pretrained()
       .setInputCols(Array("documents"))
       .setMaxOutputLength(50)
       .setDoSample(false)
       .setTopK(50)
       .setNoRepeatNgramSize(3)
       .setOutputCol("generation")
-
-    //    gpt2.write.overwrite.save("/tmp/gpt2")
 
     val pipeline = new Pipeline().setStages(Array(documentAssembler, gpt2))
 
@@ -47,7 +45,7 @@ class GPT2TestSpec extends AnyFlatSpec {
       .setOutputCol("documents")
 
     val gpt2 = GPT2Transformer
-      .load("/tmp/gpt2")
+      .pretrained()
       .setTask("Is it true that")
       .setInputCols(Array("documents"))
       .setDoSample(true)
@@ -78,7 +76,7 @@ class GPT2TestSpec extends AnyFlatSpec {
       .setOutputCol("documents")
 
     val gpt2 = GPT2Transformer
-      .load("/tmp/gpt2")
+      .pretrained()
       .setInputCols(Array("documents"))
       .setDoSample(true)
       .setMaxOutputLength(50)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/T5TestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/T5TestSpec.scala
@@ -16,7 +16,6 @@
 
 package com.johnsnowlabs.nlp.annotators.seq2seq
 
-import com.johnsnowlabs.nlp.Annotation
 import com.johnsnowlabs.nlp.annotator.SentenceDetectorDLModel
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
@@ -27,56 +26,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 
 class T5TestSpec extends AnyFlatSpec {
-
-  "t5-small" should "run SparkNLP pipeline" taggedAs SlowTest in {
-    val testData = ResourceHelper.spark.createDataFrame(Seq(
-
-      (1, "Preheat the oven to 220°C/ fan200°C/gas 7. Trim the lamb fillet of fat and cut into slices the thickness" +
-        " of a chop. Cut the kidneys in half and snip out the white core. Melt a knob of dripping or 2 tablespoons " +
-        "of vegetable oil in a heavy large pan. Fry the lamb fillet in batches for 3-4 minutes, turning once, until " +
-        "browned. Set aside. Fry the kidneys and cook for 1-2 minutes, turning once, until browned. Set aside." +
-        "Wipe the pan with kitchen paper, then add the butter. Add the onions and fry for about 10 minutes until " +
-        "softened. Sprinkle in the flour and stir well for 1 minute. Gradually pour in the stock, stirring all the " +
-        "time to avoid lumps. Add the herbs. Stir the lamb and kidneys into the onions. Season well. Transfer to a" +
-        " large 2.5-litre casserole. Slice the peeled potatoes thinly and arrange on top in overlapping rows. Brush " +
-        "with melted butter and season. Cover and bake for 30 minutes. Reduce the oven temperature to 160°C" +
-        "/fan140°C/gas 3 and cook for a further 2 hours. Then increase the oven temperature to 200°C/ fan180°C/gas 6," +
-        " uncover, and brush the potatoes with more butter. Cook uncovered for 15-20 minutes, or until golden."),
-      (1, "Donald John Trump (born June 14, 1946) is the 45th and current president of the United States. Before " +
-        "entering politics, he was a businessman and television personality. Born and raised in Queens, New York " +
-        "City, Trump attended Fordham University for two years and received a bachelor's degree in economics from the " +
-        "Wharton School of the University of Pennsylvania. He became president of his father Fred Trump's real " +
-        "estate business in 1971, renamed it The Trump Organization, and expanded its operations to building or " +
-        "renovating skyscrapers, hotels, casinos, and golf courses. Trump later started various side ventures," +
-        " mostly by licensing his name. Trump and his businesses have been involved in more than 4,000 state and" +
-        " federal legal actions, including six bankruptcies. He owned the Miss Universe brand of beauty pageants " +
-        "from 1996 to 2015, and produced and hosted the reality television series The Apprentice from 2004 to 2015.")
-    )).toDF("id", "text")
-
-    val documentAssembler = new DocumentAssembler()
-      .setInputCol("text")
-      .setOutputCol("documents")
-
-    val t5 = T5Transformer.pretrained("t5_small")
-      .setTask("summarize:")
-      .setInputCols(Array("documents"))
-      .setMaxOutputLength(200)
-      .setIgnoreTokenIds(Array(12065))//ignore token "vegetable"
-      .setOutputCol("summaries")
-
-    val pipeline = new Pipeline().setStages(Array(documentAssembler, t5))
-
-    val model = pipeline.fit(testData)
-    val results = model.transform(testData).cache()
-
-    results.select("summaries.result").show(truncate = false)
-
-    assert(
-      results
-        .selectExpr("explode(summaries) AS summary")
-        .where(col("summary.result").contains(" vegetable ")).count() == 0,
-      "should not include ignored tokens")
-  }
 
   "google/t5-small-ssm-nq " should "run SparkNLP pipeline" taggedAs SlowTest in {
     val testData = ResourceHelper.spark.createDataFrame(Seq(
@@ -144,7 +93,7 @@ class T5TestSpec extends AnyFlatSpec {
     val dataframe = results.select("summaries.result").collect()
     val result = dataframe.toSeq.head.getAs[Seq[String]](0).head
 
-    assert("a knob of dripping or 2 tablespoons of vegetable oil in a large large pan . cut the kidneys in half and snip out the white core . heat the pan for 1-2 minutes, turning once, until browned ." == result)
+    assert(result == "a knob of dripping or 2 tablespoons of vegetable oil in a large large pan . cut the kidneys in half and snip out the white core . heat the pan for 1-2 minutes, turning once, until browned .")
   }
 
   "t5-small" should "run SparkNLP pipeline with doSample=true " taggedAs SlowTest in {
@@ -384,4 +333,55 @@ class T5TestSpec extends AnyFlatSpec {
     assert("the lamb fillet of fat and cut into slices the thickness of a chop . melt dripping or 2 tablespoons vegetable oil in 'large pan'" == dataframe1)
 
   }
+
+  "t5-small" should "run SparkNLP pipeline and ignore a token" taggedAs SlowTest in {
+    val testData = ResourceHelper.spark.createDataFrame(Seq(
+
+      (1, "Preheat the oven to 220°C/ fan200°C/gas 7. Trim the lamb fillet of fat and cut into slices the thickness" +
+        " of a chop. Cut the kidneys in half and snip out the white core. Melt a knob of dripping or 2 tablespoons " +
+        "of vegetable oil in a heavy large pan. Fry the lamb fillet in batches for 3-4 minutes, turning once, until " +
+        "browned. Set aside. Fry the kidneys and cook for 1-2 minutes, turning once, until browned. Set aside." +
+        "Wipe the pan with kitchen paper, then add the butter. Add the onions and fry for about 10 minutes until " +
+        "softened. Sprinkle in the flour and stir well for 1 minute. Gradually pour in the stock, stirring all the " +
+        "time to avoid lumps. Add the herbs. Stir the lamb and kidneys into the onions. Season well. Transfer to a" +
+        " large 2.5-litre casserole. Slice the peeled potatoes thinly and arrange on top in overlapping rows. Brush " +
+        "with melted butter and season. Cover and bake for 30 minutes. Reduce the oven temperature to 160°C" +
+        "/fan140°C/gas 3 and cook for a further 2 hours. Then increase the oven temperature to 200°C/ fan180°C/gas 6," +
+        " uncover, and brush the potatoes with more butter. Cook uncovered for 15-20 minutes, or until golden."),
+      (1, "Donald John Trump (born June 14, 1946) is the 45th and current president of the United States. Before " +
+        "entering politics, he was a businessman and television personality. Born and raised in Queens, New York " +
+        "City, Trump attended Fordham University for two years and received a bachelor's degree in economics from the " +
+        "Wharton School of the University of Pennsylvania. He became president of his father Fred Trump's real " +
+        "estate business in 1971, renamed it The Trump Organization, and expanded its operations to building or " +
+        "renovating skyscrapers, hotels, casinos, and golf courses. Trump later started various side ventures," +
+        " mostly by licensing his name. Trump and his businesses have been involved in more than 4,000 state and" +
+        " federal legal actions, including six bankruptcies. He owned the Miss Universe brand of beauty pageants " +
+        "from 1996 to 2015, and produced and hosted the reality television series The Apprentice from 2004 to 2015.")
+    )).toDF("id", "text")
+
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("documents")
+
+    val t5 = T5Transformer.pretrained("t5_small")
+      .setTask("summarize:")
+      .setInputCols(Array("documents"))
+      .setMaxOutputLength(200)
+      .setIgnoreTokenIds(Array(12065))//ignore token "vegetable"
+      .setOutputCol("summaries")
+
+    val pipeline = new Pipeline().setStages(Array(documentAssembler, t5))
+
+    val model = pipeline.fit(testData)
+    val results = model.transform(testData).cache()
+
+    results.select("summaries.result").show(truncate = false)
+
+    assert(
+      results
+        .selectExpr("explode(summaries) AS summary")
+        .where(col("summary.result").contains(" vegetable ")).count() == 0,
+      "should not include ignored tokens")
+  }
+
 }


### PR DESCRIPTION
Add HasBatchAnnotate trait to T5 and GPT2. Batch processing will only work for clusters.

## Description
I've removed the HasSimpleAnnotate trait from T5 and GPT2 and implemented HasBatchAnnotate. The batch size parameter is added to the python wrapping. 

Note that batch processing will not make any difference on a single machine with a GPU. This is because the documents are currently processed one by one within a single process. The only to speed up processing by using batches is if you have multiple concurrent processes running on the same device (i.e. a GPU) - our experience so far suggests this only happens when Spark runs in a cluster.

I've also checked MarianMT transformer. It already implements HasBatchAnnotate and supports batch processing with batchSize > 1. So the only case in which MarianMT  will not utilize the GPU will be when there is a single document/sentence per row and the model runs on a single machine.

The default value of batchSize for T5, GPT2 and MarianMT is set to 8. 

## Motivation and Context

Running a transformer on a GPU greatly improves performance. To fully utilize GPUs we need to let it process multiple documents in parallel, which is achieved by batching.

## How Has This Been Tested?
The Scala and Python GPT2 and T5 tests ran without errors. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
