### PR TITLE
fixed docs for transformers question answering annotaters

### DIFF
--- a/docs/en/transformer_entries/AlbertForQuestionAnswering.md
+++ b/docs/en/transformer_entries/AlbertForQuestionAnswering.md
@@ -39,7 +39,7 @@ from pyspark.ml import Pipeline
 
 documentAssembler = MultiDocumentAssembler() \
     .setInputCols(["question", "context"]) \
-    .setOutputCol(["document_question", "document_context"])
+    .setOutputCols(["document_question", "document_context"])
 
 spanClassifier = AlbertForQuestionAnswering.pretrained() \
     .setInputCols(["document_question", "document_context"]) \

--- a/docs/en/transformer_entries/BertForQuestionAnswering.md
+++ b/docs/en/transformer_entries/BertForQuestionAnswering.md
@@ -39,7 +39,7 @@ from sparknlp.annotator import *
 from pyspark.ml import Pipeline
 documentAssembler = MultiDocumentAssembler() \
     .setInputCols(["question", "context"]) \
-    .setOutputCol(["document_question", "document_context"])
+    .setOutputCols(["document_question", "document_context"])
 
 spanClassifier = BertForQuestionAnswering.pretrained() \
     .setInputCols(["document_question", "document_context"]) \

--- a/docs/en/transformer_entries/DeBertaForQuestionAnswering.md
+++ b/docs/en/transformer_entries/DeBertaForQuestionAnswering.md
@@ -39,7 +39,7 @@ from pyspark.ml import Pipeline
 
 documentAssembler = MultiDocumentAssembler() \
     .setInputCols(["question", "context"]) \
-    .setOutputCol(["document_question", "document_context"])
+    .setOutputCols(["document_question", "document_context"])
 
 spanClassifier = DeBertaForQuestionAnswering.pretrained() \
     .setInputCols(["document_question", "document_context"]) \

--- a/docs/en/transformer_entries/DistilBertForQuestionAnswering.md
+++ b/docs/en/transformer_entries/DistilBertForQuestionAnswering.md
@@ -39,7 +39,7 @@ from pyspark.ml import Pipeline
 
 documentAssembler = MultiDocumentAssembler() \
     .setInputCols(["question", "context"]) \
-    .setOutputCol(["document_question", "document_context"])
+    .setOutputCols(["document_question", "document_context"])
 
 spanClassifier = DistilBertForQuestionAnswering.pretrained() \
     .setInputCols(["document_question", "document_context"]) \

--- a/docs/en/transformer_entries/LongformerForQuestionAnswering.md
+++ b/docs/en/transformer_entries/LongformerForQuestionAnswering.md
@@ -39,7 +39,7 @@ from pyspark.ml import Pipeline
 
 documentAssembler = MultiDocumentAssembler() \
     .setInputCols(["question", "context"]) \
-    .setOutputCol(["document_question", "document_context"])
+    .setOutputCols(["document_question", "document_context"])
 
 spanClassifier = LongformerForQuestionAnswering.pretrained() \
     .setInputCols(["document_question", "document_context"]) \

--- a/docs/en/transformer_entries/RoBertaForQuestionAnswering.md
+++ b/docs/en/transformer_entries/RoBertaForQuestionAnswering.md
@@ -39,7 +39,7 @@ from pyspark.ml import Pipeline
 
 documentAssembler = MultiDocumentAssembler() \
     .setInputCols(["question", "context"]) \
-    .setOutputCol(["document_question", "document_context"])
+    .setOutputCols(["document_question", "document_context"])
 
 spanClassifier = RoBertaForQuestionAnswering.pretrained() \
     .setInputCols(["document_question", "document_context"]) \

--- a/docs/en/transformer_entries/XlmRoBertaForQuestionAnswering.md
+++ b/docs/en/transformer_entries/XlmRoBertaForQuestionAnswering.md
@@ -39,7 +39,7 @@ from pyspark.ml import Pipeline
 
 documentAssembler = MultiDocumentAssembler() \
     .setInputCols(["question", "context"]) \
-    .setOutputCol(["document_question", "document_context"])
+    .setOutputCols(["document_question", "document_context"])
 
 spanClassifier = XlmRoBertaForQuestionAnswering.pretrained() \
     .setInputCols(["document_question", "document_context"]) \


### PR DESCRIPTION
Fixed docs for transformer question answering annotators 

## Description
All questions Answer Transformers use



```

documentAssembler = MultiDocumentAssembler() \
    .setInputCols(["question", "context"]) \
    .setOutputCols(["document_question", "document_context"])
```







But the docs are wrong and say
```
documentAssembler = MultiDocumentAssembler() \
    .setInputCols(["question", "context"]) \
    .setOutputCol(["document_question", "document_context"])
```