### PR TITLE
Implement setReplaceEntities feature in NerOverwriter annotator

### DIFF
--- a/python/sparknlp/annotator/ner/ner_overwriter.py
+++ b/python/sparknlp/annotator/ner/ner_overwriter.py
@@ -127,7 +127,7 @@ class NerOverwriter(AnnotatorModel):
     newResult = Param(Params._dummy(), "newResult", "new NER class to apply to those stopwords",
                       typeConverter=TypeConverters.toString)
     replaceEntities = Param(Params._dummy(), "replaceEntities", "Ner tags to be replaced",
-                      typeConverter=TypeConverters.identity)
+                            typeConverter=TypeConverters.identity)
 
     def setStopWords(self, value):
         """Sets the words to be overwritten.
@@ -160,4 +160,3 @@ class NerOverwriter(AnnotatorModel):
         """
         self._call_java('setReplaceEntities', rw)
         return self
-

--- a/python/sparknlp/annotator/ner/ner_overwriter.py
+++ b/python/sparknlp/annotator/ner/ner_overwriter.py
@@ -126,6 +126,8 @@ class NerOverwriter(AnnotatorModel):
                       typeConverter=TypeConverters.toListString)
     newResult = Param(Params._dummy(), "newResult", "new NER class to apply to those stopwords",
                       typeConverter=TypeConverters.toString)
+    replaceWords = Param(Params._dummy(), "replaceWords", "Ner tags to be replaced",
+                      typeConverter=TypeConverters.identity)
 
     def setStopWords(self, value):
         """Sets the words to be overwritten.
@@ -147,4 +149,15 @@ class NerOverwriter(AnnotatorModel):
             NER class to apply the stopwords to
         """
         return self._set(newResult=value)
+
+    def setReplaceWords(self, rw):
+        """Sets weights dictionary with the tags that you want to replace.
+
+        Parameters
+        ----------
+        rw : Dict[str, str]
+        Sets weights dictionary with the tags that you want to replace...
+        """
+        self._call_java('setReplaceWords', rw)
+        return self
 

--- a/python/sparknlp/annotator/ner/ner_overwriter.py
+++ b/python/sparknlp/annotator/ner/ner_overwriter.py
@@ -126,7 +126,7 @@ class NerOverwriter(AnnotatorModel):
                       typeConverter=TypeConverters.toListString)
     newResult = Param(Params._dummy(), "newResult", "new NER class to apply to those stopwords",
                       typeConverter=TypeConverters.toString)
-    replaceWords = Param(Params._dummy(), "replaceWords", "Ner tags to be replaced",
+    replaceEntities = Param(Params._dummy(), "replaceEntities", "Ner tags to be replaced",
                       typeConverter=TypeConverters.identity)
 
     def setStopWords(self, value):
@@ -150,7 +150,7 @@ class NerOverwriter(AnnotatorModel):
         """
         return self._set(newResult=value)
 
-    def setReplaceWords(self, rw):
+    def setReplaceEntities(self, rw):
         """Sets weights dictionary with the tags that you want to replace.
 
         Parameters
@@ -158,6 +158,6 @@ class NerOverwriter(AnnotatorModel):
         rw : Dict[str, str]
         Sets weights dictionary with the tags that you want to replace...
         """
-        self._call_java('setReplaceWords', rw)
+        self._call_java('setReplaceEntities', rw)
         return self
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriter.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriter.scala
@@ -194,25 +194,25 @@ class NerOverwriter(override val uid: String)
     */
   def getNewResult: String = $(newResult)
 
-  val replaceWords: MapFeature[String, String] =
-    new MapFeature[String, String](this, "replaceWords")
+  val replaceEntities: MapFeature[String, String] =
+    new MapFeature[String, String](this, "replaceEntities")
 
-  def setReplaceWords(w: Map[String, String]): this.type = set(replaceWords, w)
+  def setReplaceEntities(w: Map[String, String]): this.type = set(replaceEntities, w)
 
   // for Python access
 
   /** @group setParam */
-  def setReplaceWords(w: util.HashMap[String, String]): this.type = {
+  def setReplaceEntities(w: util.HashMap[String, String]): this.type = {
 
     val ws = w.asScala.toMap
-    set(replaceWords, ws)
+    set(replaceEntities, ws)
   }
 
-  def getReplaceWords(): Map[String, String] = {
-    if (!replaceWords.isSet) {
+  def getReplaceEntities(): Map[String, String] = {
+    if (!replaceEntities.isSet) {
       Map.empty[String, String]
     } else {
-      $$(replaceWords)
+      $$(replaceEntities)
     }
   }
 
@@ -221,7 +221,7 @@ class NerOverwriter(override val uid: String)
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
 
     val annotationsOverwritten = annotations
-    val replace = getReplaceWords()
+    val replace = getReplaceEntities()
     annotationsOverwritten
       .map { tokenAnnotation =>
         val stopWordsSet = $(stopWords).toSet

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriter.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriter.scala
@@ -208,7 +208,7 @@ class NerOverwriter(override val uid: String)
     set(replaceEntities, ws)
   }
 
-  def getReplaceEntities(): Map[String, String] = {
+  def getReplaceEntities: Map[String, String] = {
     if (!replaceEntities.isSet) {
       Map.empty[String, String]
     } else {
@@ -221,7 +221,7 @@ class NerOverwriter(override val uid: String)
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
 
     val annotationsOverwritten = annotations
-    val replace = getReplaceEntities()
+    val replace = getReplaceEntities
     annotationsOverwritten
       .map { tokenAnnotation =>
         val stopWordsSet = $(stopWords).toSet

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriterTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriterTest.scala
@@ -27,14 +27,11 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 class NerOverwriterTest extends AnyFlatSpec {
 
-
-
   "NeC Overwriter" should "correctly should change the tag" taggedAs SlowTest in {
     import ResourceHelper.spark.implicits._
 
     val testDF =
-      Seq(" john Doe lives in texas.floria, ").toDF(
-        "text")
+      Seq(" john Doe lives in texas.floria, ").toDF("text")
 
     val documentAssembler = new DocumentAssembler()
       .setInputCol("text")

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriterTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriterTest.scala
@@ -76,7 +76,7 @@ class NerOverwriterTest extends AnyFlatSpec {
     val converter = new NerOverwriter()
       .setInputCols("ner")
       .setOutputCol("ner2")
-      .setReplaceWords(Map("B-PERSON" -> "B-PER2"))
+      .setReplaceEntities(Map("B-PERSON" -> "B-PER2"))
 
     val pipeline = new Pipeline()
       .setStages(

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriterTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriterTest.scala
@@ -25,7 +25,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 class NerOverwriterTest extends AnyFlatSpec {
 
-  "NeC Overwriter" should "correctly should change the tag" taggedAs SlowTest in {
+  "NerOverwriter" should "correctly should change all the NER tags" taggedAs SlowTest in {
     import ResourceHelper.spark.implicits._
 
     val testDF =

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriterTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/NerOverwriterTest.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.ner
+
+import com.johnsnowlabs.nlp.annotator._
+import com.johnsnowlabs.nlp.base._
+import com.johnsnowlabs.nlp.embeddings.WordEmbeddingsModel
+import com.johnsnowlabs.nlp.training.CoNLL
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.SlowTest
+import org.apache.spark.ml.Pipeline
+import org.scalatest.flatspec.AnyFlatSpec
+
+class NerOverwriterTest extends AnyFlatSpec {
+
+
+
+  "NeC Overwriter" should "correctly should change the tag" taggedAs SlowTest in {
+    import ResourceHelper.spark.implicits._
+
+    val testDF =
+      Seq(" john Doe lives in texas.floria, ").toDF(
+        "text")
+
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+      .setCleanupMode("inplace_full")
+
+    val document_normalizer = new DocumentNormalizer()
+      .setInputCols("document")
+      .setOutputCol("document_normalized")
+
+    val sentenceDetector = new SentenceDetector()
+      .setInputCols("document_normalized")
+      .setOutputCol("sentence")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("sentence"))
+      .setOutputCol("token")
+      .setMinLength(2)
+      .setSplitChars(Array("-", ","))
+      .setContextChars(Array("(", ")", "?", "!"))
+
+    val normalize = new Normalizer()
+      .setInputCols("token")
+      .setOutputCol("token_normalized")
+      .setSlangMatchCase(true)
+
+    val embeddings = BertEmbeddings
+      .pretrained("small_bert_L2_128")
+      .setInputCols("sentence", "token_normalized")
+      .setOutputCol("embeddings")
+
+    val ner = NerDLModel
+      .pretrained("onto_small_bert_L2_128")
+      .setInputCols("sentence", "token_normalized", "embeddings")
+      .setOutputCol("ner")
+      .setIncludeConfidence(false)
+      .setIncludeAllConfidenceScores(false)
+
+    val converter = new NerOverwriter()
+      .setInputCols("ner")
+      .setOutputCol("ner2")
+      .setReplaceWords(Map("B-PERSON" -> "B-PER2"))
+
+    val pipeline = new Pipeline()
+      .setStages(
+        Array(
+          documentAssembler,
+          document_normalizer,
+          sentenceDetector,
+          tokenizer,
+          normalize,
+          embeddings,
+          ner,
+          converter))
+
+    val nermodel = pipeline.fit(testDF).transform(testDF)
+
+    nermodel.select("ner2.result").show(1, truncate = false)
+
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add in NerOverwriter the test that allows us to replace some entities by another entities using the .setReplaceWords({"B-PER" : "B-PERSON" }) method.



## Motivation and Context
Example :

```

    documentAssembler = DocumentAssembler() \
        .setInputCol("text") \
        .setOutputCol("document")
    tokenizer = Tokenizer() \
        .setInputCols(["document"]) \
        .setOutputCol("token")

    tokenClassifier = AlbertForTokenClassification.pretrained() \
        .setInputCols(["token", "document"]) \
        .setOutputCol("label") \
        .setCaseSensitive(True)

    nerOverwrite  = NerOverwriter().setInputCols("label").setOutputCol("label2").setReplaceEntities({"B-PER" : "B-PERSON" })

    pipeline = Pipeline().setStages([
        documentAssembler,
        tokenizer,
        tokenClassifier,
        nerOverwrite
    ])
    data = SparkContextForTest.spark.createDataFrame([["John Lenon was born in London and lived in Paris. My name is Sarah and I live in London"]]).toDF("text")
    result = pipeline.fit(data).transform(data)
    result.select("label2.result").show(truncate=False)
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
