### PR TITLE
Fix Word2VecModel being cast to Doc2VecModel by mistake

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -420,7 +420,7 @@ package object annotator {
 
   object Word2VecApproach extends DefaultParamsReadable[Word2VecApproach]
 
-  type Word2VecModel = com.johnsnowlabs.nlp.embeddings.Doc2VecModel
+  type Word2VecModel = com.johnsnowlabs.nlp.embeddings.Word2VecModel
 
   object Word2VecModel extends ReadablePretrainedWord2Vec
 


### PR DESCRIPTION
This PR fixes casting Word2VecModel to Doc2VecModel by mistake in annotator object. 