### PR TITLE
Add a new functionality to download and extract models from S3 via direct link

### DIFF
--- a/python/sparknlp/internal.py
+++ b/python/sparknlp/internal.py
@@ -212,6 +212,9 @@ class _DownloadModel(ExtendedJavaWrapper):
     def __init__(self, reader, name, language, remote_loc, validator):
         super(_DownloadModel, self).__init__("com.johnsnowlabs.nlp.pretrained." + validator + ".downloadModel", reader,
                                              name, language, remote_loc)
+class _DownloadModelDirectly(ExtendedJavaWrapper):
+    def __init__(self, name, remote_loc="public/models"):
+        super(_DownloadModelDirectly, self).__init__("com.johnsnowlabs.nlp.pretrained.PythonResourceDownloader.downloadModelDirectly",name, remote_loc)
 
 
 class _DownloadPipeline(ExtendedJavaWrapper):

--- a/python/sparknlp/pretrained.py
+++ b/python/sparknlp/pretrained.py
@@ -65,6 +65,9 @@ class ResourceDownloader(object):
                 t1.join()
 
             return reader(classname=None, java_model=j_obj)
+    @staticmethod
+    def downloadModelDirectly(name, remote_loc="public/models"):
+        _internal._DownloadModelDirectly(name, remote_loc).apply()
 
     @staticmethod
     def downloadPipeline(name, language, remote_loc=None):

--- a/src/test/scala/com/johnsnowlabs/nlp/pretrained/MockResourceDownloader.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/pretrained/MockResourceDownloader.scala
@@ -35,4 +35,5 @@ class MockResourceDownloader(resourcePath: String) extends ResourceDownloader {
 
   def downloadMetadataIfNeed(folder: String): List[ResourceMetadata] = resources
 
+  override def downloadAndUnzipFile(s3FilePath: String): Option[String] = Some("model")
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloaderMetaSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloaderMetaSpec.scala
@@ -16,7 +16,7 @@
 
 package com.johnsnowlabs.nlp.pretrained
 
-import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.tags.{FastTest, SlowTest}
 import com.johnsnowlabs.util.Version
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.BeforeAndAfter
@@ -180,6 +180,13 @@ class ResourceDownloaderMetaSpec extends AnyFlatSpec with BeforeAndAfter {
     assert(noAnnoFieldFilter.length == 1)
     assert(noAnnoFieldFilter.head.equals("anno_not_missing:tst:2.5.4"))
 
+  }
+  it should "should download a model and unzip file" taggedAs SlowTest in {
+    ResourceDownloader.defaultDownloader = realDefaultDownloader
+    ResourceDownloader.publicDownloader = realPublicDownloader
+    ResourceDownloader.communityDownloader = realCommunityDownloader
+    ResourceDownloader.downloadModelDirectly(
+      "public/models/bert_base_cased_es_3.2.2_3.0_1630999631885.zip")
   }
 
   it should "be able to list from online metadata" in {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a method to download a specific model from s3.
 
We going to use the code as following
```python
ResourceDownloader.downloadModelDirectly("public/models/bert_base_cased_es_3.2.2_3.0_1630999631885.zip","clininal/models")
```

## Motivation and Context


## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
