### PR TITLE
Feature/sbt 156

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -51,7 +51,12 @@ jobs:
           sbt -mem 4096 -Dis_spark24=true assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 2.4.x
         run: |
-          sbt -mem 4096 -Dis_spark24=true test
+          sbt -mem 4096 -Dis_spark24=true coverage test
+      - name: Upload coverage data to Coveralls
+        run: sbt coverageReport coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: Apache Spark 2.4.x - Scala 2.11
       - name: Test Spark NLP in Python - Apache Spark 2.4.x
         run: |
           cd python
@@ -85,7 +90,12 @@ jobs:
           sbt -mem 4096 -Dis_spark23=true assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 2.3.x
         run: |
-          sbt -mem 4096 -Dis_spark23=true test
+          sbt -mem 4096 -Dis_spark23=true coverage test
+      - name: Upload coverage data to Coveralls
+        run: sbt coverageReport coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: Apache Spark 2.3.x - Scala 2.11
       - name: Test Spark NLP in Python - Apache Spark 2.3.x
         run: |
           cd python
@@ -119,7 +129,12 @@ jobs:
           sbt -mem 4096 assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.0.x
         run: |
-          sbt -mem 4096 test
+          sbt -mem 4096 coverage test
+      - name: Upload coverage data to Coveralls
+        run: sbt coverageReport coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: Apache Spark 3.0.x - Scala 2.12
       - name: Test Spark NLP in Python - Apache Spark 3.0.x
         run: |
           cd python

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -51,12 +51,7 @@ jobs:
           sbt -mem 4096 -Dis_spark24=true assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 2.4.x
         run: |
-          sbt -mem 4096 -Dis_spark24=true coverage test
-      - name: Upload coverage data to Coveralls
-        run: sbt coverageReport coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: Apache Spark 2.4.x - Scala 2.11
+          sbt -mem 4096 -Dis_spark24=true test
       - name: Test Spark NLP in Python - Apache Spark 2.4.x
         run: |
           cd python
@@ -90,12 +85,7 @@ jobs:
           sbt -mem 4096 -Dis_spark23=true assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 2.3.x
         run: |
-          sbt -mem 4096 -Dis_spark23=true coverage test
-      - name: Upload coverage data to Coveralls
-        run: sbt coverageReport coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: Apache Spark 2.3.x - Scala 2.11
+          sbt -mem 4096 -Dis_spark23=true test
       - name: Test Spark NLP in Python - Apache Spark 2.3.x
         run: |
           cd python

--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,9 @@ organization := "com.johnsnowlabs.nlp"
 
 version := "3.4.0"
 
-scalaVersion in ThisBuild := scalaVer
+(ThisBuild / scalaVersion) := scalaVer
 
-scalacOptions in ThisBuild += "-target:jvm-1.8"
+(ThisBuild / scalacOptions) += "-target:jvm-1.8"
 
 scalacOptions ++= Seq(
   "-unchecked",
@@ -18,7 +18,7 @@ scalacOptions ++= Seq(
   "-language:implicitConversions"
 )
 
-scalacOptions in(Compile, doc) ++= Seq(
+(Compile / doc / scalacOptions) ++= Seq(
   "-groups",
   "-doc-title",
   "Spark NLP " + version.value + " ScalaDoc",
@@ -27,18 +27,18 @@ scalacOptions in(Compile, doc) ++= Seq(
   "-nowarn"
 )
 
-target in Compile in doc := baseDirectory.value / "docs/api"
+Compile / doc / target := baseDirectory.value / "docs/api"
 
 licenses += "Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")
 
-resolvers in ThisBuild := m2Resolvers
+(ThisBuild / resolvers) := m2Resolvers
 
-assemblyShadeRules in assembly := Seq(
+(assembly / assemblyShadeRules) := Seq(
   ShadeRule.rename("org.apache.http.**" -> "org.apache.httpShaded@1").inAll,
   ShadeRule.rename("com.amazonaws.**" -> "com.amazonaws.ShadedByJSL@1").inAll
 )
 
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(
+(assembly / assemblyOption) := (assembly / assemblyOption).value.copy(
   includeScala = false
 )
 
@@ -62,7 +62,7 @@ scmInfo := Some(
   )
 )
 
-developers in ThisBuild := List(
+(ThisBuild / developers) := List(
   Developer(id = "saifjsl", name = "Saif Addin", email = "saif@johnsnowlabs.com", url = url("https://github.com/saifjsl")),
   Developer(id = "maziyarpanahi", name = "Maziyar Panahi", email = "maziyar@johnsnowlabs.com", url = url("https://github.com/maziyarpanahi")),
   Developer(id = "albertoandreottiATgmail", name = "Alberto Andreotti", email = "alberto@pacific.ai", url = url("https://github.com/albertoandreottiATgmail")),
@@ -131,7 +131,7 @@ lazy val root = (project in file("."))
     }
   )
 
-assemblyMergeStrategy in assembly := {
+(assembly / assemblyMergeStrategy) := {
   case PathList("META-INF", "versions", "9", "module-info.class") => MergeStrategy.discard
   case PathList("apache.commons.lang3", _@_*) => MergeStrategy.discard
   case PathList("org.apache.hadoop", _@_*) => MergeStrategy.first
@@ -140,7 +140,7 @@ assemblyMergeStrategy in assembly := {
   case PathList("META-INF", "io.netty.versions.properties") => MergeStrategy.first
   case PathList("org", "tensorflow", _@_*) => MergeStrategy.first
   case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)
 }
 
@@ -152,42 +152,42 @@ lazy val SlowTest = config("slow") extend Test
 
 configs(FastTest, SlowTest)
 
-parallelExecution in Test := false
-logBuffered in Test := false
-testOptions in Test := Seq(Tests.Argument("-l", "com.johnsnowlabs.tags.SlowTest")) // exclude
+(Test / parallelExecution) := false
+(Test / logBuffered) := false
+(Test / testOptions) := Seq(Tests.Argument("-l", "com.johnsnowlabs.tags.SlowTest")) // exclude
 
 inConfig(FastTest)(Defaults.testTasks)
-testOptions in FastTest := Seq(Tests.Argument("-l", "com.johnsnowlabs.tags.SlowTest")) // exclude
-parallelExecution in FastTest := false
+(FastTest / testOptions) := Seq(Tests.Argument("-l", "com.johnsnowlabs.tags.SlowTest")) // exclude
+(FastTest / parallelExecution) := false
 
 inConfig(SlowTest)(Defaults.testTasks)
-testOptions in SlowTest := Seq(Tests.Argument("-n", "com.johnsnowlabs.tags.SlowTest")) // include
-parallelExecution in SlowTest := false
+(SlowTest / testOptions) := Seq(Tests.Argument("-n", "com.johnsnowlabs.tags.SlowTest")) // include
+(SlowTest / parallelExecution) := false
 
 /** Test tagging end */
 
 /** Enable for debugging */
-testOptions in Test += Tests.Argument("-oF")
+(Test / testOptions) += Tests.Argument("-oF")
 
 /** Disables tests in assembly */
-test in assembly := {}
+(assembly / test) := {}
 
 /** Publish test artifact * */
-publishArtifact in Test := true
+(Test / publishArtifact) := true
 
 /** Copies the assembled jar to the pyspark/lib dir * */
 lazy val copyAssembledJar = taskKey[Unit]("Copy assembled jar to pyspark/lib")
 lazy val copyAssembledJarForPyPi = taskKey[Unit]("Copy assembled jar to pyspark/sparknlp/lib")
 
 copyAssembledJar := {
-  val jarFilePath = (assemblyOutputPath in assembly).value
+  val jarFilePath = (assembly / assemblyOutputPath).value
   val newJarFilePath = baseDirectory(_ / "python" / "lib" / "sparknlp.jar").value
   IO.copyFile(jarFilePath, newJarFilePath)
   println(s"[info] $jarFilePath copied to $newJarFilePath ")
 }
 
 copyAssembledJarForPyPi := {
-  val jarFilePath = (assemblyOutputPath in assembly).value
+  val jarFilePath = (assembly / assemblyOutputPath).value
   val newJarFilePath = baseDirectory(_ / "python" / "sparknlp" / "lib" / "sparknlp.jar").value
   IO.copyFile(jarFilePath, newJarFilePath)
   println(s"[info] $jarFilePath copied to $newJarFilePath ")

--- a/build.sbt
+++ b/build.sbt
@@ -44,17 +44,6 @@ assemblyOption in assembly := (assemblyOption in assembly).value.copy(
 
 credentials += Credentials(Path.userHome / ".ivy2" / ".sbtcredentials")
 
-/** Bintray settings */
-bintrayPackageLabels := Seq("nlp", "nlu",
-  "natural-language-processing", "natural-language-understanding",
-  "spark", "spark-ml", "pyspark", "machine-learning",
-  "named-entity-recognition", "sentiment-analysis", "lemmatizer", "spell-checker",
-  "tokenizer", "stemmer", "part-of-speech-tagger", "annotation-framework")
-
-bintrayRepository := "spark-nlp"
-
-bintrayOrganization := Some("johnsnowlabs")
-
 sonatypeProfileName := "com.johnsnowlabs"
 
 publishTo := Some(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,3 @@
-resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
-
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")
-
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-val scoverageVersion = "1.6.1"
-
 resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.6.1")
@@ -9,4 +7,6 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 /** scoverage */
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % scoverageVersion)
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.1")


### PR DESCRIPTION
This PR:
- bumps `sbt` to 1.5.6 that updates log4j 2 to 2.15.0, which fixes remote code execution vulnerability ([CVE-2021-44228](GHSA-jfh8-c2jp-5v3q))
- Update `sbt-scoverage` plugin
- Add `sbt-coveralls` plugin
- Add coveralls to GAs
