### PR TITLE
Fix a bug introduced in 4.0.0 release between Transformer-based Word Embeddings and SentenceEmbeddings

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowAlbert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowAlbert.scala
@@ -80,7 +80,7 @@ class TensorflowAlbert(
   private val SentencePadTokenId = spp.getSppModel.pieceToId("[pad]")
   private val SentencePieceDelimiterId = spp.getSppModel.pieceToId("▁")
 
-  def prepareBatchInputs(
+  def encode(
       sentences: Seq[(WordpieceTokenizedSentence, Int)],
       maxSequenceLength: Int): Seq[Array[Int]] = {
     val maxSentenceLength =
@@ -197,18 +197,20 @@ class TensorflowAlbert(
     wordPieceTokenizedSentences.zipWithIndex
       .grouped(batchSize)
       .flatMap { batch =>
-        val batchedInputsIds = prepareBatchInputs(batch, maxSentenceLength)
-        val vectors = tag(batchedInputsIds)
+        val encoded = encode(batch, maxSentenceLength)
+        val vectors = tag(encoded)
 
         /*Combine tokens and calculated embeddings*/
         batch.zip(vectors).map { case (sentence, tokenVectors) =>
           val tokenLength = sentence._1.tokens.length
           /*All wordpiece embeddings*/
           val tokenEmbeddings = tokenVectors.slice(1, tokenLength + 1)
+          val originalIndexedTokens = tokenizedSentences(sentence._2)
+
           val tokensWithEmbeddings =
             sentence._1.tokens.zip(tokenEmbeddings).flatMap { case (token, tokenEmbedding) =>
               val tokenWithEmbeddings = TokenPieceEmbeddings(token, tokenEmbedding)
-              val originalTokensWithEmbeddings = tokenizedSentences(sentence._2).indexedTokens
+              val originalTokensWithEmbeddings = originalIndexedTokens.indexedTokens
                 .find(p =>
                   p.begin == tokenWithEmbeddings.begin && tokenWithEmbeddings.isWordStart)
                 .map { token =>
@@ -226,7 +228,7 @@ class TensorflowAlbert(
               originalTokensWithEmbeddings
             }
 
-          WordpieceEmbeddingsSentence(tokensWithEmbeddings, sentence._2)
+          WordpieceEmbeddingsSentence(tokensWithEmbeddings, originalIndexedTokens.sentenceIndex)
         }
       }
       .toSeq

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowCamemBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowCamemBert.scala
@@ -55,7 +55,7 @@ class TensorflowCamemBert(
   private val SentencePadTokenId = spp.getSppModel.pieceToId("<pad>") + PieceIdOffset
   private val SentencePieceDelimiterId = spp.getSppModel.pieceToId("▁") + PieceIdOffset
 
-  def prepareBatchInputs(
+  def encode(
       sentences: Seq[(WordpieceTokenizedSentence, Int)],
       maxSequenceLength: Int): Seq[Array[Int]] = {
     val maxSentenceLength =
@@ -165,18 +165,20 @@ class TensorflowCamemBert(
     wordPieceTokenizedSentences.zipWithIndex
       .grouped(batchSize)
       .flatMap { batch =>
-        val batchedInputsIds = prepareBatchInputs(batch, maxSentenceLength)
-        val vectors = tag(batchedInputsIds)
+        val encoded = encode(batch, maxSentenceLength)
+        val vectors = tag(encoded)
 
         /*Combine tokens and calculated embeddings*/
         batch.zip(vectors).map { case (sentence, tokenVectors) =>
           val tokenLength = sentence._1.tokens.length
           /*All wordpiece embeddings*/
           val tokenEmbeddings = tokenVectors.slice(1, tokenLength + 1)
+          val originalIndexedTokens = tokenizedSentences(sentence._2)
+
           val tokensWithEmbeddings =
             sentence._1.tokens.zip(tokenEmbeddings).flatMap { case (token, tokenEmbedding) =>
               val tokenWithEmbeddings = TokenPieceEmbeddings(token, tokenEmbedding)
-              val originalTokensWithEmbeddings = tokenizedSentences(sentence._2).indexedTokens
+              val originalTokensWithEmbeddings = originalIndexedTokens.indexedTokens
                 .find(p =>
                   p.begin == tokenWithEmbeddings.begin && tokenWithEmbeddings.isWordStart)
                 .map { token =>
@@ -194,7 +196,7 @@ class TensorflowCamemBert(
               originalTokensWithEmbeddings
             }
 
-          WordpieceEmbeddingsSentence(tokensWithEmbeddings, sentence._2)
+          WordpieceEmbeddingsSentence(tokensWithEmbeddings, originalIndexedTokens.sentenceIndex)
         }
       }
       .toSeq

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowDistilBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowDistilBert.scala
@@ -232,6 +232,7 @@ class TensorflowDistilBert(
 
           /*All wordpiece embeddings*/
           val tokenEmbeddings = tokenVectors.slice(1, tokenLength + 1)
+          val originalIndexedTokens = originalTokenSentences(sentence._2)
 
           /*Word-level and span-level alignment with Tokenizer
         https://github.com/google-research/bert#tokenization
@@ -246,25 +247,24 @@ class TensorflowDistilBert(
           val tokensWithEmbeddings =
             sentence._1.tokens.zip(tokenEmbeddings).flatMap { case (token, tokenEmbedding) =>
               val tokenWithEmbeddings = TokenPieceEmbeddings(token, tokenEmbedding)
-              val originalTokensWithEmbeddings =
-                originalTokenSentences(sentence._2).indexedTokens
-                  .find(p => p.begin == tokenWithEmbeddings.begin)
-                  .map { token =>
-                    val originalTokenWithEmbedding = TokenPieceEmbeddings(
-                      TokenPiece(
-                        wordpiece = tokenWithEmbeddings.wordpiece,
-                        token = if (caseSensitive) token.token else token.token.toLowerCase(),
-                        pieceId = tokenWithEmbeddings.pieceId,
-                        isWordStart = tokenWithEmbeddings.isWordStart,
-                        begin = token.begin,
-                        end = token.end),
-                      tokenEmbedding)
-                    originalTokenWithEmbedding
-                  }
+              val originalTokensWithEmbeddings = originalIndexedTokens.indexedTokens
+                .find(p => p.begin == tokenWithEmbeddings.begin)
+                .map { token =>
+                  val originalTokenWithEmbedding = TokenPieceEmbeddings(
+                    TokenPiece(
+                      wordpiece = tokenWithEmbeddings.wordpiece,
+                      token = if (caseSensitive) token.token else token.token.toLowerCase(),
+                      pieceId = tokenWithEmbeddings.pieceId,
+                      isWordStart = tokenWithEmbeddings.isWordStart,
+                      begin = token.begin,
+                      end = token.end),
+                    tokenEmbedding)
+                  originalTokenWithEmbedding
+                }
               originalTokensWithEmbeddings
             }
 
-          WordpieceEmbeddingsSentence(tokensWithEmbeddings, sentence._2)
+          WordpieceEmbeddingsSentence(tokensWithEmbeddings, originalIndexedTokens.sentenceIndex)
         }
       }
       .toSeq

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowElmo.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowElmo.scala
@@ -86,7 +86,6 @@ class TensorflowElmo(
         /*Combine tokens and sentences  and their calculated embeddings*/
         batch.zip(vectors).map { case (sentence, tokenVectors) =>
           val tokenLength = sentence._1.indexedTokens.length
-          //        val endRange =
           val tokenEmbeddings = tokenVectors.slice(0, tokenLength)
 
           val tokensWithEmbeddings = sentence._1.indexedTokens

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlnet.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowXlnet.scala
@@ -99,7 +99,7 @@ class TensorflowXlnet(
     spp.getSppModel.encodeAsIds(token)
   }
 
-  def prepareBatchInputs(
+  def encode(
       sentences: Seq[(WordpieceTokenizedSentence, Int)],
       maxSequenceLength: Int): Seq[Array[Int]] = {
     val maxSentenceLength =
@@ -214,18 +214,20 @@ class TensorflowXlnet(
     wordPieceTokenizedSentences.zipWithIndex
       .grouped(batchSize)
       .flatMap { batch =>
-        val batchedInputsIds = prepareBatchInputs(batch, maxSentenceLength)
-        val vectors = tag(batchedInputsIds)
+        val encoded = encode(batch, maxSentenceLength)
+        val vectors = tag(encoded)
 
         /*Combine tokens and calculated embeddings*/
         batch.zip(vectors).map { case (sentence, tokenVectors) =>
           val tokenLength = sentence._1.tokens.length
           /*All wordpiece embeddings*/
           val tokenEmbeddings = tokenVectors.slice(1, tokenLength + 1)
+          val originalIndexedTokens = tokenizedSentences(sentence._2)
+
           val tokensWithEmbeddings =
             sentence._1.tokens.zip(tokenEmbeddings).flatMap { case (token, tokenEmbedding) =>
               val tokenWithEmbeddings = TokenPieceEmbeddings(token, tokenEmbedding)
-              val originalTokensWithEmbeddings = tokenizedSentences(sentence._2).indexedTokens
+              val originalTokensWithEmbeddings = originalIndexedTokens.indexedTokens
                 .find(p =>
                   p.begin == tokenWithEmbeddings.begin && tokenWithEmbeddings.isWordStart)
                 .map { token =>
@@ -243,7 +245,7 @@ class TensorflowXlnet(
               originalTokensWithEmbeddings
             }
 
-          WordpieceEmbeddingsSentence(tokensWithEmbeddings, sentence._2)
+          WordpieceEmbeddingsSentence(tokensWithEmbeddings, originalIndexedTokens.sentenceIndex)
         }
       }
       .toSeq

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/CamemBertEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/CamemBertEmbeddingsTestSpec.scala
@@ -148,8 +148,8 @@ class CamemBertEmbeddingsTestSpec extends AnyFlatSpec {
     val loadedPipelineModel = PipelineModel.load("./tmp_camembert_pipeline")
     loadedPipelineModel.transform(ddd).show()
 
-    val loadedDistilBertModel = RoBertaEmbeddings.load("./tmp_camembert_model")
-    loadedDistilBertModel.getDimension
+    val loadedCamemBertModel = CamemBertEmbeddings.load("./tmp_camembert_model")
+    loadedCamemBertModel.getDimension
 
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/DeBertaEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/DeBertaEmbeddingsTestSpec.scala
@@ -105,9 +105,7 @@ class DeBertaEmbeddingsTestSpec extends AnyFlatSpec {
       println(s"total tokens: $totalTokens")
       println(s"total embeddings: $totalEmbeddings")
 
-      // it is normal that the embeddings is less than total tokens in a sentence/document
-      // tokens generate multiple sub-wrods or pieces which won't be included in the final results
-      assert(totalTokens >= totalEmbeddings)
+      assert(totalTokens == totalEmbeddings)
 
     }
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddingsTestSpec.scala
@@ -253,14 +253,14 @@ class SentenceEmbeddingsTestSpec extends AnyFlatSpec {
 
     val embedStorageRef = embeddings.getStorageRef
 
-    val setnEmbedRef = embeddingsSentence.getStorageRef
-    val setnEmbedRefPipeModel =
+    val sentEmbedRef = embeddingsSentence.getStorageRef
+    val sentEmbedRefPipeModel =
       pipelineModel.stages(4).asInstanceOf[SentenceEmbeddings].getStorageRef
     val classifierStorageRef =
       pipelineModel.stages.last.asInstanceOf[ClassifierDLModel].getStorageRef
 
-    assert(setnEmbedRef == embedStorageRef)
-    assert(setnEmbedRefPipeModel == embedStorageRef)
+    assert(sentEmbedRef == embedStorageRef)
+    assert(sentEmbedRefPipeModel == embedStorageRef)
     assert(classifierStorageRef == embedStorageRef)
   }
 }


### PR DESCRIPTION
In 4.0.0 the following annotators were migrated to BatchAnnotate to improve their performance, especially on GPU. However, a bug was introduced in sentence indices which when it is combined with SentenceEmbeddings to average them for Text Classifications (ClassifierDLApproach, SentimentDLApproach, and ClassifierDLApproach) tasks will result in very low accuracy:

- AlbertEmbeddings
- CamemBertEmbeddings
- DeBertaEmbeddings
- DistilBertEmbeddings
- LongformerEmbeddings
- RoBertaEmbeddings
- XlmRoBertaEmbeddings
- XlnetEmbeddings