### PR TITLE
LightPipeline support for 2 Array Targets

### DIFF
--- a/python/sparknlp/annotation.py
+++ b/python/sparknlp/annotation.py
@@ -76,6 +76,19 @@ class Annotation:
     def __repr__(self):
         return self.__str__()
 
+    def __eq__(self, other):
+        same_annotator_type = self.annotator_type == other.annotator_type
+        same_result = self.result == other.result
+        same_begin = self.begin == other.begin
+        same_end = self.end == other.end
+        same_metadata = self.metadata == other.metadata
+        same_embeddings = self.embeddings == other.embeddings
+
+        same_annotation = \
+            same_annotator_type and same_result and same_begin and same_end and same_metadata and same_embeddings
+
+        return same_annotation
+
     @staticmethod
     def dataType():
         """Returns a Spark `StructType`, that represents the schema of the
@@ -152,6 +165,5 @@ class Annotation:
             The new Row.
         """
         from pyspark.sql import Row
-        return Row(annotation.annotator_type, annotation.begin, annotation.end, annotation.result, annotation.metadata, annotation.embeddings)
-
-
+        return Row(annotation.annotator_type, annotation.begin, annotation.end, annotation.result, annotation.metadata,
+                   annotation.embeddings)

--- a/python/test/base/multi_document_assembler_test.py
+++ b/python/test/base/multi_document_assembler_test.py
@@ -1,0 +1,168 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+
+import pytest
+
+from sparknlp.base import *
+from sparknlp.annotator import *
+from test.util import SparkSessionForTest
+
+
+@pytest.mark.fast
+class MultiDocumentAssemblerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.spark = SparkSessionForTest.spark
+        self.input1 = "This is the first input"
+        self.input2 = "This is the second input"
+        self.twoInputDataSet = self.spark.createDataFrame([[self.input1, self.input2]]) \
+            .toDF("input1", "input2")
+
+    def runTest(self):
+
+        multi_document_assembler = MultiDocumentAssembler() \
+            .setInputCols("input1", "input2") \
+            .setOutputCols("output1", "output2")
+
+        tokenizer = Tokenizer() \
+            .setInputCols("output2") \
+            .setOutputCol("token")
+
+        pipeline = Pipeline().setStages([multi_document_assembler, tokenizer])
+        result_df = pipeline.fit(self.twoInputDataSet).transform(self.twoInputDataSet)
+
+        output1 = result_df.select("output1.result").collect()[0]
+        output2 = result_df.select("output2.result").collect()[0]
+        tokens = result_df.select("token.result").collect()[0]
+
+        assert len(output1) > 0
+        assert len(output2) > 0
+        assert len(tokens) > 0
+
+
+@pytest.mark.fast
+class LightFullAnnotateMultiDocumentAssemblerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.spark = SparkSessionForTest.spark
+        self.input1 = "This is the first input"
+        self.input2 = "This is the second input"
+        self.twoInputDataSet = self.spark.createDataFrame([[self.input1, self.input2]]) \
+            .toDF("input1", "input2")
+
+    def runTest(self):
+
+        multi_document_assembler = MultiDocumentAssembler() \
+            .setInputCols("input1", "input2") \
+            .setOutputCols("output1", "output2")
+
+        tokenizer = Tokenizer() \
+            .setInputCols("output2") \
+            .setOutputCol("token")
+
+        pipeline = Pipeline().setStages([multi_document_assembler, tokenizer])
+        model = pipeline.fit(self.twoInputDataSet)
+        light_pipeline = LightPipeline(model)
+
+        actual_result = light_pipeline.fullAnnotate(self.input1, self.input2)
+        expected_result = [{
+            "output1": [Annotation("document", 0, len(self.input1) - 1, self.input1, {}, [])],
+            "output2": [Annotation("document", 0, len(self.input2) - 1, self.input2, {}, [])],
+            "token": [
+                Annotation("token", 0, 3, "This", {"sentence": "0"}, []),
+                Annotation("token", 5, 6, "is", {"sentence": "0"}, []),
+                Annotation("token", 8, 10, "the", {"sentence": "0"}, []),
+                Annotation("token", 12, 17, "second", {"sentence": "0"}, []),
+                Annotation("token", 19, 23, "input", {"sentence": "0"}, [])
+            ]
+        }]
+
+        assert actual_result == expected_result
+
+        actual_result2 = light_pipeline.fullAnnotate([[self.input1, self.input2], [self.input1, self.input2]])
+        expected_result2 = [{
+            "output1": [Annotation("document", 0, len(self.input1) - 1, self.input1, {}, [])],
+            "output2": [Annotation("document", 0, len(self.input2) - 1, self.input2, {}, [])],
+            "token": [
+                Annotation("token", 0, 3, "This", {"sentence": "0"}, []),
+                Annotation("token", 5, 6, "is", {"sentence": "0"}, []),
+                Annotation("token", 8, 10, "the", {"sentence": "0"}, []),
+                Annotation("token", 12, 17, "second", {"sentence": "0"}, []),
+                Annotation("token", 19, 23, "input", {"sentence": "0"}, [])
+            ]
+            },
+            {
+                "output1": [Annotation("document", 0, len(self.input1) - 1, self.input1, {}, [])],
+                "output2": [Annotation("document", 0, len(self.input2) - 1, self.input2, {}, [])],
+                "token": [
+                    Annotation("token", 0, 3, "This", {"sentence": "0"}, []),
+                    Annotation("token", 5, 6, "is", {"sentence": "0"}, []),
+                    Annotation("token", 8, 10, "the", {"sentence": "0"}, []),
+                    Annotation("token", 12, 17, "second", {"sentence": "0"}, []),
+                    Annotation("token", 19, 23, "input", {"sentence": "0"}, [])
+                ]
+            }
+        ]
+
+        assert actual_result2 == expected_result2
+
+
+@pytest.mark.fast
+class LightAnnotateMultiDocumentAssemblerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.spark = SparkSessionForTest.spark
+        self.input1 = "This is the first input"
+        self.input2 = "This is the second input"
+        self.twoInputDataSet = self.spark.createDataFrame([[self.input1, self.input2]]) \
+            .toDF("input1", "input2")
+
+    def runTest(self):
+
+        multi_document_assembler = MultiDocumentAssembler() \
+            .setInputCols("input1", "input2") \
+            .setOutputCols("output1", "output2")
+
+        tokenizer = Tokenizer() \
+            .setInputCols("output2") \
+            .setOutputCol("token")
+
+        pipeline = Pipeline().setStages([multi_document_assembler, tokenizer])
+        model = pipeline.fit(self.twoInputDataSet)
+        light_pipeline = LightPipeline(model)
+
+        actual_result = light_pipeline.annotate(self.input1, self.input2)
+        expected_result = {
+            "output1": [self.input1],
+            "output2": [self.input2],
+            "token": ["This", "is", "the", "second", "input"]
+        }
+
+        assert actual_result == expected_result
+
+        actual_result2 = light_pipeline.annotate([[self.input1, self.input2], [self.input1, self.input2]])
+        expected_result2 = [{
+            "output1": [self.input1],
+            "output2": [self.input2],
+            "token": ["This", "is", "the", "second", "input"]
+            },
+            {
+            "output1": [self.input1],
+            "output2": [self.input2],
+            "token": ["This", "is", "the", "second", "input"]
+            }
+        ]
+
+        assert actual_result2 == expected_result2

--- a/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
@@ -40,10 +40,11 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddingsVectors: Bo
       .toArray
   }
 
-  def fullAnnotate(targets: Array[(String, String)]): Array[Map[String, Seq[Annotation]]] = {
-    targets.par
-      .map(target => fullAnnotate(target._1, target._2))
-      .toArray
+  def fullAnnotate(targets: Array[Array[String]]): Array[Map[String, Seq[Annotation]]] = {
+    targets.par.map { target =>
+      val optionalTarget = if (targets.head.length <= 1) "" else target(1)
+      fullAnnotate(target.head, optionalTarget)
+    }.toArray
   }
 
   def fullAnnotate(target: String, optionalTarget: String = ""): Map[String, Seq[Annotation]] = {
@@ -238,6 +239,14 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddingsVectors: Bo
     fullAnnotateImage(pathToImage).mapValues(_.asJava).asJava
   }
 
+  def fullAnnotateJavaMultipleInput(targets: java.util.ArrayList[java.util.ArrayList[String]])
+      : java.util.List[java.util.Map[String, java.util.List[JavaAnnotation]]] = {
+    targets.asScala.par
+      .map(target => fullAnnotateJava(target.get(0), target.get(1)))
+      .toList
+      .asJava
+  }
+
   def fullAnnotateImageJava(pathToImages: java.util.ArrayList[String])
       : java.util.List[java.util.Map[String, java.util.List[IAnnotation]]] = {
 
@@ -255,10 +264,11 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddingsVectors: Bo
       .toArray
   }
 
-  def annotate(targets: Array[(String, String)]): Array[Map[String, Seq[String]]] = {
-    targets.par
-      .map(target => annotate(target._1, target._2))
-      .toArray
+  def annotate(targets: Array[Array[String]]): Array[Map[String, Seq[String]]] = {
+    targets.par.map { target =>
+      val optionalTarget = if (targets.head.length <= 1) "" else target(1)
+      annotate(target.head, optionalTarget)
+    }.toArray
   }
 
   def annotate(target: String, optionalTarget: String = ""): Map[String, Seq[String]] = {
@@ -288,6 +298,13 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddingsVectors: Bo
       .map(target => annotateJava(target))
       .toList
       .asJava
+  }
+
+  def annotateJavaMultipleInput(targets: java.util.ArrayList[java.util.ArrayList[String]])
+      : java.util.List[java.util.Map[String, java.util.List[String]]] = {
+    val inputs: Array[Array[String]] =
+      targets.asScala.par.toArray.map(target => target.asScala.par.toArray)
+    annotate(inputs).map(_.mapValues(_.asJava).asJava).toList.asJava
   }
 
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
@@ -48,8 +48,8 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddingsVectors: Bo
       targets: Array[String],
       optionalTargets: Array[String]): Array[Map[String, Seq[Annotation]]] = {
 
-    if (targets.length != 2 || optionalTargets.length != 2) {
-      throw new UnsupportedOperationException("Only two inputs per list is available")
+    if (targets.length != optionalTargets.length) {
+      throw new UnsupportedOperationException("targets and optionalTargets must be of the same length")
     }
 
     (targets zip optionalTargets).par.map { case (target, optionalTarget) =>
@@ -289,8 +289,8 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddingsVectors: Bo
       targets: Array[String],
       optionalTargets: Array[String]): Array[Map[String, Seq[String]]] = {
 
-    if (targets.length != 2 || optionalTargets.length != 2) {
-      throw new UnsupportedOperationException("Only two inputs per list is available")
+    if (targets.length != optionalTargets.length) {
+      throw new UnsupportedOperationException("targets and optionalTargets must be of the same length")
     }
 
     (targets zip optionalTargets).par.map { case (target, optionalTarget) =>

--- a/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
@@ -40,6 +40,12 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddingsVectors: Bo
       .toArray
   }
 
+  def fullAnnotate(targets: Array[(String, String)]): Array[Map[String, Seq[Annotation]]] = {
+    targets.par
+      .map(target => fullAnnotate(target._1, target._2))
+      .toArray
+  }
+
   def fullAnnotate(target: String, optionalTarget: String = ""): Map[String, Seq[Annotation]] = {
     fullAnnotateInternal(target, optionalTarget).mapValues(_.map(_.asInstanceOf[Annotation]))
   }
@@ -246,6 +252,12 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddingsVectors: Bo
   def annotate(targets: Array[String]): Array[Map[String, Seq[String]]] = {
     targets.par
       .map(target => annotate(target))
+      .toArray
+  }
+
+  def annotate(targets: Array[(String, String)]): Array[Map[String, Seq[String]]] = {
+    targets.par
+      .map(target => annotate(target._1, target._2))
       .toArray
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/LightPipelineTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/LightPipelineTestSpec.scala
@@ -212,4 +212,12 @@ class LightPipelineTestSpec extends AnyFlatSpec {
     assert(t1 > t2)
   }
 
+  it should "raise an error when using a wrong input size" taggedAs FastTest in {
+    val lightPipeline = new LightPipeline(fixtureWithNormalizer.model)
+
+    assertThrows[UnsupportedOperationException] {
+      lightPipeline.fullAnnotate(Array("1", "2", "3"), Array("1", "2", "3"))
+    }
+  }
+
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/LightPipelineTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/LightPipelineTestSpec.scala
@@ -216,7 +216,7 @@ class LightPipelineTestSpec extends AnyFlatSpec {
     val lightPipeline = new LightPipeline(fixtureWithNormalizer.model)
 
     assertThrows[UnsupportedOperationException] {
-      lightPipeline.fullAnnotate(Array("1", "2", "3"), Array("1", "2", "3"))
+      lightPipeline.fullAnnotate(Array("1", "2", "3"), Array("1", "2"))
     }
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/MultiDocumentAssemblerTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/MultiDocumentAssemblerTest.scala
@@ -2,6 +2,7 @@ package com.johnsnowlabs.nlp
 
 import com.johnsnowlabs.nlp.AnnotatorType.{DOCUMENT, TOKEN}
 import com.johnsnowlabs.nlp.annotators.SparkSessionTest
+import com.johnsnowlabs.tags.FastTest
 import org.scalatest.flatspec.AnyFlatSpec
 
 class MultiDocumentAssemblerTest extends AnyFlatSpec with SparkSessionTest {
@@ -14,7 +15,7 @@ class MultiDocumentAssemblerTest extends AnyFlatSpec with SparkSessionTest {
   private val twoInputDataset = Seq((input1, input2)).toDS.toDF("input1", "input2")
   private val dataset = Seq(input1).toDS.toDF("text")
 
-  "MultiDocumentAssembler with two input cols" should "transform and output two cols" in {
+  "MultiDocumentAssembler with two input cols" should "transform and output two cols" taggedAs FastTest in {
 
     val multiDocumentAssembler = new MultiDocumentAssembler()
       .setInputCols("input1", "input2")
@@ -46,7 +47,7 @@ class MultiDocumentAssemblerTest extends AnyFlatSpec with SparkSessionTest {
     AssertAnnotations.assertFields(actualResultToken, expectedResultToken)
   }
 
-  it should "fullAnnotate with LightPipeline and output two cols" in {
+  it should "fullAnnotate with LightPipeline and output two cols" taggedAs FastTest in {
     val multiDocumentAssembler = new MultiDocumentAssembler()
       .setInputCols("input1", "input2")
       .setOutputCols("output1", "output2")
@@ -75,7 +76,7 @@ class MultiDocumentAssemblerTest extends AnyFlatSpec with SparkSessionTest {
 
   }
 
-  it should "fullAnnotate a list of inputs with LightPipeline and output of two cols" in {
+  it should "fullAnnotate a list of inputs with LightPipeline and output of two cols" taggedAs FastTest in {
     val multiDocumentAssembler = new MultiDocumentAssembler()
       .setInputCols("input1", "input2")
       .setOutputCols("output1", "output2")
@@ -87,7 +88,7 @@ class MultiDocumentAssemblerTest extends AnyFlatSpec with SparkSessionTest {
 
     val lightPipeline = new LightPipeline(pipelineModel)
     val actualResults =
-      lightPipeline.fullAnnotate(Array(Array(input1, input2), Array(input1, input2)))
+      lightPipeline.fullAnnotate(Array(input1, input1), Array(input2, input2))
 
     val expectedResults = Array(
       Map(
@@ -116,7 +117,7 @@ class MultiDocumentAssemblerTest extends AnyFlatSpec with SparkSessionTest {
     }
   }
 
-  it should "annotate with LightPipeline and output two cols" in {
+  it should "annotate with LightPipeline and output two cols" taggedAs FastTest in {
     val multiDocumentAssembler = new MultiDocumentAssembler()
       .setInputCols("input1", "input2")
       .setOutputCols("output1", "output2")
@@ -139,7 +140,7 @@ class MultiDocumentAssemblerTest extends AnyFlatSpec with SparkSessionTest {
     assert(actualResult.values.toList == expectedResult.values.toList)
   }
 
-  it should "annotate a list of inputs with LightPipeline and output two cols" in {
+  it should "annotate a list of inputs with LightPipeline and output two cols" taggedAs FastTest in {
     val multiDocumentAssembler = new MultiDocumentAssembler()
       .setInputCols("input1", "input2")
       .setOutputCols("output1", "output2")
@@ -151,7 +152,7 @@ class MultiDocumentAssemblerTest extends AnyFlatSpec with SparkSessionTest {
 
     val lightPipeline = new LightPipeline(pipelineModel)
     val actualResults =
-      lightPipeline.annotate(Array(Array(input1, input2), Array(input1, input2)))
+      lightPipeline.annotate(Array(input1, input1), Array(input2, input2))
 
     val expectedResults = Array(
       Map(
@@ -171,7 +172,7 @@ class MultiDocumentAssemblerTest extends AnyFlatSpec with SparkSessionTest {
 
   }
 
-  "MultiDocumentAssembler with one column" should "transform and output one col" in {
+  "MultiDocumentAssembler with one column" should "transform and output one col" taggedAs FastTest in {
 
     val multiDocumentAssembler = new MultiDocumentAssembler()
       .setInputCols("text")
@@ -198,7 +199,7 @@ class MultiDocumentAssemblerTest extends AnyFlatSpec with SparkSessionTest {
     AssertAnnotations.assertFields(actualResultToken, expectedResultToken)
   }
 
-  it should "fullAnnotate with LightPipeline and output one col" in {
+  it should "fullAnnotate with LightPipeline and output one col" taggedAs FastTest in {
     val multiDocumentAssembler = new MultiDocumentAssembler()
       .setInputCols("text")
       .setOutputCols("output")
@@ -223,7 +224,7 @@ class MultiDocumentAssemblerTest extends AnyFlatSpec with SparkSessionTest {
     AssertAnnotations.assertFields(expectedResult.values.toArray, actualResult.values.toArray)
   }
 
-  it should "annotate with LightPipeline and output one col" in {
+  it should "annotate with LightPipeline and output one col" taggedAs FastTest in {
     val multiDocumentAssembler = new MultiDocumentAssembler()
       .setInputCols("text")
       .setOutputCols("output")

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/multipleannotations/MultiAnnotationsSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/multipleannotations/MultiAnnotationsSpec.scala
@@ -74,8 +74,7 @@ class MultiAnnotationsSpec extends AnyFlatSpec {
       "document" -> Seq(text),
       "document2" -> Seq(text),
       "document3" -> Seq(text),
-      "multiple_document" -> Seq(text, text, text)
-    )
+      "multiple_document" -> Seq(text, text, text))
 
     val actualResult = new LightPipeline(pipelineModel).annotate(text)
 
@@ -88,16 +87,15 @@ class MultiAnnotationsSpec extends AnyFlatSpec {
 
     val expectedResults = Array(
       Map(
-      "document" -> Seq(text),
-      "document2" -> Seq(text),
-      "document3" -> Seq(text),
-      "multiple_document" -> Seq(text, text, text)),
+        "document" -> Seq(text),
+        "document2" -> Seq(text),
+        "document3" -> Seq(text),
+        "multiple_document" -> Seq(text, text, text)),
       Map(
         "document" -> Seq(text2),
         "document2" -> Seq(text2),
         "document3" -> Seq(text2),
-        "multiple_document" -> Seq(text2, text2, text2))
-    )
+        "multiple_document" -> Seq(text2, text2, text2)))
 
     val actualResults = new LightPipeline(pipelineModel).annotate(Array(text, text2))
 
@@ -117,13 +115,18 @@ class MultiAnnotationsSpec extends AnyFlatSpec {
         "document" -> Seq(expectedAnnotationText),
         "document2" -> Seq(expectedAnnotationText),
         "document3" -> Seq(expectedAnnotationText),
-        "multiple_document" -> Seq(expectedAnnotationText, expectedAnnotationText, expectedAnnotationText)),
+        "multiple_document" -> Seq(
+          expectedAnnotationText,
+          expectedAnnotationText,
+          expectedAnnotationText)),
       Map(
         "document" -> Seq(expectedAnnotationText2),
         "document2" -> Seq(expectedAnnotationText2),
         "document3" -> Seq(expectedAnnotationText2),
-        "multiple_document" -> Seq(expectedAnnotationText2, expectedAnnotationText2, expectedAnnotationText2))
-    )
+        "multiple_document" -> Seq(
+          expectedAnnotationText2,
+          expectedAnnotationText2,
+          expectedAnnotationText2)))
 
     val annotationResults = new LightPipeline(pipelineModel).fullAnnotate(Array(text, text2))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Now, `fullAnnotate` and `annotate` can receive two input two arrays of strings arguments. This will allow `LightPipeline` to support functionality such as the Question Answering feature.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, only one context and question at a time are supported in LightPipeline for Question Answering features. Now, we can create a list of contexts and questions to send to LightPipeline, making it easier for the user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
