### PR TITLE
Fix Inconsistent Names Annotator Schema

### DIFF
--- a/python/sparknlp/annotation.py
+++ b/python/sparknlp/annotation.py
@@ -40,8 +40,8 @@ class Annotation:
         Embeddings vector where applicable
     """
 
-    def __init__(self, annotator_type, begin, end, result, metadata, embeddings):
-        self.annotator_type = annotator_type
+    def __init__(self, annotatorType, begin, end, result, metadata, embeddings):
+        self.annotatorType = annotatorType
         self.begin = begin
         self.end = end
         self.result = result
@@ -62,11 +62,11 @@ class Annotation:
         Annotation
             Newly created Annotation
         """
-        return Annotation(self.annotator_type, self.begin, self.end, result, self.metadata, self.embeddings)
+        return Annotation(self.annotatorType, self.begin, self.end, result, self.metadata, self.embeddings)
 
     def __str__(self):
         return "Annotation(%s, %i, %i, %s, %s)" % (
-            self.annotator_type,
+            self.annotatorType,
             self.begin,
             self.end,
             self.result,
@@ -77,7 +77,7 @@ class Annotation:
         return self.__str__()
 
     def __eq__(self, other):
-        same_annotator_type = self.annotator_type == other.annotator_type
+        same_annotator_type = self.annotatorType == other.annotatorType
         same_result = self.result == other.result
         same_begin = self.begin == other.begin
         same_end = self.end == other.end
@@ -165,5 +165,5 @@ class Annotation:
             The new Row.
         """
         from pyspark.sql import Row
-        return Row(annotation.annotator_type, annotation.begin, annotation.end, annotation.result, annotation.metadata,
+        return Row(annotation.annotatorType, annotation.begin, annotation.end, annotation.result, annotation.metadata,
                    annotation.embeddings)

--- a/python/sparknlp/annotation_audio.py
+++ b/python/sparknlp/annotation_audio.py
@@ -29,8 +29,8 @@ class AnnotationAudio:
         Associated metadata for this annotation
     """
 
-    def __init__(self, annotator_type, result, metadata):
-        self.annotator_type = annotator_type
+    def __init__(self, annotatorType, result, metadata):
+        self.annotatorType = annotatorType
         self.result = result
         self.metadata = metadata
 
@@ -48,11 +48,11 @@ class AnnotationAudio:
         AnnotationAudio
             Newly created AnnotationAudio
         """
-        return AnnotationAudio(self.annotator_type, result, self.metadata)
+        return AnnotationAudio(self.annotatorType, result, self.metadata)
 
     def __str__(self):
         return "AnnotationAudio(%s, %s, %s)" % (
-            self.annotator_type,
+            self.annotatorType,
             str(self.result),
             str(self.metadata)
         )

--- a/python/sparknlp/annotation_image.py
+++ b/python/sparknlp/annotation_image.py
@@ -39,8 +39,8 @@ class AnnotationImage:
         Associated metadata for this annotation
     """
 
-    def __init__(self, annotator_type, origin, height, width, nChannels, mode, result, metadata):
-        self.annotator_type = annotator_type
+    def __init__(self, annotatorType, origin, height, width, nChannels, mode, result, metadata):
+        self.annotatorType = annotatorType
         self.origin = origin
         self.height = height
         self.width = width
@@ -63,12 +63,12 @@ class AnnotationImage:
         AnnotationImage
             Newly created AnnotationImage
         """
-        return AnnotationImage(self.annotator_type, self.origin, self.height, self.width,
+        return AnnotationImage(self.annotatorType, self.origin, self.height, self.width,
                                self.nChannels, self.mode, result, self.metadata)
 
     def __str__(self):
         return "AnnotationImage(%s, %s, %i, %i, %i, %i, %s, %s)" % (
-            self.annotator_type,
+            self.annotatorType,
             self.origin,
             self.height,
             self.width,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Unifies annotatorType name in Python and Scala for spark schema in `Annotation`, `AnnotationImage` and `AnnotationAudio`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Check issue #12934

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Local Testing
- [Google Colab notebook](https://colab.research.google.com/drive/182DKGCdBEg19SZ6DbwE9c2dXyphCZvI6?usp=sharing)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
