### PR TITLE
Bugfix/8546 docnorm

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DocumentNormalizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DocumentNormalizer.scala
@@ -20,7 +20,6 @@ import com.johnsnowlabs.nlp.AnnotatorType.DOCUMENT
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, AnnotatorType, HasSimpleAnnotate}
 import org.apache.spark.ml.param.{BooleanParam, Param, StringArrayParam}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
-import org.apache.spark.sql.Row
 
 import java.nio.charset.{Charset, StandardCharsets}
 import scala.util.{Failure, Success, Try}
@@ -412,7 +411,7 @@ class DocumentNormalizer(override val uid: String)
             cleanedDoc,
             annotation.metadata)
         case Failure(_) =>
-          Annotation.apply(Row.empty) // Seq.empty[Annotation].head
+          Annotation.apply("")
       }
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DocumentNormalizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DocumentNormalizer.scala
@@ -20,8 +20,10 @@ import com.johnsnowlabs.nlp.AnnotatorType.DOCUMENT
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, AnnotatorType, HasSimpleAnnotate}
 import org.apache.spark.ml.param.{BooleanParam, Param, StringArrayParam}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
+import org.apache.spark.sql.Row
 
 import java.nio.charset.{Charset, StandardCharsets}
+import scala.util.{Failure, Success, Try}
 import scala.xml.XML
 
 /** Annotator which normalizes raw text from tagged text, e.g. scraped web pages or xml documents,
@@ -359,9 +361,6 @@ class DocumentNormalizer(override val uid: String)
       policy: String,
       lowercase: Boolean,
       encoding: String): String = {
-    require(
-      !text.isEmpty && !action.isEmpty && patterns.length > 0 && !patterns(
-        0).isEmpty && !policy.isEmpty)
 
     val processedWithActionPatterns: String = policy match {
       case "all" => withAllFormatter(text, action, patterns, replacement)
@@ -394,9 +393,9 @@ class DocumentNormalizer(override val uid: String)
     }
   }
 
-  override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
-    annotations.map { annotation =>
-      val cleanedDoc =
+  override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = annotations.map {
+    annotation =>
+      Try(
         applyDocumentNormalization(
           annotation.result,
           getAction,
@@ -404,15 +403,17 @@ class DocumentNormalizer(override val uid: String)
           getReplacement,
           getPolicy,
           getLowercase,
-          getEncoding)
-
-      Annotation(
-        DOCUMENT,
-        annotation.begin,
-        cleanedDoc.length - 1,
-        cleanedDoc,
-        annotation.metadata)
-    }
+          getEncoding)) match {
+        case Success(cleanedDoc) =>
+          Annotation(
+            DOCUMENT,
+            annotation.begin,
+            cleanedDoc.length - 1,
+            cleanedDoc,
+            annotation.metadata)
+        case Failure(_) =>
+          Annotation.apply(Row.empty) // Seq.empty[Annotation].head
+      }
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
DocumentNormalizer needs the ability to be replicated as stage in a pipeline.
Requirements have been removed so that consecutive stage processing can produce empty text annotations without breaking the pipeline.


## Motivation and Context
Issue https://github.com/JohnSnowLabs/spark-nlp/issues/8546#

## How Has This Been Tested?
Local non regression tests.

## Screenshots (if appropriate):
[info] Total number of tests run: 652
[info] Suites: completed 135, aborted 0
[info] Tests: succeeded 652, failed 0, canceled 0, ignored 3, pending 0
[info] All tests passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
