### PR TITLE
Fix AttributeError for ImageAssembler in PretrainedPipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 Spark NLP is a state-of-the-art Natural Language Processing library built on top of Apache Spark. It provides **simple**, **performant** & **accurate** NLP annotations for machine learning pipelines that **scale** easily in a distributed environment.
-Spark NLP comes with **14000+** pretrained **pipelines** and **models** in more than **200+** languages.
+Spark NLP comes with **11000+** pretrained **pipelines** and **models** in more than **200+** languages.
 It also offers tasks such as **Tokenization**, **Word Segmentation**, **Part-of-Speech Tagging**, Word and Sentence **Embeddings**, **Named Entity Recognition**, **Dependency Parsing**, **Spell Checking**, **Text Classification**, **Sentiment Analysis**, **Token Classification**, **Machine Translation** (+180 languages), **Summarization**, **Question Answering**, **Table Question Answering**, **Text Generation**, **Image Classification**, **Automatic Speech Recognition**, and many more [NLP tasks](#features).
 
 **Spark NLP** is the only open-source NLP library in **production** that offers state-of-the-art transformers such as **BERT**, **CamemBERT**, **ALBERT**, **ELECTRA**, **XLNet**, **DistilBERT**, **RoBERTa**, **DeBERTa**, **XLM-RoBERTa**, **Longformer**, **ELMO**, **Universal Sentence Encoder**, **Google T5**, **MarianMT**, **GPT2**, and **Vision Transformers (ViT)** not only to **Python** and **R**, but also to **JVM** ecosystem (**Java**, **Scala**, and **Kotlin**) at **scale** by extending **Apache Spark** natively.

--- a/docs/_layouts/landing.html
+++ b/docs/_layouts/landing.html
@@ -345,8 +345,8 @@ article_header:
                     <li>Easy <strong>TensorFlow</strong> integration</li>
                     <li><strong>GPU</strong> Support</li>
                     <li>Full integration with <strong>Spark ML</strong> functions</li>
-                    <li><strong>10000+</strong> pre-trained <strong>models </strong> in <strong>200+ languages! </strong>
-                    <li><strong>4000+</strong> pre-trained <strong>pipelines </strong> in <strong>200+ languages! </strong>
+                    <li><strong>8000+</strong> pre-trained <strong>models </strong> in <strong>200+ languages! </strong>
+                    <li><strong>3000+</strong> pre-trained <strong>pipelines </strong> in <strong>200+ languages! </strong>
                   </ul>
                 </div>
 {% highlight python %}

--- a/python/README.md
+++ b/python/README.md
@@ -17,7 +17,7 @@
 </p>
 
 Spark NLP is a state-of-the-art Natural Language Processing library built on top of Apache Spark. It provides **simple**, **performant** & **accurate** NLP annotations for machine learning pipelines that **scale** easily in a distributed environment.
-Spark NLP comes with **14000+** pretrained **pipelines** and **models** in more than **200+** languages.
+Spark NLP comes with **11000+** pretrained **pipelines** and **models** in more than **200+** languages.
 It also offers tasks such as **Tokenization**, **Word Segmentation**, **Part-of-Speech Tagging**, Word and Sentence **Embeddings**, **Named Entity Recognition**, **Dependency Parsing**, **Spell Checking**, **Text Classification**, **Sentiment Analysis**, **Token Classification**, **Machine Translation** (+180 languages), **Summarization**, **Question Answering**, **Table Question Answering**, **Text Generation**, **Image Classification**, **Automatic Speech Recognition**, and many more [NLP tasks](#features).
 
 **Spark NLP** is the only open-source NLP library in **production** that offers state-of-the-art transformers such as **BERT**, **CamemBERT**, **ALBERT**, **ELECTRA**, **XLNet**, **DistilBERT**, **RoBERTa**, **DeBERTa**, **XLM-RoBERTa**, **Longformer**, **ELMO**, **Universal Sentence Encoder**, **Google T5**, **MarianMT**, **GPT2**, and **Vision Transformers (ViT)** not only to **Python** and **R**, but also to **JVM** ecosystem (**Java**, **Scala**, and **Kotlin**) at **scale** by extending **Apache Spark** natively.

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -17,8 +17,9 @@ import subprocess
 import threading
 from pyspark.sql import SparkSession
 from sparknlp import annotator
+# Must be declared here one by one or else PretrainedPipeline will fail with AttributeError
 from sparknlp.base import DocumentAssembler, MultiDocumentAssembler, Finisher, EmbeddingsFinisher, TokenAssembler, \
-    Chunk2Doc, Doc2Chunk
+    Chunk2Doc, Doc2Chunk, AudioAssembler, GraphFinisher, ImageAssembler, TableAssembler
 from pyspark.conf import SparkConf
 from pyspark.context import SparkContext
 from pyspark.java_gateway import launch_gateway

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/audio/Wav2Vec2ForCTCTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/audio/Wav2Vec2ForCTCTestSpec.scala
@@ -17,6 +17,7 @@
 package com.johnsnowlabs.nlp.annotators.audio
 
 import com.johnsnowlabs.nlp.AudioAssembler
+import com.johnsnowlabs.nlp.pretrained.PretrainedPipeline
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.tags.SlowTest
 import com.johnsnowlabs.util.Benchmark
@@ -97,7 +98,7 @@ class Wav2Vec2ForCTCTestSpec extends AnyFlatSpec {
 
   }
 
-  "ViTForImageClassification" should "benchmark" taggedAs SlowTest in {
+  "Wav2Vec2ForCTC" should "benchmark" taggedAs SlowTest in {
 
     val speechToText: Wav2Vec2ForCTC = Wav2Vec2ForCTC
       .pretrained()
@@ -122,6 +123,15 @@ class Wav2Vec2ForCTCTestSpec extends AnyFlatSpec {
         pipelineDF.select("text").count()
       }
     })
+  }
+
+  "Wav2Vec2ForCTC" should "pretrained pipeline" taggedAs SlowTest in {
+
+    val pipelineModel = PretrainedPipeline("pipeline_asr_wav2vec2_base_960h")
+
+    val pipelineDF = pipelineModel.transform(processedAudioFloats)
+    pipelineDF.show()
+
   }
 
 }


### PR DESCRIPTION
When `PretrainedPipeline` is used in Python with ImageAssembler as one of the stages it will fail with `AttributeError: module 'sparknlp' has no attribute 'ImageAssembler'`. This PR fixes this issue.