### PR TITLE
Add bestModelMetric param to choose between Micro-average or Macro-average for best model

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -4786,6 +4786,8 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     useBestModel
         Whether to restore and use the model that has achieved the best performance
         at the end of the training.
+    bestModelMetric
+        Whether to check F1 Micro-average or F1 Macro-average as a final metric for the best model
     Examples
     --------
     >>> import sparknlp
@@ -4891,6 +4893,10 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
     useBestModel = Param(Params._dummy(), "useBestModel",
                          "Whether to restore and use the model that has achieved the best performance at the end of the training.",
                          TypeConverters.toBoolean)
+
+    bestModelMetric = Param(Params._dummy(), "bestModelMetric",
+                            "Whether to check F1 Micro-average or F1 Macro-average as a final metric for the best model.",
+                            TypeConverters.toString)
 
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
@@ -5086,6 +5092,16 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
         """
         return self._set(useBestModel=value)
 
+    def setBestModelMetric(self, value):
+        """Whether to check F1 Micro-average or F1 Macro-average as a final metric for the best model when setUseBestModel is True
+
+        Parameters
+        ----------
+        value : str
+            Whether to check F1 Micro-average or F1 Macro-average as a final metric for the best model
+        """
+        return self._set(bestModelMetric=value)
+
     @keyword_only
     def __init__(self):
         super(NerDLApproach, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ner.dl.NerDLApproach")
@@ -5105,7 +5121,8 @@ class NerDLApproach(AnnotatorApproach, NerApproach):
             includeAllConfidenceScores=False,
             enableOutputLogs=False,
             enableMemoryOptimizer=False,
-            useBestModel=False
+            useBestModel=False,
+            bestModelMetric="f1_micro"
         )
 
 

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowNer.scala
@@ -161,6 +161,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
             dropout: Float,
             batchSize: Int = 8,
             useBestModel: Boolean = false,
+            bestModelMetric: String = ModelMetrics.microF1,
             startEpoch: Int = 0,
             endEpoch: Int,
             graphFileName: String = "",
@@ -250,7 +251,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
       if (validationSplit > 0.0) {
         println(s"Quality on validation dataset (${validationSplit * 100}%), validation examples = $validLength")
         outputLog(s"Quality on validation dataset (${validationSplit * 100}%), validation examples = $validLength", uuid, enableOutputLogs, outputLogsPath)
-        val (_, newValMicroF1) = measure(validDataset, extended = evaluationLogExtended, enableOutputLogs = enableOutputLogs, outputLogsPath = outputLogsPath, batchSize = batchSize, uuid = uuid)
+        val (newValMicroF1, newValMacroF1) = measure(validDataset, extended = evaluationLogExtended, enableOutputLogs = enableOutputLogs, outputLogsPath = outputLogsPath, batchSize = batchSize, uuid = uuid)
         if (useBestModel && bestModelMetric == ModelMetrics.valMicroF1) {
           if (newValMicroF1 >= lastValMicroF1) {
             lastCheckPoints = saveBestModel()
@@ -262,7 +263,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
       if (test.nonEmpty) {
         println("Quality on test dataset: ")
         outputLog("Quality on test dataset: ", uuid, enableOutputLogs, outputLogsPath)
-        val (_, newTestMicroF1) = measure(test, extended = evaluationLogExtended, enableOutputLogs = enableOutputLogs, outputLogsPath = outputLogsPath, batchSize = batchSize, uuid = uuid)
+        val (newTestMicroF1, newTestMacroF1) = measure(test, extended = evaluationLogExtended, enableOutputLogs = enableOutputLogs, outputLogsPath = outputLogsPath, batchSize = batchSize, uuid = uuid)
         if (useBestModel && bestModelMetric == ModelMetrics.testMicroF1) {
           if (newTestMicroF1 >= lastTestMircoF1) {
             lastCheckPoints = saveBestModel()
@@ -422,6 +423,7 @@ class TensorflowNer(val tensorflow: TensorflowWrapper,
     println(s"Micro-average\t prec: $prec, rec: $rec, f1: $f1")
     outputLog(s"Micro-average\t prec: $prec, rec: $rec, f1: $f1", uuid, enableOutputLogs, outputLogsPath)
 
+    // (Micro-average, Macro-average)
     (f1, macroF1)
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerApproach.scala
@@ -146,6 +146,8 @@ object Verbose extends Enumeration {
 
 object ModelMetrics {
 
+  val microF1 = "f1_micro"
+  val macroF1 = "f1_macro"
   val testMicroF1 = "test_micro_f1"
   val testMacroF1 = "test_macro_f1"
   val valMicroF1 = "val_micro_f1"

--- a/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
+++ b/src/test/scala/com/johnsnowlabs/benchmarks/jvm/NerDLCoNLL2003.scala
@@ -83,7 +83,7 @@ object NerDLCoNLL2003 extends App {
     val model = new TensorflowNer(tf, encoder, Verbose.All)
     for (epoch <- 0 until 150) {
       model.train(trainDataset.grouped(32), trainDataset.size, Array[(TextSentenceLabels, WordpieceEmbeddingsSentence)]().grouped(32),
-        trainDataset.length, 1e-3f, 0.005f, 0.5f, 8, false, epoch, epoch + 1, outputLogsPath = "")
+        trainDataset.length, 1e-3f, 0.005f, 0.5f, 8, false, "f1_micro", epoch, epoch + 1, outputLogsPath = "")
 
       System.out.println("\n\nQuality on train data")
       model.measure(trainDataset.grouped(32), extended = true, outputLogsPath = "")


### PR DESCRIPTION
This PR introduces a new param to NerDLApproach `bestModelMetric` to set to either `f1_micro` or `f1_macro`. This will be the metric to keep track of during the training when `useBestModel` is set to `true`. (by default it will be `f1_micro`)

