### PR TITLE
Adding enableRegexTokenizer in WordSegmenter

### DIFF
--- a/python/sparknlp/annotator/ws/word_segmenter.py
+++ b/python/sparknlp/annotator/ws/word_segmenter.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the WordSegmenter."""
 
-
 from sparknlp.common import *
 
 
@@ -60,6 +59,12 @@ class WordSegmenterApproach(AnnotatorApproach):
     ambiguityThreshold
         How much percentage of total amount of words are covered to be marked as
         frequent, by default 0.97
+    enableRegexTokenizer
+        Whether to use RegexTokenizer before segmentation. Useful for multilingual text
+    toLowercase
+        Indicates whether to convert all characters to lowercase before tokenizing. Used only when enableRegexTokenizer is true
+    pattern
+        regex pattern used for tokenizing. Used only when enableRegexTokenizer is true
 
     Examples
     --------
@@ -114,12 +119,28 @@ class WordSegmenterApproach(AnnotatorApproach):
                                "How much percentage of total amount of words are covered to be marked as frequent",
                                typeConverter=TypeConverters.toFloat)
 
+    enableRegexTokenizer = Param(Params._dummy(),
+                                 "enableRegexTokenizer",
+                                 "Whether to use RegexTokenizer before segmentation. Useful for multilingual text",
+                                 typeConverter=TypeConverters.toBoolean)
+
+    toLowercase = Param(Params._dummy(),
+                        "toLowercase",
+                        "Indicates whether to convert all characters to lowercase before tokenizing.",
+                        typeConverter=TypeConverters.toBoolean)
+
+    pattern = Param(Params._dummy(),
+                    "pattern",
+                    "regex pattern used for tokenizing. Defaults \\s+",
+                    typeConverter=TypeConverters.toString)
+
     @keyword_only
     def __init__(self):
         super(WordSegmenterApproach, self).__init__(
             classname="com.johnsnowlabs.nlp.annotators.ws.WordSegmenterApproach")
         self._setDefault(
-            nIterations=5, frequencyThreshold=5, ambiguityThreshold=0.97
+            nIterations=5, frequencyThreshold=5, ambiguityThreshold=0.97,
+            enableRegexTokenizer=False, toLowercase=False, pattern="\\s+"
         )
 
     def setPosColumn(self, value):
@@ -199,8 +220,41 @@ class WordSegmenterApproach(AnnotatorApproach):
         """
         return self.getOrDefault(self.ambiguityThreshold)
 
+    def setEnableRegexTokenizer(self, value):
+        """Sets whether to to use RegexTokenizer before segmentation.
+        Useful for multilingual text
+
+        Parameters
+        ----------
+        value : bool
+            Whether to use RegexTokenizer before segmentation
+        """
+        return self._set(enableRegexTokenizer=value)
+
+    def setToLowercase(self, value):
+        """Sets whether to convert all characters to lowercase before
+        tokenizing, by default False.
+
+        Parameters
+        ----------
+        value : bool
+            Whether to convert all characters to lowercase before tokenizing
+        """
+        return self._set(toLowercase=value)
+
+    def setPattern(self, value):
+        """Sets the regex pattern used for tokenizing, by default ``\\s+``.
+
+        Parameters
+        ----------
+        value : str
+            Regex pattern used for tokenizing
+        """
+        return self._set(pattern=value)
+
     def _create_model(self, java_model):
         return WordSegmenterModel(java_model=java_model)
+
 
 class WordSegmenterModel(AnnotatorModel):
     """WordSegmenter which tokenizes non-english or non-whitespace separated
@@ -266,6 +320,53 @@ class WordSegmenterModel(AnnotatorModel):
     """
     name = "WordSegmenterModel"
 
+    enableRegexTokenizer = Param(Params._dummy(),
+                                 "enableRegexTokenizer",
+                                 "Whether to use RegexTokenizer before segmentation. Useful for multilingual text",
+                                 typeConverter=TypeConverters.toBoolean)
+
+    toLowercase = Param(Params._dummy(),
+                        "toLowercase",
+                        "Indicates whether to convert all characters to lowercase before tokenizing.",
+                        typeConverter=TypeConverters.toBoolean)
+
+    pattern = Param(Params._dummy(),
+                    "pattern",
+                    "regex pattern used for tokenizing. Defaults \\s+",
+                    typeConverter=TypeConverters.toString)
+
+    def setEnableRegexTokenizer(self, value):
+        """Sets whether to to use RegexTokenizer before segmentation.
+        Useful for multilingual text
+
+        Parameters
+        ----------
+        value : bool
+            Whether to use RegexTokenizer before segmentation
+        """
+        return self._set(enableRegexTokenizer=value)
+
+    def setToLowercase(self, value):
+        """Sets whether to convert all characters to lowercase before
+        tokenizing, by default False.
+
+        Parameters
+        ----------
+        value : bool
+            Whether to convert all characters to lowercase before tokenizing
+        """
+        return self._set(toLowercase=value)
+
+    def setPattern(self, value):
+        """Sets the regex pattern used for tokenizing, by default ``\\s+``.
+
+        Parameters
+        ----------
+        value : str
+            Regex pattern used for tokenizing
+        """
+        return self._set(pattern=value)
+
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.ws.WordSegmenterModel", java_model=None):
         super(WordSegmenterModel, self).__init__(
             classname=classname,
@@ -293,4 +394,3 @@ class WordSegmenterModel(AnnotatorModel):
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(WordSegmenterModel, name, lang, remote_loc)
-

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterApproach.scala
@@ -23,7 +23,7 @@ import com.johnsnowlabs.nlp.annotators.pos.perceptron.{
   TrainingPerceptronLegacy
 }
 import org.apache.spark.ml.PipelineModel
-import org.apache.spark.ml.param.{DoubleParam, IntParam, Param}
+import org.apache.spark.ml.param.{BooleanParam, DoubleParam, IntParam, Param}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.sql.Dataset
 
@@ -131,7 +131,6 @@ class WordSegmenterApproach(override val uid: String)
     this,
     "nIterations",
     "Number of iterations in training, converges to better accuracy")
-  setDefault(nIterations, 5)
 
   /** How many times at least a tag on a word to be marked as frequent (Default: `20`)
     *
@@ -141,7 +140,6 @@ class WordSegmenterApproach(override val uid: String)
     this,
     "frequencyThreshold",
     "How many times at least a tag on a word to be marked as frequent")
-  setDefault(frequencyThreshold, 20)
 
   /** How much percentage of total amount of words are covered to be marked as frequent (Default:
     * `0.97`)
@@ -152,7 +150,30 @@ class WordSegmenterApproach(override val uid: String)
     this,
     "ambiguityThreshold",
     "How much percentage of total amount of words are covered to be marked as frequent")
-  setDefault(ambiguityThreshold, 0.97)
+
+  val enableRegexTokenizer: BooleanParam = new BooleanParam(
+    this,
+    "enableRegexTokenizer",
+    "Whether to use RegexTokenizer before segmentation. Useful for multilingual text")
+
+  /** Indicates whether to convert all characters to lowercase before tokenizing (Default:
+    * `false`).
+    *
+    * @group param
+    */
+  val toLowercase: BooleanParam = new BooleanParam(
+    this,
+    "toLowercase",
+    "Indicates whether to convert all characters to lowercase before tokenizing. Used only when enableRegexTokenizer is true")
+
+  /** Regex pattern used to match delimiters (Default: `"\\s+"`)
+    *
+    * @group param
+    */
+  val pattern: Param[String] = new Param(
+    this,
+    "pattern",
+    "regex pattern used for tokenizing. Used only when enableRegexTokenizer is true")
 
   /** @group setParam */
   def setPosColumn(value: String): this.type = set(posCol, value)
@@ -165,6 +186,22 @@ class WordSegmenterApproach(override val uid: String)
 
   /** @group setParam */
   def setAmbiguityThreshold(value: Double): this.type = set(ambiguityThreshold, value)
+
+  def setEnableRegexTokenizer(value: Boolean): this.type = set(enableRegexTokenizer, value)
+
+  /** @group setParam */
+  def setToLowercase(value: Boolean): this.type = set(toLowercase, value)
+
+  /** @group setParam */
+  def setPattern(value: String): this.type = set(pattern, value)
+
+  setDefault(
+    nIterations -> 5,
+    frequencyThreshold -> 20,
+    ambiguityThreshold -> 0.97,
+    enableRegexTokenizer -> false,
+    toLowercase -> false,
+    pattern -> "\\s+")
 
   /** @group getParam */
   def getNIterations: Int = $(nIterations)
@@ -184,6 +221,9 @@ class WordSegmenterApproach(override val uid: String)
 
     new WordSegmenterModel()
       .setModel(finalModel)
+      .setEnableRegexTokenizer($(enableRegexTokenizer))
+      .setToLowercase($(toLowercase))
+      .setPattern($(pattern))
   }
 
   /** Output Annotator Types: TOKEN

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterApproach.scala
@@ -187,6 +187,7 @@ class WordSegmenterApproach(override val uid: String)
   /** @group setParam */
   def setAmbiguityThreshold(value: Double): this.type = set(ambiguityThreshold, value)
 
+  /** @group setParam */
   def setEnableRegexTokenizer(value: Boolean): this.type = set(enableRegexTokenizer, value)
 
   /** @group setParam */

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterModel.scala
@@ -25,6 +25,8 @@ import com.johnsnowlabs.nlp.annotators.pos.perceptron.{
 import com.johnsnowlabs.nlp.annotators.ws.TagsType.{LEFT_BOUNDARY, MIDDLE, RIGHT_BOUNDARY}
 import com.johnsnowlabs.nlp.serialization.StructFeature
 import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.annotators.RegexTokenizer
+import org.apache.spark.ml.param.{BooleanParam, Param}
 import org.apache.spark.ml.util.Identifiable
 
 /** WordSegmenter which tokenizes non-english or non-whitespace separated texts.
@@ -119,11 +121,42 @@ class WordSegmenterModel(override val uid: String)
   val model: StructFeature[AveragedPerceptron] =
     new StructFeature[AveragedPerceptron](this, "POS Model")
 
+  val enableRegexTokenizer: BooleanParam = new BooleanParam(
+    this,
+    "enableRegexTokenizer",
+    "Whether to use RegexTokenizer before segmentation. Useful for multi-lingual text")
+
+  /** Indicates whether to convert all characters to lowercase before tokenizing (Default:
+    * `false`).
+    *
+    * @group param
+    */
+  val toLowercase: BooleanParam = new BooleanParam(
+    this,
+    "toLowercase",
+    "Indicates whether to convert all characters to lowercase before tokenizing.\n")
+
+  /** Regex pattern used to match delimiters (Default: `"\\s+"`)
+    *
+    * @group param
+    */
+  val pattern: Param[String] = new Param(this, "pattern", "regex pattern used for tokenizing")
+
   /** @group getParam */
   def getModel: AveragedPerceptron = $$(model)
 
   /** @group setParam */
   def setModel(targetModel: AveragedPerceptron): this.type = set(model, targetModel)
+
+  def setEnableRegexTokenizer(value: Boolean): this.type = set(enableRegexTokenizer, value)
+
+  /** @group setParam */
+  def setToLowercase(value: Boolean): this.type = set(toLowercase, value)
+
+  /** @group setParam */
+  def setPattern(value: String): this.type = set(pattern, value)
+
+  setDefault(enableRegexTokenizer -> false, toLowercase -> false, pattern -> "\\s+")
 
   /** takes a document and annotations and produces new annotations of this annotator's annotation
     * type
@@ -135,11 +168,59 @@ class WordSegmenterModel(override val uid: String)
     *   relationship
     */
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
+
+    if ($(enableRegexTokenizer)) {
+      return segmentWithRegexAnnotator(annotations)
+    }
+
     val sentences = SentenceSplit.unpack(annotations)
     val tokens = getTokenAnnotations(sentences)
     val tokenizedSentences = TokenizedWithSentence.unpack(annotations ++ tokens)
     val tagged = tag($$(model), tokenizedSentences.toArray)
     buildWordSegments(tagged)
+  }
+
+  private def segmentWithRegexAnnotator(annotatedSentences: Seq[Annotation]): Seq[Annotation] = {
+
+    val outputCol = Identifiable.randomUID("regex_token")
+
+    val regexTokenizer = new RegexTokenizer()
+      .setInputCols(getInputCols)
+      .setOutputCol(outputCol)
+      .setToLowercase($(toLowercase))
+      .setPattern($(pattern))
+
+    val annotatedTokens = regexTokenizer.annotate(annotatedSentences)
+
+    val segmentedResult = annotatedTokens.flatMap { annotatedToken =>
+      val codePoint = annotatedToken.result.codePointAt(0)
+      val unicodeScript = Character.UnicodeScript.of(codePoint)
+      if (unicodeScript == Character.UnicodeScript.LATIN) {
+        Seq(annotatedToken)
+      } else {
+        val sentenceIndex = annotatedToken.metadata("sentence")
+
+        val annotatedSentence = Annotation(
+          DOCUMENT,
+          annotatedToken.begin,
+          annotatedToken.end,
+          annotatedToken.result,
+          Map("sentence" -> sentenceIndex))
+        val sentence = Sentence(
+          annotatedToken.result,
+          annotatedToken.begin,
+          annotatedToken.end,
+          sentenceIndex.toInt)
+        val annotatedTokens = getTokenAnnotations(Seq(sentence))
+
+        val tokenizedSentences =
+          TokenizedWithSentence.unpack(annotatedTokens ++ Seq(annotatedSentence))
+        val tagged = tag($$(model), tokenizedSentences.toArray)
+        buildWordSegments(tagged)
+      }
+    }
+
+    segmentedResult
   }
 
   private def getTokenAnnotations(annotation: Seq[Sentence]): Seq[Annotation] = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ws/WordSegmenterModel.scala
@@ -124,7 +124,7 @@ class WordSegmenterModel(override val uid: String)
   val enableRegexTokenizer: BooleanParam = new BooleanParam(
     this,
     "enableRegexTokenizer",
-    "Whether to use RegexTokenizer before segmentation. Useful for multi-lingual text")
+    "Whether to use RegexTokenizer before segmentation. Useful for multilingual text")
 
   /** Indicates whether to convert all characters to lowercase before tokenizing (Default:
     * `false`).
@@ -148,6 +148,7 @@ class WordSegmenterModel(override val uid: String)
   /** @group setParam */
   def setModel(targetModel: AveragedPerceptron): this.type = set(model, targetModel)
 
+  /** @group setParam */
   def setEnableRegexTokenizer(value: Boolean): this.type = set(enableRegexTokenizer, value)
 
   /** @group setParam */

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/WordSegmenterTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/WordSegmenterTest.scala
@@ -19,23 +19,19 @@ package com.johnsnowlabs.nlp.annotators
 import com.johnsnowlabs.nlp.AnnotatorType.TOKEN
 import com.johnsnowlabs.nlp.annotators.ws.{WordSegmenterApproach, WordSegmenterModel}
 import com.johnsnowlabs.nlp.training.POS
-import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.nlp.{Annotation, AssertAnnotations, DocumentAssembler, SparkAccessor}
-import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.nlp.{Annotation, AssertAnnotations, SparkAccessor}
+import com.johnsnowlabs.tags.{FastTest, SlowTest}
 import com.johnsnowlabs.util.PipelineModels
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.DataFrame
 import org.scalatest.flatspec.AnyFlatSpec
+import org.apache.spark.sql.functions.{size, col}
 
 import java.nio.file.{Files, Paths}
 
-class WordSegmenterTest extends AnyFlatSpec {
+class WordSegmenterTest extends AnyFlatSpec with SparkSessionTest {
 
   import SparkAccessor.spark.implicits._
-
-  private val documentAssembler = new DocumentAssembler()
-    .setInputCol("text")
-    .setOutputCol("document")
 
   private val wordSegmenter = new WordSegmenterApproach()
     .setInputCols("document")
@@ -44,7 +40,7 @@ class WordSegmenterTest extends AnyFlatSpec {
     .setNIterations(5)
 
   private def getWordSegmenterDataSet(dataSetFile: String): DataFrame = {
-    val posDataSet = POS().readDataset(ResourceHelper.spark, dataSetFile)
+    val posDataSet = POS().readDataset(spark, dataSetFile)
     posDataSet
 
   }
@@ -58,7 +54,6 @@ class WordSegmenterTest extends AnyFlatSpec {
         Annotation(TOKEN, 0, 1, "十四", Map("sentence" -> "0")),
         Annotation(TOKEN, 2, 3, "不是", Map("sentence" -> "0")),
         Annotation(TOKEN, 4, 5, "四十", Map("sentence" -> "0"))))
-
     val pipeline = new Pipeline().setStages(Array(documentAssembler, wordSegmenter))
     val pipelineModel = pipeline.fit(trainingDataSet)
     val wsDataSet = pipelineModel.transform(testDataSet)
@@ -131,6 +126,25 @@ class WordSegmenterTest extends AnyFlatSpec {
 
     val actualResult = AssertAnnotations.getActualResult(wsDataSet, "token")
     AssertAnnotations.assertFields(expectedResult, actualResult)
+  }
+
+  it should "segment multilingual texts" taggedAs SlowTest in {
+    val text =
+      "oem loomma สำหรับฐานลำโพง apple homepod อุปกรณ์เครื่องเสียงยึดขาตั้งไม้แข็งตั้งพื้น speaker stands null. oem loomma สำหรับฐานลำโพง apple"
+    val testDataSet = Seq(text).toDS.toDF("text")
+    val wordSegmenter = WordSegmenterModel
+      .pretrained("wordseg_best", "th")
+      .setInputCols("sentence")
+      .setOutputCol("token")
+      .setEnableRegexTokenizer(true)
+    val pipeline =
+      new Pipeline().setStages(Array(documentAssembler, sentenceDetector, wordSegmenter))
+
+    val resultDataSet = pipeline.fit(testDataSet).transform(testDataSet)
+
+    val totalTokens =
+      resultDataSet.select(size(col("token.result"))).collect().map(_.getAs[Int](0))
+    assert(totalTokens.head > text.split(" ").length)
   }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding `enableRegexTokenizer` parameter in *WordSegmenter*. This parameter will allow *WordSegmenter* to tokenize (using *RegexTokenizer*) the text before applying word segmentation inference.
This change also adds the parameters `setToLowercase` and `setPattern`, allowing users to customize these RegexTokenizer parameters to tokenize the document.

After this change, the user will have two options when dealing with multilingual documents:
1. Set `enableRegexTokenizer` to true, such that WordSegmenter inference is applied only in non-Latin tokens.
2. Train a multilingual model using the format for training POS annotator, for example for this text: 
`สำหรับฐานลำโพง apple homepod`
the format will lool like:
`สำ|LL ห|MM รั|MM บ|RR ฐ|LL า|MM น|RR ลำ|LL โ|MM พ|MM ง|RR a|LL p|MM p|MM l|MM e|RR h|LL o|MM m|MM e|MM p|MM o|MM d|RR`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are some documents that have multilingual text, in those scenarios `WordSegmenter` runs also in Latin words, which transforms a word into a list of characters. Using `enableRegexTokenizer` word segmented won't segment Latin words.

Check issue #9891

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Local Tests
- Google Colab Notebook

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
