### PR TITLE
WIP: Draft for universal loadSavedModel refactor

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasDlModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasDlModel.scala
@@ -1,0 +1,14 @@
+package com.johnsnowlabs.nlp.embeddings
+import com.johnsnowlabs.ml.tensorflow.TensorflowWrapper
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.SparkSession
+
+trait HasDlModel[AnnoClass, FrameworkModel] {
+  protected var _model: Option[Broadcast[FrameworkModel]] = None
+
+  def getModelIfNotSet: FrameworkModel = _model.get.value
+
+  // TODO: Might be able to put implementation here with pattern matching traits
+  def setModelIfNotSet(spark: SparkSession, tensorflow: TensorflowWrapper): AnnoClass
+
+}

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasLoadSavedModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasLoadSavedModel.scala
@@ -1,0 +1,60 @@
+package com.johnsnowlabs.nlp.embeddings
+import com.johnsnowlabs.ml.tensorflow.TensorflowWrapper
+import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
+import org.apache.spark.sql.SparkSession
+
+import java.io.File
+import scala.reflect._
+
+trait HasLoadSavedModel[AnnoClass <: HasDlModel[AnnoClass, FrameworkModel], FrameworkModel] {
+
+  /** Loads a saved model from either a local or remote directory.
+    *
+    * TODO: Remote, potential TF/PT flexibility
+    * @param folder
+    *   Path to folder of the model
+    * @param spark
+    *   Current Spark session
+    * @return
+    */
+  def loadSavedModel(folder: String, spark: SparkSession)(implicit
+      tag: ClassTag[AnnoClass]): AnnoClass = {
+    val f = new File(folder)
+    val savedModel = new File(folder, "saved_model.pb")
+
+    require(f.exists, s"Folder $folder not found")
+    require(f.isDirectory, s"File $folder is not folder")
+    require(savedModel.exists(), s"savedModel file saved_model.pb not found in folder $folder")
+
+    val (wrapper, signatures) =
+      TensorflowWrapper.read(folder, zipped = false, useBundle = true)
+
+    // Create new instance using the implicitly declared ClassTag to avoid type erasure
+    val annoRuntimeClass: Class[_] = tag.runtimeClass
+    val annoInstance: AnnoClass = annoRuntimeClass
+      .newInstance() // TODO: Some annos might have parameters?
+      .asInstanceOf[AnnoClass]
+
+    annoInstance match {
+      case a: AnnoClass with HasSignature with HasVocabulary =>
+        // Process Vocab
+        val vocab = new File(folder + "/assets", "vocab.txt")
+        require(vocab.exists(), s"Vocabulary file vocab.txt not found in folder $folder")
+
+        val vocabResource =
+          new ExternalResource(vocab.getAbsolutePath, ReadAs.TEXT, Map("format" -> "text"))
+        val words = ResourceHelper.parseLines(vocabResource).zipWithIndex.toMap
+
+        // Process Signature
+        val _signatures = signatures match {
+          case Some(s) => s
+          case None => throw new Exception("Cannot load signature definitions from model!")
+        }
+
+        a.setVocabulary(words).setSignatures(_signatures)
+      case _ => ??? // TODO: Other cases for other Annotator specific resources
+    }
+
+    annoInstance.setModelIfNotSet(spark, wrapper)
+  }
+}

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasSignature.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasSignature.scala
@@ -1,0 +1,24 @@
+package com.johnsnowlabs.nlp.embeddings
+
+import com.johnsnowlabs.nlp.HasFeatures
+import com.johnsnowlabs.nlp.serialization.MapFeature
+
+trait HasSignature {
+  this: HasFeatures =>
+
+  /** It contains TF model signatures for the laded saved model
+    *
+    * @group param
+    */
+  val signatures = new MapFeature[String, String](model = this, name = "signatures")
+
+  /** @group setParam */
+  def setSignatures(value: Map[String, String]): this.type = {
+    if (get(signatures).isEmpty)
+      set(signatures, value)
+    this
+  }
+
+  /** @group getParam */
+  def getSignatures: Option[Map[String, String]] = get(this.signatures)
+}

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasVocabulary.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/HasVocabulary.scala
@@ -1,0 +1,27 @@
+package com.johnsnowlabs.nlp.embeddings
+
+import com.johnsnowlabs.nlp.HasFeatures
+import com.johnsnowlabs.nlp.serialization.MapFeature
+
+trait HasVocabulary {
+  this: HasFeatures =>
+
+  /** @group setParam */
+  def sentenceStartTokenId: Int = {
+    $$(vocabulary)("[CLS]")
+  }
+
+  /** @group setParam */
+  def sentenceEndTokenId: Int = {
+    $$(vocabulary)("[SEP]")
+  }
+
+  /** Vocabulary used to encode the words to ids with WordPieceEncoder
+    *
+    * @group param
+    */
+  val vocabulary: MapFeature[String, Int] = new MapFeature(this, "vocabulary")
+
+  /** @group setParam */
+  def setVocabulary(value: Map[String, Int]): this.type = set(vocabulary, value)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# WIP
## Description
<!--- Describe your changes in detail -->
This PR aims to refactor `loadSavedModel` into a more universal function that enables to load more types of models from more different locations (including remote locations). 

@maziyarpanahi This is still a very early draft and you can review my current progress here to leave comments.

**TODO**:

- [ ] Refactor `loadSavedModel` from the current Annotators into a generalized trait
  - [ ]  dynamically deduce requirements (vocab, signatures, sentencepiece model etc.)
  - [ ] until Spark NLP 5.0: Model type (Tensorflow/PyTorch)
- [ ] Enable remote loading (S3, HDFS, DBFS)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users train models from all kinds of different setups, usually remote as well. With this change, it will be more convenient for users to load fine-tuned models from all kinds of different environments into Spark NLP, while bypassing a manual download and import.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test is passing for BertEmbeddings, implementations for other annotators are still needed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
