### PR TITLE
Adding support for S3 in cache folder config

### DIFF
--- a/src/main/scala/com/johnsnowlabs/client/aws/AWSGateway.scala
+++ b/src/main/scala/com/johnsnowlabs/client/aws/AWSGateway.scala
@@ -132,6 +132,11 @@ class AWSGateway(
     client.getObject(req, tmpFile)
   }
 
+  def getS3Object(bucket: String, s3FilePath: String): S3Object = {
+    val s3Object = client.getObject(bucket, s3FilePath)
+    s3Object
+  }
+
   def getS3DownloadSize(
       s3Path: String,
       folder: String,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -751,13 +751,12 @@ trait WithGraphResolver {
 
     if (localGraphPath.isDefined && localGraphPath.get.startsWith("s3://")) {
 
-      val bucketName = localGraphPath.get.substring("s3://".length).split("/").head
+      val (bucketName, keyPrefix) = ResourceHelper.parseS3URI(localGraphPath.get)
 
       require(
         bucketName != "",
         "S3 bucket name is not define. Please define it with parameter setS3BucketName")
 
-      val keyPrefix = localGraphPath.get.substring(("s3://" + bucketName).length + 1)
       var tmpDirectory = SparkFiles.getRootDirectory()
 
       val awsGateway = new AWSGateway()

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -44,6 +44,7 @@ import com.johnsnowlabs.util._
 import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.ml.util.DefaultParamsReadable
 import org.apache.spark.ml.{PipelineModel, PipelineStage}
+import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -75,6 +76,8 @@ trait ResourceDownloader {
 }
 
 object ResourceDownloader {
+
+  private val logger = LoggerFactory.getLogger(this.getClass.toString)
 
   val fileSystem: FileSystem = OutputHelper.getFileSystem
 
@@ -418,7 +421,7 @@ object ResourceDownloader {
     *   path of downloaded resource
     */
   def downloadResource(request: ResourceRequest): String = {
-    val f = Future {
+    val future = Future {
       if (request.folder.equals(publicLoc)) {
         publicDownloader.download(request)
       } else if (request.folder.startsWith("@")) {
@@ -435,24 +438,24 @@ object ResourceDownloader {
       }
     }
 
-    var download_finished = false
+    var downloadFinished = false
     var path: Option[String] = None
-    val file_size = getDownloadSize(request)
+    val fileSize = getDownloadSize(request)
     require(
-      !file_size.equals("-1"),
+      !fileSize.equals("-1"),
       s"Can not find ${request.name} inside ${request.folder} to download. Please make sure the name and location are correct!")
     println(request.name + " download started this may take some time.")
-    println("Approximate size to download " + file_size)
+    println("Approximate size to download " + fileSize)
 
-    var nextc = 0
-    while (!download_finished) {
-      nextc += 1
-      f.onComplete {
+    while (!downloadFinished) {
+      future.onComplete {
         case Success(value) =>
-          download_finished = true
+          downloadFinished = true
           path = value
-        case Failure(_) =>
-          download_finished = true
+        case Failure(exception) =>
+          println(s"Error: ${exception.getMessage}")
+          logger.error(exception.getMessage)
+          downloadFinished = true
           path = None
       }
       Thread.sleep(1000)

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -645,4 +645,12 @@ object ResourceHelper {
 
   }
 
+  def parseS3URI(s3URI: String): (String, String) = {
+    val prefix = if (s3URI.startsWith("s3:")) "s3://" else "s3a://"
+    val bucketName = s3URI.substring(prefix.length).split("/").head
+    val key = s3URI.substring((prefix + bucketName).length + 1)
+
+    (bucketName, key)
+  }
+
 }

--- a/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
@@ -47,11 +47,11 @@ object ConfigHelper {
   val s3SocketTimeout = "spark.jsl.settings.pretrained.s3_socket_timeout"
 
   // Stores info for AWS S3 logging output when training models
-  val awsLogCredentials = "spark.jsl.settings.aws.credentials"
-  val awsExternalAccessKeyId: String = awsLogCredentials + ".access_key_id"
-  val awsExternalSecretAccessKey: String = awsLogCredentials + ".secret_access_key"
-  val awsExternalSessionToken: String = awsLogCredentials + ".session_token"
-  val awsExternalProfileName: String = awsLogCredentials + ".aws_profile_name"
+  val awsExternalCredentials = "spark.jsl.settings.aws.credentials"
+  val awsExternalAccessKeyId: String = awsExternalCredentials + ".access_key_id"
+  val awsExternalSecretAccessKey: String = awsExternalCredentials + ".secret_access_key"
+  val awsExternalSessionToken: String = awsExternalCredentials + ".session_token"
+  val awsExternalProfileName: String = awsExternalCredentials + ".aws_profile_name"
   val awsExternalS3BucketKey = "spark.jsl.settings.aws.s3_bucket"
   val awsExternalRegion = "spark.jsl.settings.aws.region"
 

--- a/src/test/scala/com/johnsnowlabs/util/ResourceHelperTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/util/ResourceHelperTestSpec.scala
@@ -151,4 +151,20 @@ class ResourceHelperTestSpec extends AnyFlatSpec {
     assert(files.nonEmpty)
   }
 
+  it should "parse S3 URIs" taggedAs FastTest in {
+    val s3URIs =
+      Array("s3a://my.bucket.com/my/S3/path/my_file.tmp", "s3://my.bucket.com/my/S3/path/")
+    val expectedOutput =
+      Array(("my.bucket.com", "my/S3/path/my_file.tmp"), ("my.bucket.com", "my/S3/path/"))
+
+    s3URIs.zipWithIndex.foreach { case (s3URI, index) =>
+      val (actualBucket, actualKey) = ResourceHelper.parseS3URI(s3URI)
+
+      val (expectedBucket, expectedKey) = expectedOutput(index)
+
+      assert(expectedBucket == actualBucket)
+      assert(expectedKey == actualKey)
+    }
+  }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change increases the `S3ResourceDownloader` functionality to download, unzip, and upload model content to an external S3 URI.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some users do not have write access to HDFS or Driver/Executors file systems e.g in K8 environments. To solve this, we include the option to define an S3 URI in `cache_folder` configuration such that these users can use their S3 bucket to store pre-trained models.
Check issues #10755 and #10786

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by adding an S3 URI in `cache_folder`, checking the models are uploaded in S3 and that the output is the expected one, in the following environments:
- Bare Metal Server (physical local computer)
- Google Colab
- Databricks
- GCP

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
