### PR TITLE
BUGFIX-NMH55: Fix all commits dont trigger github action when merged [skip test]

### DIFF
--- a/.github/workflows/create_search_index.yml
+++ b/.github/workflows/create_search_index.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 2
+          fetch-depth: 20
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
@@ -24,8 +24,8 @@ jobs:
           ELASTICSEARCH_ACCESS_TOKEN: ${{ secrets.ELASTICSEARCH_ACCESS_TOKEN }}
         working-directory: docs
         run: |
-          git diff --name-only HEAD~1..HEAD > changes.txt
-          git diff --name-only HEAD..HEAD~1 >> changes.txt
+          git diff --name-only ${{github.event.before}}..${{github.event.after}} > changes.txt
+          git diff --name-only ${{github.event.after}}..${{github.event.before}} >> changes.txt
           bundle exec jekyll build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Fixes issue [NMH-55](https://johnsnowlabs.atlassian.net/browse/NMH-55)

- When merges are directly pushed to the master branch (without pull requests), only the last commit will trigger the github action `create_search_index.yml`. This fix will index all the changes to the post made since the last commit to the master branch.