### PR TITLE
RocksDBConnection: Add error message mentioning K8s clusters

### DIFF
--- a/src/main/scala/com/johnsnowlabs/storage/RocksDBConnection.scala
+++ b/src/main/scala/com/johnsnowlabs/storage/RocksDBConnection.scala
@@ -52,10 +52,16 @@ final class RocksDBConnection private (path: String) extends AutoCloseable {
       require(
         new File(localFromClusterPath).exists(),
         s"Storage not found under given ref: $path\n" +
-          s" This usually means:\n1. You have not loaded any storage under such ref or one of your Storage based annotators " +
-          s"has `includeStorage` set to false and must be loaded manually\n2." +
-          s" You are trying to use cluster mode without a proper shared filesystem.\n3. source was not provided to Storage creation" +
-          s"\n4. If you are trying to utilize Storage defined elsewhere, make sure it has the appropriate ref. ")
+          "This usually means:\n" +
+          "1. You have not loaded any storage under such ref or one of your Storage based " +
+          "annotators has `includeStorage` set to false and must be loaded manually\n" +
+          "2. You are trying to use cluster mode without a proper shared filesystem.\n" +
+          "3. You are trying to use a Kubernetes cluster without a proper shared filesystem. " +
+          "In this case, try to enable the parameter to keep models in memory " +
+          "(setEnableInMemoryStorage) if available.\n" +
+          "4. Your source was not provided to storage creation\n" +
+          "5. If you are trying to utilize Storage defined elsewhere, make sure it has the " +
+          "appropriate ref. ")
       localFromClusterPath
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

## Description

This PR adds an additional error message for RocksDBConnection based annotators if no shared filesystem is used for clusters. 

Specifically, this mentions the case of Kubernetes clusters and recommends using the `setEnableInMemoryStorage` parameter.

BytesKey error still persists.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with a WordEmbeddings pipeline on a local K8s cluster with 5 executors.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
