### PR TITLE
Preserve the actual trained weights from NerDLApproach

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -293,7 +293,8 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
   }
 
   def saveBestModel(): Session = {
-    tensorflow.getTFSession()
+    val newWrapper = new TensorflowWrapper(TensorflowWrapper.extractVariablesSavedModel(tensorflow.getTFSession()), tensorflow.graph)
+    newWrapper.getTFSession()
   }
 
   def calcStat(tp: Int, fp: Int, fn: Int): (Float, Float, Float) = {

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
@@ -273,13 +273,14 @@ class NerDLSpec extends AnyFlatSpec {
       .setMaxEpochs(5)
       .setRandomSeed(0)
       .setVerbose(0)
-      .setBatchSize(32)
+      .setBatchSize(8)
       .setEvaluationLogExtended(true)
       .setGraphFolder("src/test/resources/graph/")
       .setTestDataset("./tmp_test_coll")
+      .setUseBestModel(true)
+      .fit(trainDF)
 
-    nerModel.fit(trainDF)
-
+    nerModel.write.overwrite() save ("./tmp_ner_dl_glove_conll03_100d")
   }
 
   "NerDLModel" should "benchmark test" taggedAs SlowTest in {

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
@@ -219,6 +219,7 @@ class NerDLSpec extends AnyFlatSpec {
       .setEvaluationLogExtended(true)
       .setEnableOutputLogs(true)
       .setGraphFolder("src/test/resources/graph/")
+      .setUseBestModel(true)
       .fit(trainData)
 
     ner.write.overwrite() save ("./tmp_ner_dl_tf115")


### PR DESCRIPTION
In order to use bestModel, we need the actual weights rather than the reference to a TF session.