### PR TITLE
Fix bug that attempts to create spark session on executors

### DIFF
--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/GraphExtractionTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/GraphExtractionTest.scala
@@ -17,7 +17,6 @@
 package com.johnsnowlabs.nlp.annotators
 
 import com.johnsnowlabs.nlp.AnnotatorType.NODE
-import com.johnsnowlabs.nlp.annotator.SentenceDetector
 import com.johnsnowlabs.nlp.annotators.ner.NerConverter
 import com.johnsnowlabs.nlp.annotators.ner.dl.NerDLModel
 import com.johnsnowlabs.nlp.annotators.parser.dep.DependencyParserModel
@@ -283,8 +282,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
     AssertAnnotations.assertFields(expectedGraph, actualGraph)
   }
 
-  it should "handle overlapping entities" ignore {
-    // Ignored because it downloads POS and Dependency Parser pretrained models
+  it should "handle overlapping entities" taggedAs SlowTest in {
     val testDataSet = getOverlappingEntities(spark, tokenizerWithSentencePipeline)
     val graphExtractor = new GraphExtraction()
       .setInputCols("sentence", "token", "entities")
@@ -473,7 +471,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setInputCols("sentence", "token", "entities")
       .setOutputCol("graph")
       .setExplodeEntities(true)
-      .setMergeEntities(false)
+      .setMergeEntities(true)
       .setMergeEntitiesIOBFormat("IOB")
       .setIncludeEdges(false)
     val expectedGraph = Array(
@@ -513,13 +511,6 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
   }
 
   "Graph Extraction with LightPipeline" should "return dependency graphs between all entities" taggedAs SlowTest in {
-    val sentence = new SentenceDetector()
-      .setInputCols("document")
-      .setOutputCol("sentence")
-
-    val tokenizer = new Tokenizer()
-      .setInputCols("sentence")
-      .setOutputCol("token")
 
     val embeddings = WordEmbeddingsModel
       .pretrained()
@@ -563,7 +554,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
     val graphPipeline = new Pipeline().setStages(
       Array(
         documentAssembler,
-        sentence,
+        sentenceDetector,
         tokenizer,
         embeddings,
         nerSmall,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactoring `PretrainedAnnotations` object to instantiate classes in driver

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
GraphExctraction is forcing to create spark session on executors when setting setMergeEntities=true in Spark > 3.0.

The error raised is: 

`Caused by: java.lang.IllegalStateException: SparkSession should only be created and accessed on the driver.`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit tests
- Google Colab Notebooks
- Databricks Notebooks

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
