### PR TITLE
BpeTokenizer: add flag for "AddPrefixSpace"

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/BpeTokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/BpeTokenizer.scala
@@ -24,12 +24,23 @@ import scala.collection.mutable.ListBuffer
 
 /** A BPE Tokenizer based on GPT2's tokenization scheme. The tokenization can then be used for
   * models based on this scheme (e.g. GPT2, roBERTa, DeBERTa) TODO: truncation assumed?
+  * @param merges
+  *   Map of tokens that are mergeable
+  * @param vocab
+  *   Map of tokens to encoded representation
+  * @param specialTokens
+  *   Collection of special tokens
+  * @param padWithSentenceTokens
+  *   Whether to pad the sentence with sentence tokens at the start and end
+  * @param addPrefixSpace
+  *   Whether to add a space to the first word of a sentence
   */
 private[nlp] abstract class BpeTokenizer(
     val merges: Map[(String, String), Int],
     val vocab: Map[String, Int],
     val specialTokens: SpecialTokens,
-    var padWithSentenceTokens: Boolean) {
+    val padWithSentenceTokens: Boolean,
+    val addPrefixSpace: Boolean) {
 
   protected val bpeRanks: Map[(String, String), Int] = {
     merges
@@ -109,13 +120,17 @@ private[nlp] abstract class BpeTokenizer(
       .zip(wordIndexes)
       .map { case (subWord: String, indexes: (Int, Int)) =>
         val isWordStart = indToken.begin == indexes._1
+        val isDocumentStart = indToken.begin == 0
         var processedSubWord = subWord
-        processedSubWord = prependForPieceId match {
-          case None => processedSubWord
-          case Some(prepend) =>
-            if (isWordStart && subWord.indexOf(prepend) < 0) prepend + processedSubWord
-            else processedSubWord
-        }
+        processedSubWord = if (isDocumentStart && !addPrefixSpace) {
+          processedSubWord
+        } else
+          prependForPieceId match {
+            case None => processedSubWord
+            case Some(prepend) =>
+              if (isWordStart && subWord.indexOf(prepend) < 0) prepend + processedSubWord
+              else processedSubWord
+          }
         processedSubWord = appendForPieceId match {
           case None => processedSubWord
           case Some(append) =>
@@ -296,6 +311,7 @@ object BpeTokenizer {
       merges: Map[(String, String), Int],
       vocab: Map[String, Int],
       padWithSentenceTokens: Boolean = false,
+      addPrefixSpace: Boolean = false,
       specialTokens: Option[SpecialTokens] = None): BpeTokenizer = {
     val availableModels = Array("roberta", "xlm", "gpt2")
     require(
@@ -309,9 +325,21 @@ object BpeTokenizer {
 
     modelType match {
       case "roberta" =>
-        new RobertaTokenizer(merges, vocab, modelSpecialTokens, padWithSentenceTokens)
-      case "xlm" => new XlmTokenizer(merges, vocab, modelSpecialTokens, padWithSentenceTokens)
-      case "gpt2" => new Gpt2Tokenizer(merges, vocab, modelSpecialTokens, padWithSentenceTokens)
+        new RobertaTokenizer(
+          merges,
+          vocab,
+          modelSpecialTokens,
+          padWithSentenceTokens,
+          addPrefixSpace = addPrefixSpace)
+      case "xlm" =>
+        new XlmTokenizer(merges, vocab, modelSpecialTokens, padWithSentenceTokens)
+      case "gpt2" =>
+        new Gpt2Tokenizer(
+          merges,
+          vocab,
+          modelSpecialTokens,
+          padWithSentenceTokens,
+          addPrefixSpace = addPrefixSpace)
 
     }
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/Gpt2Tokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/Gpt2Tokenizer.scala
@@ -27,8 +27,9 @@ class Gpt2Tokenizer(
     vocab: Map[String, Int],
     specialTokens: SpecialTokens,
     padWithSentenceTokens: Boolean = true,
-    prependString: String = "")
-    extends BpeTokenizer(merges, vocab, specialTokens, padWithSentenceTokens) {
+    prependString: String = "",
+    addPrefixSpace: Boolean = false)
+    extends BpeTokenizer(merges, vocab, specialTokens, padWithSentenceTokens, addPrefixSpace) {
 
   /** Mapping for bytes to a different set of unicode characters (especially white spaces). This
     * improved model performance for gpt-2

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/RobertaTokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/RobertaTokenizer.scala
@@ -20,10 +20,12 @@ class RobertaTokenizer(
     merges: Map[(String, String), Int],
     vocab: Map[String, Int],
     specialTokens: SpecialTokens,
-    padWithSentenceTokens: Boolean = false)
+    padWithSentenceTokens: Boolean = false,
+    addPrefixSpace: Boolean = false)
     extends Gpt2Tokenizer(
       merges,
       vocab,
       specialTokens,
       padWithSentenceTokens,
-      prependString = "Ġ")
+      prependString = "Ġ",
+      addPrefixSpace)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/XlmTokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/XlmTokenizer.scala
@@ -40,7 +40,12 @@ private[nlp] class XlmTokenizer(
     padWithSentenceTokens: Boolean = false,
     lang: String = "en",
     doLowercaseAndRemoveAccent: Boolean = true)
-    extends BpeTokenizer(merges, vocab, specialTokens, padWithSentenceTokens) {
+    extends BpeTokenizer(
+      merges,
+      vocab,
+      specialTokens,
+      padWithSentenceTokens,
+      addPrefixSpace = false) {
   require(lang == "en", "Only English is supported currently.")
 
   /** Lowercase and strips accents from a piece of text based on

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/Gpt2TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/Gpt2TokenizerTestSpec.scala
@@ -65,20 +65,17 @@ class Gpt2TokenizerTestSpec extends AnyFlatSpec with BpeTokenizerBehaviours {
     "Ġ I").map(_.split(" ")).map { case Array(c1, c2) => (c1, c2) }.zipWithIndex.toMap
 
   val modelType: String = "gpt2"
-  val tokenizer: BpeTokenizer = BpeTokenizer.forModel(modelType, merges, vocab)
 
   override val replaceCharBeforeAssertion: Some[String] = Some("Ġ")
 
   "Gpt2Tokenizer" should behave like correctBpeTokenizer(
-    tokenizer = tokenizer,
     text = " I unambigouosly good 3Asd!",
     expected = Array("ĠI", "Ġunamb", "ig", "ou", "os", "ly", "Ġgood", "Ġ3", "As", "d", "!"),
     expectedIds = Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
 
-  it should behave like correctBpeTokenizerInFringeSituations(tokenizer = tokenizer)
+  it should behave like correctBpeTokenizerInFringeSituations()
 
   it should behave like correctBpeTokenizerSpecialTokens(
-    tokenizer = tokenizer,
     text = " I unambigouosly <|endoftext|> good 3Asd <|endoftext|>",
     expected = Array(
       "ĠI",

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/RobertaTokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/RobertaTokenizerTestSpec.scala
@@ -36,11 +36,8 @@ class RobertaTokenizerTestSpec extends AnyFlatSpec with BpeTokenizerBehaviours {
       "d",
       "Ġ!",
       "<unk>",
-      "<pad>"
-      //        "ĠI",
-      //        "ĠAs",
-      //        "Ġ!",
-    ).zipWithIndex.toMap
+      "<pad>",
+      "I").zipWithIndex.toMap
 
   val merges: Map[(String, String), Int] = Array(
     "o u",
@@ -71,22 +68,25 @@ class RobertaTokenizerTestSpec extends AnyFlatSpec with BpeTokenizerBehaviours {
     "Ġgo od",
     "Ġ 3").map(_.split(" ")).map { case Array(c1, c2) => (c1, c2) }.zipWithIndex.toMap
 
-  val tokenizer: BpeTokenizer = BpeTokenizer.forModel("roberta", merges, vocab)
+  override val modelType = "roberta"
 
   override val replaceCharBeforeAssertion: Some[String] = Some("Ġ")
 
   "RobertaTokenizer" should behave like correctBpeTokenizer(
-    tokenizer = tokenizer,
+    text = "I unambigouosly good 3Asd!",
+    Array("I", "Ġunamb", "ig", "ou", "os", "ly", "Ġgood", "Ġ3", "As", "d", "!"),
+    Array(16, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13))
+
+  "RobertaTokenizer" should behave like correctBpeTokenizerWithAddedPrefixSpace(
     text = "I unambigouosly good 3Asd!",
     Array("I", "Ġunamb", "ig", "ou", "os", "ly", "Ġgood", "Ġ3", "As", "d", "!"),
     Array(3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13))
 
-  it should behave like correctBpeTokenizerInFringeSituations(tokenizer = tokenizer)
+  it should behave like correctBpeTokenizerInFringeSituations()
 
   it should behave like correctBpeTokenizerSpecialTokens(
-    tokenizer = tokenizer,
     text = "I unambigouosly <mask> good 3Asd <mask>",
     expected =
       Array("I", "Ġunamb", "ig", "ou", "os", "ly", "<mask>", "Ġgood", "Ġ3", "As", "d", "<mask>"),
-    expectedIds = Array(3, 4, 5, 6, 7, 8, 2, 9, 10, 11, 12, 2))
+    expectedIds = Array(16, 4, 5, 6, 7, 8, 2, 9, 10, 11, 12, 2))
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/XlmTokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/tokenizer/bpe/XlmTokenizerTestSpec.scala
@@ -70,7 +70,7 @@ class XlmTokenizerTestSpec extends AnyFlatSpec with BpeTokenizerBehaviours {
     "s d</w>",
     "o o").map(_.split(" ")).map { case Array(c1, c2) => (c1, c2) }.zipWithIndex.toMap
 
-  val tokenizer: BpeTokenizer = BpeTokenizer.forModel("xlm", merges, vocab)
+  val modelType = "xlm"
 
   override def assertEncodedCorrectly(
       text: String,
@@ -90,15 +90,13 @@ class XlmTokenizerTestSpec extends AnyFlatSpec with BpeTokenizerBehaviours {
   }
 
   "XlmTokenizer" should behave like correctBpeTokenizer(
-    tokenizer = tokenizer,
     text = "I unambigouosly good 3Asd!",
     expected = Array("i", "un", "ambi", "gou", "os", "ly", "good", "3", "as", "d", "!"),
     expectedIds = Array(14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24))
 
-  it should behave like correctBpeTokenizerInFringeSituations(tokenizer = tokenizer)
+  it should behave like correctBpeTokenizerInFringeSituations()
 
   it should behave like correctBpeTokenizerSpecialTokens(
-    tokenizer = tokenizer,
     text = "I unambigouosly <special1> good 3Asd <special1>",
     expected = Array(
       "i",


### PR DESCRIPTION
This PR adds a flag for the BpeTokenizer, so that not always a space is prepended to the input.

- added new flag whether to add a space to the initial input sentence
- slight improvement to test structure

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new test to reflect the change and other tests for BpeTokenizers are passing.
