### PR TITLE
Removing json4s-ext dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -139,8 +139,8 @@ lazy val utilDependencies = Seq(
   liblevenshtein
     exclude ("com.google.guava", "guava")
     exclude ("org.apache.commons", "commons-lang3"),
-  greex,
-  json4s)
+  greex
+)
 
 lazy val typedDependencyParserDependencies = Seq(junit)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,12 +74,6 @@ object Dependencies {
   val greexVersion = "1.0"
   val greex = "com.navigamez" % "greex" % greexVersion
 
-  /** json4s-ext must match the version of json4s-jackson from spark-core. The spark-core 3.2.x
-    * release comes with json4s-jackson 3.7.0-M11 and spark-core 3.1.x comes with 3.7.0-M5
-    */
-  val json4sVersion: String = if (is_spark30 == "true") "3.7.0-M5" else "3.7.0-M11"
-  val json4s = "org.json4s" %% "json4s-ext" % json4sVersion
-
   val junitVersion = "4.13.2"
   val junit = "junit" % "junit" % junitVersion % Test
 

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceMetadata.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceMetadata.scala
@@ -16,9 +16,7 @@
 
 package com.johnsnowlabs.nlp.pretrained
 
-import com.johnsnowlabs.nlp.pretrained.ResourceType.ResourceType
 import com.johnsnowlabs.util.{JsonParser, Version}
-import org.json4s.ext.EnumNameSerializer
 import org.json4s.jackson.Serialization
 import org.json4s.jackson.Serialization.write
 import org.json4s.{Formats, NoTypeHints}
@@ -35,7 +33,7 @@ case class ResourceMetadata(
     readyToUse: Boolean,
     time: Timestamp,
     isZipped: Boolean = false,
-    category: Option[ResourceType] = Some(ResourceType.NOT_DEFINED),
+    category: Option[String] = Some(ResourceType.NOT_DEFINED.toString),
     checksum: String = "",
     annotator: Option[String] = None)
     extends Ordered[ResourceMetadata] {
@@ -94,8 +92,8 @@ case class ResourceMetadata(
 }
 
 object ResourceMetadata {
-  implicit val formats: Formats =
-    Serialization.formats(NoTypeHints) + new EnumNameSerializer(ResourceType)
+
+  implicit val formats: Formats = Serialization.formats(NoTypeHints)
 
   def toJson(meta: ResourceMetadata): String = {
     write(meta)

--- a/src/main/scala/com/johnsnowlabs/util/TrainingHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/TrainingHelper.scala
@@ -51,7 +51,7 @@ object TrainingHelper {
       true,
       timestamp,
       true,
-      category = category)
+      category = Some(category.get.toString))
 
     // 3. Save model to file
     val file = Paths.get(folder, meta.key).toString.replaceAllLiterally("\\", "/")

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/DateMatcherMultiLanguageTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/DateMatcherMultiLanguageTestSpec.scala
@@ -16,12 +16,12 @@
 
 package com.johnsnowlabs.nlp.annotators
 
+import com.amazonaws.thirdparty.joda.time.LocalDateTime
+import com.amazonaws.thirdparty.joda.time.format.DateTimeFormat
 import com.johnsnowlabs.nlp.{Annotation, DataBuilder}
 import com.johnsnowlabs.tags.FastTest
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.{Dataset, Row}
-import org.joda.time.LocalDateTime
-import org.joda.time.format.DateTimeFormat
 import org.scalatest.flatspec.AnyFlatSpec
 
 import java.time.LocalDate

--- a/src/test/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloaderMetaSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloaderMetaSpec.scala
@@ -129,7 +129,9 @@ class ResourceDownloaderMetaSpec extends AnyFlatSpec with BeforeAndAfter {
     })
     assert(
       allModels.length == mockResourceDownloader.resources.count(
-        _.category.getOrElse(ResourceType.NOT_DEFINED).equals(ResourceType.MODEL)))
+        _.category
+          .getOrElse(ResourceType.NOT_DEFINED.toString)
+          .equals(ResourceType.MODEL.toString)))
 
     val allContextSpell = extractTableContent(captureOutput {
       ResourceDownloader.showPublicModels("TestAnnotator")

--- a/src/test/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloaderSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloaderSpec.scala
@@ -41,6 +41,22 @@ class ResourceDownloaderSpec extends AnyFlatSpec {
     assert(deserialized == resource)
   }
 
+  "CloudResourceMetadata with category" should "serialize and deserialize correctly" taggedAs FastTest in {
+    val resource = new ResourceMetadata(
+      "name",
+      Some("en"),
+      Some(Version(1, 2, 3)),
+      Some(Version(5, 4, 3)),
+      true,
+      new Timestamp(123213),
+      category = Some(ResourceType.MODEL.toString))
+
+    val json = ResourceMetadata.toJson(resource)
+    val deserialized = ResourceMetadata.parseJson(json)
+
+    assert(deserialized == resource)
+  }
+
   "CloudResourceDownloader" should "choose the newest Spark version" taggedAs FastTest in {
     val sparkNLPVersion = Version(1, 2, 3)
     val sparkVersion = Version(3, 4, 5)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes `json4s-ext` dependency used in ResourceMetadata to serialze/deserialize enumerate types

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`json4s-ext` dependency forces us to publish/release spark-nlp and spark-nlp-spark32. By removing it, we only need to publish/release 1 package for spark-nlp and 1 for spark-nlp-gpu

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Scale unit tests
We need to test it thoroughly when merged with 4.0.0

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
