### PR TITLE
Fix bug in generating NER TF2 graphs when sequence length is 1

### DIFF
--- a/python/sparknlp/training/_tf_graph_builders/ner_dl/create_graph.py
+++ b/python/sparknlp/training/_tf_graph_builders/ner_dl/create_graph.py
@@ -14,6 +14,7 @@ def create_graph(
         is_medical=False
 ):
     tf.disable_v2_behavior()
+    tf.enable_v2_tensorshape()
     tf.reset_default_graph()
 
     if model_filename is None:

--- a/python/sparknlp/training/_tf_graph_builders/ner_dl/ner_model.py
+++ b/python/sparknlp/training/_tf_graph_builders/ner_dl/ner_model.py
@@ -14,7 +14,8 @@ class NerModel:
     def __init__(self, session=None, dummy_tags=None, use_contrib=True, use_gpu_device=0):
 
         tf.disable_v2_behavior()
-
+        tf.enable_v2_tensorshape()
+        
         self.word_repr = None
         self.word_embeddings = None
         self.session = session


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When TFGraphBuilder is used with TF2 to generate NerDL graphs, the resulting graphs raise an exception when the sequence length is 1. This commit fixes the problem.

## Description
The problem is that the NerDL graph builder calls tf.compat.v1.disable_v2_behavior(). One of the side effects if this function is that the tensor shapes are represented in TF 1 style. Part of the NerDL graph uses a function called crf_decode from tf_addons which checks the shape of the tensors and generates different graphs depending on whether the input is static or dynamic. When the tensor shapes are in TF1 style, the function fails to detect that their shape is dynamic and generates a static graph which only works for sequences of size >1.

The problem is fixed by calling  tf.compat.v1.enable_v2_tensorshape() after  tf.compat.v1.disable_v2_behavior(). This makes tensor shapes to be compatible with TF2 and crf_decode works properly.

## Motivation and Context
The change is required in order to generate TF2 NerDL graphs which support sequences of length 1.

## How Has This Been Tested?
I've generated TF2 NerDL with and without the fix and tested training and running a model. When the fix is not applied, the model fails at sequences of length 1. With the fix, the graphs works regarding of sequence size. I've also inspected the graph ops  to make sure it can handle both sequences of length 1 and longer.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
