### PR TITLE
Add support for BatchAnnotate to UniversalSentenceEncoder

### DIFF
--- a/python/sparknlp/annotator.py
+++ b/python/sparknlp/annotator.py
@@ -7515,7 +7515,10 @@ class NerOverwriter(AnnotatorModel):
         return self._set(newResult=value)
 
 
-class UniversalSentenceEncoder(AnnotatorModel, HasEmbeddingsProperties, HasStorageRef):
+class UniversalSentenceEncoder(AnnotatorModel,
+                               HasEmbeddingsProperties,
+                               HasStorageRef,
+                               HasBatchedAnnotate):
     """The Universal Sentence Encoder encodes text into high dimensional vectors
     that can be used for text classification, semantic similarity, clustering
     and other natural language tasks.
@@ -7654,7 +7657,9 @@ class UniversalSentenceEncoder(AnnotatorModel, HasEmbeddingsProperties, HasStora
             java_model=java_model
         )
         self._setDefault(
-            loadSP=False
+            loadSP=False,
+            dimension=512,
+            batchSize=2
         )
 
     @staticmethod
@@ -17887,8 +17892,8 @@ class DeBertaForSequenceClassification(AnnotatorModel,
 
 
 class DeBertaForTokenClassification(AnnotatorModel,
-                                 HasCaseSensitiveProperties,
-                                 HasBatchedAnnotate):
+                                    HasCaseSensitiveProperties,
+                                    HasBatchedAnnotate):
     """DeBertaForTokenClassification can load DeBERTa v2&v3 Models with a token
     classification head on top (a linear layer on top of the hidden-states
     output) e.g. for Named-Entity-Recognition (NER) tasks.
@@ -18054,4 +18059,3 @@ class DeBertaForTokenClassification(AnnotatorModel,
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(DeBertaForTokenClassification, name, lang, remote_loc)
-

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowUSE.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowUSE.scala
@@ -48,48 +48,60 @@ class TensorflowUSE(
   private val inputKey = "input"
   private val outPutKey = "output"
 
-  def predict(sentences: Seq[Sentence]): Seq[Annotation] = {
-
-    val tensors = new TensorResources()
-    val batchSize = sentences.length
-
-    val sentencesContent = sentences.map { x =>
-      x.content
-    }.toArray
-
-    val sentenceTensors = tensors.createTensor(sentencesContent)
-
-    val runner = tensorflow
-      .getTFSessionWithSignature(configProtoBytes = configProtoBytes, loadSP = loadSP)
-      .runner
-
-    runner
-      .feed(inputKey, sentenceTensors)
-      .fetch(outPutKey)
-
-    val outs = runner.run().asScala
-    val allEmbeddings = TensorResources.extractFloats(outs.head)
-
-    tensors.clearSession(outs)
-    tensors.clearTensors()
-    sentenceTensors.close()
-
-    val dim = allEmbeddings.length / batchSize
-    val embeddings = allEmbeddings.grouped(dim).toArray
-
-    sentences.zip(embeddings).map { case (sentence, vectors) =>
-      Annotation(
-        annotatorType = AnnotatorType.SENTENCE_EMBEDDINGS,
-        begin = sentence.start,
-        end = sentence.end,
-        result = sentence.content,
-        metadata = Map(
-          "sentence" -> sentence.index.toString,
-          "token" -> sentence.content,
-          "pieceId" -> "-1",
-          "isWordStart" -> "true"),
-        embeddings = vectors)
-    }
+  private def sessionWarmup(): Unit = {
+    val content = "Let's warmup the TF Session for the first inference."
+    val dummyInput = Sentence(content, 0, content.length, 1, None)
+    predict(Seq(dummyInput), 1)
   }
+
+  sessionWarmup()
+
+  def predict(sentences: Seq[Sentence], batchSize: Int): Seq[Annotation] = {
+
+    sentences
+      .grouped(batchSize)
+      .flatMap { batch =>
+        val tensors = new TensorResources()
+        val batchSize = batch.length
+
+        val sentencesContent = batch.map { x =>
+          x.content
+        }.toArray
+
+        val sentenceTensors = tensors.createTensor(sentencesContent)
+
+        val runner = tensorflow
+          .getTFSessionWithSignature(configProtoBytes = configProtoBytes, loadSP = loadSP)
+          .runner
+
+        runner
+          .feed(inputKey, sentenceTensors)
+          .fetch(outPutKey)
+
+        val outs = runner.run().asScala
+        val allEmbeddings = TensorResources.extractFloats(outs.head)
+
+        tensors.clearSession(outs)
+        tensors.clearTensors()
+        sentenceTensors.close()
+
+        val dim = allEmbeddings.length / batchSize
+        val embeddings = allEmbeddings.grouped(dim).toArray
+
+        batch.zip(embeddings).map { case (sentence, vectors) =>
+          Annotation(
+            annotatorType = AnnotatorType.SENTENCE_EMBEDDINGS,
+            begin = sentence.start,
+            end = sentence.end,
+            result = sentence.content,
+            metadata = Map(
+              "sentence" -> sentence.index.toString,
+              "token" -> sentence.content,
+              "pieceId" -> "-1",
+              "isWordStart" -> "true"),
+            embeddings = vectors)
+        }
+      }
+  }.toSeq
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -256,9 +256,9 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
     Annotation(AnnotatorType.TOKEN, 60, 60, ".", Map("sentence" -> "0")))
 
   def getTokenizerOutput[T](
-                             tokenizer: TokenizerModel,
-                             data: DataFrame,
-                             mode: String = "finisher"): Array[T] = {
+      tokenizer: TokenizerModel,
+      data: DataFrame,
+      mode: String = "finisher"): Array[T] = {
     val finisher = new Finisher()
       .setInputCols("token")
       .setOutputAsArray(true)
@@ -275,10 +275,10 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
 
   /* here assembler can either be a SentenceDetector or a DocumentAssembler */
   def getTokenizerPipelineOutput[T](
-                                     assembler: Transformer,
-                                     tokenizer: TokenizerModel,
-                                     data: DataFrame,
-                                     mode: String = "finisher"): Array[T] = {
+      assembler: Transformer,
+      tokenizer: TokenizerModel,
+      data: DataFrame,
+      mode: String = "finisher"): Array[T] = {
 
     val finisher = new Finisher()
       .setInputCols("token")
@@ -673,18 +673,17 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       .setInputCols("document")
       .setOutputCol("token")
 
-    val pipeline = new Pipeline().setStages(Array(
-      documentAssembler,
-      tokenizer
-    ))
+    val pipeline = new Pipeline().setStages(Array(documentAssembler, tokenizer))
 
     /** Run first to cache for more consistent results */
     var result: Array[Row] = pipeline.fit(data).transform(data).select("token.result").collect()
 
-    val tokens = result.foldLeft(ArrayBuffer.empty[String]) { (arr: ArrayBuffer[String], i: Row) =>
-      val Row(tokens: mutable.WrappedArray[String]) = i
-      arr ++= tokens.map(_.replaceAll("\\W", "")).filter(_.nonEmpty)
-    }.toArray
+    val tokens = result
+      .foldLeft(ArrayBuffer.empty[String]) { (arr: ArrayBuffer[String], i: Row) =>
+        val Row(tokens: mutable.WrappedArray[String]) = i
+        arr ++= tokens.map(_.replaceAll("\\W", "")).filter(_.nonEmpty)
+      }
+      .toArray
 
     val documentAssembler2 = new DocumentAssembler()
       .setInputCol("text")
@@ -695,17 +694,17 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       .setOutputCol("token")
       .setExceptions(tokens.slice(0, 200))
 
-    val pipelineWithExceptions = new Pipeline().setStages(Array(
-      documentAssembler2,
-      tokenizerWithExceptions
-    ))
+    val pipelineWithExceptions =
+      new Pipeline().setStages(Array(documentAssembler2, tokenizerWithExceptions))
 
-    Benchmark.measure(iterations=20, forcePrint = true, description = "Time to tokenize Sherlock Holmes with exceptions") {
+    Benchmark.measure(
+      iterations = 20,
+      forcePrint = true,
+      description = "Time to tokenize Sherlock Holmes with exceptions") {
       pipelineWithExceptions.fit(data).transform(data).select("token.result").collect()
     }
 
   }
-
 
   "RecursiveTokenizer" should "split suffixes" taggedAs FastTest in {
 


### PR DESCRIPTION
This PR migrate UniversalSentenceEncoder from single-row UDF to BatchAnnotate via mapPartition to feed more rows/sentences at once to improve performance, especially on GPU devices.


The GPU utilization varies depending on the size and complexity of the model. For instance, the `tfhub_use` is not computational enough to go beyond 20%-30%, however, it will be faster or equal to the CPU with this PR unlike previously when the GPU performed slower. On the other hand, the `tfhub_use_lg` model is computationally more expensive so the GPU utilization is around 90% and more depending on the batchSize, number of partitions, and how many sentences are in 1 document. This model also was slower on GPU prior to the 3.4.4 release under extreme circumstances like having only 1 sentence per row. With this PR, the USE models on GPU will either outperform or be equal to CPU in the worst-case scenario unline previous releases.

|version|sentence/row|CPU|GPU|model|
|---|----|----|-----|----|
|3.4.3|single|43|315|tfhub_use_lg
|3.4.3|multiple|43|27|tfhub_use_lg
|3.4.4|single|44|17|tfhub_use_lg
|3.4.4|multiple|45|16|tfhub_use_lg
