### PR TITLE
impossiblePenultimates added to SentenceDetectorDLModel

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -10948,6 +10948,9 @@ class SentenceDetectorDLModel(AnnotatorModel):
         Set the minimum allowed length for each sentence, by default 0
     maxLength
         Set the maximum allowed length for each sentence, by default 99999
+    impossiblePenultimates
+        Impossible penultimates - list of strings which a sentence can't end
+        with
 
     Examples
     --------
@@ -11032,6 +11035,11 @@ class SentenceDetectorDLModel(AnnotatorModel):
                       "Set the maximum allowed length for each sentence",
                       typeConverter=TypeConverters.toInt)
 
+    impossiblePenultimates = Param(Params._dummy(),
+                                   "impossiblePenultimates",
+                                   "Impossible penultimates - list of strings which a sentence can't end with",
+                                   typeConverter=TypeConverters.toListString)
+
     def setModel(self, modelArchitecture):
         """Sets the Model architecture. Currently only ``"cnn"`` is available.
 
@@ -11105,6 +11113,18 @@ class SentenceDetectorDLModel(AnnotatorModel):
             Maximum allowed length for each sentence
         """
         return self._set(maxLength=value)
+
+    def setImpossiblePenultimates(self, impossible_penultimates):
+        """Sets impossible penultimates - list of strings which a sentence can't
+        end with.
+
+        Parameters
+        ----------
+        impossible_penultimates : List[str]
+            List of strings which a sentence can't end with
+
+        """
+        return self._set(impossiblePenultimates=impossible_penultimates)
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.sentence_detector_dl.SentenceDetectorDLModel",
                  java_model=None):

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLEncoder.scala
@@ -201,7 +201,8 @@ class SentenceDetectorDLEncoder extends Serializable {
         val leftC = getLeftContext(text, pos)
         val rightC = getRightContext(text, pos)
 
-        if (impossiblePenultimates.find(penultimate => leftC.endsWith(penultimate)).isDefined) {
+        if (impossiblePenultimates.exists(penultimate =>
+            leftC.endsWith(penultimate) || text.slice(0, pos).trim.endsWith(penultimate))) {
           (-1, "")
         } else {
           (


### PR DESCRIPTION
Add impossiblePenultimates parameter to the model.

## Description
The parameter was only available for the Approach, not it is also usable in the model. 

Note that removing some of the existing impossible penultimates (i.e. the ones used in the approach for training the model) may not necessary result in splitting the sentence around the penultimate. For example, if the penultimate "dr" was used in the approach, then the approach have never encountered any sentence ending with "dr." and therefore just removing the penultimate doesn't not necessary entail the the model will start splitting sentences around "dr." 

Adding new penultimates always works.

## Motivation and Context

Users have requested the ability to modify/extend the list of impossible penultimates of already trained models.

## How Has This Been Tested?

The changes have been test in both Scala and Python. The tests appended a new penultimate and verified no sentences ending with it are detected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
