### PR TITLE
Introducing DeBERTa annotator

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -17319,3 +17319,201 @@ class Word2VecModel(AnnotatorModel, HasStorageRef, HasEmbeddingsProperties):
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(Word2VecModel, name, lang, remote_loc)
+
+
+class DeBertaEmbeddings(AnnotatorModel,
+                        HasEmbeddingsProperties,
+                        HasCaseSensitiveProperties,
+                        HasStorageRef,
+                        HasBatchedAnnotate):
+    """The DeBERTa model was proposed in DeBERTa: Decoding-enhanced BERT with Disentangled Attention  by Pengcheng
+    He, Xiaodong Liu, Jianfeng Gao, Weizhu Chen It is based on Google’s BERT model released in 2018 and Facebook’s
+    RoBERTa model released in 2019. This model requires input tokenization with SentencePiece model,
+    which is provided by Spark NLP (See tokenizers package). Pretrained models can be loaded with pretrained of the
+    companion object: val embeddings = DeBertaEmbeddings.pretrained() .setInputCols("sentence",
+    "token") .setOutputCol("embeddings")
+
+    The default model is "deberta_v3_base", if no name is provided. Models from the HuggingFace 🤗 Transformers library
+    are also compatible with Spark NLP 🚀. The Spark NLP Workshop example shows how to import them
+    https://github.com/JohnSnowLabs/spark-nlp/discussions/5669 . It builds on RoBERTa with disentangled attention and
+    enhanced mask decoder training with half of the data used in RoBERTa. Sources:
+    https://github.com/microsoft/DeBERTa https://www.microsoft.com/en-us/research/blog/microsoft-deberta-surpasses-human-performance-on-the-superglue-benchmark/
+
+    >>> embeddings = DeBertaEmbeddings.pretrained() \\
+    ...    .setInputCols(["sentence", "token"]) \\
+    ...    .setOutputCol("embeddings")
+
+
+    The default model is ``"deberta_v3_base"``, if no name is provided.
+
+    For extended examples of usage, see the `Spark NLP Workshop
+    <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/dl-ner/ner_albert.ipynb>`__.
+    Models from the HuggingFace 🤗 Transformers library are also compatible with
+    Spark NLP 🚀. To see which models are compatible and how to import them see
+    `Import Transformers into Spark NLP 🚀
+    <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT, TOKEN``    ``WORD_EMBEDDINGS``
+    ====================== ======================
+
+    Parameters
+    ----------
+    batchSize
+        Size of every batch, by default 8
+    dimension
+        Number of embedding dimensions, by default 768
+    caseSensitive
+        Whether to ignore case in tokens for embeddings matching, by default
+        False
+    configProtoBytes
+        ConfigProto from tensorflow, serialized into byte array.
+    maxSentenceLength
+        Max sentence length to process, by default 128
+
+    References
+    ----------
+    https://github.com/microsoft/DeBERTa https://www.microsoft.com/en-us/research/blog/microsoft-deberta-surpasses-human-performance-on-the-superglue-benchmark/
+
+    **Paper abstract:**
+
+    *Paper abstract: Recent progress in pre-trained neural language models has significantly improved the performance
+    of many natural language processing (NLP) tasks. In this paper we propose a new model architecture DeBERTa (
+    Decoding-enhanced BERT with disentangled attention) that improves the BERT and RoBERTa models using two novel
+    techniques. The first is the disentangled attention mechanism, where each word is represented using two vectors
+    that encode its content and position, respectively, and the attention weights among words are computed using
+    disentangled matrices on their contents and relative positions. Second, an enhanced mask decoder is used to
+    replace the output softmax layer to predict the masked tokens for model pretraining. We show that these two
+    techniques significantly improve the efficiency of model pretraining and performance of downstream tasks.
+    Compared to RoBERTa-Large, a DeBERTa model trained on half of the training data performs consistently better on a
+    wide range of NLP tasks, achieving improvements on MNLI by +0.9% (90.2% vs. 91.1%), on SQuAD v2.0 by +2.3% (88.4%
+    vs. 90.7%) and RACE by +3.6% (83.2% vs. 86.8%). The DeBERTa code and pre-trained models will be made publicly
+    available at https://github.com/microsoft/DeBERTa.*
+
+    Examples
+    --------
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["document"]) \\
+    >>> embeddings = DeBertaEmbeddings.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("embeddings")
+    >>> embeddingsFinisher = EmbeddingsFinisher() \\
+    ...     .setInputCols(["embeddings"]) \\
+    ...     .setOutputCols("finished_embeddings") \\
+    ...     .setOutputAsVector(True) \\
+    ...     .setCleanAnnotations(False)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     tokenizer,
+    ...     embeddings,
+    ...     embeddingsFinisher
+    ... ])
+    >>> data = spark.createDataFrame([["This is a sentence."]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.selectExpr("explode(finished_embeddings) as result").show(5, 80)
+    +--------------------------------------------------------------------------------+
+    |                                                                          result|
+    +--------------------------------------------------------------------------------+
+    |[1.1342473030090332,-1.3855540752410889,0.9818322062492371,-0.784737348556518...|
+    |[0.847029983997345,-1.047153353691101,-0.1520637571811676,-0.6245765686035156...|
+    |[-0.009860038757324219,-0.13450059294700623,2.707749128341675,1.2916892766952...|
+    |[-0.04192575812339783,-0.5764210224151611,-0.3196685314178467,-0.527840495109...|
+    |[0.15583214163780212,-0.1614152491092682,-0.28423872590065,-0.135491415858268...|
+    +--------------------------------------------------------------------------------+
+    """
+
+    name = "DeBertaEmbeddings"
+
+    configProtoBytes = Param(Params._dummy(),
+                             "configProtoBytes",
+                             "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
+                             TypeConverters.toListInt)
+
+    maxSentenceLength = Param(Params._dummy(),
+                              "maxSentenceLength",
+                              "Max sentence length to process",
+                              typeConverter=TypeConverters.toInt)
+
+    def setConfigProtoBytes(self, b):
+        """Sets configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[int]
+            ConfigProto from tensorflow, serialized into byte array
+        """
+        return self._set(configProtoBytes=b)
+
+    def setMaxSentenceLength(self, value):
+        """Sets max sentence length to process.
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
+        return self._set(maxSentenceLength=value)
+
+    @keyword_only
+    def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.DeBertaEmbeddings", java_model=None):
+        super(DeBertaEmbeddings, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        self._setDefault(
+            batchSize=8,
+            dimension=768,
+            maxSentenceLength=128,
+            caseSensitive=True
+        )
+
+    @staticmethod
+    def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        DeBertaEmbeddings
+            The restored model
+        """
+        from sparknlp.internal import _DeBERTaLoader
+        jModel = _DeBERTaLoader(folder, spark_session._jsparkSession)._java_obj
+        return DeBertaEmbeddings(java_model=jModel)
+
+    @staticmethod
+    def pretrained(name="deberta_v3_base", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "deberta_v3_base"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None. Will use
+            Spark NLPs repositories otherwise.
+
+        Returns
+        -------
+        DeBertaEmbeddings
+            The restored model
+        """
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(DeBertaEmbeddings, name, lang, remote_loc)

--- a/python/sparknlp/internal.py
+++ b/python/sparknlp/internal.py
@@ -353,10 +353,12 @@ class _T5Loader(ExtendedJavaWrapper):
         super(_T5Loader, self).__init__(
             "com.johnsnowlabs.nlp.annotators.seq2seq.T5Transformer.loadSavedModel", path, jspark)
 
+
 class _GPT2Loader(ExtendedJavaWrapper):
     def __init__(self, path, jspark):
         super(_GPT2Loader, self).__init__(
             "com.johnsnowlabs.nlp.annotators.seq2seq.GPT2Transformer.loadSavedModel", path, jspark)
+
 
 class _MarianLoader(ExtendedJavaWrapper):
     def __init__(self, path, jspark):
@@ -494,7 +496,8 @@ class _XlnetSequenceClassifierLoader(ExtendedJavaWrapper):
             jspark)
 
 
-class _GPT2Loader(ExtendedJavaWrapper):
+class _DeBERTaLoader(ExtendedJavaWrapper):
     def __init__(self, path, jspark):
-        super(_GPT2Loader, self).__init__(
-            "com.johnsnowlabs.nlp.annotators.seq2seq.GPT2Transformer.loadSavedModel", path, jspark)
+        super(_DeBERTaLoader, self).__init__(
+            "com.johnsnowlabs.nlp.embeddings.DistilBertEmbeddings.loadSavedModel", path,
+            jspark)

--- a/python/sparknlp/internal.py
+++ b/python/sparknlp/internal.py
@@ -499,5 +499,5 @@ class _XlnetSequenceClassifierLoader(ExtendedJavaWrapper):
 class _DeBERTaLoader(ExtendedJavaWrapper):
     def __init__(self, path, jspark):
         super(_DeBERTaLoader, self).__init__(
-            "com.johnsnowlabs.nlp.embeddings.DistilBertEmbeddings.loadSavedModel", path,
+            "com.johnsnowlabs.nlp.embeddings.DeBertaEmbeddings.loadSavedModel", path,
             jspark)

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowDeBerta.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowDeBerta.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.ml.tensorflow
+
+import com.johnsnowlabs.ml.tensorflow.sentencepiece._
+import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
+import com.johnsnowlabs.nlp.annotators.common._
+import org.tensorflow.ndarray.buffer.DataBuffers
+
+import scala.collection.JavaConverters._
+
+/**
+ *
+ * @param tensorflow       DeBERTa Model wrapper with TensorFlowWrapper
+ * @param spp              DeBERTa SentencePiece model with SentencePieceWrapper
+ * @param batchSize        size of batch
+ * @param configProtoBytes Configuration for TensorFlow session
+ */
+
+class TensorflowDeBerta(val tensorflow: TensorflowWrapper,
+                        val spp: SentencePieceWrapper,
+                        batchSize: Int,
+                        configProtoBytes: Option[Array[Byte]] = None,
+                        signatures: Option[Map[String, String]] = None
+                       ) extends Serializable {
+
+  val _tfDeBertaSignatures: Map[String, String] = signatures.getOrElse(ModelSignatureManager.apply())
+
+  // keys representing the input and output tensors of the DeBERTa model
+  private val SentenceStartTokenId = spp.getSppModel.pieceToId("[CLS]")
+  private val SentenceEndTokenId = spp.getSppModel.pieceToId("[SEP]")
+  private val SentencePadTokenId = spp.getSppModel.pieceToId("[PAD]")
+  private val SentencePieceDelimiterId = spp.getSppModel.pieceToId("▁")
+
+  def prepareBatchInputs(sentences: Seq[(WordpieceTokenizedSentence, Int)], maxSequenceLength: Int): Seq[Array[Int]] = {
+    val maxSentenceLength =
+      Array(
+        maxSequenceLength - 2,
+        sentences.map { case (wpTokSentence, _) => wpTokSentence.tokens.length }.max).min
+
+    sentences
+      .map { case (wpTokSentence, _) =>
+        val tokenPieceIds = wpTokSentence.tokens.map(t => t.pieceId)
+        val padding = Array.fill(maxSentenceLength - tokenPieceIds.length)(SentencePadTokenId)
+
+        Array(SentenceStartTokenId) ++ tokenPieceIds.take(maxSentenceLength) ++ Array(SentenceEndTokenId) ++ padding
+      }
+  }
+
+  def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
+
+    val tensors = new TensorResources()
+    val tensorsMasks = new TensorResources()
+    val tensorsSegments = new TensorResources()
+
+    /* Actual size of each sentence to skip padding in the TF model */
+    val sequencesLength = batch.map(x => x.length).toArray
+    val maxSentenceLength = sequencesLength.max
+
+    val tokenBuffers = DataBuffers.ofInts(batch.length * maxSentenceLength)
+    val maskBuffers = DataBuffers.ofInts(batch.length * maxSentenceLength)
+    val segmentBuffers = DataBuffers.ofInts(batch.length * maxSentenceLength)
+
+    val shape = Array(batch.length.toLong, maxSentenceLength)
+
+    batch.zipWithIndex.foreach { case (tokenIds, idx) =>
+      // this one marks the beginning of each sentence in the flatten structure
+      val offset = idx * maxSentenceLength
+      val diff = maxSentenceLength - tokenIds.length
+      segmentBuffers.offset(offset).write(Array.fill(maxSentenceLength)(0))
+
+      val padding = Array.fill(diff)(SentencePadTokenId)
+      val newTokenIds = tokenIds ++ padding
+
+      tokenBuffers.offset(offset).write(newTokenIds)
+      maskBuffers.offset(offset).write(newTokenIds.map(x => if (x == SentencePadTokenId) 0 else 1))
+    }
+
+    val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
+    val maskTensors = tensorsMasks.createIntBufferTensor(shape, maskBuffers)
+    val segmentTensors = tensorsSegments.createIntBufferTensor(shape, segmentBuffers)
+
+    val runner = tensorflow.getTFSessionWithSignature(configProtoBytes = configProtoBytes, savedSignatures = signatures, initAllTables = false).runner
+
+    runner
+      .feed(_tfDeBertaSignatures.getOrElse(ModelSignatureConstants.InputIds.key, "missing_input_id_key"), tokenTensors)
+      .feed(_tfDeBertaSignatures.getOrElse(ModelSignatureConstants.AttentionMask.key, "missing_input_mask_key"), maskTensors)
+      .feed(_tfDeBertaSignatures.getOrElse(ModelSignatureConstants.TokenTypeIds.key, "missing_segment_ids_key"), segmentTensors)
+      .fetch(_tfDeBertaSignatures.getOrElse(ModelSignatureConstants.LastHiddenState.key, "missing_sequence_output_key"))
+
+    val outs = runner.run().asScala
+    val embeddings = TensorResources.extractFloats(outs.head)
+
+    tensors.clearSession(outs)
+    tensors.clearTensors()
+
+    val dim = embeddings.length / (batch.length * maxSentenceLength)
+    val shrinkedEmbeddings: Array[Array[Array[Float]]] =
+      embeddings
+        .grouped(dim).toArray
+        .grouped(maxSentenceLength).toArray
+
+    val emptyVector = Array.fill(dim)(0f)
+
+    batch.zip(shrinkedEmbeddings).map { case (ids, embeddings) =>
+      if (ids.length > embeddings.length) {
+        embeddings.take(embeddings.length - 1) ++
+          Array.fill(embeddings.length - ids.length)(emptyVector) ++
+          Array(embeddings.last)
+      } else {
+        embeddings
+      }
+    }
+  }
+
+  def predict(tokenizedSentences: Seq[TokenizedSentence],
+              batchSize: Int,
+              maxSentenceLength: Int,
+              caseSensitive: Boolean
+             ): Seq[WordpieceEmbeddingsSentence] = {
+
+    val wordPieceTokenizedSentences = tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
+    wordPieceTokenizedSentences.zipWithIndex.grouped(batchSize).flatMap { batch =>
+      val batchedInputsIds = prepareBatchInputs(batch, maxSentenceLength)
+      val vectors = tag(batchedInputsIds)
+
+      /*Combine tokens and calculated embeddings*/
+      batch.zip(vectors).map { case (sentence, tokenVectors) =>
+        val tokenLength = sentence._1.tokens.length
+        /*All wordpiece embeddings*/
+        val tokenEmbeddings = tokenVectors.slice(1, tokenLength + 1)
+        val tokensWithEmbeddings = sentence._1.tokens.zip(tokenEmbeddings).flatMap {
+          case (token, tokenEmbedding) =>
+            val tokenWithEmbeddings = TokenPieceEmbeddings(token, tokenEmbedding)
+            val originalTokensWithEmbeddings = tokenizedSentences(sentence._2).indexedTokens.find(
+              p => p.begin == tokenWithEmbeddings.begin && tokenWithEmbeddings.isWordStart).map {
+              token =>
+                val originalTokenWithEmbedding = TokenPieceEmbeddings(
+                  TokenPiece(wordpiece = tokenWithEmbeddings.wordpiece,
+                    token = if (caseSensitive) token.token else token.token.toLowerCase(),
+                    pieceId = tokenWithEmbeddings.pieceId,
+                    isWordStart = tokenWithEmbeddings.isWordStart,
+                    begin = token.begin,
+                    end = token.end
+                  ),
+                  tokenEmbedding
+                )
+                originalTokenWithEmbedding
+            }
+            originalTokensWithEmbeddings
+        }
+
+        WordpieceEmbeddingsSentence(tokensWithEmbeddings, sentence._2)
+      }
+    }.toSeq
+  }
+
+  def tokenizeWithAlignment(sentences: Seq[TokenizedSentence], maxSeqLength: Int, caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = {
+    val encoder = new SentencepieceEncoder(spp, caseSensitive, delimiterId = SentencePieceDelimiterId)
+
+    val sentenceTokenPieces = sentences.map { s =>
+      val shrinkedSentence = s.indexedTokens.take(maxSeqLength - 2)
+      val wordpieceTokens = shrinkedSentence.flatMap(token => encoder.encode(token)).take(maxSeqLength)
+      WordpieceTokenizedSentence(wordpieceTokens)
+    }
+    sentenceTokenPieces
+  }
+
+}

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -28,7 +28,7 @@ import com.johnsnowlabs.nlp.annotators.parser.typdep.ReadablePretrainedTypedDepe
 import com.johnsnowlabs.nlp.annotators.pos.perceptron.ReadablePretrainedPerceptron
 import com.johnsnowlabs.nlp.annotators.sda.vivekn.ReadablePretrainedVivekn
 import com.johnsnowlabs.nlp.annotators.sentence_detector_dl.{ReadablePretrainedSentenceDetectorDL, ReadsSentenceDetectorDLGraph}
-import com.johnsnowlabs.nlp.annotators.seq2seq.{ReadGPT2TransformerTensorflowModel, ReadMarianMTTensorflowModel, ReadT5TransformerTensorflowModel, ReadablePretrainedGPT2TransformerModel, ReadablePretrainedMarianMTModel, ReadablePretrainedT5TransformerModel}
+import com.johnsnowlabs.nlp.annotators.seq2seq._
 import com.johnsnowlabs.nlp.annotators.spell.norvig.ReadablePretrainedNorvig
 import com.johnsnowlabs.nlp.annotators.spell.symmetric.ReadablePretrainedSymmetric
 import com.johnsnowlabs.nlp.annotators.ws.ReadablePretrainedWordSegmenter
@@ -423,5 +423,9 @@ package object annotator {
   type Word2VecModel = com.johnsnowlabs.nlp.embeddings.Word2VecModel
 
   object Word2VecModel extends ReadablePretrainedWord2Vec
+
+  type DeBertaEmbeddings = com.johnsnowlabs.nlp.embeddings.DeBertaEmbeddings
+
+  object DeBertaEmbeddings extends ReadablePretrainedDeBertaModel with ReadDeBertaTensorflowModel
 
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/DeBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/DeBertaEmbeddings.scala
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.embeddings
+
+import com.johnsnowlabs.ml.tensorflow._
+import com.johnsnowlabs.ml.tensorflow.sentencepiece._
+import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.serialization.MapFeature
+import com.johnsnowlabs.storage.HasStorageRef
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.param.{IntArrayParam, IntParam}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import java.io.File
+
+/** The DeBERTa model was proposed in [[https://arxiv.org/abs/2006.03654 DeBERTa: Decoding-enhanced BERT with Disentangled Attention]] by Pengcheng He, Xiaodong Liu, Jianfeng Gao, Weizhu Chen It is based on Google’s BERT model released in 2018 and Facebook’s RoBERTa model released in 2019.
+ *
+ * This model requires input tokenization with SentencePiece model, which is provided by Spark NLP (See tokenizers package).
+ *
+ * Pretrained models can be loaded with `pretrained` of the companion object:
+ * {{{
+ * val embeddings = DeBertaEmbeddings.pretrained()
+ *  .setInputCols("sentence", "token")
+ *  .setOutputCol("embeddings")
+ * }}}
+ * The default model is `"deberta_v3_base"`, if no name is provided.
+ *
+ * For extended examples see [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/DeBertaEmbeddingsTestSpec.scala DeBertaEmbeddingsTestSpec]].
+ * Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. The Spark NLP Workshop
+ * example shows how to import them [[https://github.com/JohnSnowLabs/spark-nlp/discussions/5669]].
+ *
+ * It builds on RoBERTa with disentangled attention and enhanced mask decoder training with half of the data used in RoBERTa.
+ * '''Sources:'''
+ *
+ * [[https://github.com/microsoft/DeBERTa]]
+ *
+ * [[https://www.microsoft.com/en-us/research/blog/microsoft-deberta-surpasses-human-performance-on-the-superglue-benchmark/]]
+ *
+ * '''Paper abstract:'''
+ *
+ * ''Recent progress in pre-trained neural language models has significantly improved the performance of many natural language processing (NLP) tasks. In this paper we propose a new model architecture DeBERTa (Decoding-enhanced BERT with disentangled attention) that improves the BERT and RoBERTa models using two novel techniques. The first is the disentangled attention mechanism, where each word is represented using two vectors that encode its content and position, respectively, and the attention weights among words are computed using disentangled matrices on their contents and relative positions. Second, an enhanced mask decoder is used to replace the output softmax layer to predict the masked tokens for model pretraining. We show that these two techniques significantly improve the efficiency of model pretraining and performance of downstream tasks. Compared to RoBERTa-Large, a DeBERTa model trained on half of the training data performs consistently better on a wide range of NLP tasks, achieving improvements on MNLI by +0.9% (90.2% vs. 91.1%), on SQuAD v2.0 by +2.3% (88.4% vs. 90.7%) and RACE by +3.6% (83.2% vs. 86.8%). The DeBERTa code and pre-trained models will be made publicly available at https://github.com/microsoft/DeBERTa.''
+ *
+ * ==Example==
+ * {{{
+ * import spark.implicits._
+ * import com.johnsnowlabs.nlp.base.DocumentAssembler
+ * import com.johnsnowlabs.nlp.annotators.Tokenizer
+ * import com.johnsnowlabs.nlp.embeddings.DeBertaEmbeddings
+ * import com.johnsnowlabs.nlp.EmbeddingsFinisher
+ * import org.apache.spark.ml.Pipeline
+ *
+ * val documentAssembler = new DocumentAssembler()
+ *   .setInputCol("text")
+ *   .setOutputCol("document")
+ *
+ * val tokenizer = new Tokenizer()
+ *   .setInputCols("document")
+ *   .setOutputCol("token")
+ *
+ * val embeddings = DeBertaEmbeddings.pretrained()
+ *   .setInputCols("token", "document")
+ *   .setOutputCol("embeddings")
+ *
+ * val embeddingsFinisher = new EmbeddingsFinisher()
+ *   .setInputCols("embeddings")
+ *   .setOutputCols("finished_embeddings")
+ *   .setOutputAsVector(true)
+ *   .setCleanAnnotations(false)
+ *
+ * val pipeline = new Pipeline().setStages(Array(
+ *   documentAssembler,
+ *   tokenizer,
+ *   embeddings,
+ *   embeddingsFinisher
+ * ))
+ *
+ * val data = Seq("This is a sentence.").toDF("text")
+ * val result = pipeline.fit(data).transform(data)
+ *
+ * result.selectExpr("explode(finished_embeddings) as result").show(5, 80)
+ * +--------------------------------------------------------------------------------+
+ * |                                                                          result|
+ * +--------------------------------------------------------------------------------+
+ * |[1.1342473030090332,-1.3855540752410889,0.9818322062492371,-0.784737348556518...|
+ * |[0.847029983997345,-1.047153353691101,-0.1520637571811676,-0.6245765686035156...|
+ * |[-0.009860038757324219,-0.13450059294700623,2.707749128341675,1.2916892766952...|
+ * |[-0.04192575812339783,-0.5764210224151611,-0.3196685314178467,-0.527840495109...|
+ * |[0.15583214163780212,-0.1614152491092682,-0.28423872590065,-0.135491415858268...|
+ * +--------------------------------------------------------------------------------+
+ * }}}
+ *
+ * @see [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of transformer based embeddings
+ * @param uid required uid for storing annotator to disk
+ * @groupname anno Annotator types
+ * @groupdesc anno Required input and expected output annotator types
+ * @groupname Ungrouped Members
+ * @groupname param Parameters
+ * @groupname setParam Parameter setters
+ * @groupname getParam Parameter getters
+ * @groupname Ungrouped Members
+ * @groupprio param  1
+ * @groupprio anno  2
+ * @groupprio Ungrouped 3
+ * @groupprio setParam  4
+ * @groupprio getParam  5
+ * @groupdesc param A list of (hyper-)parameter keys this annotator can take. Users can set and get the parameter values through setters and getters, respectively.
+ */
+class DeBertaEmbeddings(override val uid: String)
+  extends AnnotatorModel[DeBertaEmbeddings]
+    with HasBatchedAnnotate[DeBertaEmbeddings]
+    with WriteTensorflowModel
+    with WriteSentencePieceModel
+    with HasEmbeddingsProperties
+    with HasStorageRef
+    with HasCaseSensitiveProperties {
+
+  /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator type */
+  def this() = this(Identifiable.randomUID("DEBERTA_EMBEDDINGS"))
+
+  /**
+   * Input Annotator Types: DOCUMENT, TOKEN
+   *
+   * @group anno
+   */
+  override val inputAnnotatorTypes: Array[String] = Array(AnnotatorType.DOCUMENT, AnnotatorType.TOKEN)
+  /**
+   * Output Annotator Types: WORD_EMBEDDINGS
+   *
+   * @group anno
+   */
+  override val outputAnnotatorType: AnnotatorType = AnnotatorType.WORD_EMBEDDINGS
+
+  /**
+   * ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()
+   *
+   * @group param
+   */
+  val configProtoBytes = new IntArrayParam(this, "configProtoBytes", "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
+
+  /** @group setParam */
+  def setConfigProtoBytes(bytes: Array[Int]): DeBertaEmbeddings.this.type = set(this.configProtoBytes, bytes)
+
+  /** @group getParam */
+  def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
+
+  /**
+   * Max sentence length to process (Default: `128`)
+   *
+   * @group param
+   */
+  val maxSentenceLength = new IntParam(this, "maxSentenceLength", "Max sentence length to process")
+
+  /** @group setParam */
+  def setMaxSentenceLength(value: Int): this.type = {
+    require(value <= 512, "DeBERTa models do not support sequences longer than 512 because of trainable positional embeddings")
+    require(value >= 1, "The maxSentenceLength must be at least 1")
+    set(maxSentenceLength, value)
+    this
+  }
+
+  /** @group getParam */
+  def getMaxSentenceLength: Int = $(maxSentenceLength)
+
+  /** @group setParam */
+  override def setDimension(value: Int): this.type = {
+    if (get(dimension).isEmpty)
+      set(this.dimension, value)
+    this
+  }
+
+  /**
+   * It contains TF model signatures for the laded saved model
+   *
+   * @group param
+   * */
+  val signatures = new MapFeature[String, String](model = this, name = "signatures")
+
+  /** @group setParam */
+  def setSignatures(value: Map[String, String]): this.type = {
+    if (get(signatures).isEmpty)
+      set(signatures, value)
+    this
+  }
+
+  /** @group getParam */
+  def getSignatures: Option[Map[String, String]] = get(this.signatures)
+
+  private var _model: Option[Broadcast[TensorflowDeBerta]] = None
+
+  /** @group setParam */
+  def setModelIfNotSet(spark: SparkSession, tensorflowWrapper: TensorflowWrapper, spp: SentencePieceWrapper): DeBertaEmbeddings = {
+    if (_model.isEmpty) {
+
+      _model = Some(
+        spark.sparkContext.broadcast(
+          new TensorflowDeBerta(
+            tensorflowWrapper,
+            spp,
+            batchSize = $(batchSize),
+            configProtoBytes = getConfigProtoBytes,
+            signatures = getSignatures
+          )
+        )
+      )
+    }
+
+    this
+  }
+
+  def getModelIfNotSet: TensorflowDeBerta = _model.get.value
+
+  setDefault(
+    batchSize -> 8,
+    dimension -> 768,
+    maxSentenceLength -> 128,
+    caseSensitive -> true
+  )
+
+  /**
+   * takes a document and annotations and produces new annotations of this annotator's annotation type
+   *
+   * @param batchedAnnotations Annotations that correspond to inputAnnotationCols generated by previous annotators if any
+   * @return any number of annotations processed for every input annotation. Not necessary one to one relationship
+   */
+  override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
+    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations.map(annotations =>
+      TokenizedWithSentence.unpack(annotations).toArray
+    ).toArray
+
+    /*Return empty if the real tokens are empty*/
+    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+
+      val embeddings = getModelIfNotSet.predict(
+        tokenizedSentences,
+        $(batchSize),
+        $(maxSentenceLength),
+        $(caseSensitive)
+      )
+      WordpieceEmbeddingsSentence.pack(embeddings)
+    }) else {
+      Seq(Seq.empty[Annotation])
+    }
+  }
+
+  override def onWrite(path: String, spark: SparkSession): Unit = {
+    super.onWrite(path, spark)
+    writeTensorflowModelV2(path, spark, getModelIfNotSet.tensorflow, "_deberta", DeBertaEmbeddings.tfFile, configProtoBytes = getConfigProtoBytes)
+    writeSentencePieceModel(path, spark, getModelIfNotSet.spp, "_deberta", DeBertaEmbeddings.sppFile)
+
+  }
+
+  override protected def afterAnnotate(dataset: DataFrame): DataFrame = {
+    dataset.withColumn(getOutputCol, wrapEmbeddingsMetadata(dataset.col(getOutputCol), $(dimension), Some($(storageRef))))
+  }
+
+}
+
+trait ReadablePretrainedDeBertaModel extends ParamsAndFeaturesReadable[DeBertaEmbeddings] with HasPretrained[DeBertaEmbeddings] {
+  override val defaultModelName: Some[String] = Some("deberta_v3_base")
+
+  /** Java compliant-overrides */
+  override def pretrained(): DeBertaEmbeddings = super.pretrained()
+
+  override def pretrained(name: String): DeBertaEmbeddings = super.pretrained(name)
+
+  override def pretrained(name: String, lang: String): DeBertaEmbeddings = super.pretrained(name, lang)
+
+  override def pretrained(name: String, lang: String, remoteLoc: String): DeBertaEmbeddings = super.pretrained(name, lang, remoteLoc)
+}
+
+trait ReadDeBertaTensorflowModel extends ReadTensorflowModel with ReadSentencePieceModel {
+  this: ParamsAndFeaturesReadable[DeBertaEmbeddings] =>
+
+  override val tfFile: String = "deberta_tensorflow"
+  override val sppFile: String = "deberta_spp"
+
+  def readTensorflow(instance: DeBertaEmbeddings, path: String, spark: SparkSession): Unit = {
+    val tf = readTensorflowModel(path, spark, "_deberta_tf", initAllTables = false)
+    val spp = readSentencePieceModel(path, spark, "_deberta_spp", sppFile)
+    instance.setModelIfNotSet(spark, tf, spp)
+  }
+
+  addReader(readTensorflow)
+
+  def loadSavedModel(tfModelPath: String, spark: SparkSession): DeBertaEmbeddings = {
+
+    val f = new File(tfModelPath)
+    val savedModel = new File(tfModelPath, "saved_model.pb")
+    require(f.exists, s"Folder $tfModelPath not found")
+    require(f.isDirectory, s"File $tfModelPath is not folder")
+    require(
+      savedModel.exists(),
+      s"savedModel file saved_model.pb not found in folder $tfModelPath"
+    )
+    val sppModelPath = tfModelPath + "/assets"
+    val sppModel = new File(sppModelPath, "spm.model")
+    require(sppModel.exists(), s"SentencePiece model spm.model not found in folder $sppModelPath")
+
+    val (wrapper, signatures) = TensorflowWrapper.read(tfModelPath, zipped = false, useBundle = true)
+    val spp = SentencePieceWrapper.read(sppModel.toString)
+
+    val _signatures = signatures match {
+      case Some(s) => s
+      case None => throw new Exception("Cannot load signature definitions from model!")
+    }
+
+    /** the order of setSignatures is important is we use getSignatures inside setModelIfNotSet */
+    new DeBertaEmbeddings()
+      .setSignatures(_signatures)
+      .setModelIfNotSet(spark, wrapper, spp)
+  }
+}
+
+
+/**
+ * This is the companion object of [[DeBertaEmbeddings]]. Please refer to that class for the documentation.
+ */
+object DeBertaEmbeddings extends ReadablePretrainedDeBertaModel with ReadDeBertaTensorflowModel

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -536,7 +536,8 @@ object PythonResourceDownloader {
     "AlbertForSequenceClassification" -> AlbertForSequenceClassification,
     "XlnetForSequenceClassification" -> XlnetForSequenceClassification,
     "GPT2Transformer" -> GPT2Transformer,
-    "Word2VecModel" -> Word2VecModel
+    "Word2VecModel" -> Word2VecModel,
+    "DeBertaEmbeddings" -> DeBertaEmbeddings
   )
 
   def downloadModel(readerStr: String, name: String, language: String = null, remoteLoc: String = null): PipelineStage = {

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/DeBertaEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/DeBertaEmbeddingsTestSpec.scala
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.embeddings
+
+import com.johnsnowlabs.nlp.annotator._
+import com.johnsnowlabs.nlp.base._
+import com.johnsnowlabs.nlp.training.CoNLL
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.SlowTest
+import com.johnsnowlabs.util.Benchmark
+import org.apache.spark.ml.Pipeline
+import org.apache.spark.sql.functions.{col, explode, size}
+import org.scalatest.flatspec.AnyFlatSpec
+
+
+class DeBertaEmbeddingsTestSpec extends AnyFlatSpec {
+
+  "DeBertaEmbeddings" should "correctly load pretrained model" taggedAs SlowTest in {
+
+    val smallCorpus = ResourceHelper.spark.read.option("header", "true")
+      .csv("src/test/resources/embeddings/sentence_embeddings.csv")
+
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentence = new SentenceDetector()
+      .setInputCols("document")
+      .setOutputCol("sentence")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("sentence"))
+      .setOutputCol("token")
+
+    val embeddings = DeBertaEmbeddings.pretrained()
+      .setInputCols("sentence", "token")
+      .setOutputCol("embeddings")
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        documentAssembler,
+        sentence,
+        tokenizer,
+        embeddings
+      ))
+
+    val pipelineDF = pipeline.fit(smallCorpus).transform(smallCorpus)
+    pipelineDF.select("token.result").show(1, truncate = false)
+    pipelineDF.select("embeddings.result").show(1, truncate = false)
+    pipelineDF.select("embeddings.metadata").show(1, truncate = false)
+    pipelineDF.select("embeddings.embeddings").show(1, truncate = 300)
+    pipelineDF.select(size(pipelineDF("embeddings.embeddings")).as("embeddings_size")).show(1)
+    Benchmark.time("Time to save BertEmbeddings results") {
+      pipelineDF.select("embeddings").write.mode("overwrite").parquet("./tmp_embeddings")
+    }
+  }
+
+  "DeBertaEmbeddings" should "benchmark test" taggedAs SlowTest in {
+    import ResourceHelper.spark.implicits._
+
+    val conll = CoNLL(explodeSentences = false)
+    val training_data = conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.train")
+
+    val embeddings = DeBertaEmbeddings.pretrained()
+      .setInputCols("sentence", "token")
+      .setOutputCol("embeddings")
+      .setMaxSentenceLength(512)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(
+        embeddings
+      ))
+
+    val pipelineDF = pipeline.fit(training_data).transform(training_data)
+    Benchmark.time("Time to save DeBertaEmbeddings results") {
+      pipelineDF.write.mode("overwrite").parquet("./tmp_bert_embeddings")
+    }
+
+    Benchmark.time("Time to finish checking counts in results") {
+      println("missing tokens/embeddings: ")
+      pipelineDF.withColumn("sentence_size", size(col("sentence")))
+        .withColumn("token_size", size(col("token")))
+        .withColumn("embed_size", size(col("embeddings")))
+        .where(col("token_size") =!= col("embed_size"))
+        .select("sentence_size", "token_size", "embed_size")
+        .show(false)
+    }
+
+    Benchmark.time("Time to finish explod/count in results") {
+      println("total sentences: ", pipelineDF.select(explode($"sentence.result")).count)
+      val totalTokens = pipelineDF.select(explode($"token.result")).count.toInt
+      val totalEmbeddings = pipelineDF.select(explode($"embeddings.embeddings")).count.toInt
+
+      println(s"total tokens: $totalTokens")
+      println(s"total embeddings: $totalEmbeddings")
+
+      // it is normal that the embeddings is less than total tokens in a sentence/document
+      // tokens generate multiple sub-wrods or pieces which won't be included in the final results
+      assert(totalTokens >= totalEmbeddings)
+
+    }
+  }
+
+  "DeBertaEmbeddings" should "be aligned with custom tokens from Tokenizer" taggedAs SlowTest in {
+
+    import ResourceHelper.spark.implicits._
+
+    val ddd = Seq(
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21",
+      " carbon emissions have come down without impinging on our growth . . .",
+      "carbon emissions have come down without impinging on our growth .\\u2009.\\u2009."
+    ).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val embeddings = DeBertaEmbeddings.pretrained()
+      .setInputCols("document", "token")
+      .setOutputCol("embeddings")
+      .setMaxSentenceLength(128)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, embeddings))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("token").show(false)
+    pipelineDF.select("embeddings.result").show(false)
+    pipelineDF
+      .withColumn("token_size", size(col("token")))
+      .withColumn("embed_size", size(col("embeddings")))
+      .where(col("token_size") =!= col("embed_size"))
+      .select("token_size", "embed_size", "token.result", "embeddings.result")
+      .show(false)
+
+    val totalTokens = pipelineDF.select(explode($"token.result")).count.toInt
+    val totalEmbeddings = pipelineDF.select(explode($"embeddings.embeddings")).count.toInt
+
+    println(s"total tokens: $totalTokens")
+    println(s"total embeddings: $totalEmbeddings")
+
+    assert(totalTokens == totalEmbeddings)
+
+  }
+}


### PR DESCRIPTION
This PR introduces `DeBertaEmbeddings` for DeBERTa v2 and v3 models using the `SentencePiece` model for tokenization. 


```python
embeddings = DeBertaEmbeddings\
      .pretrained()\
      .setInputCols(["token", "sentence"])\
      .setOutputCol("embeddings")\
      .setCaseSensitive(True)\
      .setMaxSentenceLength(512)\
      .setBatchSize(16)
```