### PR TITLE
Adding sentence match parameter to EntityRuler

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,6 +9,7 @@ on:
       - 'example/**'
       - '**.md'
       - '**.yaml'
+      - '**.yml'
     branches:
       - 'master'
       - '*release*'
@@ -22,6 +23,7 @@ on:
       - 'example/**'
       - '**.md'
       - '**.yaml'
+      - '**.yml'
     branches:
       - 'master'
       - 'main'

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -14903,6 +14903,11 @@ class EntityRulerApproach(AnnotatorApproach, HasStorage):
                        "Whether to use RocksDB storage to serialize patterns",
                        typeConverter=TypeConverters.toBoolean)
 
+    sentenceMatch = Param(Params._dummy(),
+                          "sentenceMatch",
+                          "Whether to find match at sentence level. True: sentence level. False: token level",
+                          typeConverter=TypeConverters.toBoolean)
+
     @keyword_only
     def __init__(self):
         super(EntityRulerApproach, self).__init__(
@@ -14941,6 +14946,16 @@ class EntityRulerApproach(AnnotatorApproach, HasStorage):
             Whether to use RocksDB storage to serialize patterns.
         """
         return self._set(useStorage=value)
+
+    def setSentenceMatch(self, value):
+        """Sets whether to find match at sentence level.
+
+        Parameters
+        ----------
+        value : bool
+            True: sentence level. False: token level
+        """
+        return self._set(sentenceMatch=value)
 
     def _create_model(self, java_model):
         return EntityRulerModel(java_model=java_model)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/er/EntityRulerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/er/EntityRulerModel.scala
@@ -17,7 +17,7 @@
 package com.johnsnowlabs.nlp.annotators.er
 
 import com.johnsnowlabs.nlp.AnnotatorType.{CHUNK, DOCUMENT, TOKEN}
-import com.johnsnowlabs.nlp.annotators.common.{TokenizedSentence, TokenizedWithSentence}
+import com.johnsnowlabs.nlp.annotators.common.{IndexedToken, Sentence, SentenceSplit, TokenizedSentence, TokenizedWithSentence}
 import com.johnsnowlabs.nlp.serialization.StructFeature
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasPretrained, HasSimpleAnnotate}
 import com.johnsnowlabs.storage.Database.{ENTITY_PATTERNS, ENTITY_REGEX_PATTERNS, Name}
@@ -63,6 +63,9 @@ class EntityRulerModel(override val uid: String) extends AnnotatorModel[EntityRu
   private[er] val entityRulerFeatures: StructFeature[EntityRulerFeatures] =
     new StructFeature[EntityRulerFeatures](this, "Structure to store data when RocksDB is not used")
 
+  private[er] val sentenceMatch = new BooleanParam(this, "sentenceMatch",
+    "Whether to find match at sentence level. True: sentence level. False: token level")
+
   private[er] def setEnablePatternRegex(value: Boolean): this.type = set(enablePatternRegex, value)
 
   private[er] def setRegexEntities(value: Array[String]): this.type = set(regexEntities, value)
@@ -70,6 +73,8 @@ class EntityRulerModel(override val uid: String) extends AnnotatorModel[EntityRu
   private[er] def setEntityRulerFeatures(value: EntityRulerFeatures): this.type = set(entityRulerFeatures, value)
 
   private[er] def setUseStorage(value: Boolean): this.type = set(useStorage, value)
+
+  private[er] def setSentenceMatch(value: Boolean): this.type = set(sentenceMatch, value)
 
   /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */
   val inputAnnotatorTypes: Array[String] = Array(DOCUMENT, TOKEN)
@@ -83,6 +88,11 @@ class EntityRulerModel(override val uid: String) extends AnnotatorModel[EntityRu
    */
   def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
 
+    if ($(sentenceMatch)) getAnnotationBySentence(annotations) else getAnnotationByToken(annotations)
+
+  }
+
+  private def getAnnotationByToken(annotations: Seq[Annotation]): Seq[Annotation] = {
     val tokenizedWithSentences = TokenizedWithSentence.unpack(annotations)
     var annotatedEntities: Seq[Annotation] = Seq()
 
@@ -98,8 +108,15 @@ class EntityRulerModel(override val uid: String) extends AnnotatorModel[EntityRu
     annotatedEntities
   }
 
+  private def getAnnotationBySentence(annotations: Seq[Annotation]): Seq[Annotation] = {
+    val patternsReader = if ($(useStorage)) Some(getReader(Database.ENTITY_REGEX_PATTERNS).asInstanceOf[RegexPatternsReader]) else None
+    val sentences = SentenceSplit.unpack(annotations)
+    annotateEntitiesFromPatternsBySentence(sentences, patternsReader)
+  }
+
   private def annotateEntitiesFromRegexPatterns(tokenizedWithSentences: Seq[TokenizedSentence],
                                                 regexPatternsReader: Option[RegexPatternsReader]): Seq[Annotation] = {
+
     val annotatedEntities = tokenizedWithSentences.flatMap { tokenizedWithSentence =>
       tokenizedWithSentence.indexedTokens.flatMap { indexedToken =>
         val entity = getMatchedEntity(indexedToken.token, regexPatternsReader)
@@ -134,8 +151,48 @@ class EntityRulerModel(override val uid: String) extends AnnotatorModel[EntityRu
     matchesByEntity.headOption
   }
 
+  private def getMatchedEntityBySentence(sentence: Sentence, regexPatternsReader: Option[RegexPatternsReader]):
+  Array[(IndexedToken, String)] = {
+
+    val matchesByEntity = $(regexEntities).flatMap { regexEntity =>
+      val regexPatterns: Option[Seq[String]] = regexPatternsReader match {
+        case Some(rpr) => rpr.lookup(regexEntity)
+        case None => $$(entityRulerFeatures).regexPatterns.get(regexEntity)
+      }
+      if (regexPatterns.isDefined) {
+
+        val resultMatches = regexPatterns.get.flatMap{ regexPattern =>
+          val matchedResult = regexPattern.r.findFirstMatchIn(sentence.content)
+          if (matchedResult.isDefined) {
+            val begin = matchedResult.get.start + sentence.start
+            val end = matchedResult.get.end + sentence.start - 1
+            Some(matchedResult.get.toString(), begin, end, regexEntity)
+          } else None
+        }
+
+        val filteredMatches = filterOverlappingMatches(resultMatches)
+        if (filteredMatches.nonEmpty) Some(filteredMatches) else None
+      } else None
+    }.flatten.sortBy(_._2)
+
+    matchesByEntity.map(matches => (IndexedToken(matches._1, matches._2, matches._3), matches._4))
+  }
+
+  private def filterOverlappingMatches(matches: Seq[(String, Int, Int, String)]): Seq[(String, Int, Int, String)] = {
+
+    val groupByBegin = matches.groupBy(_._2).filter(_._2.length > 1)
+    val groupByEnd = matches.groupBy(_._3).filter(_._2.length > 1)
+
+    val overlappingBegin = groupByBegin.flatMap(ngram => ngram._2.sortBy(_._1.length)).dropRight(1)
+    val overlappingEnd = groupByEnd.flatMap(ngram => ngram._2.sortBy(_._1.length)).dropRight(1)
+    val overlappingMatches = (overlappingBegin ++ overlappingEnd).toSeq.distinct
+
+    matches diff overlappingMatches
+  }
+
   private def annotateEntitiesFromPatterns(tokenizedWithSentences: Seq[TokenizedSentence],
                                            patternsReader: Option[PatternsReader]): Seq[Annotation] = {
+
     val annotatedEntities = tokenizedWithSentences.flatMap { tokenizedWithSentence =>
       tokenizedWithSentence.indexedTokens.flatMap { indexedToken =>
         val labelData: Option[String] = patternsReader match {
@@ -151,6 +208,20 @@ class EntityRulerModel(override val uid: String) extends AnnotatorModel[EntityRu
       }
     }
 
+    annotatedEntities
+  }
+
+  private def annotateEntitiesFromPatternsBySentence(sentences: Seq[Sentence],
+                                                     patternsReader: Option[RegexPatternsReader]): Seq[Annotation] = {
+
+    val annotatedEntities = sentences.flatMap{ sentence =>
+      val matchedEntities = getMatchedEntityBySentence(sentence, patternsReader)
+      matchedEntities.map{ case (indexedToken, label) =>
+        val entityMetadata = getEntityMetadata(Some(label))
+        Annotation(CHUNK, indexedToken.begin, indexedToken.end, indexedToken.token,
+          entityMetadata ++ Map("sentence" -> sentence.index.toString))
+      }
+    }
     annotatedEntities
   }
 

--- a/src/main/scala/com/johnsnowlabs/util/spark/SparkUtil.scala
+++ b/src/main/scala/com/johnsnowlabs/util/spark/SparkUtil.scala
@@ -1,0 +1,13 @@
+package com.johnsnowlabs.util.spark
+
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions.udf
+
+object SparkUtil {
+
+  //Helper UDF function to flatten arrays for Spark < 2.4.0
+  def flattenArrays: UserDefinedFunction = udf { (arrayColumn: Seq[Seq[String]]) =>
+    arrayColumn.flatten.distinct
+  }
+
+}

--- a/src/test/resources/entity-ruler/patterns.csv
+++ b/src/test/resources/entity-ruler/patterns.csv
@@ -1,4 +1,5 @@
 PERSON|Jon
 PERSON|John
 PERSON|John Snow
+PERSON|Jon Snow
 LOCATION|Winterfell

--- a/src/test/resources/entity-ruler/patterns.json
+++ b/src/test/resources/entity-ruler/patterns.json
@@ -1,11 +1,11 @@
 [
   {
     "label": "PERSON",
-    "patterns": ["Jon", "John", "John Snow"]
+    "patterns": ["Jon", "John", "John Snow", "Jon Snow"]
   },
   {
     "label": "PERSON",
-    "patterns": ["Stark", "Snow"]
+    "patterns": ["Stark", "Snow", "Doctor John Snow"]
   },
   {
     "label": "PERSON",

--- a/src/test/resources/entity-ruler/patterns.jsonl
+++ b/src/test/resources/entity-ruler/patterns.jsonl
@@ -1,4 +1,4 @@
-{"id": "names-with-j", "label": "PERSON", "patterns": ["Jon", "John", "John Snow"]}
-{"id": "names-with-s", "label": "PERSON", "patterns": ["Stark", "Snow"]}
+{"id": "names-with-j", "label": "PERSON", "patterns": ["Jon", "John", "John Snow", "Jon Snow"]}
+{"id": "names-with-s", "label": "PERSON", "patterns": ["Stark"]}
 {"id": "names-with-e", "label": "PERSON", "patterns": ["Eddard", "Eddard Stark"]}
 {"id": "locations", "label": "LOCATION", "patterns": ["Winterfell"]}

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/er/EntityRulerTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/er/EntityRulerTest.scala
@@ -17,6 +17,7 @@
 package com.johnsnowlabs.nlp.annotators.er
 
 import com.johnsnowlabs.nlp.AnnotatorType.CHUNK
+import com.johnsnowlabs.nlp.annotator.SentenceDetector
 import com.johnsnowlabs.nlp.annotators.SparkSessionTest
 import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs}
 import com.johnsnowlabs.nlp.{Annotation, AssertAnnotations}
@@ -115,7 +116,7 @@ class EntityRulerTest extends AnyFlatSpec with SparkSessionTest {
     val textDataSet = Seq("John Snow lives in Winterfell").toDS.toDF("text")
     tokenizer.setExceptions(Array("John Snow"))
     val externalResource = ExternalResource(s"$testPath/patterns.csv", ReadAs.TEXT, Map("format" -> "csv", "delimiter" -> "\\|"))
-    val entityRulerPipeline = getEntityRulerPipeline(externalResource)
+    val entityRulerPipeline = getEntityRulerPipeline(externalResource, regexPatterns = true)
     val expectedEntities = Array(Seq(
       Annotation(CHUNK, 0, 8, "John Snow", Map("entity" -> "PERSON", "sentence" -> "0")),
       Annotation(CHUNK, 19, 28, "Winterfell", Map("entity" -> "LOCATION", "sentence" -> "0"))
@@ -301,7 +302,7 @@ class EntityRulerTest extends AnyFlatSpec with SparkSessionTest {
     val textDataSet = Seq("John Snow lives in Winterfell").toDS.toDF("text")
     tokenizer.setExceptions(Array("John Snow"))
     val externalResource = ExternalResource(s"$testPath/patterns.csv", ReadAs.TEXT, Map("format" -> "csv", "delimiter" -> "\\|"))
-    val entityRulerPipeline = getEntityRulerPipeline(externalResource, usageStorage = false)
+    val entityRulerPipeline = getEntityRulerPipeline(externalResource, regexPatterns = true, usageStorage = false)
     val expectedEntities = Array(Seq(
       Annotation(CHUNK, 0, 8, "John Snow", Map("entity" -> "PERSON", "sentence" -> "0")),
       Annotation(CHUNK, 19, 28, "Winterfell", Map("entity" -> "LOCATION", "sentence" -> "0"))
@@ -525,6 +526,209 @@ class EntityRulerTest extends AnyFlatSpec with SparkSessionTest {
     val entityRulerPipeline = new Pipeline().setStages(Array(documentAssembler, tokenizer, loadedEntityRulerModel))
 
     val resultDataSet = entityRulerPipeline.fit(emptyDataSet).transform(textDataSet)
+    val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
+
+    AssertAnnotations.assertFields(expectedEntities, actualEntities)
+  }
+
+  private def getEntityRulerPipelineAtSentenceLevel(externalResource: ExternalResource, regexPatterns: Boolean = false,
+                                     useStorage: Boolean = true): PipelineModel = {
+
+    val sentenceDetector = new SentenceDetector().setInputCols("document").setOutputCol("sentence")
+
+    val entityRuler = new EntityRulerApproach()
+      .setInputCols("sentence", "token")
+      .setOutputCol("entities")
+      .setPatternsResource(externalResource.path, externalResource.readAs, externalResource.options)
+      .setEnablePatternRegex(regexPatterns)
+      .setUseStorage(useStorage)
+      .setSentenceMatch(true)
+
+    val pipeline = new Pipeline().setStages(Array(documentAssembler, sentenceDetector, tokenizer, entityRuler))
+    val entityRulerPipeline = pipeline.fit(emptyDataSet)
+
+    entityRulerPipeline
+  }
+
+  "An Entity Ruler model at sentence level" should "infer entities when reading JSON file" taggedAs FastTest in {
+    val textDataSet = Seq("Doctor John Snow lives in London, whereas Lord Commander Jon Snow lives in Castle Black").toDS.toDF("text")
+    val externalResource = ExternalResource(s"$testPath/patterns.json", ReadAs.TEXT, Map("format" -> "json"))
+    val entityRulerPipeline = getEntityRulerPipelineAtSentenceLevel(externalResource)
+    val expectedEntities = Array(Seq(
+      Annotation(CHUNK, 0, 15, "Doctor John Snow", Map("entity" -> "PERSON", "sentence" -> "0")),
+      Annotation(CHUNK, 57, 64, "Jon Snow", Map("entity" -> "PERSON", "sentence" -> "0"))
+    ))
+
+    val resultDataSet = entityRulerPipeline.transform(textDataSet)
+    val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
+
+    AssertAnnotations.assertFields(expectedEntities, actualEntities)
+  }
+
+  it should "infer entities when reading JSON file as Spark" taggedAs FastTest in {
+    val textDataSet = Seq("Doctor John Snow lives in London, whereas Lord Commander Jon Snow lives in Castle Black").toDS.toDF("text")
+    val externalResource = ExternalResource(s"$testPath/patterns.json", ReadAs.SPARK, Map("format" -> "json"))
+    val entityRulerPipeline = getEntityRulerPipelineAtSentenceLevel(externalResource)
+    val expectedEntities = Array(Seq(
+      Annotation(CHUNK, 0, 15, "Doctor John Snow", Map("entity" -> "PERSON", "sentence" -> "0")),
+      Annotation(CHUNK, 57, 64, "Jon Snow", Map("entity" -> "PERSON", "sentence" -> "0"))
+    ))
+
+    val resultDataSet = entityRulerPipeline.transform(textDataSet)
+    val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
+
+    AssertAnnotations.assertFields(expectedEntities, actualEntities)
+  }
+
+  it should "infer entities when reading JSON file without storage" taggedAs FastTest in {
+    val textDataSet = Seq("Doctor John Snow lives in London, whereas Lord Commander Jon Snow lives in Castle Black").toDS.toDF("text")
+    val externalResource = ExternalResource(s"$testPath/patterns.json", ReadAs.TEXT, Map("format" -> "json"))
+    val entityRulerPipeline = getEntityRulerPipelineAtSentenceLevel(externalResource, useStorage = false)
+    val expectedEntities = Array(Seq(
+      Annotation(CHUNK, 0, 15, "Doctor John Snow", Map("entity" -> "PERSON", "sentence" -> "0")),
+      Annotation(CHUNK, 57, 64, "Jon Snow", Map("entity" -> "PERSON", "sentence" -> "0"))
+    ))
+
+    val resultDataSet = entityRulerPipeline.transform(textDataSet)
+    val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
+
+    AssertAnnotations.assertFields(expectedEntities, actualEntities)
+  }
+
+  it should "infer entities when reading JSON file without storage and Spark" taggedAs FastTest in {
+    val textDataSet = Seq("Doctor John Snow lives in London, whereas Lord Commander Jon Snow lives in Castle Black").toDS.toDF("text")
+    val externalResource = ExternalResource(s"$testPath/patterns.json", ReadAs.SPARK, Map("format" -> "json"))
+    val entityRulerPipeline = getEntityRulerPipelineAtSentenceLevel(externalResource, useStorage = false)
+    val expectedEntities = Array(Seq(
+      Annotation(CHUNK, 0, 15, "Doctor John Snow", Map("entity" -> "PERSON", "sentence" -> "0")),
+      Annotation(CHUNK, 57, 64, "Jon Snow", Map("entity" -> "PERSON", "sentence" -> "0"))
+    ))
+
+    val resultDataSet = entityRulerPipeline.transform(textDataSet)
+    val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
+
+    AssertAnnotations.assertFields(expectedEntities, actualEntities)
+  }
+
+  it should "infer entities when reading JSON lines file" taggedAs FastTest in {
+    val textDataSet = Seq("In London, John Snow is a Physician. In Castle Black, Jon Snow is a Lord Commander").toDS.toDF("text")
+    val externalResource = ExternalResource(s"$testPath/patterns.jsonl", ReadAs.TEXT, Map("format" -> "jsonl"))
+    val entityRulerPipeline = getEntityRulerPipelineAtSentenceLevel(externalResource)
+    val expectedEntities = Array(Seq(
+      Annotation(CHUNK, 11, 19, "John Snow", Map("entity" -> "PERSON", "id" -> "names-with-j", "sentence" -> "0")),
+      Annotation(CHUNK, 54, 61, "Jon Snow", Map("entity" -> "PERSON", "id" -> "names-with-j", "sentence" -> "1"))
+    ))
+
+    val resultDataSet = entityRulerPipeline.transform(textDataSet)
+    val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
+
+    AssertAnnotations.assertFields(expectedEntities, actualEntities)
+  }
+
+  it should "infer entities when reading JSON lines file as Spark" taggedAs FastTest in {
+    val textDataSet = Seq("In London, John Snow is a Physician. In Castle Black, Jon Snow is a Lord Commander").toDS.toDF("text")
+    val externalResource = ExternalResource(s"$testPath/patterns.jsonl", ReadAs.SPARK, Map("format" -> "jsonl"))
+    val entityRulerPipeline = getEntityRulerPipelineAtSentenceLevel(externalResource)
+    val expectedEntities = Array(Seq(
+      Annotation(CHUNK, 11, 19, "John Snow", Map("entity" -> "PERSON", "id" -> "names-with-j", "sentence" -> "0")),
+      Annotation(CHUNK, 54, 61, "Jon Snow", Map("entity" -> "PERSON", "id" -> "names-with-j", "sentence" -> "1"))
+    ))
+
+    val resultDataSet = entityRulerPipeline.transform(textDataSet)
+    val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
+
+    AssertAnnotations.assertFields(expectedEntities, actualEntities)
+  }
+
+  it should "infer entities when reading JSON lines file without storage" taggedAs FastTest in {
+    val textDataSet = Seq("In London, John Snow is a Physician. In Castle Black, Jon Snow is a Lord Commander").toDS.toDF("text")
+    val externalResource = ExternalResource(s"$testPath/patterns.jsonl", ReadAs.TEXT, Map("format" -> "jsonl"))
+    val entityRulerPipeline = getEntityRulerPipelineAtSentenceLevel(externalResource, useStorage = false)
+    val expectedEntities = Array(Seq(
+      Annotation(CHUNK, 11, 19, "John Snow", Map("entity" -> "PERSON", "id" -> "names-with-j", "sentence" -> "0")),
+      Annotation(CHUNK, 54, 61, "Jon Snow", Map("entity" -> "PERSON", "id" -> "names-with-j", "sentence" -> "1"))
+    ))
+
+    val resultDataSet = entityRulerPipeline.transform(textDataSet)
+    val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
+
+    AssertAnnotations.assertFields(expectedEntities, actualEntities)
+  }
+
+  it should "infer entities when reading JSON lines file without storage and Spark" taggedAs FastTest in {
+    val textDataSet = Seq("In London, John Snow is a Physician. In Castle Black, Jon Snow is a Lord Commander").toDS.toDF("text")
+    val externalResource = ExternalResource(s"$testPath/patterns.jsonl", ReadAs.SPARK, Map("format" -> "jsonl"))
+    val entityRulerPipeline = getEntityRulerPipelineAtSentenceLevel(externalResource, useStorage = false)
+    val expectedEntities = Array(Seq(
+      Annotation(CHUNK, 11, 19, "John Snow", Map("entity" -> "PERSON", "id" -> "names-with-j", "sentence" -> "0")),
+      Annotation(CHUNK, 54, 61, "Jon Snow", Map("entity" -> "PERSON", "id" -> "names-with-j", "sentence" -> "1"))
+    ))
+
+    val resultDataSet = entityRulerPipeline.transform(textDataSet)
+    val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
+
+    AssertAnnotations.assertFields(expectedEntities, actualEntities)
+  }
+
+  it should "infer entities when reading CSV file" taggedAs FastTest in {
+    val textDataSet = Seq("In London, John Snow is a Physician. In Castle Black, Jon Snow is a Lord Commander").toDS.toDF("text")
+    val externalResource = ExternalResource(s"$testPath/patterns.csv", ReadAs.TEXT,
+      Map("format" -> "csv", "delimiter" -> "\\|"))
+    val entityRulerPipeline = getEntityRulerPipelineAtSentenceLevel(externalResource, regexPatterns = true)
+    val expectedEntities = Array(Seq(
+      Annotation(CHUNK, 11, 19, "John Snow", Map("entity" -> "PERSON", "sentence" -> "0")),
+      Annotation(CHUNK, 54, 61, "Jon Snow", Map("entity" -> "PERSON", "sentence" -> "1"))
+    ))
+
+    val resultDataSet = entityRulerPipeline.transform(textDataSet)
+    val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
+
+    AssertAnnotations.assertFields(expectedEntities, actualEntities)
+  }
+
+  it should "infer entities when reading CSV file as Spark" taggedAs FastTest in {
+    val textDataSet = Seq("In London, John Snow is a Physician. In Castle Black, Jon Snow is a Lord Commander").toDS.toDF("text")
+    val externalResource = ExternalResource(s"$testPath/patterns.csv", ReadAs.SPARK,
+      Map("format" -> "csv", "delimiter" -> "|"))
+    val entityRulerPipeline = getEntityRulerPipelineAtSentenceLevel(externalResource, regexPatterns = true)
+    val expectedEntities = Array(Seq(
+      Annotation(CHUNK, 11, 19, "John Snow", Map("entity" -> "PERSON", "sentence" -> "0")),
+      Annotation(CHUNK, 54, 61, "Jon Snow", Map("entity" -> "PERSON", "sentence" -> "1"))
+    ))
+
+    val resultDataSet = entityRulerPipeline.transform(textDataSet)
+    val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
+
+    AssertAnnotations.assertFields(expectedEntities, actualEntities)
+  }
+
+  it should "infer entities when reading CSV file without storage" taggedAs FastTest in {
+    val textDataSet = Seq("In London, John Snow is a Physician. In Castle Black, Jon Snow is a Lord Commander").toDS.toDF("text")
+    val externalResource = ExternalResource(s"$testPath/patterns.csv", ReadAs.TEXT,
+      Map("format" -> "csv", "delimiter" -> "\\|"))
+    val entityRulerPipeline = getEntityRulerPipelineAtSentenceLevel(externalResource, useStorage = false)
+    val expectedEntities = Array(Seq(
+      Annotation(CHUNK, 11, 19, "John Snow", Map("entity" -> "PERSON", "sentence" -> "0")),
+      Annotation(CHUNK, 54, 61, "Jon Snow", Map("entity" -> "PERSON", "sentence" -> "1"))
+    ))
+
+    val resultDataSet = entityRulerPipeline.transform(textDataSet)
+    val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
+
+    AssertAnnotations.assertFields(expectedEntities, actualEntities)
+  }
+
+  it should "infer entities when reading CSV file without storage and Spark" taggedAs FastTest in {
+    val textDataSet = Seq("In London, John Snow is a Physician. In Castle Black, Jon Snow is a Lord Commander").toDS.toDF("text")
+    val externalResource = ExternalResource(s"$testPath/patterns.csv", ReadAs.SPARK,
+      Map("format" -> "csv", "delimiter" -> "|"))
+    val entityRulerPipeline = getEntityRulerPipelineAtSentenceLevel(externalResource, useStorage = false)
+    val expectedEntities = Array(Seq(
+      Annotation(CHUNK, 11, 19, "John Snow", Map("entity" -> "PERSON", "sentence" -> "0")),
+      Annotation(CHUNK, 54, 61, "Jon Snow", Map("entity" -> "PERSON", "sentence" -> "1"))
+    ))
+
+    val resultDataSet = entityRulerPipeline.transform(textDataSet)
     val actualEntities = AssertAnnotations.getActualResult(resultDataSet, "entities")
 
     AssertAnnotations.assertFields(expectedEntities, actualEntities)

--- a/src/test/scala/com/johnsnowlabs/util/JsonParserTest.scala
+++ b/src/test/scala/com/johnsnowlabs/util/JsonParserTest.scala
@@ -47,8 +47,8 @@ class JsonParserTest extends AnyFlatSpec {
     val stream = ResourceHelper.getResourceStream("src/test/resources/entity-ruler/patterns.json")
     val jsonContent = Source.fromInputStream(stream).mkString
     val expectedResult = Array(
-      EntityPattern("PERSON", Seq("Jon", "John", "John Snow")),
-      EntityPattern("PERSON", Seq("Stark", "Snow")),
+      EntityPattern("PERSON", Seq("Jon", "John", "John Snow", "Jon Snow")),
+      EntityPattern("PERSON", Seq("Stark", "Snow", "Doctor John Snow")),
       EntityPattern("PERSON", Seq("Eddard", "Eddard Stark")),
       EntityPattern("LOCATION", Seq("Winterfell")))
 

--- a/src/test/scala/com/johnsnowlabs/util/ResourceHelperTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/util/ResourceHelperTestSpec.scala
@@ -129,8 +129,8 @@ class ResourceHelperTestSpec extends AnyFlatSpec {
   it should "get content from SourceStream" taggedAs FastTest in {
     val sourceStream =  ResourceHelper.SourceStream("src/test/resources/entity-ruler/patterns.jsonl")
     val expectedContent = Array(
-      "{\"id\": \"names-with-j\", \"label\": \"PERSON\", \"patterns\": [\"Jon\", \"John\", \"John Snow\"]}",
-      "{\"id\": \"names-with-s\", \"label\": \"PERSON\", \"patterns\": [\"Stark\", \"Snow\"]}",
+      "{\"id\": \"names-with-j\", \"label\": \"PERSON\", \"patterns\": [\"Jon\", \"John\", \"John Snow\", \"Jon Snow\"]}",
+      "{\"id\": \"names-with-s\", \"label\": \"PERSON\", \"patterns\": [\"Stark\"]}",
       "{\"id\": \"names-with-e\", \"label\": \"PERSON\", \"patterns\": [\"Eddard\", \"Eddard Stark\"]}",
       "{\"id\": \"locations\", \"label\": \"LOCATION\", \"patterns\": [\"Winterfell\"]}"
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
Adding `sentenceMatch` parameter to allow finding matches at the sentence level.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are scenarios that require multi-token matches. Since this annotator finds matches at the token level it was not possible. 

By adding `sentenceMatch` parameter (set to true), the annotator allows finding a match at the sentence level, which will allow matching words with spaces. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Adding unit test to the test suite

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
