### PR TITLE
Fix GraphExtraction crashing when fullAnnotate and document are used at the same time

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/GraphExtraction.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/GraphExtraction.scala
@@ -49,7 +49,7 @@ import scala.collection.immutable.Map
  *   1. Setting `setMergeEntities` to `true` will download the default pretrained models for those two Annotators
  *      automatically. The specific models can also be set with `setDependencyParserModel` and
  *      `setTypedDependencyParserModel`:
- *      {{{
+ * {{{
  *            val graph_extraction = new GraphExtraction()
  *              .setInputCols("document", "token", "ner")
  *              .setOutputCol("graph")
@@ -57,7 +57,7 @@ import scala.collection.immutable.Map
  *              .setMergeEntities(true)
  *            //.setDependencyParserModel(Array("dependency_conllu", "en",  "public/models"))
  *            //.setTypedDependencyParserModel(Array("dependency_typed_conllu", "en",  "public/models"))
- *      }}}
+ * }}}
  *
  * To transform the resulting graph into a more generic form such as RDF, see the
  * [[com.johnsnowlabs.nlp.GraphFinisher GraphFinisher]].
@@ -159,6 +159,7 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * Find paths between a pair of token and entity (Default: `Array()`)
+   *
    * @group param
    */
   val relationshipTypes = new StringArrayParam(this, "relationshipTypes",
@@ -166,6 +167,7 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * Find paths between a pair of entities (Default: `Array()`)
+   *
    * @group param
    */
   val entityTypes = new StringArrayParam(this, "entityTypes",
@@ -173,6 +175,7 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * When set to true find paths between entities (Default: `false`)
+   *
    * @group param
    */
   val explodeEntities = new BooleanParam(this, "explodeEntities",
@@ -180,6 +183,7 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * Tokens to be consider as root to start traversing the paths (Default: `Array()`). Use it along with `explodeEntities`
+   *
    * @group param
    */
   val rootTokens = new StringArrayParam(this, "rootTokens",
@@ -187,6 +191,7 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * Maximum sentence size that the annotator will process (Default: `1000`). Above this, the sentence is skipped
+   *
    * @group param
    */
   val maxSentenceSize = new IntParam(this, "maxSentenceSize",
@@ -194,6 +199,7 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * Minimum sentence size that the annotator will process (Default: `2`). Below this, the sentence is skipped
+   *
    * @group param
    */
   val minSentenceSize = new IntParam(this, "minSentenceSize",
@@ -201,6 +207,7 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * Merge same neighboring entities as a single token (Default: `false`)
+   *
    * @group param
    */
   val mergeEntities = new BooleanParam(this, "mergeEntities",
@@ -208,12 +215,14 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * IOB format to apply when merging entities
+   *
    * @group param
    */
   val mergeEntitiesIOBFormat = new Param[String](this, "mergeEntitiesIOBFormat", "IOB format to apply when merging entities. Values: IOB or IOB2")
 
   /**
    * Whether to include edges when building paths (Default: `true`)
+   *
    * @group param
    */
   val includeEdges = new BooleanParam(this, "includeEdges",
@@ -221,6 +230,7 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * Delimiter symbol used for path output (Default: `","`)
+   *
    * @group param
    */
   val delimiter = new Param[String](this, "delimiter",
@@ -228,6 +238,7 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * Coordinates (name, lang, remoteLoc) to a pretrained POS model (Default: `Array()`)
+   *
    * @group param
    */
   val posModel = new StringArrayParam(this, "posModel",
@@ -235,6 +246,7 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * Coordinates (name, lang, remoteLoc) to a pretrained Dependency Parser model (Default: `Array()`)
+   *
    * @group param
    */
   val dependencyParserModel = new StringArrayParam(this, "dependencyParserModel",
@@ -242,6 +254,7 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * Coordinates (name, lang, remoteLoc) to a pretrained Typed Dependency Parser model (Default: `Array()`)
+   *
    * @group param
    */
   val typedDependencyParserModel = new StringArrayParam(this, "typedDependencyParserModel",
@@ -333,8 +346,9 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
       .filter(annotation => annotation.result.length > $(maxSentenceSize) || annotation.result.length < $(minSentenceSize))
       .map(annotation => annotation.metadata("sentence")).toList.distinct
 
-    val annotationsToProcess = annotations.filter(annotation =>
-      !sentenceIndexesToSkip.contains(annotation.metadata("sentence")))
+    val annotationsToProcess = annotations.filter(annotation => {
+      !sentenceIndexesToSkip.contains(annotation.metadata.getOrElse("sentence", "0"))
+    })
 
     if (annotationsToProcess.isEmpty) {
       Seq(Annotation(NODE, 0, 0, "", Map()))
@@ -344,7 +358,7 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
   }
 
   private def computeAnnotatePaths(annotations: Seq[Annotation]): Seq[Annotation] = {
-    val annotationsBySentence = annotations.groupBy(token => token.metadata("sentence").toInt)
+    val annotationsBySentence = annotations.groupBy(token => token.metadata.getOrElse("sentence", "0").toInt)
       .toSeq.sortBy(_._1)
       .map(annotationBySentence => annotationBySentence._2)
 
@@ -564,13 +578,16 @@ class GraphExtraction(override val uid: String) extends AnnotatorModel[GraphExtr
 
   /**
    * Output annotator types: NODE
+   *
    * @group anno
    */
   override val outputAnnotatorType: AnnotatorType = NODE
+
   /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */
 
   /**
    * Input annotator types: DOCUMENT, TOKEN, NAMED_ENTITY
+   *
    * @group anno
    */
   override val inputAnnotatorTypes: Array[String] = Array(DOCUMENT, TOKEN, NAMED_ENTITY)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/GraphExtractionTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/GraphExtractionTest.scala
@@ -17,8 +17,17 @@
 package com.johnsnowlabs.nlp.annotators
 
 import com.johnsnowlabs.nlp.AnnotatorType.NODE
-import com.johnsnowlabs.nlp.{Annotation, AssertAnnotations}
-import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.nlp.annotator.SentenceDetector
+import com.johnsnowlabs.nlp.annotators.ner.NerConverter
+import com.johnsnowlabs.nlp.annotators.ner.dl.NerDLModel
+import com.johnsnowlabs.nlp.annotators.parser.dep.DependencyParserModel
+import com.johnsnowlabs.nlp.annotators.parser.typdep.TypedDependencyParserModel
+import com.johnsnowlabs.nlp.annotators.pos.perceptron.PerceptronModel
+import com.johnsnowlabs.nlp.base.LightPipeline
+import com.johnsnowlabs.nlp.embeddings.WordEmbeddingsModel
+import com.johnsnowlabs.nlp.{Annotation, AssertAnnotations, GraphFinisher}
+import com.johnsnowlabs.tags.{FastTest, SlowTest}
+import org.apache.spark.ml.Pipeline
 import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.collection.mutable
@@ -319,7 +328,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
     AssertAnnotations.assertFields(expectedGraph, actualGraph)
   }
 
-  it should "output paths when Typed Dependency Parser cannot label relations" ignore {
+  it should "output paths when Typed Dependency Parser cannot label relations" taggedAs SlowTest in {
     //Ignored because it requires to download pretrained models which takes a considerable time
     val testDataSet = getEntitiesWithNoTypeParserOutput(spark, tokenizerWithSentencePipeline)
     val graphExtractor = new GraphExtraction()
@@ -342,6 +351,73 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
 
     val actualGraph = AssertAnnotations.getActualResult(graphDataSet, "graph")
     AssertAnnotations.assertFields(expectedGraph, actualGraph)
+  }
+
+  "Graph Extraction with LightPipeline" should "return dependency graphs between all entities" taggedAs SlowTest in {
+    val sentence = new SentenceDetector()
+      .setInputCols("document")
+      .setOutputCol("sentence")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols("sentence")
+      .setOutputCol("token")
+
+    val embeddings = WordEmbeddingsModel.pretrained()
+      .setInputCols("sentence", "token")
+      .setOutputCol("embeddings")
+
+    val nerSmall = NerDLModel.pretrained()
+      .setInputCols(Array("sentence", "token", "embeddings"))
+      .setOutputCol("ner")
+
+    val nerConverter = new NerConverter()
+      .setInputCols("document", "token", "ner")
+      .setOutputCol("entities")
+
+    val pos = PerceptronModel.pretrained()
+      .setInputCols("document", "token")
+      .setOutputCol("pos")
+
+    val dependencyParser = DependencyParserModel.pretrained()
+      .setInputCols("sentence", "pos", "token")
+      .setOutputCol("dependency")
+
+    val typedDependencyParser = TypedDependencyParserModel.pretrained()
+      .setInputCols("dependency", "pos", "token")
+      .setOutputCol("dependency_type")
+
+    val graphExtractor = new GraphExtraction()
+      .setInputCols("document", "token", "ner")
+      .setOutputCol("graph")
+      .setRelationshipTypes(Array("lad-PER", "lad-LOC"))
+
+    val graphFinisher = new GraphFinisher()
+      .setInputCol("graph")
+      .setOutputCol("graph_finished")
+      .setOutputAsArray(false)
+
+    val graphPipeline = new Pipeline().setStages(Array(
+      documentAssembler,
+      sentence,
+      tokenizer,
+      embeddings,
+      nerSmall,
+      nerConverter,
+      pos,
+      dependencyParser,
+      typedDependencyParser,
+      graphExtractor,
+      graphFinisher
+    ))
+
+    val expectedResult = Seq(Annotation(NODE, 0, 0, "[(lad,flat,York),(York,flat,New)],[(lad,flat,York)]", Map()))
+
+    val graphPipelineModel = graphPipeline.fit(emptyDataSet)
+    val lightPipeline = new LightPipeline(graphPipelineModel)
+    val result = lightPipeline.fullAnnotate("Peter Parker is a nice lad and lives in New York")
+
+    assert(result("graph_finished") == expectedResult)
+
   }
 
 }


### PR DESCRIPTION
This PR fixes an exception that happens during the following scenario:

- One of the inputCols in GraphExtraction is `document` instead of `sentence`
- `.fullAnnotate` is used from `LightPipeline`

Then it crashes due to not having a `sentence` index inside metadata coming from `.fullAnnotate`