### PR TITLE
FEATURE NMH-74: Integrate spark ocr version in editions

### DIFF
--- a/docs/_frontend/src/models/FilterForm/FilterForm.js
+++ b/docs/_frontend/src/models/FilterForm/FilterForm.js
@@ -110,7 +110,8 @@ const FilterForm = ({ onSubmit, isLoading, meta, params }) => {
               (acc, item) => {
                 if (
                   item.key !== 'Spark NLP' &&
-                  item.key !== 'Spark NLP for Healthcare'
+                  item.key !== 'Spark NLP for Healthcare' &&
+                  item.key !== 'Spark OCR'
                 ) {
                   acc.push(item);
                 }
@@ -125,6 +126,14 @@ const FilterForm = ({ onSubmit, isLoading, meta, params }) => {
                     value: 'Spark NLP',
                   },
                   'All Spark NLP versions'
+                ),
+                e(
+                  'option',
+                  {
+                    key: 'All Spark OCR versions',
+                    value: 'Spark OCR',
+                  },
+                  'All Spark OCR versions'
                 ),
                 e(
                   'option',

--- a/docs/_plugins/search_index.rb
+++ b/docs/_plugins/search_index.rb
@@ -27,11 +27,16 @@ def compatible_editions(editions, model_editions, edition)
   outdated_editions = ['Spark NLP 2.1', 'Spark NLP for Healthcare 2.0']
   return edition if outdated_editions.include? edition
 
-  for_healthcare = edition.include?('Healthcare')
-  editions = editions.select do |v|
-    for_healthcare == v.include?('Healthcare') && !outdated_editions.include?(v)
+  if edition.include?('Healthcare')
+    selection_lambda = lambda {|v| v.include?('Healthcare') && !outdated_editions.include?(v)}
+  elsif edition.include?('OCR')
+    selection_lambda = lambda {|v| v.include?('OCR')}
+  else
+    selection_lambda = lambda {|v| !v.include?('Healthcare') && !v.include?('OCR')}
   end
-  model_editions = model_editions.select { |v| for_healthcare == v.include?('Healthcare') }
+
+  editions = editions.select &selection_lambda
+  model_editions = model_editions.select &selection_lambda
 
   curr_index = model_editions.index(edition)
   return edition if curr_index.nil?


### PR DESCRIPTION
Jira Ticket [NMH-74](https://johnsnowlabs.atlassian.net/browse/NMH-74)

- Add Spark OCR in filter fields.
- Modify search_index script to consider Spark OCR Versions