### PR TITLE
Update Doc2VecApproach.scala

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/Doc2VecApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/Doc2VecApproach.scala
@@ -286,7 +286,7 @@ class Doc2VecApproach(override val uid: String)
       .setMaxSentenceLength($(maxSentenceLength))
       .setSeed($(seed))
 
-    val input = dataset.select(dataset.col(inputColumns)).rdd.map(r => r.getSeq[String](0))
+    val input = dataset.select(dataset.col(inputColumns)).rdd.map(r => r.getSeq[String](0)).cache()
 
     val model = word2Vec.fit(input)
 


### PR DESCRIPTION
The steps to reproduce are as follows:
1) Doc2VecExample.scala from spark-nlp is deployed  in Spark. 
2) observe WebUI.  The variable input at Doc2VecApproach.scala:289 is used by two jobs. Caching _input_ (MapPartitionsRDD [6]map at Doc2VecApproach.scala:289)  can help improve application execution efficiency.



