### PR TITLE
Migrate to Scala 2.12.15

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -26,6 +26,8 @@ on:
       - '**.yml'
     branches:
       - 'master'
+      - '*release*'
+      - 'release/**'
       - 'main'
 
 jobs:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,8 +28,8 @@ object Dependencies {
     spark32Ver
   }
 
-  def getJavaTarget(is_spark30: String, is_spark32: String): String = {
-    if (is_spark30.equals("true") || is_spark32.equals("true")) {
+  def getJavaTarget(is_spark32: String): String = {
+    if (is_spark32.equals("true")) {
       "-target:jvm-1.8"
     } else {
       ""
@@ -37,7 +37,7 @@ object Dependencies {
   }
 
   /** ------- Scala version start ------- */
-  lazy val scala212 = "2.12.10"
+  lazy val scala212 = "2.12.15"
   lazy val scalaVer: String = scala212
 
   lazy val supportedScalaVersions: Seq[String] = List(scala212)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,6 +7,6 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
 /** scoverage */
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.1")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.2")

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/er/EntityRulerUtil.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/er/EntityRulerUtil.scala
@@ -1,0 +1,35 @@
+package com.johnsnowlabs.nlp.annotators.er
+
+import scala.collection.mutable.ListBuffer
+
+object EntityRulerUtil {
+
+  def mergeIntervals(intervals: List[List[Int]]): List[List[Int]] = {
+
+    val mergedIntervals = ListBuffer[List[Int]]()
+    var currentMergedInterval = List[Int]()
+    val sortedIntervals = intervals.sortBy(interval => interval.head)
+
+    sortedIntervals.zipWithIndex.foreach { case (interval, index) =>
+      if (index == 0) {
+        currentMergedInterval = interval
+      } else {
+        val mergedEnd = currentMergedInterval(1)
+        val currentBegin = interval.head
+        if (mergedEnd >= currentBegin) {
+          val currentEnd = interval(1)
+          val maxEnd = math.max(currentEnd, mergedEnd)
+          currentMergedInterval = List(currentMergedInterval.head, maxEnd)
+        } else {
+          mergedIntervals.append(currentMergedInterval)
+          currentMergedInterval = interval
+        }
+      }
+    }
+
+    mergedIntervals.append(currentMergedInterval)
+    mergedIntervals.toList
+
+  }
+
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/AssertAnnotations.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/AssertAnnotations.scala
@@ -28,17 +28,37 @@ object AssertAnnotations {
     val metadata = columnName + ".metadata"
     val begin = columnName + ".begin"
     val end = columnName + ".end"
+    val annotatorType = columnName + ".annotatorType"
+    val embeddings = columnName + ".embeddings"
+
     dataSet
-      .select(result, metadata, begin, end)
+      .select(result, metadata, begin, end, annotatorType, embeddings)
       .rdd
       .map { row =>
-        val resultSeq: Seq[String] = row.get(0).asInstanceOf[mutable.WrappedArray[String]]
-        val metadataSeq: Seq[Map[String, String]] =
-          row.get(1).asInstanceOf[mutable.WrappedArray[Map[String, String]]]
-        val beginSeq: Seq[Int] = row.get(2).asInstanceOf[mutable.WrappedArray[Int]]
-        val endSeq: Seq[Int] = row.get(3).asInstanceOf[mutable.WrappedArray[Int]]
+        val resultSeq: Seq[String] =
+          row.getAs[String]("result").asInstanceOf[mutable.WrappedArray[String]]
+        val metadataSeq: Seq[Map[String, String]] = row
+          .getAs[Map[String, String]]("metadata")
+          .asInstanceOf[mutable.WrappedArray[Map[String, String]]]
+        val beginSeq: Seq[Int] = row.getAs[Int]("begin").asInstanceOf[mutable.WrappedArray[Int]]
+        val endSeq: Seq[Int] = row.getAs[Int]("end").asInstanceOf[mutable.WrappedArray[Int]]
+        val annotatorTypeSeq: Seq[String] = row
+          .getAs[String]("annotatorType")
+          .asInstanceOf[mutable.WrappedArray[String]]
+        val embeddings: Seq[Seq[Float]] = row
+          .getAs[Seq[Float]]("embeddings")
+          .asInstanceOf[mutable.WrappedArray[Seq[Float]]]
+
         resultSeq.zipWithIndex.map { case (token, index) =>
-          Annotation(TOKEN, beginSeq(index), endSeq(index), token, metadataSeq(index))
+          val annotatorType = annotatorTypeSeq(index)
+          val embedding = embeddings(index).toArray
+          Annotation(
+            annotatorType,
+            beginSeq(index),
+            endSeq(index),
+            token,
+            metadataSeq(index),
+            embedding)
         }
       }
       .collect()
@@ -54,10 +74,12 @@ object AssertAnnotations {
         val actualBegin = actualDocument(index).begin
         val actualEnd = actualDocument(index).end
         val actualMetadata = actualDocument(index).metadata
+        val actualAnnotatorType = actualDocument(index).annotatorType
         val expectedResult = expectedAnnotation.result
         val expectedBegin = expectedAnnotation.begin
         val expectedEnd = expectedAnnotation.end
         val expectedMetadata = expectedAnnotation.metadata
+        val expectedAnnotatorType = expectedAnnotation.annotatorType
         assert(
           actualResult == expectedResult,
           s"actual result $actualResult != expected result $expectedResult")
@@ -68,6 +90,9 @@ object AssertAnnotations {
         assert(
           actualMetadata == expectedMetadata,
           s"actual begin $actualMetadata != expected result $expectedMetadata")
+        assert(
+          actualAnnotatorType == expectedAnnotatorType,
+          s"actual annotatorType $actualMetadata != expected annotatorType $expectedMetadata")
       }
     }
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/er/EntityRulerUtilTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/er/EntityRulerUtilTest.scala
@@ -1,0 +1,30 @@
+package com.johnsnowlabs.nlp.annotators.er
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class EntityRulerUtilTest extends AnyFlatSpec {
+
+  "EntityRulerUtil" should "merge intervals" in {
+
+    var intervals =
+      List(List(57, 59), List(7, 10), List(7, 15), List(57, 64), List(12, 15), List(0, 15))
+    var expectedMerged = List(List(0, 15), List(57, 64))
+
+    var actualMerged = EntityRulerUtil.mergeIntervals(intervals)
+
+    assert(expectedMerged == actualMerged)
+
+    intervals = List(List(2, 3), List(4, 5), List(6, 7), List(8, 9), List(1, 10))
+    expectedMerged = List(List(1, 10))
+
+    actualMerged = EntityRulerUtil.mergeIntervals(intervals)
+    assert(expectedMerged == actualMerged)
+
+    intervals = List(List(5, 10), List(15, 20))
+    expectedMerged = List(List(5, 10), List(15, 20))
+
+    actualMerged = EntityRulerUtil.mergeIntervals(intervals)
+    assert(expectedMerged == actualMerged)
+  }
+
+}


### PR DESCRIPTION
This PR updates the Scala from 2.12.10 to 2.12.15 to make the transition to Scala 3.x later on easier. (there are also many enhancements, bug fixes, etc. in the releases after 2.12.10)

- [x] Pretrained models should work
- [x] All unit tests should pass (some EntityRuler unit tests fail)