### PR TITLE
SPARKNLP-561: Adjust return format of copyToLocal 

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/util/LoadExternalModel.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/util/LoadExternalModel.scala
@@ -74,7 +74,7 @@ object LoadExternalModel {
     *   URL to the local path of the folder
     */
   def modelSanityCheck(path: String): (String, String) = {
-    val localPath: String = ResourceHelper.copyToLocal(path).getPath
+    val localPath: String = ResourceHelper.copyToLocal(path)
 
     (localPath, detectEngine(localPath))
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -651,7 +651,7 @@ trait WithGraphResolver {
         files = localGraphPath
           .map(path =>
             ResourceHelper
-              .listLocalFiles(ResourceHelper.copyToLocal(path).getPath)
+              .listLocalFiles(ResourceHelper.copyToLocal(path))
               .map(_.getAbsolutePath))
           .getOrElse(ResourceHelper.listResourceDirectory("/ner-dl"))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerApproach.scala
@@ -754,7 +754,7 @@ class ContextSpellCheckerApproach(override val uid: String)
     val graphFiles = localGraphPath
       .map(path =>
         ResourceHelper
-          .listLocalFiles(ResourceHelper.copyToLocal(path).getPath)
+          .listLocalFiles(ResourceHelper.copyToLocal(path))
           .map(_.getAbsolutePath))
       .getOrElse(ResourceHelper.listResourceDirectory("/spell_nlm"))
 

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -188,8 +188,8 @@ object ResourceHelper {
     * @return
     *   Absolute path to the temporary or local folder of the resource
     */
-  def copyToLocal(path: String): URI = try {
-    if (path.startsWith("s3:/") || path.startsWith("s3a:/")) { // Download directly from S3
+  def copyToLocal(path: String): String = try {
+    val localUri = if (path.startsWith("s3:/") || path.startsWith("s3a:/")) { // Download directly from S3
       ResourceDownloader.downloadS3Directory(path)
     } else { // Use Source Stream
       val pathWithProtocol: String =
@@ -197,6 +197,8 @@ object ResourceHelper {
       val resource = SourceStream(pathWithProtocol)
       resource.copyToLocal()
     }
+
+    new File(localUri).getAbsolutePath // Platform independent path
   } catch {
     case awsE: AmazonServiceException =>
       println("Error while retrieving folder from S3. Make sure you have set the right " +

--- a/src/test/scala/com/johnsnowlabs/util/ResourceHelperTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/util/ResourceHelperTestSpec.scala
@@ -22,7 +22,6 @@ import com.johnsnowlabs.tags.{FastTest, SlowTest}
 import org.scalatest.flatspec.AnyFlatSpec
 
 import java.io.{File, FileNotFoundException}
-import java.net.URI
 import java.nio.file.Paths
 
 class ResourceHelperTestSpec extends AnyFlatSpec {
@@ -172,7 +171,7 @@ class ResourceHelperTestSpec extends AnyFlatSpec {
 
   it should "not copyToLocal a local file" taggedAs FastTest in {
     val resourcePath = "src/test/resources/tf-hub-bert/model"
-    val resourceUri = new File("src/test/resources/tf-hub-bert/model").toURI
+    val resourceUri = new File("src/test/resources/tf-hub-bert/model").getAbsolutePath
 
     val tmpFolder = ResourceHelper.copyToLocal(resourcePath)
 
@@ -186,7 +185,7 @@ class ResourceHelperTestSpec extends AnyFlatSpec {
     val hdfsFolderPath = "hdfs://localhost:9000/sparknlp/tf-hub-bert/model"
     val resourcePath = "src/test/resources/tf-hub-bert/model"
     val resourceFolderContent: Array[String] = new File(resourcePath).listFiles().map(_.getName)
-    val tmpFolder: URI = ResourceHelper.copyToLocal(hdfsFolderPath)
+    val tmpFolder = ResourceHelper.copyToLocal(hdfsFolderPath)
 
     val localPath = new File(tmpFolder)
 
@@ -199,7 +198,7 @@ class ResourceHelperTestSpec extends AnyFlatSpec {
     // Single File
     val hdfsFilePath = "hdfs://localhost:9000/sparknlp/tf-hub-bert/model/assets/vocab.txt"
 
-    val tmpFolderFile: String = ResourceHelper.copyToLocal(hdfsFilePath).getPath
+    val tmpFolderFile: String = ResourceHelper.copyToLocal(hdfsFilePath)
     assert(Paths.get(tmpFolderFile, "vocab.txt").toFile.exists(), "Copied file doesn't exist.")
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR changes how the link to the local resource of copyToLocal is returned to enable cross platform compatibility.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on all platforms and tests passing.
