### PR TITLE
Introducing enableCaching param in Doc2Vec and Word2Vec trainable annotators

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -15194,7 +15194,7 @@ class BertForSequenceClassification(AnnotatorModel,
         return ResourceDownloader.downloadModel(BertForSequenceClassification, name, lang, remote_loc)
 
 
-class Doc2VecApproach(AnnotatorApproach, HasStorageRef):
+class Doc2VecApproach(AnnotatorApproach, HasStorageRef, HasEnableCachingProperties):
     """Trains a Word2Vec model that creates vector representations of words in a
     text corpus.
 
@@ -16999,7 +16999,7 @@ class GPT2Transformer(AnnotatorModel, HasBatchedAnnotate):
         return ResourceDownloader.downloadModel(GPT2Transformer, name, lang, remote_loc)
 
 
-class Word2VecApproach(AnnotatorApproach, HasStorageRef):
+class Word2VecApproach(AnnotatorApproach, HasStorageRef, HasEnableCachingProperties):
     """Trains a Word2Vec model that creates vector representations of words in a
     text corpus.
 

--- a/python/sparknlp/common.py
+++ b/python/sparknlp/common.py
@@ -24,7 +24,6 @@ import sparknlp.internal as _internal
 
 
 class AnnotatorProperties(Params):
-
     inputCols = Param(Params._dummy(),
                       "inputCols",
                       "previous annotations columns, if renamed",
@@ -89,7 +88,8 @@ class AnnotatorProperties(Params):
         self.getOrDefault(self.lazyAnnotator)
 
 
-class AnnotatorModel(JavaModel, _internal.AnnotatorJavaMLReadable, JavaMLWritable, AnnotatorProperties, _internal.ParamsGettersSetters):
+class AnnotatorModel(JavaModel, _internal.AnnotatorJavaMLReadable, JavaMLWritable, AnnotatorProperties,
+                     _internal.ParamsGettersSetters):
 
     @keyword_only
     def setParams(self):
@@ -129,7 +129,6 @@ class HasEmbeddingsProperties(Params):
 
 
 class HasStorageRef:
-
     storageRef = Param(Params._dummy(), "storageRef",
                        "unique reference name for identification",
                        TypeConverters.toString)
@@ -156,7 +155,6 @@ class HasStorageRef:
 
 
 class HasBatchedAnnotate:
-
     batchSize = Param(Params._dummy(), "batchSize", "Size of every batch", TypeConverters.toInt)
 
     def setBatchSize(self, v):
@@ -208,7 +206,6 @@ class HasCaseSensitiveProperties:
 
 
 class HasExcludableStorage:
-
     includeStorage = Param(Params._dummy(),
                            "includeStorage",
                            "whether to include indexed storage in trained model",
@@ -236,7 +233,6 @@ class HasExcludableStorage:
 
 
 class HasStorage(HasStorageRef, HasCaseSensitiveProperties, HasExcludableStorage):
-
     storagePath = Param(Params._dummy(),
                         "storagePath",
                         "path to file",
@@ -308,7 +304,8 @@ class AnnotatorApproach(JavaEstimator, JavaMLWritable, _internal.AnnotatorJavaML
         raise NotImplementedError('Please implement _create_model in %s' % self)
 
 
-class RecursiveAnnotatorApproach(_internal.RecursiveEstimator, JavaMLWritable, _internal.AnnotatorJavaMLReadable, AnnotatorProperties,
+class RecursiveAnnotatorApproach(_internal.RecursiveEstimator, JavaMLWritable, _internal.AnnotatorJavaMLReadable,
+                                 AnnotatorProperties,
                                  _internal.ParamsGettersSetters):
     @keyword_only
     def __init__(self, classname):
@@ -365,3 +362,30 @@ class CoverageResult:
         self.covered = cov_obj.covered()
         self.total = cov_obj.total()
         self.percentage = cov_obj.percentage()
+
+
+class HasEnableCachingProperties:
+    enableCaching = Param(Params._dummy(),
+                          "enableCaching",
+                          "Whether to enable caching DataFrames or RDDs during the training",
+                          typeConverter=TypeConverters.toBoolean)
+
+    def setEnableCaching(self, value):
+        """Sets whether to enable caching DataFrames or RDDs during the training
+
+        Parameters
+        ----------
+        value : bool
+            Whether to enable caching DataFrames or RDDs during the training
+        """
+        return self._set(enableCaching=value)
+
+    def getEnableCaching(self):
+        """Gets whether to enable caching DataFrames or RDDs during the training
+
+        Returns
+        -------
+        bool
+            Whether to enable caching DataFrames or RDDs during the training
+        """
+        return self.getOrDefault(self.enableCaching)

--- a/python/test/annotators.py
+++ b/python/test/annotators.py
@@ -2098,6 +2098,7 @@ class Doc2VecTestSpec(unittest.TestCase):
             .setNumPartitions(1) \
             .setMaxIter(2) \
             .setSeed(42) \
+            .setEnableCaching(True) \
             .setStorageRef("doc2vec_aclImdb")
 
         pipeline = Pipeline(stages=[document_assembler, tokenizer, doc2vec])
@@ -2259,6 +2260,7 @@ class Word2VecTestSpec(unittest.TestCase):
             .setNumPartitions(1) \
             .setMaxIter(2) \
             .setSeed(42) \
+            .setEnableCaching(True) \
             .setStorageRef("doc2vec_aclImdb")
 
         pipeline = Pipeline(stages=[document_assembler, tokenizer, doc2vec])

--- a/src/main/scala/com/johnsnowlabs/nlp/HasEnableCachingProperties.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasEnableCachingProperties.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp
+
+import org.apache.spark.ml.param.BooleanParam
+
+trait HasEnableCachingProperties extends ParamsAndFeaturesWritable {
+
+  /** Whether to enable caching DataFrames or RDDs during the training
+   *
+   * @group param
+   */
+  val enableCaching = new BooleanParam(this, "enableCaching", "Whether to enable caching DataFrames or RDDs during the training")
+
+  setDefault(enableCaching, false)
+
+  /** @group getParam */
+  def getEnableCaching: Boolean = $(enableCaching)
+
+  /** @group setParam */
+  def setEnableCaching(value: Boolean): this.type = set(this.enableCaching, value)
+
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/Doc2VecTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/Doc2VecTestSpec.scala
@@ -68,6 +68,7 @@ class Doc2VecTestSpec extends AnyFlatSpec {
       .setOutputCol("sentence_embeddings")
       .setMaxSentenceLength(512)
       .setStorageRef("my_awesome_doc2vec")
+      .setEnableCaching(true)
 
     val pipeline = new Pipeline().setStages(Array(
       document,

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/Word2VecTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/Word2VecTestSpec.scala
@@ -68,6 +68,7 @@ class Word2VecTestSpec extends AnyFlatSpec {
       .setOutputCol("embeddings")
       .setMaxSentenceLength(512)
       .setStorageRef("my_awesome_word2vec")
+      .setEnableCaching(true)
 
     val pipeline = new Pipeline().setStages(Array(
       document,


### PR DESCRIPTION
This PR introduces a new param `enableCaching` in Doc2VecApproach and Word2VecApproach which if enabled speeds up the training. 