### PR TITLE
FIX: ContextSpellCheckerModel updateVocabClass Nullpointer

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerModel.scala
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory
 
 import java.util
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 /** Implements a deep-learning based Noisy Channel Model Spell Algorithm. Correction candidates
   * are extracted combining context information and word information.
@@ -382,6 +383,8 @@ class ContextSpellCheckerModel(override val uid: String)
 
     classes.filter(_.label.equals(label)).head match {
       case v: VocabParser =>
+        if (v.vocab.eq(null)) v.vocab = mutable.Set.empty[String]
+
         val newSet = if (append) v.vocab ++ vocab else vocab
         v.vocab = newSet
         v.transducer = v.generateTransducer

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala
@@ -488,4 +488,41 @@ class ContextSpellCheckerTestSpec extends AnyFlatSpec {
     assert(tmp.equals("( 08/10/1982 )"))
   }
 
+
+
+
+  "when using ContextSpellchecker" should "Adding Multiple values for updateVocabClass when append=true should not crash" taggedAs SlowTest in {
+
+    import SparkAccessor.spark
+    import spark.implicits._
+
+    val data =
+      Seq("We should take a trup to Supercalifragilisticexpialidoccious Land").toDF("text")
+    val meds: java.util.ArrayList[String] = new java.util.ArrayList[String]()
+    meds.add("Supercalifragilisticexpialidocious")
+    meds.add("Monika")
+    meds.add("Peter")
+
+    val documentAssembler =
+      new DocumentAssembler().setInputCol("text").setOutputCol("doc")
+
+    val tokenizer: Tokenizer = new Tokenizer()
+      .setInputCols(Array("doc"))
+      .setOutputCol("token")
+
+    val spellChecker = ContextSpellCheckerModel
+      .pretrained()
+      .updateVocabClass("_LOC_", meds, append = true)
+      .setInputCols("token")
+      .setOutputCol("checked")
+      .setUseNewLines(true)
+
+    val pipeline =
+      new Pipeline().setStages(Array(documentAssembler, tokenizer, spellChecker)).fit(data)
+    val result = pipeline.transform(data).show()
+
+  }
+
+
+
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
ContextSpellCheckerModel throws nullPointer exception when updateVocabClass with an array and `append=true`. 
For some reason the `vocab` attribute of the specialTransducers classes is not properly initialized.

## How Has This Been Tested?
Tested in Scala, added new test with re-produces the error in Spark-NLP 4.2.0 and added fix with a simple null check.

