### PR TITLE
Introducing CamemBERT for Token Classification

### DIFF
--- a/python/sparknlp/annotator/classifier_dl/__init__.py
+++ b/python/sparknlp/annotator/classifier_dl/__init__.py
@@ -38,3 +38,4 @@ from sparknlp.annotator.classifier_dl.xlm_roberta_for_token_classification impor
 from sparknlp.annotator.classifier_dl.xlm_roberta_for_question_answering import *
 from sparknlp.annotator.classifier_dl.xlnet_for_sequence_classification import *
 from sparknlp.annotator.classifier_dl.xlnet_for_token_classification import *
+from sparknlp.annotator.classifier_dl.camembert_for_token_classification import *

--- a/python/sparknlp/annotator/classifier_dl/camembert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/camembert_for_token_classification.py
@@ -1,0 +1,182 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Contains classes for CamemBertForTokenClassification."""
+
+from sparknlp.common import *
+
+
+class CamemBertForTokenClassification(AnnotatorModel,
+                                      HasCaseSensitiveProperties,
+                                      HasBatchedAnnotate):
+    """CamemBertForTokenClassification can load CamemBERT Models with a token
+    classification head on top (a linear layer on top of the hidden-states
+    output) e.g. for Named-Entity-Recognition (NER) tasks.
+
+    Pretrained models can be loaded with :meth:`.pretrained` of the companion
+    object:
+
+    >>> token_classifier = CamemBertForTokenClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label")
+    The default model is ``"camembert_base_token_classifier_wikiner"``, if no
+    name is provided.
+
+    For available pretrained models please see the `Models Hub
+    <https://nlp.johnsnowlabs.com/models?task=Named+Entity+Recognition>`__.
+    To see which models are compatible and how to import them see
+    `Import Transformers into Spark NLP 🚀
+    <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT, TOKEN``    ``NAMED_ENTITY``
+    ====================== ======================
+
+    Parameters
+    ----------
+    batchSize
+        Batch size. Large values allows faster processing but requires more
+        memory, by default 8
+    caseSensitive
+        Whether to ignore case in tokens for embeddings matching, by default
+        True
+    configProtoBytes
+        ConfigProto from tensorflow, serialized into byte array.
+    maxSentenceLength
+        Max sentence length to process, by default 128
+
+    Examples
+    --------
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("token")
+    >>> tokenClassifier = CamemBertForTokenClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label") \\
+    ...     .setCaseSensitive(True)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     tokenizer,
+    ...     tokenClassifier
+    ... ])
+    >>> data = spark.createDataFrame([["george washington est allé à washington"]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.select("label.result").show(truncate=False)
+    +------------------------------+
+    |result                        |
+    +------------------------------+
+    |[I-PER, I-PER, O, O, O, I-LOC]|
+    +------------------------------+
+    """
+    name = "CamemBertForTokenClassification"
+
+    maxSentenceLength = Param(Params._dummy(),
+                              "maxSentenceLength",
+                              "Max sentence length to process",
+                              typeConverter=TypeConverters.toInt)
+
+    configProtoBytes = Param(Params._dummy(),
+                             "configProtoBytes",
+                             "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
+                             TypeConverters.toListInt)
+
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
+
+    def setConfigProtoBytes(self, b):
+        """Sets configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[int]
+            ConfigProto from tensorflow, serialized into byte array
+        """
+        return self._set(configProtoBytes=b)
+
+    def setMaxSentenceLength(self, value):
+        """Sets max sentence length to process, by default 128.
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
+        return self._set(maxSentenceLength=value)
+
+    @keyword_only
+    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForTokenClassification",
+                 java_model=None):
+        super(CamemBertForTokenClassification, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        self._setDefault(
+            batchSize=8,
+            maxSentenceLength=128,
+            caseSensitive=True
+        )
+
+    @staticmethod
+    def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        CamemBertForTokenClassification
+            The restored model
+        """
+        from sparknlp.internal import _CamemBertForTokenClassification
+        jModel = _CamemBertForTokenClassification(folder, spark_session._jsparkSession)._java_obj
+        return CamemBertForTokenClassification(java_model=jModel)
+
+    @staticmethod
+    def pretrained(name="camembert_base_token_classifier_wikiner", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default
+            "camembert_base_token_classifier_wikiner"
+        lang : str, optional
+            Language of the pretrained model, by default "en"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None. Will use
+            Spark NLPs repositories otherwise.
+
+        Returns
+        -------
+        CamemBertForTokenClassification
+            The restored model
+        """
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(CamemBertForTokenClassification, name, lang, remote_loc)

--- a/python/sparknlp/internal/__init__.py
+++ b/python/sparknlp/internal/__init__.py
@@ -423,3 +423,10 @@ class _ViTForImageClassification(ExtendedJavaWrapper):
         super(_ViTForImageClassification, self).__init__(
             "com.johnsnowlabs.nlp.annotators.cv.ViTForImageClassification.loadSavedModel", path,
             jspark)
+
+
+class _CamemBertForTokenClassification(ExtendedJavaWrapper):
+    def __init__(self, path, jspark):
+        super(_CamemBertForTokenClassification, self).__init__(
+            "com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForTokenClassification.loadSavedModel", path,
+            jspark)

--- a/python/test/annotator/classifier_dl/camembert_for_token_classification_test.py
+++ b/python/test/annotator/classifier_dl/camembert_for_token_classification_test.py
@@ -1,0 +1,49 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class CamemBertForTokenClassificationTestSpec(unittest.TestCase):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+    def runTest(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        token_classifier = CamemBertForTokenClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("ner")
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            token_classifier
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowCamemBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowCamemBertClassification.scala
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.ml.tensorflow
+
+import com.johnsnowlabs.ml.tensorflow.sentencepiece.{SentencePieceWrapper, SentencepieceEncoder}
+import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.{ActivationFunction, Annotation}
+import org.tensorflow.ndarray.buffer.IntDataBuffer
+
+import scala.collection.JavaConverters._
+
+/** @param tensorflowWrapper
+  *   CamemBERT Model wrapper with TensorFlow Wrapper
+  * @param spp
+  *   XlmRoberta SentencePiece model with SentencePieceWrapper
+  * @param configProtoBytes
+  *   Configuration for TensorFlow session
+  * @param tags
+  *   labels which model was trained with in order
+  * @param signatures
+  *   TF v2 signatures in Spark NLP
+  */
+class TensorflowCamemBertClassification(
+    val tensorflowWrapper: TensorflowWrapper,
+    val spp: SentencePieceWrapper,
+    configProtoBytes: Option[Array[Byte]] = None,
+    tags: Map[String, Int],
+    signatures: Option[Map[String, String]] = None)
+    extends Serializable
+    with TensorflowForClassification {
+
+  val _tfCamemBertSignatures: Map[String, String] =
+    signatures.getOrElse(ModelSignatureManager.apply())
+
+  /** HACK: These tokens were added by fairseq but don't seem to be actually used when duplicated
+    * in the actual # sentencepiece vocabulary (this is the case for '''<s>''' and '''</s>''')
+    * '''<s>NOTUSED": 0''','''"<pad>": 1''', '''"</s>NOTUSED": 2''', '''"<unk>": 3'''
+    */
+  private val pieceIdOffset: Int = 4
+  protected val sentenceStartTokenId: Int = spp.getSppModel.pieceToId("<s>") + pieceIdOffset
+  protected val sentenceEndTokenId: Int = spp.getSppModel.pieceToId("</s>") + pieceIdOffset
+  protected val sentencePadTokenId: Int = spp.getSppModel.pieceToId("<pad>") + pieceIdOffset
+  protected val sentencePieceDelimiterId: Int = spp.getSppModel.pieceToId("▁") + pieceIdOffset
+
+  def tokenizeWithAlignment(
+      sentences: Seq[TokenizedSentence],
+      maxSeqLength: Int,
+      caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = {
+
+    val encoder =
+      new SentencepieceEncoder(
+        spp,
+        caseSensitive,
+        sentencePieceDelimiterId,
+        pieceIdOffset = pieceIdOffset)
+
+    val sentenceTokenPieces = sentences.map { s =>
+      val trimmedSentence = s.indexedTokens.take(maxSeqLength - 2)
+      val wordpieceTokens =
+        trimmedSentence.flatMap(token => encoder.encode(token)).take(maxSeqLength)
+      WordpieceTokenizedSentence(wordpieceTokens)
+    }
+    sentenceTokenPieces
+  }
+
+  def tokenizeDocument(
+      docs: Seq[Annotation],
+      maxSeqLength: Int,
+      caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = {
+
+    val encoder =
+      new SentencepieceEncoder(
+        spp,
+        caseSensitive,
+        sentencePieceDelimiterId - 1,
+        pieceIdOffset = 1)
+
+    val sentences = docs.map { s => Sentence(s.result, s.begin, s.end, 0) }
+
+    val sentenceTokenPieces = sentences.map { s =>
+      val wordpieceTokens = encoder.encodeSentence(s, maxLength = maxSeqLength).take(maxSeqLength)
+      WordpieceTokenizedSentence(wordpieceTokens)
+    }
+    sentenceTokenPieces
+  }
+
+  def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
+    val tensors = new TensorResources()
+
+    val maxSentenceLength = batch.map(encodedSentence => encodedSentence.length).max
+    val batchLength = batch.length
+
+    val tokenBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+    val maskBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+
+    // [nb of encoded sentences , maxSentenceLength]
+    val shape = Array(batch.length.toLong, maxSentenceLength)
+
+    batch.zipWithIndex
+      .foreach { case (sentence, idx) =>
+        val offset = idx * maxSentenceLength
+        tokenBuffers.offset(offset).write(sentence)
+        maskBuffers
+          .offset(offset)
+          .write(sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
+      }
+
+    val runner = tensorflowWrapper
+      .getTFSessionWithSignature(configProtoBytes = configProtoBytes, initAllTables = false)
+      .runner
+
+    val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
+    val maskTensors = tensors.createIntBufferTensor(shape, maskBuffers)
+
+    runner
+      .feed(
+        _tfCamemBertSignatures
+          .getOrElse(ModelSignatureConstants.InputIds.key, "missing_input_id_key"),
+        tokenTensors)
+      .feed(
+        _tfCamemBertSignatures
+          .getOrElse(ModelSignatureConstants.AttentionMask.key, "missing_input_mask_key"),
+        maskTensors)
+      .fetch(_tfCamemBertSignatures
+        .getOrElse(ModelSignatureConstants.LogitsOutput.key, "missing_logits_key"))
+
+    val outs = runner.run().asScala
+    val rawScores = TensorResources.extractFloats(outs.head)
+
+    outs.foreach(_.close())
+    tensors.clearSession(outs)
+    tensors.clearTensors()
+
+    val dim = rawScores.length / (batchLength * maxSentenceLength)
+    val batchScores: Array[Array[Array[Float]]] = rawScores
+      .grouped(dim)
+      .map(scores => calculateSoftmax(scores))
+      .toArray
+      .grouped(maxSentenceLength)
+      .toArray
+
+    batchScores
+  }
+
+  def tagSequence(batch: Seq[Array[Int]], activation: String): Array[Array[Float]] = {
+    val tensors = new TensorResources()
+
+    val maxSentenceLength = batch.map(encodedSentence => encodedSentence.length).max
+    val batchLength = batch.length
+
+    val tokenBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+    val maskBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+
+    // [nb of encoded sentences , maxSentenceLength]
+    val shape = Array(batch.length.toLong, maxSentenceLength)
+
+    batch.zipWithIndex
+      .foreach { case (sentence, idx) =>
+        val offset = idx * maxSentenceLength
+        tokenBuffers.offset(offset).write(sentence)
+        maskBuffers
+          .offset(offset)
+          .write(sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
+      }
+
+    val runner = tensorflowWrapper
+      .getTFSessionWithSignature(configProtoBytes = configProtoBytes, initAllTables = false)
+      .runner
+
+    val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
+    val maskTensors = tensors.createIntBufferTensor(shape, maskBuffers)
+
+    runner
+      .feed(
+        _tfCamemBertSignatures
+          .getOrElse(ModelSignatureConstants.InputIds.key, "missing_input_id_key"),
+        tokenTensors)
+      .feed(
+        _tfCamemBertSignatures
+          .getOrElse(ModelSignatureConstants.AttentionMask.key, "missing_input_mask_key"),
+        maskTensors)
+      .fetch(_tfCamemBertSignatures
+        .getOrElse(ModelSignatureConstants.LogitsOutput.key, "missing_logits_key"))
+
+    val outs = runner.run().asScala
+    val rawScores = TensorResources.extractFloats(outs.head)
+
+    outs.foreach(_.close())
+    tensors.clearSession(outs)
+    tensors.clearTensors()
+
+    val dim = rawScores.length / batchLength
+    val batchScores: Array[Array[Float]] =
+      rawScores
+        .grouped(dim)
+        .map(scores =>
+          activation match {
+            case ActivationFunction.softmax => calculateSoftmax(scores)
+            case ActivationFunction.sigmoid => calculateSigmoid(scores)
+            case _ => calculateSoftmax(scores)
+          })
+        .toArray
+
+    batchScores
+  }
+
+  def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) = {
+    val tensors = new TensorResources()
+
+    val maxSentenceLength = batch.map(encodedSentence => encodedSentence.length).max
+    val batchLength = batch.length
+
+    val tokenBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+    val maskBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+
+    // [nb of encoded sentences , maxSentenceLength]
+    val shape = Array(batch.length.toLong, maxSentenceLength)
+
+    batch.zipWithIndex
+      .foreach { case (sentence, idx) =>
+        val offset = idx * maxSentenceLength
+        tokenBuffers.offset(offset).write(sentence)
+        maskBuffers
+          .offset(offset)
+          .write(sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
+      }
+
+    val runner = tensorflowWrapper
+      .getTFSessionWithSignature(configProtoBytes = configProtoBytes, initAllTables = false)
+      .runner
+
+    val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
+    val maskTensors = tensors.createIntBufferTensor(shape, maskBuffers)
+
+    runner
+      .feed(
+        _tfCamemBertSignatures
+          .getOrElse(ModelSignatureConstants.InputIds.key, "missing_input_id_key"),
+        tokenTensors)
+      .feed(
+        _tfCamemBertSignatures
+          .getOrElse(ModelSignatureConstants.AttentionMask.key, "missing_input_mask_key"),
+        maskTensors)
+      .fetch(_tfCamemBertSignatures
+        .getOrElse(ModelSignatureConstants.EndLogitsOutput.key, "missing_end_logits_key"))
+      .fetch(_tfCamemBertSignatures
+        .getOrElse(ModelSignatureConstants.StartLogitsOutput.key, "missing_start_logits_key"))
+
+    val outs = runner.run().asScala
+    val endLogits = TensorResources.extractFloats(outs.head)
+    val startLogits = TensorResources.extractFloats(outs.last)
+
+    outs.foreach(_.close())
+    tensors.clearSession(outs)
+    tensors.clearTensors()
+
+    val endDim = endLogits.length / batchLength
+    val endScores: Array[Array[Float]] =
+      endLogits.grouped(endDim).map(scores => calculateSoftmax(scores)).toArray
+
+    val startDim = startLogits.length / batchLength
+    val startScores: Array[Array[Float]] =
+      startLogits.grouped(startDim).map(scores => calculateSoftmax(scores)).toArray
+
+    (startScores, endScores)
+  }
+
+  def findIndexedToken(
+      tokenizedSentences: Seq[TokenizedSentence],
+      sentence: (WordpieceTokenizedSentence, Int),
+      tokenPiece: TokenPiece): Option[IndexedToken] = {
+    tokenizedSentences(sentence._2).indexedTokens.find(p =>
+      p.begin == tokenPiece.begin && tokenPiece.isWordStart)
+  }
+
+}

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -621,4 +621,10 @@ package object annotator {
       extends ReadablePretrainedViTForImageModel
       with ReadViTForImageTensorflowModel
 
+  type CamemBertForTokenClassification =
+    com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForTokenClassification
+
+  object CamemBertForTokenClassification
+      extends ReadablePretrainedCamemBertForTokenModel
+      with ReadCamemBertForTokenTensorflowModel
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForTokenClassification.scala
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.ml.tensorflow._
+import com.johnsnowlabs.ml.tensorflow.sentencepiece.{
+  ReadSentencePieceModel,
+  SentencePieceWrapper,
+  WriteSentencePieceModel
+}
+import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.serialization.MapFeature
+import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.param.{IntArrayParam, IntParam}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.SparkSession
+
+import java.io.File
+
+/** CamemBertForTokenClassification can load CamemBERT Models with a token classification head on
+  * top (a linear layer on top of the hidden-states output) e.g. for Named-Entity-Recognition
+  * (NER) tasks.
+  *
+  * Pretrained models can be loaded with `pretrained` of the companion object:
+  * {{{
+  * val tokenClassifier = CamemBertForTokenClassification.pretrained()
+  *   .setInputCols("token", "document")
+  *   .setOutputCol("label")
+  * }}}
+  * The default model is `"camembert_base_token_classifier_wikiner"`, if no name is provided.
+  *
+  * For available pretrained models please see the
+  * [[https://nlp.johnsnowlabs.com/models?task=Named+Entity+Recognition Models Hub]].
+  *
+  * and the
+  * [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForTokenClassificationTestSpec.scala CamemBertForTokenClassificationTestSpec]].
+  * To see which models are compatible and how to import them see
+  * [[https://github.com/JohnSnowLabs/spark-nlp/discussions/5669]].
+  *
+  * ==Example==
+  * {{{
+  * import spark.implicits._
+  * import com.johnsnowlabs.nlp.base._
+  * import com.johnsnowlabs.nlp.annotator._
+  * import org.apache.spark.ml.Pipeline
+  *
+  * val documentAssembler = new DocumentAssembler()
+  *   .setInputCol("text")
+  *   .setOutputCol("document")
+  *
+  * val tokenizer = new Tokenizer()
+  *   .setInputCols("document")
+  *   .setOutputCol("token")
+  *
+  * val tokenClassifier = CamemBertForTokenClassification.pretrained()
+  *   .setInputCols("token", "document")
+  *   .setOutputCol("label")
+  *   .setCaseSensitive(true)
+  *
+  * val pipeline = new Pipeline().setStages(Array(
+  *   documentAssembler,
+  *   tokenizer,
+  *   tokenClassifier
+  * ))
+  *
+  * val data = Seq("John Lenon was born in London and lived in Paris. My name is Sarah and I live in London").toDF("text")
+  * val result = pipeline.fit(data).transform(data)
+  *
+  * result.select("label.result").show(false)
+  * +------------------------------------------------------------------------------------+
+  * |result                                                                              |
+  * +------------------------------------------------------------------------------------+
+  * |[B-PER, I-PER, O, O, O, B-LOC, O, O, O, B-LOC, O, O, O, O, B-PER, O, O, O, O, B-LOC]|
+  * +------------------------------------------------------------------------------------+
+  * }}}
+  *
+  * @see
+  *   [[CamemBertForTokenClassification]] for token-level classification
+  * @see
+  *   [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of
+  *   transformer based classifiers
+  * @param uid
+  *   required uid for storing annotator to disk
+  * @groupname anno Annotator types
+  * @groupdesc anno
+  *   Required input and expected output annotator types
+  * @groupname Ungrouped Members
+  * @groupname param Parameters
+  * @groupname setParam Parameter setters
+  * @groupname getParam Parameter getters
+  * @groupname Ungrouped Members
+  * @groupprio param  1
+  * @groupprio anno  2
+  * @groupprio Ungrouped 3
+  * @groupprio setParam  4
+  * @groupprio getParam  5
+  * @groupdesc param
+  *   A list of (hyper-)parameter keys this annotator can take. Users can set and get the
+  *   parameter values through setters and getters, respectively.
+  */
+class CamemBertForTokenClassification(override val uid: String)
+    extends AnnotatorModel[CamemBertForTokenClassification]
+    with HasBatchedAnnotate[CamemBertForTokenClassification]
+    with WriteTensorflowModel
+    with WriteSentencePieceModel
+    with HasCaseSensitiveProperties {
+
+  /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator
+    * type
+    */
+  def this() = this(Identifiable.randomUID("CamemBertForTokenClassification"))
+
+  /** Input Annotator Types: DOCUMENT, TOKEN
+    *
+    * @group anno
+    */
+  override val inputAnnotatorTypes: Array[String] =
+    Array(AnnotatorType.DOCUMENT, AnnotatorType.TOKEN)
+
+  /** Output Annotator Types: WORD_EMBEDDINGS
+    *
+    * @group anno
+    */
+  override val outputAnnotatorType: AnnotatorType = AnnotatorType.NAMED_ENTITY
+
+  /** Labels used to decode predicted IDs back to string tags
+    *
+    * @group param
+    */
+  val labels: MapFeature[String, Int] = new MapFeature(this, "labels")
+
+  /** @group setParam */
+  def setLabels(value: Map[String, Int]): this.type = set(labels, value)
+
+  /** Returns labels used to train this model */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
+
+  /** ConfigProto from tensorflow, serialized into byte array. Get with
+    * `config_proto.SerializeToString()`
+    *
+    * @group param
+    */
+  val configProtoBytes = new IntArrayParam(
+    this,
+    "configProtoBytes",
+    "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
+
+  /** @group setParam */
+  def setConfigProtoBytes(bytes: Array[Int]): CamemBertForTokenClassification.this.type =
+    set(this.configProtoBytes, bytes)
+
+  /** @group getParam */
+  def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
+
+  /** Max sentence length to process (Default: `128`)
+    *
+    * @group param
+    */
+  val maxSentenceLength =
+    new IntParam(this, "maxSentenceLength", "Max sentence length to process")
+
+  /** @group setParam */
+  def setMaxSentenceLength(value: Int): this.type = {
+    require(
+      value <= 512,
+      "CamemBERT models do not support sequences longer than 512 because of trainable positional embeddings.")
+    require(value >= 1, "The maxSentenceLength must be at least 1")
+    set(maxSentenceLength, value)
+    this
+  }
+
+  /** @group getParam */
+  def getMaxSentenceLength: Int = $(maxSentenceLength)
+
+  /** It contains TF model signatures for the laded saved model
+    *
+    * @group param
+    */
+  val signatures = new MapFeature[String, String](model = this, name = "signatures")
+
+  /** @group setParam */
+  def setSignatures(value: Map[String, String]): this.type = {
+    if (get(signatures).isEmpty)
+      set(signatures, value)
+    this
+  }
+
+  /** @group getParam */
+  def getSignatures: Option[Map[String, String]] = get(this.signatures)
+
+  private var _model: Option[Broadcast[TensorflowCamemBertClassification]] = None
+
+  /** @group setParam */
+  def setModelIfNotSet(
+      spark: SparkSession,
+      tensorflowWrapper: TensorflowWrapper,
+      spp: SentencePieceWrapper): CamemBertForTokenClassification = {
+    if (_model.isEmpty) {
+      _model = Some(
+        spark.sparkContext.broadcast(
+          new TensorflowCamemBertClassification(
+            tensorflowWrapper,
+            spp,
+            configProtoBytes = getConfigProtoBytes,
+            tags = $$(labels),
+            signatures = getSignatures)))
+    }
+
+    this
+  }
+
+  /** @group getParam */
+  def getModelIfNotSet: TensorflowCamemBertClassification = _model.get.value
+
+  /** Whether to lowercase tokens or not
+    *
+    * @group setParam
+    */
+  override def setCaseSensitive(value: Boolean): this.type = {
+    if (get(caseSensitive).isEmpty)
+      set(this.caseSensitive, value)
+    this
+  }
+
+  setDefault(batchSize -> 8, maxSentenceLength -> 128, caseSensitive -> true)
+
+  /** takes a document and annotations and produces new annotations of this annotator's annotation
+    * type
+    *
+    * @param batchedAnnotations
+    *   Annotations that correspond to inputAnnotationCols generated by previous annotators if any
+    * @return
+    *   any number of annotations processed for every input annotation. Not necessary one to one
+    *   relationship
+    */
+  override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
+    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations
+      .map(annotations => TokenizedWithSentence.unpack(annotations).toArray)
+      .toArray
+    /*Return empty if the real tokens are empty*/
+    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+
+      getModelIfNotSet.predict(
+        tokenizedSentences,
+        $(batchSize),
+        $(maxSentenceLength),
+        $(caseSensitive),
+        $$(labels))
+    })
+    else {
+      Seq(Seq.empty[Annotation])
+    }
+  }
+
+  override def onWrite(path: String, spark: SparkSession): Unit = {
+    super.onWrite(path, spark)
+    writeTensorflowModelV2(
+      path,
+      spark,
+      getModelIfNotSet.tensorflowWrapper,
+      "_camembert_classification",
+      CamemBertForTokenClassification.tfFile,
+      configProtoBytes = getConfigProtoBytes)
+    writeSentencePieceModel(
+      path,
+      spark,
+      getModelIfNotSet.spp,
+      "_camembert",
+      CamemBertForTokenClassification.sppFile)
+  }
+
+}
+
+trait ReadablePretrainedCamemBertForTokenModel
+    extends ParamsAndFeaturesReadable[CamemBertForTokenClassification]
+    with HasPretrained[CamemBertForTokenClassification] {
+  override val defaultModelName: Some[String] = Some("camembert_base_token_classifier_wikiner")
+
+  /** Java compliant-overrides */
+  override def pretrained(): CamemBertForTokenClassification = super.pretrained()
+
+  override def pretrained(name: String): CamemBertForTokenClassification = super.pretrained(name)
+
+  override def pretrained(name: String, lang: String): CamemBertForTokenClassification =
+    super.pretrained(name, lang)
+
+  override def pretrained(
+      name: String,
+      lang: String,
+      remoteLoc: String): CamemBertForTokenClassification =
+    super.pretrained(name, lang, remoteLoc)
+}
+
+trait ReadCamemBertForTokenTensorflowModel
+    extends ReadTensorflowModel
+    with ReadSentencePieceModel {
+  this: ParamsAndFeaturesReadable[CamemBertForTokenClassification] =>
+
+  override val tfFile: String = "camembert_classification_tensorflow"
+  override val sppFile: String = "camembert_spp"
+
+  def readTensorflow(
+      instance: CamemBertForTokenClassification,
+      path: String,
+      spark: SparkSession): Unit = {
+
+    val tf =
+      readTensorflowModel(path, spark, "_camembert_classification_tf", initAllTables = false)
+    val spp = readSentencePieceModel(path, spark, "_camembert_spp", sppFile)
+    instance.setModelIfNotSet(spark, tf, spp)
+  }
+
+  addReader(readTensorflow)
+
+  def loadSavedModel(
+      tfModelPath: String,
+      spark: SparkSession): CamemBertForTokenClassification = {
+    val f = new File(tfModelPath)
+    val savedModel = new File(tfModelPath, "saved_model.pb")
+    require(f.exists, s"Folder $tfModelPath not found")
+    require(f.isDirectory, s"File $tfModelPath is not folder")
+    require(
+      savedModel.exists(),
+      s"savedModel file saved_model.pb not found in folder $tfModelPath")
+    val sppModelPath = tfModelPath + "/assets"
+    val sppModel = new File(sppModelPath, "sentencepiece.bpe.model")
+    require(
+      sppModel.exists(),
+      s"SentencePiece model sentencepiece.bpe.model not found in folder $sppModelPath")
+
+    val labelsPath = new File(tfModelPath + "/assets", "labels.txt")
+    require(
+      labelsPath.exists(),
+      s"Labels file labels.txt not found in folder $tfModelPath/assets/")
+
+    val labelsResource =
+      new ExternalResource(labelsPath.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
+    val labels = ResourceHelper.parseLines(labelsResource).zipWithIndex.toMap
+
+    val (wrapper, signatures) =
+      TensorflowWrapper.read(tfModelPath, zipped = false, useBundle = true)
+    val spp = SentencePieceWrapper.read(sppModel.toString)
+
+    val _signatures = signatures match {
+      case Some(s) => s
+      case None => throw new Exception("Cannot load signature definitions from model!")
+    }
+
+    /** the order of setSignatures is important if we use getSignatures inside setModelIfNotSet */
+    new CamemBertForTokenClassification()
+      .setLabels(labels)
+      .setSignatures(_signatures)
+      .setModelIfNotSet(spark, wrapper, spp)
+  }
+}
+
+/** This is the companion object of [[CamemBertForTokenClassification]]. Please refer to that
+  * class for the documentation.
+  */
+object CamemBertForTokenClassification
+    extends ReadablePretrainedCamemBertForTokenModel
+    with ReadCamemBertForTokenTensorflowModel

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -648,7 +648,8 @@ object PythonResourceDownloader {
     "RoBertaForQuestionAnswering" -> RoBertaForQuestionAnswering,
     "XlmRoBertaForQuestionAnswering" -> XlmRoBertaForQuestionAnswering,
     "SpanBertCorefModel" -> SpanBertCorefModel,
-    "ViTForImageClassification" -> ViTForImageClassification)
+    "ViTForImageClassification" -> ViTForImageClassification,
+    "CamemBertForTokenClassification" -> CamemBertForTokenClassification)
 
   def downloadModel(
       readerStr: String,

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForTokenClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForTokenClassificationTestSpec.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.training.CoNLL
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.SlowTest
+import com.johnsnowlabs.util.Benchmark
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions.{col, explode, size}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class CamemBertForTokenClassificationTestSpec extends AnyFlatSpec {
+
+  import ResourceHelper.spark.implicits._
+
+  val ddd: DataFrame = Seq(
+    "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London",
+    "Rare Hendrix song draft sells for almost $17,000.",
+    "EU rejects German call to boycott British lamb .",
+    "TORONTO 1996-08-21",
+    "Barack Obama /bəˈɹɑːk oʊˈbɑːmə/, né le 4 août 1961 à Honolulu (Hawaï), est un homme d'État américain. Il est le 44e président des États-Unis",
+    "Paris est la capitale de la France.",
+    "george washington est allé à washington",
+    "\\u2009.Les modèles de langue contextuels Camembert pour le Français : impact de la taille et de l'hétérogénéité des données d'entrainement .\\u2009.\\u2009.")
+    .toDF("text")
+
+  val document: DocumentAssembler = new DocumentAssembler()
+    .setInputCol("text")
+    .setOutputCol("document")
+
+  val tokenizer: Tokenizer = new Tokenizer()
+    .setInputCols(Array("document"))
+    .setOutputCol("token")
+
+  val tokenClassifier: CamemBertForTokenClassification = CamemBertForTokenClassification
+    .pretrained()
+    .setInputCols(Array("token", "document"))
+    .setOutputCol("ner")
+    .setCaseSensitive(true)
+    .setMaxSentenceLength(512)
+
+  "CamemBertForTokenClassification" should "correctly load custom model with extracted signatures" taggedAs SlowTest in {
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, tokenClassifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("token.result").show(false)
+    pipelineDF.select("ner.result").show(false)
+    pipelineDF
+      .withColumn("token_size", size(col("token")))
+      .withColumn("ner_size", size(col("ner")))
+      .where(col("token_size") =!= col("ner_size"))
+      .select("token_size", "ner_size", "token.result", "ner.result")
+      .show(false)
+
+    val totalTokens = pipelineDF.select(explode($"token.result")).count.toInt
+    val totalEmbeddings = pipelineDF.select(explode($"ner.result")).count.toInt
+
+    println(s"total tokens: $totalTokens")
+    println(s"total embeddings: $totalEmbeddings")
+
+  }
+
+  "CamemBertForTokenClassification" should "be saved and loaded correctly" taggedAs SlowTest in {
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, tokenClassifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("ner.result").show(false)
+
+    Benchmark.time("Time to save CamemBertForTokenClassification pipeline model") {
+      pipelineModel.write.overwrite().save("./tmp_fortoken_pipeline")
+    }
+
+    Benchmark.time("Time to save BertForTokenClassification model") {
+      pipelineModel.stages.last
+        .asInstanceOf[CamemBertForTokenClassification]
+        .write
+        .overwrite()
+        .save("./tmp_fortoken_model")
+    }
+
+    val loadedPipelineModel = PipelineModel.load("./tmp_fortoken_pipeline")
+    loadedPipelineModel.transform(ddd).select("ner.result").show(false)
+
+    val loadedSequenceModel =
+      CamemBertForTokenClassification.load("./tmp_fortoken_model")
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
+
+  }
+
+  "CamemBertForTokenClassification" should "benchmark test" taggedAs SlowTest in {
+
+    val conll = CoNLL()
+    val training_data =
+      conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.testa")
+
+    val pipeline = new Pipeline()
+      .setStages(Array(tokenClassifier))
+
+    val pipelineDF = pipeline.fit(training_data).transform(training_data)
+    Benchmark.time("Time to save the results") {
+      pipelineDF.write.mode("overwrite").parquet("./tmp_token_classifier")
+    }
+
+    println("missing tokens/tags: ")
+    pipelineDF
+      .withColumn("sentence_size", size(col("sentence")))
+      .withColumn("token_size", size(col("token")))
+      .withColumn("ner_size", size(col("ner")))
+      .where(col("token_size") =!= col("ner_size"))
+      .select("sentence_size", "token_size", "ner_size", "token.result", "ner.result")
+      .show(false)
+
+    println("total sentences: ", pipelineDF.select(explode($"sentence.result")).count)
+    val totalTokens = pipelineDF.select(explode($"token.result")).count.toInt
+    val totalTags = pipelineDF.select(explode($"ner.result")).count.toInt
+
+    println(s"total tokens: $totalTokens")
+    println(s"total embeddings: $totalTags")
+
+    assert(totalTokens == totalTags)
+  }
+}


### PR DESCRIPTION
This is a WIP to introduce CamemBERT for Token Classification such as NER or POS tasks.

- [x] Python interface
- [x] Importing models