### PR TITLE
[SentenceDetector] Added Flag for returning custom bounds

### DIFF
--- a/python/sparknlp/annotator/sentence/sentence_detector.py
+++ b/python/sparknlp/annotator/sentence/sentence_detector.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the SentenceDetector."""
 
-
 from sparknlp.common import *
 
 
@@ -35,6 +34,11 @@ class SentenceDetectorParams:
                                 "useCustomBoundsOnly",
                                 "Only utilize custom bounds in sentence detection",
                                 typeConverter=TypeConverters.toBoolean)
+
+    customBoundsStrategy = Param(Params._dummy(),
+                                 "customBoundsStrategy",
+                                 "How to return matched custom bounds",
+                                 typeConverter=TypeConverters.toString)
 
     explodeSentences = Param(Params._dummy(),
                              "explodeSentences",
@@ -106,6 +110,15 @@ class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
         characters used to explicitly mark sentence bounds, by default []
     useCustomBoundsOnly
         Only utilize custom bounds in sentence detection, by default False
+    customBoundsStrategy
+        Sets how to return matched custom bounds, by default "none".
+
+        Will have no effect if no custom bounds are used.
+        Possible values are:
+
+        - "none" - Will not return the matched bound
+        - "prepend" - Prepends a sentence break to the match
+        - "append" - Appends a sentence break to the match
     explodeSentences
         whether to explode each sentence into a different row, for better
         parallelization, by default False
@@ -165,6 +178,23 @@ class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
             Characters used to explicitly mark sentence bounds
         """
         return self._set(customBounds=value)
+
+    def setCustomBoundsStrategy(self, value):
+        """Sets how to return matched custom bounds, by default "none".
+
+        Will have no effect if no custom bounds are used.
+        Possible values are:
+
+        - "none" - Will not return the matched bound
+        - "prepend" - Prepends a sentence break to the match
+        - "append" - Appends a sentence break to the match
+
+        Parameters
+        ----------
+        value : str
+            Strategy to use
+        """
+        return self._set(customBoundsStrategy=value)
 
     def setUseAbbreviations(self, value):
         """Sets whether to apply abbreviations at sentence detection, by default
@@ -249,8 +279,8 @@ class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
             detectLists=True,
             useCustomBoundsOnly=False,
             customBounds=[],
+            customBoundsStrategy="none",
             explodeSentences=False,
             minLength=0,
             maxLength=99999
         )
-

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/SentenceDetectorParams.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/SentenceDetectorParams.scala
@@ -16,7 +16,7 @@
 
 package com.johnsnowlabs.nlp.annotators.sbd
 
-import org.apache.spark.ml.param.{BooleanParam, IntParam, Params, StringArrayParam}
+import org.apache.spark.ml.param.{BooleanParam, IntParam, Param, Params, StringArrayParam}
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -93,13 +93,26 @@ trait SentenceDetectorParams extends Params {
   val maxLength =
     new IntParam(this, "maxLength", "Set the maximum allowed length for each sentence")
 
+  /** How to return matched custom bounds (Default: `none`). Will have no effect if no custom
+    * bounds are used. Possible values are:
+    *
+    *   - "none" - Will not return the matched bound
+    *   - "prepend" - Prepends a sentence break to the match
+    *   - "append" - Appends a sentence break to the match
+    *
+    * @group param
+    */
+  val customBoundsStrategy: Param[String] =
+    new Param[String](this, "customBoundsStrategy", "How to return matched custom bounds")
+
   setDefault(
     useAbbrevations -> true,
     detectLists -> true,
     useCustomBoundsOnly -> false,
     explodeSentences -> false,
     customBounds -> Array.empty[String],
-    minLength -> 0)
+    minLength -> 0,
+    customBoundsStrategy -> "none")
 
   /** Custom sentence separator text
     * @group setParam
@@ -122,6 +135,30 @@ trait SentenceDetectorParams extends Params {
     * @group getParam
     */
   def getUseCustomBoundsOnly: Boolean = $(useCustomBoundsOnly)
+
+  /** Sets how to return matched custom bounds (Default: `none`). Will have no effect if no custom
+    * bounds are used. Possible values are:
+    *
+    *   - "none" - Will not return the matched bound
+    *   - "prepend" - Prepends a sentence break to the match
+    *   - "append" - Appends a sentence break to the match
+    *
+    * @group setParam
+    */
+  def setCustomBoundsStrategy(value: String): this.type = {
+    val possibleValues = Array("none", "prepend", "append")
+    require(
+      possibleValues.contains(value),
+      s"$value is not a valid strategy for custom bounds. " +
+        s"Possible Values: (${possibleValues.mkString(", ")}).")
+
+    set(customBoundsStrategy, value)
+  }
+
+  /** Gets how to return matched custom bounds (Default: `none`).
+    * @group getParam
+    */
+  def getCustomBoundsStrategy: String = $(customBoundsStrategy)
 
   /** Whether to consider abbreviation strategies for better accuracy but slower performance.
     * Defaults to true.

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticMethod.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/sbd/pragmatic/PragmaticMethod.scala
@@ -19,7 +19,10 @@ package com.johnsnowlabs.nlp.annotators.sbd.pragmatic
 import com.johnsnowlabs.nlp.annotators.common.Sentence
 import com.johnsnowlabs.nlp.util.regex.MatchStrategy.MATCH_ALL
 import com.johnsnowlabs.nlp.util.regex.RuleFactory
-import com.johnsnowlabs.nlp.util.regex.TransformStrategy.REPLACE_ALL_WITH_SYMBOL
+import com.johnsnowlabs.nlp.util.regex.TransformStrategy.{
+  REPLACE_ALL_WITH_SYMBOL,
+  TransformStrategy
+}
 
 protected trait PragmaticMethod {
   def extractBounds(content: String): Array[Sentence]
@@ -29,12 +32,14 @@ protected trait PragmaticMethod {
   * This approach extracts sentence bounds by first formatting the data with [[RuleSymbols]] and
   * then extracting bounds with a strong RegexBased rule application
   */
-class CustomPragmaticMethod(customBounds: Array[String])
+class CustomPragmaticMethod(
+    customBounds: Array[String],
+    transformStrategy: TransformStrategy = REPLACE_ALL_WITH_SYMBOL)
     extends PragmaticMethod
     with Serializable {
   override def extractBounds(content: String): Array[Sentence] = {
 
-    val customBoundsFactory = new RuleFactory(MATCH_ALL, REPLACE_ALL_WITH_SYMBOL)
+    val customBoundsFactory = new RuleFactory(MATCH_ALL, transformStrategy)
     customBounds.foreach(bound => customBoundsFactory.addRule(bound.r, s"split bound: $bound"))
 
     val symbolyzedData = new PragmaticContentFormatter(content)
@@ -74,10 +79,11 @@ class DefaultPragmaticMethod(useAbbreviations: Boolean = false, detectLists: Boo
 class MixedPragmaticMethod(
     useAbbreviations: Boolean = false,
     detectLists: Boolean = true,
-    customBounds: Array[String])
+    customBounds: Array[String],
+    transformStrategy: TransformStrategy = REPLACE_ALL_WITH_SYMBOL)
     extends PragmaticMethod
     with Serializable {
-  val customBoundsFactory = new RuleFactory(MATCH_ALL, REPLACE_ALL_WITH_SYMBOL)
+  val customBoundsFactory = new RuleFactory(MATCH_ALL, transformStrategy)
   customBounds.foreach(bound => customBoundsFactory.addRule(bound.r, s"split bound: $bound"))
 
   /** this is a hardcoded order of operations considered to go from those most specific


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently, if users provide custom bounds to the SentenceDetector, they will not be returned at all. This PR adds a flag which will enable returning the custom bounds with separate sentences. There are also different sentence break policies which the user can choose from (either prepend or append the sentence break)

### Example
with `setCustomBounds([r"\.", ";"])`

```
This is a sentence. This one uses custom bounds; As is this one;
```
Without the flags will result in 

```python
["This is a sentence", "This one uses custom bounds", "As is this one"]
```
With the new flag:
```python
.setCustomBounds([r"\.", ";"])
.setCustomBoundsStrategy("append")
```
the result will be
```python
["This is a sentence.", "This one uses custom bounds;", "As is this one;"]
```

Similarly with prepend:
```
1. This is a list
1.1 This is a subpoint
2. Second thing
2.2 Second subthing
```

```python
.setCustomBounds([r"\n[\d\.]+"])
.setCustomBoundsStrategy("prepend")
```
the result will be
```python
[
    "1. This is a list",
    "1.1 This is a subpoint",
    "2. Second thing",
    "2.2 Second subthing"
]
```


All [test cases here](https://github.com/JohnSnowLabs/spark-nlp/pull/10567/files#diff-b1d7ba25271f7a03bb5800a3b8d3aefb968db025f920868b3777e9365e2ce19d).

## Summary of the changes

- added parameter `customBoundsStrategy`
  - defaults to "none" which keeps the same behaviour
  - can set to "prepend": prepends sentence break and keeps delimiter
  - can set to "append": appends sentence break and keeps delimiter
- added new tests to reflect the change


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests and old test are passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
