### PR TITLE
Add Sigmoid to ForSequenceClassification annotators

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,19 +1,3 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 version = 3.4.3
 runner.dialect = scala212
 align = none
@@ -25,4 +9,5 @@ optIn = {
 }
 danglingParentheses = false
 danglingParentheses.preset = false
+docstrings.oneline = fold
 maxColumn = 98

--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -17,6 +17,7 @@ classes.
 """
 
 import sys
+
 from sparknlp.common import *
 
 # Do NOT delete. Looks redundant but this is key work around for python 2 support.
@@ -15136,7 +15137,8 @@ class EntityRulerModel(AnnotatorModel, HasStorageModel):
 
 class BertForSequenceClassification(AnnotatorModel,
                                     HasCaseSensitiveProperties,
-                                    HasBatchedAnnotate):
+                                    HasBatchedAnnotate,
+                                    HasClassifierActivationProperties):
     """BertForSequenceClassification can load Bert Models with sequence classification/regression head on top
     (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -15276,7 +15278,8 @@ class BertForSequenceClassification(AnnotatorModel,
             batchSize=8,
             maxSentenceLength=128,
             caseSensitive=True,
-            coalesceSentences=False
+            coalesceSentences=False,
+            activation="softmax"
         )
 
     @staticmethod
@@ -15647,7 +15650,8 @@ class Doc2VecModel(AnnotatorModel, HasStorageRef, HasEmbeddingsProperties):
 
 class DistilBertForSequenceClassification(AnnotatorModel,
                                           HasCaseSensitiveProperties,
-                                          HasBatchedAnnotate):
+                                          HasBatchedAnnotate,
+                                          HasClassifierActivationProperties):
     """DistilBertForSequenceClassification can load DistilBERT Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -15788,7 +15792,8 @@ class DistilBertForSequenceClassification(AnnotatorModel,
             batchSize=8,
             maxSentenceLength=128,
             caseSensitive=True,
-            coalesceSentences=False
+            coalesceSentences=False,
+            activation="softmax"
         )
 
     @staticmethod
@@ -15837,7 +15842,8 @@ class DistilBertForSequenceClassification(AnnotatorModel,
 
 class RoBertaForSequenceClassification(AnnotatorModel,
                                        HasCaseSensitiveProperties,
-                                       HasBatchedAnnotate):
+                                       HasBatchedAnnotate,
+                                       HasClassifierActivationProperties):
     """RoBertaForSequenceClassification can load RoBERTa Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -15978,7 +15984,8 @@ class RoBertaForSequenceClassification(AnnotatorModel,
             batchSize=8,
             maxSentenceLength=128,
             caseSensitive=True,
-            coalesceSentences=False
+            coalesceSentences=False,
+            activation="softmax"
         )
 
     @staticmethod
@@ -16027,7 +16034,8 @@ class RoBertaForSequenceClassification(AnnotatorModel,
 
 class XlmRoBertaForSequenceClassification(AnnotatorModel,
                                           HasCaseSensitiveProperties,
-                                          HasBatchedAnnotate):
+                                          HasBatchedAnnotate,
+                                          HasClassifierActivationProperties):
     """XlmRoBertaForSequenceClassification can load XLM-RoBERTa Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -16168,7 +16176,8 @@ class XlmRoBertaForSequenceClassification(AnnotatorModel,
             batchSize=8,
             maxSentenceLength=128,
             caseSensitive=True,
-            coalesceSentences=False
+            coalesceSentences=False,
+            activation="softmax"
         )
 
     @staticmethod
@@ -16217,7 +16226,8 @@ class XlmRoBertaForSequenceClassification(AnnotatorModel,
 
 class LongformerForSequenceClassification(AnnotatorModel,
                                           HasCaseSensitiveProperties,
-                                          HasBatchedAnnotate):
+                                          HasBatchedAnnotate,
+                                          HasClassifierActivationProperties):
     """LongformerForSequenceClassification can load Longformer Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -16358,7 +16368,8 @@ class LongformerForSequenceClassification(AnnotatorModel,
             batchSize=8,
             maxSentenceLength=4096,
             caseSensitive=True,
-            coalesceSentences=False
+            coalesceSentences=False,
+            activation="softmax"
         )
 
     @staticmethod
@@ -16407,7 +16418,8 @@ class LongformerForSequenceClassification(AnnotatorModel,
 
 class AlbertForSequenceClassification(AnnotatorModel,
                                       HasCaseSensitiveProperties,
-                                      HasBatchedAnnotate):
+                                      HasBatchedAnnotate,
+                                      HasClassifierActivationProperties):
     """AlbertForSequenceClassification can load Albert Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -16548,7 +16560,8 @@ class AlbertForSequenceClassification(AnnotatorModel,
             batchSize=8,
             maxSentenceLength=128,
             caseSensitive=False,
-            coalesceSentences=False
+            coalesceSentences=False,
+            activation="softmax"
         )
 
     @staticmethod
@@ -16597,7 +16610,8 @@ class AlbertForSequenceClassification(AnnotatorModel,
 
 class XlnetForSequenceClassification(AnnotatorModel,
                                      HasCaseSensitiveProperties,
-                                     HasBatchedAnnotate):
+                                     HasBatchedAnnotate,
+                                     HasClassifierActivationProperties):
     """XlnetForSequenceClassification can load XLNet Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -16738,7 +16752,8 @@ class XlnetForSequenceClassification(AnnotatorModel,
             batchSize=8,
             maxSentenceLength=128,
             caseSensitive=True,
-            coalesceSentences=False
+            coalesceSentences=False,
+            activation="softmax"
         )
 
     @staticmethod

--- a/python/sparknlp/common.py
+++ b/python/sparknlp/common.py
@@ -20,6 +20,7 @@ from pyspark.ml.wrapper import JavaModel, JavaEstimator
 from pyspark.ml.param.shared import Param, TypeConverters
 from pyspark.ml.param import Params
 from pyspark import keyword_only
+
 import sparknlp.internal as _internal
 
 
@@ -389,3 +390,30 @@ class HasEnableCachingProperties:
             Whether to enable caching DataFrames or RDDs during the training
         """
         return self.getOrDefault(self.enableCaching)
+
+
+class HasClassifierActivationProperties:
+    activation = Param(Params._dummy(),
+                       "activation",
+                       "Whether to calcuate logits via Softmax or Sigmoid. Default is Softmax",
+                       typeConverter=TypeConverters.toString)
+
+    def setActivation(self, value):
+        """Sets whether to calcuate logits via Softmax or Sigmoid. Default is Softmax
+
+        Parameters
+        ----------
+        value : bool
+            Whether to calcuate logits via Softmax or Sigmoid. Default is Softmax
+        """
+        return self._set(activation=value)
+
+    def getActivation(self):
+        """Gets whether to calcuate logits via Softmax or Sigmoid. Default is Softmax
+
+        Returns
+        -------
+        bool
+            Whether to calcuate logits via Softmax or Sigmoid. Default is Softmax
+        """
+        return self.getOrDefault(self.activation)

--- a/python/sparknlp/common.py
+++ b/python/sparknlp/common.py
@@ -403,7 +403,7 @@ class HasClassifierActivationProperties:
 
         Parameters
         ----------
-        value : bool
+        value : str
             Whether to calcuate logits via Softmax or Sigmoid. Default is Softmax
         """
         return self._set(activation=value)
@@ -413,7 +413,7 @@ class HasClassifierActivationProperties:
 
         Returns
         -------
-        bool
+        str
             Whether to calcuate logits via Softmax or Sigmoid. Default is Softmax
         """
         return self.getOrDefault(self.activation)

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowDistilBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowDistilBertClassification.scala
@@ -17,8 +17,9 @@
 package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
+import com.johnsnowlabs.nlp.ActivationFunction
 import com.johnsnowlabs.nlp.annotators.common._
-import com.johnsnowlabs.nlp.annotators.tokenizer.wordpiece.{BasicTokenizer, WordpieceEncoder}
+import com.johnsnowlabs.nlp.annotators.tokenizer.wordpiece.{WordpieceEncoder, BasicTokenizer}
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
 import scala.collection.JavaConverters._
@@ -138,7 +139,7 @@ class TensorflowDistilBertClassification(
     batchScores
   }
 
-  def tagSequence(batch: Seq[Array[Int]]): Array[Array[Float]] = {
+  def tagSequence(batch: Seq[Array[Int]], activation: String): Array[Array[Float]] = {
     val tensors = new TensorResources()
 
     val maxSentenceLength = batch.map(encodedSentence => encodedSentence.length).max
@@ -189,7 +190,15 @@ class TensorflowDistilBertClassification(
 
     val dim = rawScores.length / batchLength
     val batchScores: Array[Array[Float]] =
-      rawScores.grouped(dim).map(scores => calculateSoftmax(scores)).toArray
+      rawScores
+        .grouped(dim)
+        .map(scores =>
+          activation match {
+            case ActivationFunction.softmax => calculateSoftmax(scores)
+            case ActivationFunction.sigmoid => calculateSigmoid(scores)
+            case _ => calculateSoftmax(scores)
+          })
+        .toArray
 
     batchScores
   }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowForClassification.scala
@@ -83,36 +83,69 @@ trait TensorflowForClassification {
         val tokensBatch = batch.map(x => (x._1._1, x._2))
         val encoded = encode(tokensBatch, maxSentenceLength)
         val logits = tagSequence(encoded, activation)
+        activation match {
+          case ActivationFunction.softmax =>
+            if (coalesceSentences) {
+              val scores = logits.transpose.map(_.sum / logits.length)
+              val label = scoresToLabelForSequenceClassifier(tags, scores)
+              val meta = constructMetaForSequenceClassifier(tags, scores)
+              Array(constructAnnotationForSequenceClassifier(sentences.head, label, meta))
+            } else {
+              sentences.zip(logits).map { case (sentence, scores) =>
+                val label = scoresToLabelForSequenceClassifier(tags, scores)
+                val meta = constructMetaForSequenceClassifier(tags, scores)
+                constructAnnotationForSequenceClassifier(sentence, label, meta)
+              }
+            }
 
-        if (coalesceSentences) {
-          val scores = logits.transpose.map(_.sum / logits.length)
-          val label =
-            tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-          val meta = scores.zipWithIndex.flatMap(x =>
-            Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-          Array(
-            Annotation(
-              annotatorType = AnnotatorType.CATEGORY,
-              begin = sentences.head.start,
-              end = sentences.head.end,
-              result = label,
-              metadata = Map("sentence" -> sentences.head.index.toString) ++ meta))
-        } else {
-          sentences.zip(logits).map { case (sentence, scores) =>
-            val label =
-              tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-            val meta = scores.zipWithIndex.flatMap(x =>
-              Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
-            Annotation(
-              annotatorType = AnnotatorType.CATEGORY,
-              begin = sentence.start,
-              end = sentence.end,
-              result = label,
-              metadata = Map("sentence" -> sentence.index.toString) ++ meta)
-          }
+          case ActivationFunction.sigmoid =>
+            if (coalesceSentences) {
+              val scores = logits.transpose.map(_.sum / logits.length)
+              val labels = scores.zipWithIndex
+                .filter(x => x._1 > 0.5)
+                .flatMap(x => tags.filter(_._2 == x._2))
+              val meta = constructMetaForSequenceClassifier(tags, scores)
+              labels.map(label =>
+                constructAnnotationForSequenceClassifier(sentences.head, label._1, meta))
+            } else {
+              sentences.zip(logits).flatMap { case (sentence, scores) =>
+                val labels = scores.zipWithIndex
+                  .filter(x => x._1 > 0.5)
+                  .flatMap(x => tags.filter(_._2 == x._2))
+                val meta = constructMetaForSequenceClassifier(tags, scores)
+                labels.map(label =>
+                  constructAnnotationForSequenceClassifier(sentence, label._1, meta))
+              }
+            }
+
         }
       }
       .toSeq
+
+  }
+
+  def scoresToLabelForSequenceClassifier(tags: Map[String, Int], scores: Array[Float]): String = {
+    tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
+  }
+
+  def constructMetaForSequenceClassifier(
+      tags: Map[String, Int],
+      scores: Array[Float]): Array[(String, String)] = {
+    scores.zipWithIndex.flatMap(x =>
+      Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
+  }
+
+  def constructAnnotationForSequenceClassifier(
+      sentence: Sentence,
+      label: String,
+      meta: Array[(String, String)]): Annotation = {
+
+    Annotation(
+      annotatorType = AnnotatorType.CATEGORY,
+      begin = sentence.start,
+      end = sentence.end,
+      result = label,
+      metadata = Map("sentence" -> sentence.index.toString) ++ meta)
 
   }
 

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowForClassification.scala
@@ -154,8 +154,7 @@ trait TensorflowForClassification {
       maxSeqLength: Int,
       caseSensitive: Boolean): Seq[WordpieceTokenizedSentence]
 
-  /** Encode the input sequence to indexes IDs adding padding where necessary
-    */
+  /** Encode the input sequence to indexes IDs adding padding where necessary */
   def encode(
       sentences: Seq[(WordpieceTokenizedSentence, Int)],
       maxSequenceLength: Int): Seq[Array[Int]] = {

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlmRoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlmRoBertaClassification.scala
@@ -18,6 +18,7 @@ package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{SentencePieceWrapper, SentencepieceEncoder}
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
+import com.johnsnowlabs.nlp.ActivationFunction
 import com.johnsnowlabs.nlp.annotators.common._
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
@@ -130,7 +131,7 @@ class TensorflowXlmRoBertaClassification(
     batchScores
   }
 
-  def tagSequence(batch: Seq[Array[Int]]): Array[Array[Float]] = {
+  def tagSequence(batch: Seq[Array[Int]], activation: String): Array[Array[Float]] = {
     val tensors = new TensorResources()
 
     val maxSentenceLength = batch.map(encodedSentence => encodedSentence.length).max
@@ -179,7 +180,15 @@ class TensorflowXlmRoBertaClassification(
 
     val dim = rawScores.length / batchLength
     val batchScores: Array[Array[Float]] =
-      rawScores.grouped(dim).map(scores => calculateSoftmax(scores)).toArray
+      rawScores
+        .grouped(dim)
+        .map(scores =>
+          activation match {
+            case ActivationFunction.softmax => calculateSoftmax(scores)
+            case ActivationFunction.sigmoid => calculateSigmoid(scores)
+            case _ => calculateSoftmax(scores)
+          })
+        .toArray
 
     batchScores
   }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlnetClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlnetClassification.scala
@@ -18,6 +18,7 @@ package com.johnsnowlabs.ml.tensorflow
 
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{SentencePieceWrapper, SentencepieceEncoder}
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
+import com.johnsnowlabs.nlp.ActivationFunction
 import com.johnsnowlabs.nlp.annotators.common._
 import org.tensorflow.ndarray.buffer.IntDataBuffer
 
@@ -139,7 +140,7 @@ class TensorflowXlnetClassification(
     batchScores
   }
 
-  def tagSequence(batch: Seq[Array[Int]]): Array[Array[Float]] = {
+  def tagSequence(batch: Seq[Array[Int]], activation: String): Array[Array[Float]] = {
     val tensors = new TensorResources()
 
     val maxSentenceLength = batch.map(encodedSentence => encodedSentence.length).max
@@ -199,7 +200,15 @@ class TensorflowXlnetClassification(
 
     val dim = rawScores.length / batchLength
     val batchScores: Array[Array[Float]] =
-      rawScores.grouped(dim).map(scores => calculateSoftmax(scores)).toArray
+      rawScores
+        .grouped(dim)
+        .map(scores =>
+          activation match {
+            case ActivationFunction.softmax => calculateSoftmax(scores)
+            case ActivationFunction.sigmoid => calculateSigmoid(scores)
+            case _ => calculateSoftmax(scores)
+          })
+        .toArray
 
     batchScores
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/HasClassifierActivationProperties.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasClassifierActivationProperties.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp
+
+import org.apache.spark.ml.param.Param
+
+trait HasClassifierActivationProperties extends ParamsAndFeaturesWritable {
+
+  /** Whether to enable caching DataFrames or RDDs during the training
+    *
+    * @group param
+    */
+  val activation: Param[String] = new Param(
+    this,
+    "activation",
+    "Whether to calcuate logits via Softmax or Sigmoid. Default is Softmax")
+
+  setDefault(activation, ActivationFunction.softmax)
+
+  /** @group getParam */
+  def getActivation: String = $(activation)
+
+  /** @group setParam */
+  def setActivation(value: String): this.type = set(this.activation, value)
+
+}
+
+object ActivationFunction {
+
+  val softmax = "softmax"
+  val sigmoid = "sigmoid"
+
+}

--- a/src/main/scala/com/johnsnowlabs/nlp/HasClassifierActivationProperties.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasClassifierActivationProperties.scala
@@ -35,8 +35,18 @@ trait HasClassifierActivationProperties extends ParamsAndFeaturesWritable {
   def getActivation: String = $(activation)
 
   /** @group setParam */
-  def setActivation(value: String): this.type = set(this.activation, value)
+  def setActivation(value: String): this.type = {
 
+    value match {
+      case ActivationFunction.softmax =>
+        set(this.activation, ActivationFunction.softmax)
+      case ActivationFunction.sigmoid =>
+        set(this.activation, ActivationFunction.sigmoid)
+      case _ =>
+        set(this.activation, ActivationFunction.softmax)
+    }
+
+  }
 }
 
 object ActivationFunction {

--- a/src/main/scala/com/johnsnowlabs/nlp/HasMultipleInputAnnotationCols.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasMultipleInputAnnotationCols.scala
@@ -16,8 +16,7 @@
 
 package com.johnsnowlabs.nlp
 
-/** Trait used to create annotators with input columns of variable length.
-  */
+/** Trait used to create annotators with input columns of variable length. */
 trait HasMultipleInputAnnotationCols extends HasInputAnnotationCols {
 
   /** Annotator reference id. The Annotator type is the same for any of the input columns */

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DocumentNormalizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DocumentNormalizer.scala
@@ -254,8 +254,7 @@ class DocumentNormalizer(override val uid: String)
     */
   def setEncoding(value: String): this.type = set(encoding, value)
 
-  /** Applying document normalization without pretty formatting (removing multiple spaces)
-    */
+  /** Applying document normalization without pretty formatting (removing multiple spaces) */
   private def withAllFormatter(
       text: String,
       action: String,
@@ -277,8 +276,7 @@ class DocumentNormalizer(override val uid: String)
     }
   }
 
-  /** pattern to grab from text as token candidates. Defaults \\S+
-    */
+  /** pattern to grab from text as token candidates. Defaults \\S+ */
   private def withPrettyAllFormatter(
       text: String,
       action: String,
@@ -314,8 +312,7 @@ class DocumentNormalizer(override val uid: String)
     }
   }
 
-  /** pattern to grab from text as token candidates. Defaults \\S+
-    */
+  /** pattern to grab from text as token candidates. Defaults \\S+ */
   private def withPrettyFirstFormatter(
       text: String,
       action: String,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Lemmatizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Lemmatizer.scala
@@ -165,12 +165,10 @@ class Lemmatizer(override val uid: String) extends AnnotatorApproach[LemmatizerM
   val formCol =
     new Param[String](this, "formCol", "Column that correspends to CoNLLU(formCol=) output")
 
-  /** @group setParam
-    */
+  /** @group setParam */
   def setFormCol(value: String): this.type = set(formCol, value)
 
-  /** @group getParam
-    */
+  /** @group getParam */
   def getFormCol: String = $(formCol)
 
   /** Column that correspends to CoNLLU(lemmaCol=) output
@@ -180,12 +178,10 @@ class Lemmatizer(override val uid: String) extends AnnotatorApproach[LemmatizerM
   val lemmaCol =
     new Param[String](this, "lemmaCol", "Column that correspends to CoNLLU(lemmaCol=) output")
 
-  /** @group setParam
-    */
+  /** @group setParam */
   def setLemmaCol(value: String): this.type = set(lemmaCol, value)
 
-  /** @group getParam
-    */
+  /** @group getParam */
   def getLemmaCol: String = $(lemmaCol)
 
   /** External dictionary to be used by the lemmatizer

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/LemmatizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/LemmatizerModel.scala
@@ -70,8 +70,7 @@ class LemmatizerModel(override val uid: String)
     */
   override val inputAnnotatorTypes: Array[AnnotatorType] = Array(TOKEN)
 
-  /** lemmaDict
-    */
+  /** lemmaDict */
   val lemmaDict: MapFeature[String, String] = new MapFeature(this, "lemmaDict")
 
   def this() = this(Identifiable.randomUID("LEMMATIZER"))

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/NormalizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/NormalizerModel.scala
@@ -84,12 +84,10 @@ class NormalizerModel(override val uid: String)
     "cleanupPatterns",
     "normalization regex patterns which match will be removed from token")
 
-  /** @group setParam
-    */
+  /** @group setParam */
   def setCleanupPatterns(value: Array[String]): this.type = set(cleanupPatterns, value)
 
-  /** @group setParam
-    */
+  /** @group setParam */
   def getCleanupPatterns: Array[String] = $(cleanupPatterns)
 
   /** whether to convert strings to lowercase
@@ -98,12 +96,10 @@ class NormalizerModel(override val uid: String)
     */
   val lowercase = new BooleanParam(this, "lowercase", "whether to convert strings to lowercase")
 
-  /** @group setParam
-    */
+  /** @group setParam */
   def setLowercase(value: Boolean): this.type = set(lowercase, value)
 
-  /** @group setParam
-    */
+  /** @group setParam */
   def getLowercase: Boolean = $(lowercase)
 
   /** slangDict
@@ -121,18 +117,15 @@ class NormalizerModel(override val uid: String)
     "slangMatchCase",
     "whether or not to be case sensitive to match slangs. Defaults to false.")
 
-  /** @group setParam
-    */
+  /** @group setParam */
   def setSlangMatchCase(value: Boolean): this.type = set(slangMatchCase, value)
 
-  /** @group getParam
-    */
+  /** @group getParam */
   def getSlangMatchCase: Boolean = $(slangMatchCase)
 
   def this() = this(Identifiable.randomUID("NORMALIZER"))
 
-  /** @group setParam
-    */
+  /** @group setParam */
   def setSlangDict(value: Map[String, String]): this.type = set(slangDict, value)
 
   /** Set the minimum allowed length for each token
@@ -141,16 +134,14 @@ class NormalizerModel(override val uid: String)
     */
   val minLength = new IntParam(this, "minLength", "Set the minimum allowed length for each token")
 
-  /** @group setParam
-    */
+  /** @group setParam */
   def setMinLength(value: Int): this.type = {
     require(value >= 0, "minLength must be greater equal than 0")
     require(value.isValidInt, "minLength must be Int")
     set(minLength, value)
   }
 
-  /** @group getParam
-    */
+  /** @group getParam */
   def getMinLength: Int = $(minLength)
 
   /** Set the maximum allowed length for each token
@@ -159,8 +150,7 @@ class NormalizerModel(override val uid: String)
     */
   val maxLength = new IntParam(this, "maxLength", "Set the maximum allowed length for each token")
 
-  /** @group setParam
-    */
+  /** @group setParam */
   def setMaxLength(value: Int): this.type = {
     require(
       value >= $ {
@@ -171,8 +161,7 @@ class NormalizerModel(override val uid: String)
     set(maxLength, value)
   }
 
-  /** @group getParam
-    */
+  /** @group getParam */
   def getMaxLength: Int = $(maxLength)
 
   def applyRegexPatterns(word: String): String = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcher.scala
@@ -263,8 +263,7 @@ class TextMatcher(override val uid: String)
     */
   def getBuildFromTokens: Boolean = $(buildFromTokens)
 
-  /** Loads entities from a provided source.
-    */
+  /** Loads entities from a provided source. */
   private def loadEntities(dataset: Dataset[_]): Array[Array[String]] = {
     val phrases: Array[String] = ResourceHelper.parseLines($(entities))
     val parsedEntities: Array[Array[String]] = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/btm/BigTextMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/btm/BigTextMatcher.scala
@@ -151,8 +151,7 @@ class BigTextMatcher(override val uid: String)
   /** @group getParam */
   def getMergeOverlapping: Boolean = $(mergeOverlapping)
 
-  /** Loads entities from a provided source.
-    */
+  /** Loads entities from a provided source. */
   private def loadEntities(path: String, writers: Map[Database.Name, StorageWriter[_]]): Unit = {
     val inputFiles: Seq[Iterator[String]] =
       ResourceHelper.parseLinesIterator(ExternalResource(path, ReadAs.TEXT, Map()))

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassification.scala
@@ -159,8 +159,7 @@ class AlbertForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassification.scala
@@ -18,16 +18,16 @@ package com.johnsnowlabs.nlp.annotators.classifier.dl
 
 import com.johnsnowlabs.ml.tensorflow._
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{
-  ReadSentencePieceModel,
   SentencePieceWrapper,
+  ReadSentencePieceModel,
   WriteSentencePieceModel
 }
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.serialization.MapFeature
-import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
+import com.johnsnowlabs.nlp.util.io.{ReadAs, ResourceHelper, ExternalResource}
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.ml.param.{BooleanParam, IntArrayParam, IntParam}
+import org.apache.spark.ml.param.{IntParam, IntArrayParam, BooleanParam}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.SparkSession
 
@@ -120,7 +120,8 @@ class AlbertForSequenceClassification(override val uid: String)
     with HasBatchedAnnotate[AlbertForSequenceClassification]
     with WriteTensorflowModel
     with WriteSentencePieceModel
-    with HasCaseSensitiveProperties {
+    with HasCaseSensitiveProperties
+    with HasClassifierActivationProperties {
 
   /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator
     * type
@@ -307,7 +308,8 @@ class AlbertForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          $$(labels))
+          $$(labels),
+          $(activation))
       } else {
         Seq.empty[Annotation]
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForTokenClassification.scala
@@ -149,8 +149,7 @@ class AlbertForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
@@ -114,7 +114,8 @@ class BertForSequenceClassification(override val uid: String)
     extends AnnotatorModel[BertForSequenceClassification]
     with HasBatchedAnnotate[BertForSequenceClassification]
     with WriteTensorflowModel
-    with HasCaseSensitiveProperties {
+    with HasCaseSensitiveProperties
+    with HasClassifierActivationProperties {
 
   /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator
     * type
@@ -303,7 +304,9 @@ class BertForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          $$(labels))
+          $$(labels),
+          $(activation))
+
       } else {
         Seq.empty[Annotation]
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
@@ -20,9 +20,9 @@ import com.johnsnowlabs.ml.tensorflow._
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.serialization.MapFeature
-import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
+import com.johnsnowlabs.nlp.util.io.{ReadAs, ResourceHelper, ExternalResource}
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.ml.param.{BooleanParam, IntArrayParam, IntParam}
+import org.apache.spark.ml.param.{IntParam, IntArrayParam, BooleanParam}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.SparkSession
 
@@ -163,8 +163,7 @@ class BertForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala
@@ -161,8 +161,7 @@ class BertForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
@@ -163,8 +163,7 @@ class DistilBertForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
@@ -114,7 +114,8 @@ class DistilBertForSequenceClassification(override val uid: String)
     extends AnnotatorModel[DistilBertForSequenceClassification]
     with HasBatchedAnnotate[DistilBertForSequenceClassification]
     with WriteTensorflowModel
-    with HasCaseSensitiveProperties {
+    with HasCaseSensitiveProperties
+    with HasClassifierActivationProperties {
 
   /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator
     * type
@@ -303,7 +304,8 @@ class DistilBertForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          $$(labels))
+          $$(labels),
+          $(activation))
       } else {
         Seq.empty[Annotation]
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
@@ -161,8 +161,7 @@ class DistilBertForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassification.scala
@@ -165,8 +165,7 @@ class LongformerForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassification.scala
@@ -114,7 +114,8 @@ class LongformerForSequenceClassification(override val uid: String)
     extends AnnotatorModel[LongformerForSequenceClassification]
     with HasBatchedAnnotate[LongformerForSequenceClassification]
     with WriteTensorflowModel
-    with HasCaseSensitiveProperties {
+    with HasCaseSensitiveProperties
+    with HasClassifierActivationProperties {
 
   /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator
     * type
@@ -316,7 +317,8 @@ class LongformerForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          $$(labels))
+          $$(labels),
+          $(activation))
       } else {
         Seq.empty[Annotation]
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForTokenClassification.scala
@@ -164,8 +164,7 @@ class LongformerForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassification.scala
@@ -165,8 +165,7 @@ class RoBertaForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassification.scala
@@ -114,7 +114,8 @@ class RoBertaForSequenceClassification(override val uid: String)
     extends AnnotatorModel[RoBertaForSequenceClassification]
     with HasBatchedAnnotate[RoBertaForSequenceClassification]
     with WriteTensorflowModel
-    with HasCaseSensitiveProperties {
+    with HasCaseSensitiveProperties
+    with HasClassifierActivationProperties {
 
   /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator
     * type
@@ -316,7 +317,8 @@ class RoBertaForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          $$(labels))
+          $$(labels),
+          $(activation))
       } else {
         Seq.empty[Annotation]
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForTokenClassification.scala
@@ -164,8 +164,7 @@ class RoBertaForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
@@ -171,8 +171,7 @@ class XlmRoBertaForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
@@ -120,7 +120,8 @@ class XlmRoBertaForSequenceClassification(override val uid: String)
     with HasBatchedAnnotate[XlmRoBertaForSequenceClassification]
     with WriteTensorflowModel
     with WriteSentencePieceModel
-    with HasCaseSensitiveProperties {
+    with HasCaseSensitiveProperties
+    with HasClassifierActivationProperties {
 
   /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator
     * type
@@ -319,7 +320,8 @@ class XlmRoBertaForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          $$(labels))
+          $$(labels),
+          $(activation))
       } else {
         Seq.empty[Annotation]
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForTokenClassification.scala
@@ -149,8 +149,7 @@ class XlmRoBertaForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassification.scala
@@ -159,8 +159,7 @@ class XlnetForSequenceClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassification.scala
@@ -120,7 +120,8 @@ class XlnetForSequenceClassification(override val uid: String)
     with HasBatchedAnnotate[XlnetForSequenceClassification]
     with WriteTensorflowModel
     with WriteSentencePieceModel
-    with HasCaseSensitiveProperties {
+    with HasCaseSensitiveProperties
+    with HasClassifierActivationProperties {
 
   /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator
     * type
@@ -307,7 +308,8 @@ class XlnetForSequenceClassification(override val uid: String)
           $(maxSentenceLength),
           $(caseSensitive),
           $(coalesceSentences),
-          $$(labels))
+          $$(labels),
+          $(activation))
       } else {
         Seq.empty[Annotation]
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForTokenClassification.scala
@@ -149,8 +149,7 @@ class XlnetForTokenClassification(override val uid: String)
   /** @group setParam */
   def setLabels(value: Map[String, Int]): this.type = set(labels, value)
 
-  /** Returns labels used to train this model
-    */
+  /** Returns labels used to train this model */
   def getClasses: Array[String] = {
     $$(labels).keys.toArray
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceSplit.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/common/SentenceSplit.scala
@@ -20,8 +20,7 @@ import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 
 import scala.collection.Map
 
-/** structure representing a sentence and its boundaries
-  */
+/** structure representing a sentence and its boundaries */
 case class Sentence(
     content: String,
     start: Int,
@@ -40,8 +39,7 @@ object Sentence {
   }
 }
 
-/** Helper object to work work with Sentence
-  */
+/** Helper object to work work with Sentence */
 object SentenceSplit extends Annotated[Sentence] {
   override def annotatorType: String = AnnotatorType.DOCUMENT
 
@@ -69,8 +67,7 @@ object SentenceSplit extends Annotated[Sentence] {
   }
 }
 
-/** Helper object to work work with Chunks
-  */
+/** Helper object to work work with Chunks */
 object ChunkSplit extends Annotated[Sentence] {
   override def annotatorType: String = AnnotatorType.CHUNK
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/FeatureGenerator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/crf/FeatureGenerator.scala
@@ -21,8 +21,7 @@ import com.johnsnowlabs.nlp.annotators.common.{TaggedSentence, WordpieceEmbeddin
 
 import scala.collection.mutable
 
-/** Generates features for CrfBasedNer
-  */
+/** Generates features for CrfBasedNer */
 case class FeatureGenerator(dictFeatures: DictionaryFeatures) {
 
   val shapeEncoding = Map(

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -389,8 +389,7 @@ class NerDLApproach(override val uid: String)
     */
   def getUseBestModel: Boolean = $(this.useBestModel)
 
-  /** @group getParam
-    */
+  /** @group getParam */
   def getBestModelMetric: String = $(bestModelMetric)
 
   /** Learning Rate
@@ -507,12 +506,10 @@ class NerDLApproach(override val uid: String)
   def setIncludeAllConfidenceScores(value: Boolean): this.type =
     set(this.includeAllConfidenceScores, value)
 
-  /** @group setParam
-    */
+  /** @group setParam */
   def setUseBestModel(value: Boolean): NerDLApproach.this.type = set(this.useBestModel, value)
 
-  /** @group setParam
-    */
+  /** @group setParam */
   def setBestModelMetric(value: String): NerDLApproach.this.type = {
 
     if (value == ModelMetrics.macroF1)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/AveragedPerceptron.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/AveragedPerceptron.scala
@@ -174,13 +174,11 @@ class TrainingPerceptronLegacy(
     def updateFeature(tag: String, feature: String, weight: Double, value: Double): Unit = {
       val param = (feature, tag)
 
-      /** update totals and timestamps
-        */
+      /** update totals and timestamps */
       totals(param) += ((updateIteration - timestamps(param)) * weight)
       timestamps(param) = updateIteration
 
-      /** update weights
-        */
+      /** update weights */
       featuresWeight(feature)(tag) = weight + value
     }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronApproachDistributed.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronApproachDistributed.scala
@@ -222,8 +222,7 @@ class PerceptronApproachDistributed(override val uid: String)
     dataset.sparkSession.sparkContext.register(timeTotalsAcc)
     dataset.sparkSession.sparkContext.register(updateIterationAcc)
 
-    /** Generates TagBook, which holds all the word to tags mapping that are not ambiguous
-      */
+    /** Generates TagBook, which holds all the word to tags mapping that are not ambiguous */
     val taggedSentences: Dataset[TaggedSentence] = if (get(posCol).isDefined) {
       import ResourceHelper.spark.implicits._
       val tokenColumn = dataset.schema.fields
@@ -277,8 +276,7 @@ class PerceptronApproachDistributed(override val uid: String)
         .broadcast(taggedSentences.flatMap(_.tags).distinct.collect)
     }
 
-    /** Iterates for training
-      */
+    /** Iterates for training */
     (1 to $(nIterations)).foreach { iteration =>
       {
         logger.debug(s"TRAINING: Iteration n: $iteration")
@@ -335,8 +333,7 @@ class PerceptronApproachDistributed(override val uid: String)
                 weight: Double,
                 value: Double): Unit = {
 
-              /** update totals and timestamps
-                */
+              /** update totals and timestamps */
               val param = (feature, tag)
               val newTimestamp = partitionUpdateCount
               partitionTotals.update(
@@ -347,8 +344,7 @@ class PerceptronApproachDistributed(override val uid: String)
                   .getOrElse(partitionTimestamps.getOrElse(param, 0L))) * weight))
               newPartitionTimeTotals.update(param, (newTimestamp, partitionTotals(param)))
 
-              /** update weights
-                */
+              /** update weights */
               val newWeights =
                 newPartitionWeights.getOrElse(feature, MMap()) ++ MMap(tag -> (weight + value))
               newPartitionWeights.update(feature, newWeights)
@@ -413,8 +409,7 @@ class PerceptronApproachDistributed(override val uid: String)
           /** In a shuffled sentences list, try to find tag of the word, hold the correct answer
             */
           partition.foreach { taggedSentence =>
-            /** Defines a sentence context, with room to for look back
-              */
+            /** Defines a sentence context, with room to for look back */
             var prev = START(0)
             var prev2 = START(1)
             val context = START ++: taggedSentence.words.map(w => normalized(w)) ++: END
@@ -429,8 +424,7 @@ class PerceptronApproachDistributed(override val uid: String)
                     guess
                   })
 
-              /** shift the context
-                */
+              /** shift the context */
               prev2 = prev
               prev = guess
             }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronTrainingUtils.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/PerceptronTrainingUtils.scala
@@ -28,8 +28,7 @@ trait PerceptronTrainingUtils extends PerceptronUtils {
 
   private[perceptron] val logger: Logger = LoggerFactory.getLogger("PerceptronApproachUtils")
 
-  /** Generates TagBook, which holds all the word to tags mapping that are not ambiguous
-    */
+  /** Generates TagBook, which holds all the word to tags mapping that are not ambiguous */
   def generatesTagBook(dataset: Dataset[_]): Array[TaggedSentence] = {
     val taggedSentences = {
       import ResourceHelper.spark.implicits._
@@ -97,8 +96,7 @@ trait PerceptronTrainingUtils extends PerceptronUtils {
       }
   }
 
-  /** Iterates for training
-    */
+  /** Iterates for training */
   def trainPerceptron(
       nIterations: Int,
       initialModel: TrainingPerceptronLegacy,
@@ -108,12 +106,10 @@ trait PerceptronTrainingUtils extends PerceptronUtils {
       {
         logger.debug(s"TRAINING: Iteration n: $iteration")
 
-        /** In a shuffled sentences list, try to find tag of the word, hold the correct answer
-          */
+        /** In a shuffled sentences list, try to find tag of the word, hold the correct answer */
         Random.shuffle(taggedSentences.toList).foldLeft(iteratedModel) {
           (model, taggedSentence) =>
-            /** Defines a sentence context, with room to for look back
-              */
+            /** Defines a sentence context, with room to for look back */
             var prev = START(0)
             var prev2 = START(1)
             val context = START ++: taggedSentence.words.map(w => normalized(w)) ++: END
@@ -128,17 +124,14 @@ trait PerceptronTrainingUtils extends PerceptronUtils {
                     val features = getFeatures(i, word, context, prev, prev2)
                     val guess = model.predict(features)
 
-                    /** Update the model based on the prediction results
-                      */
+                    /** Update the model based on the prediction results */
                     model.update(taggedSentence.tags(i), guess, features)
 
-                    /** return the guess
-                      */
+                    /** return the guess */
                     guess
                   })
 
-              /** shift the context
-                */
+              /** shift the context */
               prev2 = prev
               prev = guess
             }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticSymbols.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticSymbols.scala
@@ -21,40 +21,30 @@ package com.johnsnowlabs.nlp.annotators.sbd.pragmatic
   */
 object PragmaticSymbols extends RuleSymbols {
 
-  /** \==================== BREAKING SYMBOLS \====================
-    */
-  /** Punctuation line breaker alt 200
-    */
+  /** \==================== BREAKING SYMBOLS \==================== */
+  /** Punctuation line breaker alt 200 */
   val PUNCT_INDICATOR = "╚"
 
-  /** Ellipsis breaker looks up -> "..." alt 203
-    */
+  /** Ellipsis breaker looks up -> "..." alt 203 */
   val ELLIPSIS_INDICATOR = "╦"
 
-  /** \===================== NON BREAKING SYMBOLS \=====================
-    */
-  /** Non separation dots for abbreviations looks up -> . alt 198
-    */
+  /** \===================== NON BREAKING SYMBOLS \===================== */
+  /** Non separation dots for abbreviations looks up -> . alt 198 */
   val ABBREVIATOR = "╞"
 
-  /** Non separation dots for numbers looks up -> . alt 199
-    */
+  /** Non separation dots for numbers looks up -> . alt 199 */
   val NUM_INDICATOR = "╟"
 
-  /** Period container non breaker looks up -> . alt 201
-    */
+  /** Period container non breaker looks up -> . alt 201 */
   val MULT_PERIOD = "╔"
 
-  /** Special non breaking symbol alt 202
-    */
+  /** Special non breaking symbol alt 202 */
   val SPECIAL_PERIOD = "╩"
 
-  /** Question in quotes alt 209
-    */
+  /** Question in quotes alt 209 */
   val QUESTION_IN_QUOTE = "╤" // ?
 
-  /** Exclamation mark in rules alt 210
-    */
+  /** Exclamation mark in rules alt 210 */
   val EXCLAMATION_INDICATOR = "╥" // !
 
   override def symbolRecovery: Map[String, String] =

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/RuleSymbols.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/RuleSymbols.scala
@@ -16,43 +16,33 @@
 
 package com.johnsnowlabs.nlp.annotators.sbd.pragmatic
 
-/** Base Symbols that may be extended later on. For now kept in the pragmatic scope.
-  */
+/** Base Symbols that may be extended later on. For now kept in the pragmatic scope. */
 trait RuleSymbols {
 
-  /** Separation symbols for list items and numbers 
-    */
+  /** Separation symbols for list items and numbers  */
   val BREAK_INDICATOR = "\uF050"
 
-  /** looks up .
-    */
+  /** looks up . */
   val DOT = "\uF051"
 
-  /** looks up ,
-    */
+  /** looks up , */
   val COMMA = "\uF052"
 
-  /** looks up ;
-    */
+  /** looks up ; */
   val SEMICOLON = "\uF053"
 
-  /** looks up ?
-    */
+  /** looks up ? */
   val QUESTION = "\uF054"
 
-  /** looks up !
-    */
+  /** looks up ! */
   val EXCLAMATION = "\uF055"
 
-  /** \==================== PROTECTION SYMBOL \====================
-    */
-  /** Between punctuations marker
-    */
+  /** \==================== PROTECTION SYMBOL \==================== */
+  /** Between punctuations marker */
   val PROTECTION_MARKER_OPEN = "\uF056"
   val PROTECTION_MARKER_CLOSE = "\uF057"
 
-  /** Magic regex ensures no breaking within protection
-    */
+  /** Magic regex ensures no breaking within protection */
   // http://rubular.com/r/Tq7lWxGkQl
   val UNPROTECTED_BREAK_INDICATOR =
     s"$BREAK_INDICATOR(?![^$PROTECTION_MARKER_OPEN]*$PROTECTION_MARKER_CLOSE)"

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteApproach.scala
@@ -189,8 +189,7 @@ class SymmetricDeleteApproach(override val uid: String)
       Identifiable.randomUID("SYMSPELL")
     ) // constructor required for the annotator to work in python
 
-  /** Given a word, derive strings with up to maxEditDistance characters deleted
-    */
+  /** Given a word, derive strings with up to maxEditDistance characters deleted */
   def getDeletes(word: String, med: Int): List[String] = {
 
     var deletes = new ListBuffer[String]()
@@ -219,8 +218,7 @@ class SymmetricDeleteApproach(override val uid: String)
     deletes.toList
   }
 
-  /** Computes derived words from a frequency of words
-    */
+  /** Computes derived words from a frequency of words */
   def derivedWordDistances(
       wordFrequencies: List[(String, Long)],
       maxEditDistance: Int): Map[String, (List[String], Long)] = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModel.scala
@@ -232,8 +232,7 @@ class SymmetricDeleteModel(override val uid: String)
     transformedWord
   }
 
-  /** Return list of suggested corrections for potentially incorrectly spelled word
-    */
+  /** Return list of suggested corrections for potentially incorrectly spelled word */
   def getSuggestedCorrections(word: String): Option[SuggestedWord] = {
     val cleanWord = Utilities.limitDuplicates($(dupsLimit), word)
     if (get(dictionary).isDefined) {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/BpeTokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/BpeTokenizer.scala
@@ -35,17 +35,14 @@ private[nlp] abstract class BpeTokenizer(
     merges
   }
 
-  /** Rankings for the byte pairs. Derived from merges.txt
-    */
+  /** Rankings for the byte pairs. Derived from merges.txt */
   protected def getBpeRanking: ((String, String)) => Int =
     (bytePair: (String, String)) => bpeRanks.getOrElse(bytePair, Integer.MAX_VALUE)
 
-  /** cache for already encoded tokens
-    */
+  /** cache for already encoded tokens */
   protected val cache: mutable.Map[String, Array[String]] = mutable.Map()
 
-  /** Create a sequence of byte-pairs of the word
-    */
+  /** Create a sequence of byte-pairs of the word */
   protected def getBytePairs(word: Array[String]): Array[(String, String)] = {
     val createPairs = (i: Int) => (word(i), word(i + 1))
     (0 until (word.length - 1)).map(createPairs).toArray
@@ -173,8 +170,7 @@ private[nlp] abstract class BpeTokenizer(
     }
   }
 
-  /** Split the the individual sub texts on special tokens, e.g. masking etc.
-    */
+  /** Split the the individual sub texts on special tokens, e.g. masking etc. */
   protected def splitOnSpecialToken(
       specialToken: SpecialToken,
       text: String): ListBuffer[String] = {
@@ -230,17 +226,14 @@ private[nlp] abstract class BpeTokenizer(
     result
   }
 
-  /** Needs to be implemented
-    */
+  /** Needs to be implemented */
   def tokenizeSubText(text: String, indexOffset: Int): Array[IndexedToken]
 
-  /** Special tokens of the model for processing
-    */
+  /** Special tokens of the model for processing */
   val sentencePadding: (String, String) =
     (specialTokens.sentenceStart.content, specialTokens.sentenceEnd.content)
 
-  /** Tokenize considering special tokens and split algorithm
-    */
+  /** Tokenize considering special tokens and split algorithm */
   def tokenize(sentence: Sentence): Array[IndexedToken] = {
     var text = sentence.content
     if (text.trim.isEmpty) Array[IndexedToken]()

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsLoader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsLoader.scala
@@ -81,8 +81,7 @@ object WordEmbeddingsBinaryIndexer {
     }
   }
 
-  /** Read a string from the binary model (System default should be UTF-8):
-    */
+  /** Read a string from the binary model (System default should be UTF-8): */
   private def readString(ds: DataInputStream): String = {
     val byteBuffer = new ByteArrayOutputStream()
 
@@ -101,8 +100,7 @@ object WordEmbeddingsBinaryIndexer {
     word
   }
 
-  /** Read a Vector - Array of Floats from the binary model:
-    */
+  /** Read a Vector - Array of Floats from the binary model: */
   private def readFloatVector(
       ds: DataInputStream,
       vectorSize: Int,

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -105,15 +105,13 @@ object ResourceDownloader {
   var communityDownloader: ResourceDownloader =
     new S3ResourceDownloader(s3BucketCommunity, s3Path, cacheFolder, "community")
 
-  /** Reset the cache and recreate ResourceDownloader S3 credentials
-    */
+  /** Reset the cache and recreate ResourceDownloader S3 credentials */
   def resetResourceDownloader(): Unit = {
     cache.empty
     this.defaultDownloader = new S3ResourceDownloader(s3Bucket, s3Path, cacheFolder, "default")
   }
 
-  /** List all pretrained models in public name_lang
-    */
+  /** List all pretrained models in public name_lang */
   def listPublicModels(): List[String] = {
     listPretrainedResources(folder = publicLoc, ResourceType.MODEL)
   }
@@ -173,8 +171,7 @@ object ResourceDownloader {
   def showPublicModels(annotator: String, lang: String, version: String): Unit =
     showPublicModels(Some(annotator), Some(lang), Some(version))
 
-  /** List all pretrained pipelines in public
-    */
+  /** List all pretrained pipelines in public */
   def listPublicPipelines(): List[String] = {
     listPretrainedResources(folder = publicLoc, ResourceType.PIPELINE)
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/training/CoNLLUCols.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/training/CoNLLUCols.scala
@@ -18,8 +18,7 @@ package com.johnsnowlabs.nlp.training
 
 object CoNLLUCols extends Enumeration {
 
-  /** CoNLL-U columns [[https://universaldependencies.org/format.html CoNLL-U format]]
-    */
+  /** CoNLL-U columns [[https://universaldependencies.org/format.html CoNLL-U format]] */
   type Format
   val ID, FORM, LEMMA, UPOS, XPOS, FEATS, HEAD, DEPREL, DEPS, MISC = Value
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/util/SparkNlpConfigKeys.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/SparkNlpConfigKeys.scala
@@ -16,8 +16,7 @@
 
 package com.johnsnowlabs.nlp.util
 
-/** Additional configure options that used by spark.nlp
-  */
+/** Additional configure options that used by spark.nlp */
 object SparkNlpConfigKeys {
 
   /** Folder to store word embeddings */

--- a/src/main/scala/com/johnsnowlabs/nlp/util/regex/RuleFactory.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/regex/RuleFactory.scala
@@ -237,8 +237,7 @@ object RuleFactory {
   case class RuleMatch(content: Regex.Match, identifier: String)
 }
 
-/** Allowed strategies for [[RuleFactory]] applications regarding replacement
-  */
+/** Allowed strategies for [[RuleFactory]] applications regarding replacement */
 object TransformStrategy extends Enumeration {
   type TransformStrategy = Value
   val NO_TRANSFORM, APPEND_WITH_SYMBOL, PREPEND_WITH_SYMBOL, REPLACE_ALL_WITH_SYMBOL,
@@ -246,8 +245,7 @@ object TransformStrategy extends Enumeration {
       REPLACE_EACH_WITH_SYMBOL, REPLACE_EACH_WITH_SYMBOL_AND_BREAK = Value
 }
 
-/** Allowed strategies for [[RuleFactory]] applications regarding matching
-  */
+/** Allowed strategies for [[RuleFactory]] applications regarding matching */
 object MatchStrategy extends Enumeration {
   type MatchStrategy = Value
   val MATCH_ALL, MATCH_FIRST, MATCH_COMPLETE = Value

--- a/src/test/scala/com/johnsnowlabs/benchmarks/spark/NerHelper.scala
+++ b/src/test/scala/com/johnsnowlabs/benchmarks/spark/NerHelper.scala
@@ -28,8 +28,7 @@ import scala.collection.mutable
 
 object NerHelper {
 
-  /** Print top n Named Entity annotations
-    */
+  /** Print top n Named Entity annotations */
   def print(annotations: Seq[Annotation], n: Int): Unit = {
     for (a <- annotations.take(n)) {
       System.out.println(s"${a.begin}, ${a.end}, ${a.result}, ${a.metadata("text")}")

--- a/src/test/scala/com/johnsnowlabs/nlp/AnnotatorBuilder.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/AnnotatorBuilder.scala
@@ -25,8 +25,7 @@ import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.scalatest.Suite
 import org.scalatest.flatspec.AnyFlatSpec
 
-/** Generates different Annotator pipeline paths Place to add different annotator constructions
-  */
+/** Generates different Annotator pipeline paths Place to add different annotator constructions */
 object AnnotatorBuilder extends AnyFlatSpec {
   this: Suite =>
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassificationTestSpec.scala
@@ -145,25 +145,27 @@ class AlbertForSequenceClassificationTestSpec extends AnyFlatSpec {
     val pipeline = new Pipeline()
       .setStages(Array(classifier))
 
-    val pipelineDF = pipeline.fit(training_data).transform(training_data)
-    Benchmark.time("Time to save AlbertForSequenceClassification results") {
+    val pipelineDF = pipeline.fit(training_data).transform(training_data).cache()
+    Benchmark.time("Time to save pipeline results") {
       pipelineDF.write.mode("overwrite").parquet("./tmp_sequence_classifier")
     }
 
-    pipelineDF.select("label").show(20, truncate = false)
-    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF.select("label").show(2, false)
+    pipelineDF.select("document.result", "label.result").show(2, false)
+
+    // only works if it's softmax - one lable per row
     pipelineDF
       .withColumn("doc_size", size(col("document")))
-      .withColumn("label_size", size(col("label")))
+      .withColumn("label_size", size(col("class")))
       .where(col("doc_size") =!= col("label_size"))
-      .select("doc_size", "label_size", "document.result", "label.result")
-      .show(20, truncate = false)
+      .select("doc_size", "label_size", "document.result", "class.result")
+      .show(20, false)
 
     val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
-    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"class.result")).count.toInt
 
-    println(s"total tokens: $totalDocs")
-    println(s"total embeddings: $totalLabels")
+    println(s"total docs: $totalDocs")
+    println(s"total classes: $totalLabels")
 
     assert(totalDocs == totalLabels)
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassificationTestSpec.scala
@@ -147,25 +147,27 @@ class DistilBertForSequenceClassificationTestSpec extends AnyFlatSpec {
     val pipeline = new Pipeline()
       .setStages(Array(tokenClassifier))
 
-    val pipelineDF = pipeline.fit(training_data).transform(training_data)
-    Benchmark.time("Time to save DistilBertForSequenceClassification results") {
-      pipelineDF.write.mode("overwrite").parquet("./tmp_distilbert_sequence_classifier")
+    val pipelineDF = pipeline.fit(training_data).transform(training_data).cache()
+    Benchmark.time("Time to save pipeline results") {
+      pipelineDF.write.mode("overwrite").parquet("./tmp_sequence_classifier")
     }
 
-    pipelineDF.select("label").show(20, truncate = false)
-    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF.select("label").show(2, false)
+    pipelineDF.select("document.result", "label.result").show(2, false)
+
+    // only works if it's softmax - one lable per row
     pipelineDF
       .withColumn("doc_size", size(col("document")))
-      .withColumn("label_size", size(col("label")))
+      .withColumn("label_size", size(col("class")))
       .where(col("doc_size") =!= col("label_size"))
-      .select("doc_size", "label_size", "document.result", "label.result")
-      .show(20, truncate = false)
+      .select("doc_size", "label_size", "document.result", "class.result")
+      .show(20, false)
 
     val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
-    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"class.result")).count.toInt
 
-    println(s"total tokens: $totalDocs")
-    println(s"total embeddings: $totalLabels")
+    println(s"total docs: $totalDocs")
+    println(s"total classes: $totalLabels")
 
     assert(totalDocs == totalLabels)
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassificationTestSpec.scala
@@ -146,25 +146,27 @@ class LongformerForSequenceClassificationTestSpec extends AnyFlatSpec {
     val pipeline = new Pipeline()
       .setStages(Array(classifier))
 
-    val pipelineDF = pipeline.fit(training_data).transform(training_data)
-    Benchmark.time("Time to save LongformerForSequenceClassification results") {
+    val pipelineDF = pipeline.fit(training_data).transform(training_data).cache()
+    Benchmark.time("Time to save pipeline results") {
       pipelineDF.write.mode("overwrite").parquet("./tmp_sequence_classifier")
     }
 
-    pipelineDF.select("label").show(20, truncate = false)
-    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF.select("label").show(2, false)
+    pipelineDF.select("document.result", "label.result").show(2, false)
+
+    // only works if it's softmax - one lable per row
     pipelineDF
       .withColumn("doc_size", size(col("document")))
-      .withColumn("label_size", size(col("label")))
+      .withColumn("label_size", size(col("class")))
       .where(col("doc_size") =!= col("label_size"))
-      .select("doc_size", "label_size", "document.result", "label.result")
-      .show(20, truncate = false)
+      .select("doc_size", "label_size", "document.result", "class.result")
+      .show(20, false)
 
     val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
-    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"class.result")).count.toInt
 
-    println(s"total tokens: $totalDocs")
-    println(s"total embeddings: $totalLabels")
+    println(s"total docs: $totalDocs")
+    println(s"total classes: $totalLabels")
 
     assert(totalDocs == totalLabels)
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassificationTestSpec.scala
@@ -145,25 +145,27 @@ class XlmRoBertaForSequenceClassificationTestSpec extends AnyFlatSpec {
     val pipeline = new Pipeline()
       .setStages(Array(classifier))
 
-    val pipelineDF = pipeline.fit(training_data).transform(training_data)
-    Benchmark.time("Time to save XlmRoBertaForSequenceClassification results") {
+    val pipelineDF = pipeline.fit(training_data).transform(training_data).cache()
+    Benchmark.time("Time to save pipeline results") {
       pipelineDF.write.mode("overwrite").parquet("./tmp_sequence_classifier")
     }
 
-    pipelineDF.select("label").show(20, truncate = false)
-    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF.select("label").show(2, false)
+    pipelineDF.select("document.result", "label.result").show(2, false)
+
+    // only works if it's softmax - one lable per row
     pipelineDF
       .withColumn("doc_size", size(col("document")))
-      .withColumn("label_size", size(col("label")))
+      .withColumn("label_size", size(col("class")))
       .where(col("doc_size") =!= col("label_size"))
-      .select("doc_size", "label_size", "document.result", "label.result")
-      .show(20, truncate = false)
+      .select("doc_size", "label_size", "document.result", "class.result")
+      .show(20, false)
 
     val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
-    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"class.result")).count.toInt
 
-    println(s"total tokens: $totalDocs")
-    println(s"total embeddings: $totalLabels")
+    println(s"total docs: $totalDocs")
+    println(s"total classes: $totalLabels")
 
     assert(totalDocs == totalLabels)
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassificationTestSpec.scala
@@ -145,25 +145,27 @@ class XlnetForSequenceClassificationTestSpec extends AnyFlatSpec {
     val pipeline = new Pipeline()
       .setStages(Array(classifier))
 
-    val pipelineDF = pipeline.fit(training_data).transform(training_data)
-    Benchmark.time("Time to save XlnetForSequenceClassification results") {
+    val pipelineDF = pipeline.fit(training_data).transform(training_data).cache()
+    Benchmark.time("Time to save pipeline results") {
       pipelineDF.write.mode("overwrite").parquet("./tmp_sequence_classifier")
     }
 
-    pipelineDF.select("label").show(20, truncate = false)
-    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF.select("label").show(2, false)
+    pipelineDF.select("document.result", "label.result").show(2, false)
+
+    // only works if it's softmax - one lable per row
     pipelineDF
       .withColumn("doc_size", size(col("document")))
-      .withColumn("label_size", size(col("label")))
+      .withColumn("label_size", size(col("class")))
       .where(col("doc_size") =!= col("label_size"))
-      .select("doc_size", "label_size", "document.result", "label.result")
-      .show(20, truncate = false)
+      .select("doc_size", "label_size", "document.result", "class.result")
+      .show(20, false)
 
     val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
-    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"class.result")).count.toInt
 
-    println(s"total tokens: $totalDocs")
-    println(s"total embeddings: $totalLabels")
+    println(s"total docs: $totalDocs")
+    println(s"total classes: $totalLabels")
 
     assert(totalDocs == totalLabels)
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/multipleannotations/MultiColumnApproach.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/multipleannotations/MultiColumnApproach.scala
@@ -30,12 +30,10 @@ class MultiColumnApproach(override val uid: String)
 
   override val description: String = "Example multiple columns"
 
-  /** Input annotator types: DOCUMEN
-    */
+  /** Input annotator types: DOCUMEN */
   override val outputAnnotatorType: AnnotatorType = DOCUMENT
 
-  /** Output annotator type:DOCUMENT
-    */
+  /** Output annotator type:DOCUMENT */
   override val inputAnnotatorType: AnnotatorType = DOCUMENT
 
   override def train(

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/multipleannotations/MultiColumnsModel.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/multipleannotations/MultiColumnsModel.scala
@@ -27,12 +27,10 @@ class MultiColumnsModel(override val uid: String)
 
   def this() = this(Identifiable.randomUID("MERGE"))
 
-  /** Input annotator types: DOCUMEN
-    */
+  /** Input annotator types: DOCUMEN */
   override val outputAnnotatorType: AnnotatorType = DOCUMENT
 
-  /** Output annotator type:DOCUMENT
-    */
+  /** Output annotator type:DOCUMENT */
   override val inputAnnotatorType: AnnotatorType = DOCUMENT
 
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/tokenizer/moses/MosesTokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/tokenizer/moses/MosesTokenizerTestSpec.scala
@@ -20,8 +20,7 @@ import com.johnsnowlabs.tags.FastTest
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 
-/** Tests ported from sacremoses
-  */
+/** Tests ported from sacremoses */
 class MosesTokenizerTestSpec extends AnyFlatSpec {
   val moses = new MosesTokenizer("en")
 

--- a/src/test/scala/com/johnsnowlabs/nlp/util/LfuCacheTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/util/LfuCacheTestSpec.scala
@@ -19,8 +19,7 @@ package com.johnsnowlabs.nlp.util
 import com.johnsnowlabs.tags.FastTest
 import org.scalatest.flatspec.AnyFlatSpec
 
-/** Inspired on Lucas Torri https://gist.github.com/lucastorri/138acfdd5f9903e5cf8e3cc1e7cbb8e7
-  */
+/** Inspired on Lucas Torri https://gist.github.com/lucastorri/138acfdd5f9903e5cf8e3cc1e7cbb8e7 */
 class LfuCacheTestSpec extends AnyFlatSpec {
 
   "A LfuCache" should "automatically adjust to new content" taggedAs FastTest in {


### PR DESCRIPTION
This PR adds `setActivation` param with either `softmax` or `sigmoid` to calculate the last scores either for multi-class (only 1 label/class will be selected and overall score ranges between 0 to 1 for all classes) or multi-label (multiple labels/classes will be selected and overall score ranges between 0 to 1 for each class)