### PR TITLE
Fix/gpt2 edge case exceptions

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowGPT2.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowGPT2.scala
@@ -284,8 +284,8 @@ class TensorflowGPT2(
       var nextToken = Array.ofDim[Int](decoderInputs.length)
 
       if (doSample) {
-        // Temperature (higher temperature => more likely to sample low probability tokens)
-        if (temperature != 1.0)
+        // Temperature (higher temperature => more likely to sample low probability tokens). May not be 0
+        if (temperature != 1.0 && temperature > 0)
           nextTokenLogits =
             for (nextTokenLogit <- nextTokenLogits)
               yield nextTokenLogit.map(_ / temperature.toFloat)
@@ -531,6 +531,11 @@ class TensorflowGPT2(
       if (accum >= randomDouble) {
         return i
       }
+    }
+    if (distFiltered.length == 0) {
+      // TODO should distFiltered.length == 0 happen (?)
+      //  Can we something better than 0?
+      return 0
     }
     indices(0)
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
PR related to bugs mentioned in [this issue](https://github.com/JohnSnowLabs/spark-nlp/issues/12256)
Following edge cases handled : 
- When `setTemperature(0)` division by 0 Exception was happening. Fixed by checking for 0 and not dividing in these cases. 
- When `setDoSample(True)` Array out of Bounds exception was happening. Fixed by returning 0 instead of accessing Array. Maybe there could be a nicer fix, like returning ID for End of Prediction token or so. But for now generations look nice and don't crash. 


## How Has This Been Tested?
- Tested in [Scala here](https://github.com/JohnSnowLabs/spark-nlp/commit/ef5113ad08b99745d9415c6fbb8c0bce47b806a0)  and works fine
- Tried testing in [Colab here](https://colab.research.google.com/drive/1nHqg3bbUI41rHyUq9TUTpKA2dHV2oqQl?usp=sharing) .  But got Serialization errors suddenly. was using `sbt assembly` to compile from Master branch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)


