### PR TITLE
Fix broken setExceptionsPath in Tokenizer in Python

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -22,6 +22,7 @@ from test.pretrained import *
 unittest.TextTestRunner().run(BasicAnnotatorsTestSpec())
 unittest.TextTestRunner().run(RegexMatcherTestSpec())
 unittest.TextTestRunner().run(TokenizerTestSpec())
+unittest.TextTestRunner().run(TokenizerWithExceptionsTestSpec())
 unittest.TextTestRunner().run(NormalizerTestSpec())
 unittest.TextTestRunner().run(ChunkTokenizerTestSpec())
 unittest.TextTestRunner().run(LemmatizerTestSpec())

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -336,7 +336,7 @@ class Tokenizer(AnnotatorApproach):
     exceptionsPath = Param(Params._dummy(),
                            "exceptionsPath",
                            "path to file containing list of exceptions",
-                           typeConverter=TypeConverters.toString)
+                           typeConverter=TypeConverters.identity)
 
     caseSensitiveExceptions = Param(Params._dummy(),
                                     "caseSensitiveExceptions",
@@ -512,6 +512,21 @@ class Tokenizer(AnnotatorApproach):
             Words that won't be affected by tokenization rules
         """
         return self.getOrDefault("exceptions")
+
+    def setExceptionsPath(self, path, read_as=ReadAs.TEXT, options={"format": "text"}):
+        """Path to txt file with list of token exceptions
+
+        Parameters
+        ----------
+        path : str
+            Path to the source file
+        read_as : str, optional
+            How to read the file, by default ReadAs.TEXT
+        options : dict, optional
+            Options to read the resource, by default {"format": "text"}
+        """
+        opts = options.copy()
+        return self._set(exceptionsPath=ExternalResource(path, read_as, opts))
 
     def addException(self, value):
         """Adds an additional word that won't be affected by tokenization rules.

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -156,6 +156,33 @@ class TokenizerTestSpec(unittest.TestCase):
         self.assertEqual(len(finished.first()['token_out']), 4)
 
 
+class TokenizerWithExceptionsTestSpec(unittest.TestCase):
+
+    def setUp(self):
+        self.session = SparkContextForTest.spark
+
+    def runTest(self):
+        data = self.session.createDataFrame(
+            [("My friend moved to New York. She likes it. Frank visited New York, and didn't like it.",)], ["text"])
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+        tokenizer = Tokenizer() \
+            .setInputCols(["document"]) \
+            .setOutputCol("token") \
+            .setExceptionsPath(path="file:///" + os.getcwd() + "/../src/test/resources/token_exception_list.txt")
+        finisher = Finisher() \
+            .setInputCols(["token"]) \
+            .setOutputCols(["token_out"]) \
+            .setOutputAsArray(True)
+        assembled = document_assembler.transform(data)
+        tokenized = tokenizer.fit(assembled).transform(assembled)
+        finished = finisher.transform(tokenized)
+        # print(finished.first()['token_out'])
+        self.assertEqual((finished.first()['token_out']).index("New York."), 4)
+        self.assertEqual((finished.first()['token_out']).index("New York,"), 11)
+
+
 class ChunkTokenizerTestSpec(unittest.TestCase):
 
     def setUp(self):

--- a/src/test/resources/token_exception_list.txt
+++ b/src/test/resources/token_exception_list.txt
@@ -1,0 +1,3 @@
+New York
+John Doe
+years old

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -32,12 +32,116 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
 
   val tokenizer = new Tokenizer()
 
-  "a Tokenizer" should s"be of type ${AnnotatorType.TOKEN}" taggedAs FastTest in {
-    assert(tokenizer.outputAnnotatorType == AnnotatorType.TOKEN)
-  }
-
   val ls: String = System.lineSeparator
   val lsl: Int = ls.length
+
+  val targetText0 = "My friend moved to New York. She likes it. Frank visited New York, and didn't like it."
+
+  val targetText1: String = "Hello, I won't be from New York in the U.S.A. (and you know it héroe). Give me my horse! or $100" +
+    " bucks 'He said', I'll defeat markus-crassus. You understand. Goodbye George E. Bush. www.google.com."
+  val expected1: Array[String] = Array(
+    "Hello", ",", "I", "won't", "be", "from", "New York", "in", "the", "U.S.A", ".", "(", "and", "you", "know", "it",
+    "héroe", ").", "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "',", "I'll",
+    "defeat", "markus-crassus", ".", "You", "understand", ".", "Goodbye", "George", "E", ".", "Bush", ".", "www.google.com", "."
+  )
+  val expected1b: Array[String] = Array(
+    "Hello", ",", "I", "won't", "be", "from", "New York", "in", "the", "U.S.A", ".", "(", "and", "you", "know", "it",
+    "héroe", ").", "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "',", "I'll",
+    "defeat", "markus", "crassus", ".", "You", "understand", ".", "Goodbye", "George", "E", ".", "Bush", ".", "www.google.com", "."
+  )
+
+  val targetText2 = "I'd like to say we didn't expect that. Jane's boyfriend."
+
+  val expected2: Array[Annotation] = Array(
+    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 19, 24, "didn't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 33, 36, "that", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 37, 37, ".", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39, 44, "Jane's", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 46, 54, "boyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 55, 55, ".", Map("sentence" -> "0"))
+  )
+
+  val targetText3: String = s"I'd      like to say${ls}we didn't${ls + ls}" +
+    s" expect\nthat. ${ls + ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls + ls}"
+
+  val expected3: Array[Annotation] = Array(
+    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 4 + 5, 7 + 5, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9 + 5, 10 + 5, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12 + 5, 14 + 5, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 15 + 5 + lsl, 16 + 5 + lsl, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 18 + 5 + lsl, 23 + 5 + lsl, "didn't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 25 + 5 + (lsl * 3), 30 + 5 + (lsl * 3), "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 32 + 5 + (lsl * 3), 35 + 5 + (lsl * 3), "that", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 36 + 5 + (lsl * 3), 36 + 5 + (lsl * 3), ".", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39 + 5 + (lsl * 5), 55 + 5 + (lsl * 5), "Jane's\\nboyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 57 + 5 + (lsl * 5), 60 + 5 + (lsl * 5), "said", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 61 + 5 + (lsl * 5), 61 + 5 + (lsl * 5), ".", Map("sentence" -> "0"))
+  )
+
+  val targetText4: String = s"I'd      like to say${ls}we didn't${ls + ls}" +
+    s" expect\nthat. ${ls + ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls + ls}"
+
+  val expected4: Array[Annotation] = Array(
+    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 19, 24, "didn't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 33, 36, "that", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 37, 37, ".", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39, 55, "Jane's\\nboyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 57, 60, "said", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 61, 61, ".", Map("sentence" -> "0"))
+  )
+
+  val targetText5: String = s"I'd      like to say${ls}we didn't${ls + ls}" +
+    s" expect\nthat. ${ls + ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls + ls}"
+
+  val expected5: Array[Annotation] = Array(
+    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 19, 24, "didn't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 33, 36, "that", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 37, 37, ".", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39, 44, "Jane's", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 46, 54, "boyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 56, 59, "said", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 60, 60, ".", Map("sentence" -> "0"))
+  )
+
+  val targetText6: String = s"I'd      like to say${ls}we didn't${ls + ls}" +
+    s" expect\nthat. ${ls + ls} " +
+    s"Jane's\\nboyfriend\tsaid.${ls + ls}"
+
+  val expected6: Array[Annotation] = Array(
+    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 19, 24, "didn't", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 33, 37, "that.", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 39, 54, "Jane's boyfriend", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 56, 59, "said", Map("sentence" -> "0")),
+    Annotation(AnnotatorType.TOKEN, 60, 60, ".", Map("sentence" -> "0"))
+  )
 
   def getTokenizerOutput[T](tokenizer: TokenizerModel, data: DataFrame, mode: String = "finisher"): Array[T] = {
     val finisher = new Finisher().setInputCols("token").setOutputAsArray(true).setCleanAnnotations(false).setOutputCols("output")
@@ -64,8 +168,9 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
     }
   }
 
-
-  val targetText0 = "My friend moved to New York. She likes it. Frank visited New York, and didn't like it."
+  "a Tokenizer" should s"be of type ${AnnotatorType.TOKEN}" taggedAs FastTest in {
+    assert(tokenizer.outputAnnotatorType == AnnotatorType.TOKEN)
+  }
 
   "a Tokenizer" should s"correctly handle exceptions in sentences and documents" taggedAs FastTest in {
 
@@ -92,20 +197,29 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
     )
   }
 
+  "a Tokenizer" should s"correctly handle exceptionsPath" taggedAs FastTest in {
 
-  val targetText1: String = "Hello, I won't be from New York in the U.S.A. (and you know it héroe). Give me my horse! or $100" +
-    " bucks 'He said', I'll defeat markus-crassus. You understand. Goodbye George E. Bush. www.google.com."
-  val expected1: Array[String] = Array(
-    "Hello", ",", "I", "won't", "be", "from", "New York", "in", "the", "U.S.A", ".", "(", "and", "you", "know", "it",
-    "héroe", ").", "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "',", "I'll",
-    "defeat", "markus-crassus", ".", "You", "understand", ".", "Goodbye", "George", "E", ".", "Bush", ".", "www.google.com", "."
-  )
-  val expected1b: Array[String] = Array(
-    "Hello", ",", "I", "won't", "be", "from", "New York", "in", "the", "U.S.A", ".", "(", "and", "you", "know", "it",
-    "héroe", ").", "Give", "me", "my", "horse", "!", "or", "$100", "bucks", "'", "He", "said", "',", "I'll",
-    "defeat", "markus", "crassus", ".", "You", "understand", ".", "Goodbye", "George", "E", ".", "Bush", ".", "www.google.com", "."
-  )
+    val data = DataBuilder.basicDataBuild(targetText0)
 
+    val sentence = new SentenceDetector()
+      .setInputCols(Array("document"))
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols("document")
+      .setOutputCol("token")
+      .setExceptionsPath("src/test/resources/token_exception_list.txt")
+      .fit(data)
+
+    val result = getTokenizerPipelineOutput[Annotation](sentence, tokenizer, data, "annotation")
+    assert(
+      result(4) == Annotation(AnnotatorType.TOKEN, 19, 27, "New York.", Map("sentence" -> "0"))
+    )
+
+    assert(
+      result(11) == Annotation(AnnotatorType.TOKEN, 57, 65, "New York,", Map("sentence" -> "2"))
+    )
+  }
 
   "a Tokenizer" should "correctly tokenize target text on its defaults parameters with composite" taggedAs FastTest in {
 
@@ -170,23 +284,6 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
     )
   }
 
-
-  val targetText2 = "I'd like to say we didn't expect that. Jane's boyfriend."
-  val expected2: Array[Annotation] = Array(
-    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 19, 24, "didn't", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 33, 36, "that", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 37, 37, ".", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 39, 44, "Jane's", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 46, 54, "boyfriend", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 55, 55, ".", Map("sentence" -> "0"))
-  )
-
   "a Tokenizer" should s"correctly tokenize a simple sentence on defaults" taggedAs FastTest in {
     val data = DataBuilder.basicDataBuild(targetText2)
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").fit(data)
@@ -197,24 +294,6 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected2.mkString("|")}"
     )
   }
-
-  val targetText3: String = s"I'd      like to say${ls}we didn't${ls + ls}" +
-    s" expect\nthat. ${ls + ls} " +
-    s"Jane's\\nboyfriend\tsaid.${ls + ls}"
-  val expected3: Array[Annotation] = Array(
-    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 4 + 5, 7 + 5, "like", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 9 + 5, 10 + 5, "to", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 12 + 5, 14 + 5, "say", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 15 + 5 + lsl, 16 + 5 + lsl, "we", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 18 + 5 + lsl, 23 + 5 + lsl, "didn't", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 25 + 5 + (lsl * 3), 30 + 5 + (lsl * 3), "expect", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 32 + 5 + (lsl * 3), 35 + 5 + (lsl * 3), "that", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 36 + 5 + (lsl * 3), 36 + 5 + (lsl * 3), ".", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 39 + 5 + (lsl * 5), 55 + 5 + (lsl * 5), "Jane's\\nboyfriend", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 57 + 5 + (lsl * 5), 60 + 5 + (lsl * 5), "said", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 61 + 5 + (lsl * 5), 61 + 5 + (lsl * 5), ".", Map("sentence" -> "0"))
-  )
 
   "a Tokenizer" should s"correctly tokenize a sentence with breaking characters on defaults" taggedAs FastTest in {
     val data = DataBuilder.basicDataBuild(targetText3)
@@ -227,24 +306,6 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
     )
   }
 
-  val targetText4: String = s"I'd      like to say${ls}we didn't${ls + ls}" +
-    s" expect\nthat. ${ls + ls} " +
-    s"Jane's\\nboyfriend\tsaid.${ls + ls}"
-  val expected4: Array[Annotation] = Array(
-    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 19, 24, "didn't", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 33, 36, "that", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 37, 37, ".", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 39, 55, "Jane's\\nboyfriend", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 57, 60, "said", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 61, 61, ".", Map("sentence" -> "0"))
-  )
-
   "a Tokenizer" should s"correctly tokenize a sentence with breaking characters on shrink cleanup" taggedAs FastTest in {
     val data = DataBuilder.basicDataBuild(targetText4)(cleanupMode = "shrink")
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").fit(data)
@@ -255,25 +316,6 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected4.mkString("|")}"
     )
   }
-
-  val targetText5: String = s"I'd      like to say${ls}we didn't${ls + ls}" +
-    s" expect\nthat. ${ls + ls} " +
-    s"Jane's\\nboyfriend\tsaid.${ls + ls}"
-  val expected5: Array[Annotation] = Array(
-    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 19, 24, "didn't", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 33, 36, "that", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 37, 37, ".", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 39, 44, "Jane's", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 46, 54, "boyfriend", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 56, 59, "said", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 60, 60, ".", Map("sentence" -> "0"))
-  )
 
   "a tokenizer" should "split French apostrophe on left" taggedAs FastTest in {
 
@@ -311,23 +353,6 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected5.mkString("|")}"
     )
   }
-
-  val targetText6: String = s"I'd      like to say${ls}we didn't${ls + ls}" +
-    s" expect\nthat. ${ls + ls} " +
-    s"Jane's\\nboyfriend\tsaid.${ls + ls}"
-  val expected6: Array[Annotation] = Array(
-    Annotation(AnnotatorType.TOKEN, 0, 2, "I'd", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 4, 7, "like", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 9, 10, "to", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 12, 14, "say", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 16, 17, "we", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 19, 24, "didn't", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 26, 31, "expect", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 33, 37, "that.", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 39, 54, "Jane's boyfriend", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 56, 59, "said", Map("sentence" -> "0")),
-    Annotation(AnnotatorType.TOKEN, 60, 60, ".", Map("sentence" -> "0"))
-  )
 
   "a Tokenizer" should s"correctly tokenize cleanup with composite and exceptions" taggedAs FastTest in {
     val data = DataBuilder.basicDataBuild(targetText6)(cleanupMode = "shrink_full")


### PR DESCRIPTION
This PR fixes the wrong type of exceptionsPath param and add a setter to Tokenizer in Python APIs.