### PR TITLE
Update XlmRoBertaForSequenceClassification.scala

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
@@ -303,14 +303,14 @@ class XlmRoBertaForSequenceClassification(override val uid: String)
       spark,
       getModelIfNotSet.tensorflowWrapper,
       "_xlm_roberta_classification",
-      XlmRoBertaForTokenClassification.tfFile,
+      XlmRoBertaForSequenceClassification.tfFile,
       configProtoBytes = getConfigProtoBytes)
     writeSentencePieceModel(
       path,
       spark,
       getModelIfNotSet.spp,
       "_xlmroberta",
-      XlmRoBertaForTokenClassification.sppFile)
+      XlmRoBertaForSequenceClassification.sppFile)
   }
 }
 


### PR DESCRIPTION
This PR fixes a simple mistake in using the wrong class to access a variable. There is no side effect before and after this change, I simply fixing this for the principle.