### PR TITLE
fix tokens order based in ContextSpellCheckerModel when there are sentences

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
@@ -515,7 +515,7 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
    * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
    */
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
-    val decodedSentPaths = annotations.groupBy(_.metadata.getOrElse("sentence", "0")).mapValues { sentTokens =>
+    val decodedSentPaths = annotations.groupBy(_.metadata.getOrElse("sentence", "0").toInt).mapValues { sentTokens =>
       val (decodedPath, cost) = toOption(getOrDefault(useNewLines)).map { _ =>
         val idxs = Seq(-1) ++ sentTokens.zipWithIndex.filter { case (a, _) => a.result.equals(System.lineSeparator) || a.result.equals(System.lineSeparator * 2) }.
           map(_._2) ++ Seq(annotations.length)
@@ -536,7 +536,7 @@ class ContextSpellCheckerModel(override val uid: String) extends AnnotatorModel[
         )
     }
 
-    decodedSentPaths.values.flatten.toSeq
+    decodedSentPaths.values.toList.reverse.flatten
   }
 
   def toOption(boolean: Boolean): Option[Boolean] = {

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
@@ -21,12 +21,13 @@ import com.johnsnowlabs.nlp.annotator.RecursiveTokenizer
 import com.johnsnowlabs.nlp.annotators.Tokenizer
 import com.johnsnowlabs.nlp.annotators.common.{PrefixedToken, SuffixedToken}
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
+import com.johnsnowlabs.nlp.annotators.sentence_detector_dl.SentenceDetectorDLModel
 import com.johnsnowlabs.nlp.annotators.spell.context.parser._
 import com.johnsnowlabs.nlp.{Annotation, DocumentAssembler, LightPipeline, SparkAccessor}
 import com.johnsnowlabs.tags.{FastTest, SlowTest}
-
 import org.apache.commons.io.FileUtils
 import org.apache.spark.ml.Pipeline
+import org.junit.Assert.assertEquals
 import org.scalatest.flatspec.AnyFlatSpec
 
 import java.io._
@@ -83,6 +84,32 @@ class ContextSpellCheckerTestSpec extends AnyFlatSpec {
     assert(results(0) < results(1))
 
   }
+  "ContextSpellchker" should "return correct order" taggedAs SlowTest in new distFile {
+    val data = Seq("It was a cold. The country was white withh snow .").toDF("text")
+    val documentAssembler = new DocumentAssembler().setInputCol("text").setOutputCol("document")
+    val sentenceDetector = new SentenceDetector().setInputCols("document").setOutputCol("sentences")
+    val tokenizer = new Tokenizer().setInputCols("sentences").setOutputCol("tokens")
+    val spell_checker = ContextSpellCheckerModel.pretrained().setInputCols("tokens").setOutputCol("corrected_tokens")
+    val pipeline = new Pipeline().setStages(Array(documentAssembler,sentenceDetector,tokenizer,spell_checker)).fit(data)
+
+
+    val output_df = pipeline.transform(data)
+
+    val annotation = Annotation.collect(output_df,"corrected_tokens").flatten
+    assertEquals("It",annotation.head.result)
+    assertEquals("was",annotation(1).result)
+    assertEquals("a",annotation(2).result)
+    assertEquals("cold",annotation(3).result)
+    assertEquals(".",annotation(4).result)
+    assertEquals("The",annotation(5).result)
+    assertEquals("country",annotation(6).result)
+    assertEquals("was",annotation(7).result)
+    assertEquals("white",annotation(8).result)
+    assertEquals("with",annotation(9).result)
+    assertEquals("snow",annotation(10).result)
+
+  }
+
   // This test fails in GitHub Actions
   "Special classes" should "serialize/deserialize properly during model save" taggedAs SlowTest in {
     import SparkAccessor.spark


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The contextSpellcheker return wrong order when we use a sentence detector.




## How Has This Been Tested?
I create a test to return the correct order.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
