### PR TITLE
Feature/init spark32 realtime output

### DIFF
--- a/.lift/ignoreFiles
+++ b/.lift/ignoreFiles
@@ -2,8 +2,10 @@
 # Created by https://www.gitignore.io/api/sbt,java,scala,python,eclipse,intellij,intellij+all
 
 **/docs/**
+docs/**
 **/*.min.js
 **/*.js
+python/**
 
 ### Eclipse ###
 

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -189,7 +189,11 @@ def start(gpu=False,
                 spark_conf.set("spark.kryoserializer.buffer.max", spark_nlp_config.serializer_max_buffer)
                 spark_conf.set("spark.driver.maxResultSize", spark_nlp_config.driver_max_result_size)
 
-                if gpu:
+                if spark32:
+                    spark_conf.set("spark.jars.packages", spark_nlp_config.maven_spark32)
+                elif gpu and spark32:
+                    spark_conf.set("spark.jars.packages", spark_nlp_config.maven_gpu_spark32)
+                elif gpu:
                     spark_conf.set("spark.jars.packages", spark_nlp_config.maven_gpu_spark)
                 else:
                     spark_conf.set("spark.jars.packages", spark_nlp_config.maven_spark)


### PR DESCRIPTION
This PR adds Spark 3.2 support to `real_time_output` function. Currently, it will only use Spark 3.0/3.1 regardless of `spark32` flag being `False` or `True`.