### PR TITLE
Fix RecursiveTokenizerModel not being readable in a saved Pipeline

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/RecursiveTokenizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/RecursiveTokenizerModel.scala
@@ -18,7 +18,7 @@ package com.johnsnowlabs.nlp.annotators
 
 import com.johnsnowlabs.nlp.annotators.common.{InfixToken, PrefixedToken, SuffixedToken}
 import com.johnsnowlabs.nlp.serialization.{ArrayFeature, SetFeature}
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, AnnotatorType, ParamsAndFeaturesWritable, HasSimpleAnnotate}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, AnnotatorType, HasSimpleAnnotate, ParamsAndFeaturesReadable, ParamsAndFeaturesWritable}
 import org.apache.spark.ml.util.Identifiable
 
 /**
@@ -45,6 +45,20 @@ class RecursiveTokenizerModel(override val uid: String)
     with HasSimpleAnnotate[RecursiveTokenizerModel]
     with ParamsAndFeaturesWritable {
 
+  /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */
+  def this() = this(Identifiable.randomUID("RecursiveTokenizerModel"))
+
+  /** Output Annotator types: TOKEN
+   *
+   * @group anno
+   */
+  override val outputAnnotatorType: AnnotatorType = AnnotatorType.TOKEN
+  /** Input Annotator types: DOCUMENT
+   *
+   * @group anno
+   */
+  override val inputAnnotatorTypes: Array[String] = Array(AnnotatorType.DOCUMENT)
+
   /** prefixes
    *
    * @group param
@@ -55,7 +69,7 @@ class RecursiveTokenizerModel(override val uid: String)
    *
    * @group setParam
    * */
-  def setPrefixes(p: Array[String]): this.type = set(prefixes, p.sortBy(_.size).reverse)
+  def setPrefixes(p: Array[String]): this.type = set(prefixes, p.sortBy(_.length).reverse)
 
   /** suffixes
    *
@@ -67,7 +81,7 @@ class RecursiveTokenizerModel(override val uid: String)
    *
    * @group setParam
    * */
-  def setSuffixes(s: Array[String]): this.type = set(suffixes, s.sortBy(_.size).reverse)
+  def setSuffixes(s: Array[String]): this.type = set(suffixes, s.sortBy(_.length).reverse)
 
   /** infixes
    *
@@ -79,7 +93,7 @@ class RecursiveTokenizerModel(override val uid: String)
    *
    * @group setParam
    * */
-  def setInfixes(s: Array[String]): this.type = set(infixes, s.sortBy(_.size).reverse)
+  def setInfixes(s: Array[String]): this.type = set(infixes, s.sortBy(_.length).reverse)
 
   /** whitelist
    *
@@ -139,18 +153,6 @@ class RecursiveTokenizerModel(override val uid: String)
       tmp
     }.filter(!_.equals(""))
 
-  /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */
-  def this() = this(Identifiable.randomUID("SimpleTokenizerModel"))
-
-
-  /** Output Annotator types: TOKEN
-   *
-   * @group anno
-   */
-  override val outputAnnotatorType: AnnotatorType = AnnotatorType.TOKEN
-  /** Input Annotator types: DOCUMENT
-   *
-   * @group anno
-   */
-  override val inputAnnotatorTypes: Array[String] = Array(AnnotatorType.DOCUMENT)
 }
+
+object RecursiveTokenizerModel extends ParamsAndFeaturesReadable[RecursiveTokenizerModel]

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -19,7 +19,7 @@ package com.johnsnowlabs.nlp.annotators
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.tags.FastTest
-import org.apache.spark.ml.{Pipeline, Transformer}
+import org.apache.spark.ml.{Pipeline, PipelineModel, Transformer}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -36,8 +36,8 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
     assert(tokenizer.outputAnnotatorType == AnnotatorType.TOKEN)
   }
 
-  val ls = System.lineSeparator
-  val lsl = ls.length
+  val ls: String = System.lineSeparator
+  val lsl: Int = ls.length
 
   def getTokenizerOutput[T](tokenizer: TokenizerModel, data: DataFrame, mode: String = "finisher"): Array[T] = {
     val finisher = new Finisher().setInputCols("token").setOutputAsArray(true).setCleanAnnotations(false).setOutputCols("output")
@@ -51,7 +51,7 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
   }
 
   /* here assembler can either be a SentenceDetector or a DocumentAssembler */
-  def getTokenizerPipelineOutput[T](assembler:Transformer, tokenizer: TokenizerModel, data: DataFrame, mode: String = "finisher"): Array[T] = {
+  def getTokenizerPipelineOutput[T](assembler: Transformer, tokenizer: TokenizerModel, data: DataFrame, mode: String = "finisher"): Array[T] = {
 
     val finisher = new Finisher().setInputCols("token").setOutputAsArray(true).setCleanAnnotations(false).setOutputCols("output")
     val pipeline = new Pipeline().setStages(Array(assembler, tokenizer, finisher))
@@ -93,16 +93,14 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
   }
 
 
-
-
-  val targetText1 = "Hello, I won't be from New York in the U.S.A. (and you know it héroe). Give me my horse! or $100" +
+  val targetText1: String = "Hello, I won't be from New York in the U.S.A. (and you know it héroe). Give me my horse! or $100" +
     " bucks 'He said', I'll defeat markus-crassus. You understand. Goodbye George E. Bush. www.google.com."
-  val expected1 = Array(
+  val expected1: Array[String] = Array(
     "Hello", ",", "I", "won't", "be", "from", "New York", "in", "the", "U.S.A", ".", "(", "and", "you", "know", "it",
     "héroe", ").", "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "',", "I'll",
     "defeat", "markus-crassus", ".", "You", "understand", ".", "Goodbye", "George", "E", ".", "Bush", ".", "www.google.com", "."
   )
-  val expected1b = Array(
+  val expected1b: Array[String] = Array(
     "Hello", ",", "I", "won't", "be", "from", "New York", "in", "the", "U.S.A", ".", "(", "and", "you", "know", "it",
     "héroe", ").", "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "',", "I'll",
     "defeat", "markus", "crassus", ".", "You", "understand", ".", "Goodbye", "George", "E", ".", "Bush", ".", "www.google.com", "."
@@ -174,7 +172,7 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
 
 
   val targetText2 = "I'd like to say we didn't expect that. Jane's boyfriend."
-  val expected2 = Array(
+  val expected2: Array[Annotation] = Array(
     Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
     Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
     Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
@@ -200,22 +198,22 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
     )
   }
 
-  val targetText3 = s"I'd      like to say${ls}we didn't${ls+ls}" +
-    s" expect\nthat. ${ls+ls} " +
-    s"Jane's\\nboyfriend\tsaid.${ls+ls}"
-  val expected3 = Array(
+  val targetText3: String = s"I'd      like to say${ls}we didn't${ls + ls}" +
+    s" expect\nthat. ${ls + ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls + ls}"
+  val expected3: Array[Annotation] = Array(
     Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 4+5, 7+5, "like", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 9+5, 10+5, "to", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 12+5, 14+5, "say", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 15+5+lsl, 16+5+lsl, "we", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 18+5+lsl, 23+5+lsl, "didn't", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 25+5+(lsl*3), 30+5+(lsl*3), "expect", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 32+5+(lsl*3), 35+5+(lsl*3), "that", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 36+5+(lsl*3), 36+5+(lsl*3), ".", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 39+5+(lsl*5), 55+5+(lsl*5), "Jane's\\nboyfriend", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 57+5+(lsl*5), 60+5+(lsl*5), "said", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 61+5+(lsl*5), 61+5+(lsl*5), ".", Map("sentence" -> "0"))
+    Annotation(AnnotatorType.TOKEN, 4 + 5, 7 + 5, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9 + 5, 10 + 5, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12 + 5, 14 + 5, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 15 + 5 + lsl, 16 + 5 + lsl, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 18 + 5 + lsl, 23 + 5 + lsl, "didn't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 25 + 5 + (lsl * 3), 30 + 5 + (lsl * 3), "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 32 + 5 + (lsl * 3), 35 + 5 + (lsl * 3), "that", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 36 + 5 + (lsl * 3), 36 + 5 + (lsl * 3), ".", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39 + 5 + (lsl * 5), 55 + 5 + (lsl * 5), "Jane's\\nboyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 57 + 5 + (lsl * 5), 60 + 5 + (lsl * 5), "said", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 61 + 5 + (lsl * 5), 61 + 5 + (lsl * 5), ".", Map("sentence" -> "0"))
   )
 
   "a Tokenizer" should s"correctly tokenize a sentence with breaking characters on defaults" taggedAs FastTest in {
@@ -229,10 +227,10 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
     )
   }
 
-  val targetText4 = s"I'd      like to say${ls}we didn't${ls+ls}" +
-    s" expect\nthat. ${ls+ls} " +
-    s"Jane's\\nboyfriend\tsaid.${ls+ls}"
-  val expected4 = Array(
+  val targetText4: String = s"I'd      like to say${ls}we didn't${ls + ls}" +
+    s" expect\nthat. ${ls + ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls + ls}"
+  val expected4: Array[Annotation] = Array(
     Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
     Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
     Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
@@ -248,7 +246,7 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
   )
 
   "a Tokenizer" should s"correctly tokenize a sentence with breaking characters on shrink cleanup" taggedAs FastTest in {
-    val data = DataBuilder.basicDataBuild(targetText4)(cleanupMode="shrink")
+    val data = DataBuilder.basicDataBuild(targetText4)(cleanupMode = "shrink")
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").fit(data)
     val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
     assert(
@@ -258,10 +256,10 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
     )
   }
 
-  val targetText5 = s"I'd      like to say${ls}we didn't${ls+ls}" +
-    s" expect\nthat. ${ls+ls} " +
-    s"Jane's\\nboyfriend\tsaid.${ls+ls}"
-  val expected5 = Array(
+  val targetText5: String = s"I'd      like to say${ls}we didn't${ls + ls}" +
+    s" expect\nthat. ${ls + ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls + ls}"
+  val expected5: Array[Annotation] = Array(
     Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
     Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
     Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
@@ -304,7 +302,7 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
   }
 
   "a Tokenizer" should s"correctly tokenize a sentence with breaking characters on shrink_full cleanup" taggedAs FastTest in {
-    val data = DataBuilder.basicDataBuild(targetText5)(cleanupMode="shrink_full")
+    val data = DataBuilder.basicDataBuild(targetText5)(cleanupMode = "shrink_full")
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").fit(data)
     val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
     assert(
@@ -314,10 +312,10 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
     )
   }
 
-  val targetText6 = s"I'd      like to say${ls}we didn't${ls+ls}" +
-    s" expect\nthat. ${ls+ls} " +
-    s"Jane's\\nboyfriend\tsaid.${ls+ls}"
-  val expected6 = Array(
+  val targetText6: String = s"I'd      like to say${ls}we didn't${ls + ls}" +
+    s" expect\nthat. ${ls + ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls + ls}"
+  val expected6: Array[Annotation] = Array(
     Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
     Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
     Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
@@ -332,7 +330,7 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
   )
 
   "a Tokenizer" should s"correctly tokenize cleanup with composite and exceptions" taggedAs FastTest in {
-    val data = DataBuilder.basicDataBuild(targetText6)(cleanupMode="shrink_full")
+    val data = DataBuilder.basicDataBuild(targetText6)(cleanupMode = "shrink_full")
     val tokenizer = new Tokenizer()
       .setInputCols("document")
       .setOutputCol("token")
@@ -400,28 +398,7 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       .fit(data)
 
     val tokenized = tokenizer.transform(assembled)
-    val result = tokenized.collect()
-  }
-
-  "a silly tokenizer" should "split suffixes" taggedAs FastTest in {
-
-    val data = DataBuilder.basicDataBuild("One, after the\n\nOther, (and) again.\nPO, QAM,")
-    val documentAssembler = new DocumentAssembler()
-      .setInputCol("text")
-      .setOutputCol("doc")
-
-    val assembled = documentAssembler.transform(data)
-
-    val tokenizer = new RecursiveTokenizer()
-      .setInputCols("doc")
-      .setOutputCol("token")
-      .fit(data)
-
-    val tokenized = tokenizer.transform(assembled)
-    val result = tokenized.select("token").as[Seq[Annotation]].collect.head.map(_.result)
-    val expected = Seq("One", ",", "after", "the", "\n", "\n", "Other", ",", "(", "and", ")", "again", ".", "\n", "PO", ",", "QAM", ",")
-    assert(result.equals(expected))
-
+    tokenized.collect()
   }
 
   "a Tokenizer" should "correctly filter out tokens based on setting minimum and maximum lengths" taggedAs FastTest in {
@@ -520,4 +497,60 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
         s"\nresult was \n${result.mkString("\n")} \nexpected is: \n${expected.mkString("\n")}"
     )
   }
+
+
+  "RecursiveTokenizer" should "split suffixes" taggedAs FastTest in {
+
+    val data = DataBuilder.basicDataBuild("One, after the\n\nOther, (and) again.\nPO, QAM,")
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("doc")
+
+    val assembled = documentAssembler.transform(data)
+
+    val tokenizer = new RecursiveTokenizer()
+      .setInputCols("doc")
+      .setOutputCol("token")
+      .fit(data)
+
+    val tokenized = tokenizer.transform(assembled)
+    val result = tokenized.select("token").as[Seq[Annotation]].collect.head.map(_.result)
+    val expected = Seq("One", ",", "after", "the", "\n", "\n", "Other", ",", "(", "and", ")", "again", ".", "\n", "PO", ",", "QAM", ",")
+    assert(result.equals(expected))
+
+  }
+
+  "RecursiveTokenizer" should "be serializable as model" taggedAs FastTest in {
+
+    val data = DataBuilder.basicDataBuild("One, after the\n\nOther, (and) again.\nPO, QAM,")
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("doc")
+
+    val tokenizer = new RecursiveTokenizer()
+      .setInputCols("doc")
+      .setOutputCol("token")
+      .setInfixes(Array("\n", "(", ")"))
+      .setSuffixes(Array(".", ":", "%", ",", ";", "?", "'", "\"", ")", "]", "\n", "!", "'s"))
+      .setWhitelist(Array("it's", "that's", "there's", "he's", "she's", "what's", "let's", "who's",
+        "It's", "That's", "There's", "He's", "She's", "What's", "Let's", "Who's"))
+      .setPrefixes(Array("'", "\"", "(", "[", "\n"))
+
+    val pipeline = new Pipeline().setStages(
+      Array(
+        documentAssembler,
+        tokenizer
+      )
+    )
+
+    val pipelineModel = pipeline.fit(data)
+    pipelineModel.transform(data).show()
+
+    pipelineModel.write.overwrite().save("./tmp_pipelineModel_with_recTokenizer")
+
+    val loadedPipelineModel = PipelineModel.load("./tmp_pipelineModel_with_recTokenizer")
+    loadedPipelineModel.transform(data).show()
+
+  }
+
 }


### PR DESCRIPTION
This PR fixes an issue when there is a `RecursiveTokenizer` annotator inside a saved PipelineModel. Previously, a saved PipelineModel with `RecursiveTokenizer` couldn't be loaded back. Now it can be saved and loaded back without any problem.