### PR TITLE
Improve Error Handling to fullAnnotateImage in LightPipeline

### DIFF
--- a/python/sparknlp/annotation.py
+++ b/python/sparknlp/annotation.py
@@ -81,7 +81,7 @@ class Annotation:
         same_result = self.result == other.result
         same_begin = self.begin == other.begin
         same_end = self.end == other.end
-        same_metadata = self.metadata == other.metadata
+        same_metadata = dict(self.metadata) == other.metadata
         same_embeddings = self.embeddings == other.embeddings
 
         same_annotation = \

--- a/python/sparknlp/base/light_pipeline.py
+++ b/python/sparknlp/base/light_pipeline.py
@@ -64,8 +64,7 @@ class LightPipeline:
         self.pipeline_model = pipelineModel
         self._lightPipeline = _internal._LightPipeline(pipelineModel, parse_embeddings).apply()
 
-    @staticmethod
-    def _annotation_from_java(java_annotations):
+    def _annotation_from_java(self, java_annotations):
         annotations = []
         for annotation in java_annotations:
 
@@ -73,6 +72,7 @@ class LightPipeline:
             annotation_type = annotation.toString()[:index]
 
             if annotation_type == "AnnotationImage":
+                result = self._get_result(annotation)
                 annotations.append(
                     AnnotationImage(annotation.annotatorType(),
                                     annotation.origin(),
@@ -80,8 +80,8 @@ class LightPipeline:
                                     annotation.width(),
                                     annotation.nChannels(),
                                     annotation.mode(),
-                                    list(annotation.result()),
-                                    dict(annotation.metadata()))
+                                    result,
+                                    annotation.metadata())
                 )
             else:
                 annotations.append(
@@ -89,10 +89,18 @@ class LightPipeline:
                                annotation.begin(),
                                annotation.end(),
                                annotation.result(),
-                               dict(annotation.metadata()),
+                               annotation.metadata(),
                                [])
                 )
         return annotations
+
+    def _get_result(self, annotation):
+        try:
+            result = list(annotation.result())
+        except TypeError:
+            result = []
+
+        return result
 
     def fullAnnotate(self, target, optional_target=""):
         """Annotates the data provided into `Annotation` type results.

--- a/python/test/annotator/cv/vit_for_image_classification_test.py
+++ b/python/test/annotator/cv/vit_for_image_classification_test.py
@@ -21,14 +21,12 @@ from sparknlp.base import *
 from test.util import SparkSessionForTest
 
 
-@pytest.mark.slow
-class ViTForImageClassificationTestSpec(unittest.TestCase):
+class ViTForImageClassificationTestSetUp(unittest.TestCase):
     def setUp(self):
-        images_path = os.getcwd() + "/../src/test/resources/image/"
+        self.images_path = os.getcwd() + "/../src/test/resources/image/"
         self.data = SparkSessionForTest.spark.read.format("image") \
-            .load(path=images_path)
+            .load(path=self.images_path)
 
-    def runTest(self):
         image_assembler = ImageAssembler() \
             .setInputCol("image") \
             .setOutputCol("image_assembler")
@@ -43,75 +41,51 @@ class ViTForImageClassificationTestSpec(unittest.TestCase):
             imageClassifier,
         ])
 
-        model = pipeline.fit(self.data)
-        result_df = model.transform(self.data)
-        assert result_df.select("class").count() > 0
+        self.model = pipeline.fit(self.data)
 
 
 @pytest.mark.slow
-class LightViTForImageClassificationOneImageTestSpec(unittest.TestCase):
-
+class ViTForImageClassificationTestSpec(ViTForImageClassificationTestSetUp, unittest.TestCase):
     def setUp(self):
-        self.images_path = os.getcwd() + "/../src/test/resources/image/"
-        self.data = SparkSessionForTest.spark.read.format("image") \
-            .load(path=self.images_path)
+        super().setUp()
 
     def runTest(self):
 
-        image_assembler = ImageAssembler() \
-            .setInputCol("image") \
-            .setOutputCol("image_assembler")
+        result_df = self.model.transform(self.data)
 
-        image_classifier = ViTForImageClassification \
-            .pretrained() \
-            .setInputCols("image_assembler") \
-            .setOutputCol("class")
-
-        pipeline = Pipeline(stages=[
-            image_assembler,
-            image_classifier,
-        ])
-
-        model = pipeline.fit(self.data)
-        light_pipeline = LightPipeline(model)
-        result = light_pipeline.fullAnnotateImage(self.images_path + "hippopotamus.JPEG")
-
-        image_assembler_result = result[0]["image_assembler"]
-        class_result = result[0]["class"]
-        assert len(image_assembler_result) > 0
-        assert len(class_result) > 0
+        self.assertTrue(result_df.select("class").count() > 0)
 
 
 @pytest.mark.slow
-class LightViTForImageClassificationTestSpec(unittest.TestCase):
+class LightViTForImageClassificationOneImageTestSpec(ViTForImageClassificationTestSetUp, unittest.TestCase):
 
     def setUp(self):
-        self.images_path = os.getcwd() + "/../src/test/resources/image/"
-        self.data = SparkSessionForTest.spark.read.format("image") \
-            .load(path=self.images_path)
+        super().setUp()
 
     def runTest(self):
+        light_pipeline = LightPipeline(self.model)
 
-        image_assembler = ImageAssembler() \
-            .setInputCol("image") \
-            .setOutputCol("image_assembler")
+        annotations_result = light_pipeline.fullAnnotateImage(self.images_path + "hippopotamus.JPEG")
 
-        image_classifier = ViTForImageClassification \
-            .pretrained() \
-            .setInputCols("image_assembler") \
-            .setOutputCol("class")
+        self.assertEqual(len(annotations_result), 1)
+        for result in annotations_result:
+            self.assertTrue(len(result["image_assembler"]) > 0)
+            self.assertTrue(len(result["class"]) > 0)
 
-        pipeline = Pipeline(stages=[
-            image_assembler,
-            image_classifier,
-        ])
 
-        model = pipeline.fit(self.data)
-        light_pipeline = LightPipeline(model)
+@pytest.mark.slow
+class LightViTForImageClassificationTestSpec(ViTForImageClassificationTestSetUp, unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+    def runTest(self):
+        light_pipeline = LightPipeline(self.model)
         images = [self.images_path + "hippopotamus.JPEG", self.images_path + "egyptian_cat.jpeg"]
+
         annotations_result = light_pipeline.fullAnnotateImage(images)
 
+        self.assertEqual(len(annotations_result), len(images))
         for result in annotations_result:
-            assert len(result["image_assembler"]) > 0
-            assert len(result["class"]) > 0
-
+            self.assertTrue(len(result["image_assembler"]) > 0)
+            self.assertTrue(len(result["class"]) > 0)

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowViTClassifier.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowViTClassifier.scala
@@ -41,7 +41,7 @@ class TensorflowViTClassifier(
   private def sessionWarmup(): Unit = {
     val image =
       ImageIOUtils.loadImage(getClass.getResourceAsStream("/image/ox.JPEG"))
-    val bytes = ImageIOUtils.bufferedImageToByte(image)
+    val bytes = ImageIOUtils.bufferedImageToByte(image.get)
     val preprocessor =
       Preprocessor(
         do_normalize = true,

--- a/src/main/scala/com/johnsnowlabs/nlp/ImageAssembler.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/ImageAssembler.scala
@@ -117,25 +117,27 @@ class ImageAssembler(override val uid: String)
   override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
 
   private[nlp] def assemble(
-      image: ImageFields,
+      image: Option[ImageFields],
       metadata: Map[String, String]): Seq[AnnotationImage] = {
 
-    Seq(
-      AnnotationImage(
-        annotatorType = outputAnnotatorType,
-        origin = image.origin,
-        height = image.height,
-        width = image.width,
-        nChannels = image.nChannels,
-        mode = image.mode,
-        result = image.data,
-        metadata = metadata))
+    if (image.isDefined) {
+      Seq(
+        AnnotationImage(
+          annotatorType = outputAnnotatorType,
+          origin = image.get.origin,
+          height = image.get.height,
+          width = image.get.width,
+          nChannels = image.get.nChannels,
+          mode = image.get.mode,
+          result = image.get.data,
+          metadata = metadata))
+    } else Seq.empty
 
   }
 
   private[nlp] def dfAssemble: UserDefinedFunction = udf { (image: ImageFields) =>
     // Apache Spark has only 1 image per row
-    assemble(image, Map("image" -> "0"))
+    assemble(Some(image), Map("image" -> "0"))
   }
 
   /** requirement for pipeline transformation validation. It is called on fit() */

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -575,7 +575,7 @@ object ResourceHelper {
     files.toList
   }
 
-  def getFileFromPath(pathToFile: String): Option[File] = {
+  def getFileFromPath(pathToFile: String): File = {
     val fileSystem = OutputHelper.getFileSystem
     val filePath = fileSystem.getScheme match {
       case "hdfs" => {
@@ -588,7 +588,7 @@ object ResourceHelper {
       case _ => new File(pathToFile)
     }
 
-    if (filePath.isFile) Some(filePath) else None
+    filePath
   }
 
   def validFile(path: String): Boolean = {

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -575,20 +575,20 @@ object ResourceHelper {
     files.toList
   }
 
-  def getFileFromPath(pathToFile: String): File = {
+  def getFileFromPath(pathToFile: String): Option[File] = {
     val fileSystem = OutputHelper.getFileSystem
     val filePath = fileSystem.getScheme match {
       case "hdfs" => {
         if (pathToFile.startsWith("file:")) {
-          Option(new File(pathToFile.replace("file:", "")))
-        } else Option(new File(pathToFile))
+          new File(pathToFile.replace("file:", ""))
+        } else new File(pathToFile)
       }
       case "dbfs" if pathToFile.startsWith("dbfs:") =>
-        Option(new File(pathToFile.replace("dbfs:", "/dbfs/")))
-      case _ => Option(new File(pathToFile))
+        new File(pathToFile.replace("dbfs:", "/dbfs/"))
+      case _ => new File(pathToFile)
     }
 
-    filePath.getOrElse(throw new FileNotFoundException(s"file: $pathToFile not found"))
+    if (filePath.isFile) Some(filePath) else None
   }
 
   def validFile(path: String): Boolean = {

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/cv/ViTImageClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/cv/ViTImageClassificationTestSpec.scala
@@ -186,7 +186,8 @@ class ViTImageClassificationTestSpec extends AnyFlatSpec {
     assert(prediction("image_assembler").isEmpty)
     assert(prediction("class").isEmpty)
 
-    val images = Array("src/test/resources/image/hen.JPEG", "src/test/resources/image/missing_file.mf")
+    val images =
+      Array("src/test/resources/image/hen.JPEG", "src/test/resources/image/missing_file.mf")
     val predictions = lightPipeline.fullAnnotateImage(images)
 
     assert(predictions(0)("image_assembler").nonEmpty)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/cv/ViTImageClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/cv/ViTImageClassificationTestSpec.scala
@@ -171,4 +171,28 @@ class ViTImageClassificationTestSpec extends AnyFlatSpec {
     assert(prediction("class").nonEmpty)
   }
 
+  "ViTForImageClassification with LightPipeline" should "return empty result when image path is wrong" in {
+
+    val imageClassifier: ViTForImageClassification = ViTForImageClassification
+      .pretrained()
+      .setInputCols("image_assembler")
+      .setOutputCol("class")
+    val pipeline: Pipeline = new Pipeline().setStages(Array(imageAssembler, imageClassifier))
+    val pipelineModel = pipeline.fit(imageDF)
+    val lightPipeline = new LightPipeline(pipelineModel)
+
+    val prediction = lightPipeline.fullAnnotateImage("./image")
+
+    assert(prediction("image_assembler").isEmpty)
+    assert(prediction("class").isEmpty)
+
+    val images = Array("src/test/resources/image/hen.JPEG", "src/test/resources/image/missing_file.mf")
+    val predictions = lightPipeline.fullAnnotateImage(images)
+
+    assert(predictions(0)("image_assembler").nonEmpty)
+    assert(predictions(0)("class").nonEmpty)
+    assert(predictions(1)("image_assembler").isEmpty)
+    assert(predictions(1)("class").isEmpty)
+  }
+
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/cv/feature_extractor/ImageUtilsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/cv/feature_extractor/ImageUtilsTestSpec.scala
@@ -42,7 +42,7 @@ class ImageUtilsTestSpec extends AnyFlatSpec {
     JsonParser.parseObject[Preprocessor](preprocessorConfigJsonContent)
 
   val imageBufferedImage: BufferedImage =
-    ImageIOUtils.loadImage("src/test/resources/image/egyptian_cat.jpeg")
+    ImageIOUtils.loadImage("src/test/resources/image/egyptian_cat.jpeg").get
   val isGray: Boolean =
     imageBufferedImage.getColorModel.getColorSpace.getType == ColorSpace.TYPE_GRAY
   val hasAlpha: Boolean = imageBufferedImage.getColorModel.hasAlpha


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change handles the errors that can rise when reading an image in the `fullAnnotateImage` method for `LightPipeline`.
When an error is raised, LightPipeline will output an empty Annotation to allow other images to process without any issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a user wants to run inference from a list of images, if one image is corrupted it will stop the process and throw an error. It’s best not to interrupt the whole process if there are some paths that cannot be loaded

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit Tests
- Local Tests
- Google Colab Notebook

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
