### PR TITLE
Adding Control for Annotators with One Column

### DIFF
--- a/python/sparknlp/annotator/audio/wav2vec2_for_ctc.py
+++ b/python/sparknlp/annotator/audio/wav2vec2_for_ctc.py
@@ -15,6 +15,7 @@
 """Contains classes concerning Wav2Vec2ForCTC."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Wav2Vec2ForCTC(AnnotatorModel,
@@ -85,6 +86,8 @@ class Wav2Vec2ForCTC(AnnotatorModel,
     +------------------------------------------------------------------------------------------+
     """
     name = "Wav2Vec2ForCTC"
+
+    inputAnnotatorTypes = [AnnotatorType.AUDIO]
 
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",

--- a/python/sparknlp/annotator/chunker.py
+++ b/python/sparknlp/annotator/chunker.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 """Contains classes for the Chunker."""
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Chunker(AnnotatorModel):
@@ -100,6 +101,7 @@ class Chunker(AnnotatorModel):
     --------
     PerceptronModel : for Part-Of-Speech tagging
     """
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.POS]
 
     regexParsers = Param(Params._dummy(),
                          "regexParsers",

--- a/python/sparknlp/annotator/classifier_dl/albert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/albert_for_question_answering.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class AlbertForQuestionAnswering(AnnotatorModel,
@@ -86,6 +87,8 @@ class AlbertForQuestionAnswering(AnnotatorModel,
     +--------------------+
     """
     name = "AlbertForQuestionAnswering"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.DOCUMENT]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/albert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/albert_for_sequence_classification.py
@@ -14,6 +14,7 @@
 """Contains classes concerning AlbertForSequenceClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class AlbertForSequenceClassification(AnnotatorModel,
@@ -100,6 +101,8 @@ class AlbertForSequenceClassification(AnnotatorModel,
     +--------------------+
     """
     name = "AlbertForSequenceClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/albert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/albert_for_token_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for AlbertForTokenClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class AlbertForTokenClassification(AnnotatorModel,
@@ -95,6 +96,8 @@ class AlbertForTokenClassification(AnnotatorModel,
     """
 
     name = "AlbertForTokenClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/bert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_question_answering.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertForQuestionAnswering(AnnotatorModel,
@@ -86,6 +87,8 @@ class BertForQuestionAnswering(AnnotatorModel,
     +--------------------+
     """
     name = "BertForQuestionAnswering"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.DOCUMENT]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/bert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_sequence_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for BertForSequenceClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertForSequenceClassification(AnnotatorModel,
@@ -100,6 +101,8 @@ class BertForSequenceClassification(AnnotatorModel,
     +--------------------+
     """
     name = "BertForSequenceClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/bert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_token_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for BertForTokenClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertForTokenClassification(AnnotatorModel,
@@ -93,6 +94,8 @@ class BertForTokenClassification(AnnotatorModel,
     +------------------------------------------------------------------------------------+
     """
     name = "BertForTokenClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/camembert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/camembert_for_token_classification.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Contains classes for CamemBertForTokenClassification."""
-
+from build.lib.sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.common import *
 
 
@@ -90,6 +90,8 @@ class CamemBertForTokenClassification(AnnotatorModel,
     +------------------------------+
     """
     name = "CamemBertForTokenClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/camembert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/camembert_for_token_classification.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Contains classes for CamemBertForTokenClassification."""
-from build.lib.sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.common import *
 
 

--- a/python/sparknlp/annotator/classifier_dl/classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/classifier_dl.py
@@ -16,6 +16,7 @@
 from sparknlp.annotator.param import EvaluationDLParams, ClassifierEncoder
 from sparknlp.base import DocumentAssembler
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEncoder):
@@ -114,6 +115,7 @@ class ClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEnco
     MultiClassifierDLApproach : for multi-class classification
     SentimentDLApproach : for sentiment analysis
     """
+    inputAnnotatorTypes = [AnnotatorType.SENTENCE_EMBEDDINGS]
 
     dropout = Param(Params._dummy(), "dropout", "Dropout coefficient", TypeConverters.toFloat)
 
@@ -234,6 +236,8 @@ class ClassifierDLModel(AnnotatorModel, HasStorageRef, HasEngine):
     """
 
     name = "ClassifierDLModel"
+
+    inputAnnotatorTypes = [AnnotatorType.SENTENCE_EMBEDDINGS]
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.ClassifierDLModel", java_model=None):
         super(ClassifierDLModel, self).__init__(

--- a/python/sparknlp/annotator/classifier_dl/deberta_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/deberta_for_question_answering.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DeBertaForQuestionAnswering(AnnotatorModel,
@@ -86,6 +87,8 @@ class DeBertaForQuestionAnswering(AnnotatorModel,
     +--------------------+
     """
     name = "DeBertaForQuestionAnswering"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.DOCUMENT]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/deberta_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/deberta_for_sequence_classification.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Contains classes for DeBertaForSequenceClassification."""
-
+from build.lib.sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.common import *
 
 
@@ -97,6 +97,8 @@ class DeBertaForSequenceClassification(AnnotatorModel,
     +--------------------+
     """
     name = "DeBertaForSequenceClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/deberta_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/deberta_for_sequence_classification.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Contains classes for DeBertaForSequenceClassification."""
-from build.lib.sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.common import *
 
 

--- a/python/sparknlp/annotator/classifier_dl/deberta_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/deberta_for_token_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for DeBertaForTokenClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DeBertaForTokenClassification(AnnotatorModel,
@@ -93,6 +94,8 @@ class DeBertaForTokenClassification(AnnotatorModel,
     +------------------------------------------------------------------------------------+
     """
     name = "DeBertaForTokenClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_question_answering.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DistilBertForQuestionAnswering(AnnotatorModel,
@@ -86,6 +87,8 @@ class DistilBertForQuestionAnswering(AnnotatorModel,
     +--------------------+
     """
     name = "DistilBertForQuestionAnswering"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.DOCUMENT]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_sequence_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for DistilBertForSequenceClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DistilBertForSequenceClassification(AnnotatorModel,
@@ -100,6 +101,8 @@ class DistilBertForSequenceClassification(AnnotatorModel,
     +--------------------+
     """
     name = "DistilBertForSequenceClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_token_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for DistilBertForTokenClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DistilBertForTokenClassification(AnnotatorModel,
@@ -91,6 +92,8 @@ class DistilBertForTokenClassification(AnnotatorModel,
     +------------------------------------------------------------------------------------+
     """
     name = "DistilBertForTokenClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/longformer_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/longformer_for_question_answering.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LongformerForQuestionAnswering(AnnotatorModel,
@@ -86,6 +87,8 @@ class LongformerForQuestionAnswering(AnnotatorModel,
     +--------------------+
     """
     name = "LongformerForQuestionAnswering"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.DOCUMENT]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/longformer_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/longformer_for_sequence_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for LongformerForSequenceClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LongformerForSequenceClassification(AnnotatorModel,
@@ -100,6 +101,8 @@ class LongformerForSequenceClassification(AnnotatorModel,
     +--------------------+
     """
     name = "LongformerForSequenceClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/longformer_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/longformer_for_token_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for LongformerForTokenClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LongformerForTokenClassification(AnnotatorModel,
@@ -92,6 +93,8 @@ class LongformerForTokenClassification(AnnotatorModel,
     """
 
     name = "LongformerForTokenClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
@@ -16,6 +16,7 @@
 from sparknlp.annotator.param import EvaluationDLParams, ClassifierEncoder
 from sparknlp.annotator.classifier_dl import ClassifierDLModel
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class MultiClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEncoder):
@@ -143,6 +144,7 @@ class MultiClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, Classifie
     ClassifierDLApproach : for single-class classification
     SentimentDLApproach : for sentiment analysis
     """
+    inputAnnotatorTypes = [AnnotatorType.SENTENCE_EMBEDDINGS]
 
     shufflePerEpoch = Param(Params._dummy(), "shufflePerEpoch", "whether to shuffle the training data on each Epoch",
                             TypeConverters.toBoolean)
@@ -289,6 +291,8 @@ class MultiClassifierDLModel(AnnotatorModel, HasStorageRef, HasEngine):
     SentimentDLModel : for sentiment analysis
     """
     name = "MultiClassifierDLModel"
+
+    inputAnnotatorTypes = [AnnotatorType.SENTENCE_EMBEDDINGS]
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.MultiClassifierDLModel",
                  java_model=None):

--- a/python/sparknlp/annotator/classifier_dl/roberta_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/roberta_for_question_answering.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaForQuestionAnswering(AnnotatorModel,
@@ -86,6 +87,8 @@ class RoBertaForQuestionAnswering(AnnotatorModel,
     +--------------------+
     """
     name = "RoBertaForQuestionAnswering"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.DOCUMENT]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/roberta_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/roberta_for_sequence_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for RoBertaForSequenceClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaForSequenceClassification(AnnotatorModel,
@@ -100,6 +101,8 @@ class RoBertaForSequenceClassification(AnnotatorModel,
     +--------------------+
     """
     name = "RoBertaForSequenceClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/roberta_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/roberta_for_token_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for RoBertaForTokenClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaForTokenClassification(AnnotatorModel,
@@ -91,6 +92,8 @@ class RoBertaForTokenClassification(AnnotatorModel,
     +------------------------------------------------------------------------------------+
     """
     name = "RoBertaForTokenClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/sentiment_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/sentiment_dl.py
@@ -15,6 +15,7 @@
 
 from sparknlp.annotator.param import EvaluationDLParams, ClassifierEncoder
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentimentDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEncoder):
@@ -113,6 +114,8 @@ class SentimentDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEncod
     ... ])
     >>> pipelineModel = pipeline.fit(smallCorpus)
     """
+
+    inputAnnotatorTypes = [AnnotatorType.SENTENCE_EMBEDDINGS]
 
     dropout = Param(Params._dummy(), "dropout", "Dropout coefficient", TypeConverters.toFloat)
 
@@ -257,6 +260,8 @@ class SentimentDLModel(AnnotatorModel, HasStorageRef, HasEngine):
     +------------------------------+----------+
     """
     name = "SentimentDLModel"
+
+    inputAnnotatorTypes = [AnnotatorType.SENTENCE_EMBEDDINGS]
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.SentimentDLModel", java_model=None):
         super(SentimentDLModel, self).__init__(

--- a/python/sparknlp/annotator/classifier_dl/tapas_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/tapas_for_question_answering.py
@@ -14,6 +14,7 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.classifier_dl import BertForQuestionAnswering
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class TapasForQuestionAnswering(BertForQuestionAnswering):
@@ -110,6 +111,8 @@ class TapasForQuestionAnswering(BertForQuestionAnswering):
     """
 
     name = "TapasForQuestionAnswering"
+
+    inputAnnotatorTypes = [AnnotatorType.TABLE, AnnotatorType.DOCUMENT]
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.TapasForQuestionAnswering",

--- a/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_question_answering.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaForQuestionAnswering(AnnotatorModel,
@@ -86,6 +87,8 @@ class XlmRoBertaForQuestionAnswering(AnnotatorModel,
     +--------------------+
     """
     name = "XlmRoBertaForQuestionAnswering"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.DOCUMENT]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_sequence_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for XlmRoBertaForSequenceClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaForSequenceClassification(AnnotatorModel,
@@ -100,6 +101,8 @@ class XlmRoBertaForSequenceClassification(AnnotatorModel,
     +--------------------+
     """
     name = "XlmRoBertaForSequenceClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_token_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for XlmRoBertaForTokenClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaForTokenClassification(AnnotatorModel,
@@ -89,6 +90,8 @@ class XlmRoBertaForTokenClassification(AnnotatorModel,
     +------------------------------------------------------------------------------------+
     """
     name = "XlmRoBertaForTokenClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/xlnet_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlnet_for_sequence_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for XlnetForSequenceClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlnetForSequenceClassification(AnnotatorModel,
@@ -100,6 +101,8 @@ class XlnetForSequenceClassification(AnnotatorModel,
     +--------------------+
     """
     name = "XlnetForSequenceClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/classifier_dl/xlnet_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlnet_for_token_classification.py
@@ -14,6 +14,7 @@
 """Contains classes for XlnetForTokenClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlnetForTokenClassification(AnnotatorModel,
@@ -92,6 +93,8 @@ class XlnetForTokenClassification(AnnotatorModel,
     """
 
     name = "XlnetForTokenClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/coref/spanbert_coref.py
+++ b/python/sparknlp/annotator/coref/spanbert_coref.py
@@ -14,6 +14,7 @@
 """Contains classes for the SpanBertCorefModel."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SpanBertCorefModel(AnnotatorModel,
@@ -109,6 +110,8 @@ class SpanBertCorefModel(AnnotatorModel,
     """
 
     name = "SpanBertCorefModel"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/cv/vit_for_image_classification.py
+++ b/python/sparknlp/annotator/cv/vit_for_image_classification.py
@@ -15,6 +15,7 @@
 """Contains classes concerning ViTForImageClassification."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ViTForImageClassification(AnnotatorModel,
@@ -103,6 +104,8 @@ class ViTForImageClassification(AnnotatorModel,
 
     """
     name = "ViTForImageClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.IMAGE]
 
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",

--- a/python/sparknlp/annotator/dependency/dependency_parser.py
+++ b/python/sparknlp/annotator/dependency/dependency_parser.py
@@ -14,6 +14,7 @@
 """Contains classes for the DependencyParser."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DependencyParserApproach(AnnotatorApproach):
@@ -94,6 +95,9 @@ class DependencyParserApproach(AnnotatorApproach):
     --------
     TypedDependencyParserApproach : to extract labels for the dependencies
     """
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.POS, AnnotatorType.TOKEN]
+
     dependencyTreeBank = Param(Params._dummy(),
                                "dependencyTreeBank",
                                "Dependency treebank source files",
@@ -158,6 +162,7 @@ class DependencyParserApproach(AnnotatorApproach):
 
     def _create_model(self, java_model):
         return DependencyParserModel(java_model=java_model)
+
 
 class DependencyParserModel(AnnotatorModel):
     """Unlabeled parser that finds a grammatical relation between two words in a
@@ -249,6 +254,8 @@ class DependencyParserModel(AnnotatorModel):
     TypedDependencyParserMdoel : to extract labels for the dependencies
     """
     name = "DependencyParserModel"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.POS, AnnotatorType.TOKEN]
 
     perceptron = Param(Params._dummy(),
                        "perceptron",

--- a/python/sparknlp/annotator/dependency/typed_dependency_parser.py
+++ b/python/sparknlp/annotator/dependency/typed_dependency_parser.py
@@ -15,6 +15,7 @@
 
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class TypedDependencyParserApproach(AnnotatorApproach):
@@ -98,6 +99,9 @@ class TypedDependencyParserApproach(AnnotatorApproach):
     >>> emptyDataSet = spark.createDataFrame([[""]]).toDF("text")
     >>> pipelineModel = pipeline.fit(emptyDataSet)
     """
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.POS, AnnotatorType.DEPENDENCY]
+
     conll2009 = Param(Params._dummy(),
                       "conll2009",
                       "Path to file with CoNLL 2009 format",
@@ -165,6 +169,7 @@ class TypedDependencyParserApproach(AnnotatorApproach):
 
     def _create_model(self, java_model):
         return TypedDependencyParserModel(java_model=java_model)
+
 
 class TypedDependencyParserModel(AnnotatorModel):
     """Labeled parser that finds a grammatical relation between two words in a
@@ -257,6 +262,8 @@ class TypedDependencyParserModel(AnnotatorModel):
     """
 
     name = "TypedDependencyParserModel"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.POS, AnnotatorType.DEPENDENCY]
 
     trainOptions = Param(Params._dummy(),
                          "trainOptions",

--- a/python/sparknlp/annotator/document_normalizer.py
+++ b/python/sparknlp/annotator/document_normalizer.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 """Contains classes for the DocumentNormalizer"""
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DocumentNormalizer(AnnotatorModel):
@@ -87,6 +88,7 @@ class DocumentNormalizer(AnnotatorModel):
     |[ the world's largest web developer site the world's largest web developer site lorem ipsum is simply dummy text of the printing and typesetting industry. lorem ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. it has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. it was popularised in the 1960s with the release of letraset sheets containing lorem ipsum passages, and more recently with desktop publishing software like aldus pagemaker including versions of lorem ipsum..]|
     +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
     """
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     action = Param(Params._dummy(),
                    "action",

--- a/python/sparknlp/annotator/embeddings/albert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/albert_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes concerning AlbertEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class AlbertEmbeddings(AnnotatorModel,
@@ -153,6 +154,8 @@ class AlbertEmbeddings(AnnotatorModel,
     """
 
     name = "AlbertEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",

--- a/python/sparknlp/annotator/embeddings/bert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bert_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for BertEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertEmbeddings(AnnotatorModel,
@@ -129,6 +130,8 @@ class BertEmbeddings(AnnotatorModel,
     """
 
     name = "BertEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/embeddings/bert_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bert_sentence_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for BertSentenceEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertSentenceEmbeddings(AnnotatorModel,
@@ -128,6 +129,8 @@ class BertSentenceEmbeddings(AnnotatorModel,
     """
 
     name = "BertSentenceEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/embeddings/camembert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/camembert_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for CamemBertEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class CamemBertEmbeddings(AnnotatorModel,
@@ -131,6 +132,8 @@ class CamemBertEmbeddings(AnnotatorModel,
         """
 
     name = "CamemBertEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     configProtoBytes = Param(
         Params._dummy(),

--- a/python/sparknlp/annotator/embeddings/chunk_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/chunk_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for ChunkEmbeddings"""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ChunkEmbeddings(AnnotatorModel):
@@ -97,6 +98,8 @@ class ChunkEmbeddings(AnnotatorModel):
     """
 
     name = "ChunkEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.CHUNK, AnnotatorType.WORD_EMBEDDINGS]
 
     @keyword_only
     def __init__(self):

--- a/python/sparknlp/annotator/embeddings/deberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/deberta_embeddings.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Contains classes for DeBertaEmbeddings."""
-from build.lib.sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.common import *
 
 

--- a/python/sparknlp/annotator/embeddings/deberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/deberta_embeddings.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Contains classes for DeBertaEmbeddings."""
-
+from build.lib.sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.common import *
 
 
@@ -132,6 +132,8 @@ class DeBertaEmbeddings(AnnotatorModel,
     """
 
     name = "DeBertaEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",

--- a/python/sparknlp/annotator/embeddings/distil_bert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/distil_bert_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for DistilBertEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DistilBertEmbeddings(AnnotatorModel,
@@ -144,6 +145,8 @@ class DistilBertEmbeddings(AnnotatorModel,
     """
 
     name = "DistilBertEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/embeddings/doc2vec.py
+++ b/python/sparknlp/annotator/embeddings/doc2vec.py
@@ -14,6 +14,7 @@
 """Contains classes for Doc2Vec."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Doc2VecApproach(AnnotatorApproach, HasStorageRef, HasEnableCachingProperties):
@@ -99,6 +100,7 @@ class Doc2VecApproach(AnnotatorApproach, HasStorageRef, HasEnableCachingProperti
     >>> dataset = spark.read.text(path).toDF("text")
     >>> pipelineModel = pipeline.fit(dataset)
     """
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     vectorSize = Param(Params._dummy(),
                        "vectorSize",
@@ -212,6 +214,7 @@ class Doc2VecApproach(AnnotatorApproach, HasStorageRef, HasEnableCachingProperti
     def _create_model(self, java_model):
         return Doc2VecModel(java_model=java_model)
 
+
 class Doc2VecModel(AnnotatorModel, HasStorageRef, HasEmbeddingsProperties):
     """Word2Vec model that creates vector representations of words in a text
     corpus.
@@ -293,6 +296,8 @@ class Doc2VecModel(AnnotatorModel, HasStorageRef, HasEmbeddingsProperties):
     +--------------------------------------------------------------------------------+
     """
     name = "Doc2VecModel"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     vectorSize = Param(Params._dummy(),
                        "vectorSize",

--- a/python/sparknlp/annotator/embeddings/elmo_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/elmo_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for ElmoEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ElmoEmbeddings(AnnotatorModel,
@@ -138,6 +139,8 @@ class ElmoEmbeddings(AnnotatorModel,
     """
 
     name = "ElmoEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     batchSize = Param(Params._dummy(),
                       "batchSize",

--- a/python/sparknlp/annotator/embeddings/longformer_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/longformer_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for LongformerEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LongformerEmbeddings(AnnotatorModel,
@@ -134,6 +135,8 @@ class LongformerEmbeddings(AnnotatorModel,
     +--------------------------------------------------------------------------------+
     """
     name = "LongformerEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/embeddings/roberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/roberta_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for RoBertaEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaEmbeddings(AnnotatorModel,
@@ -146,6 +147,8 @@ class RoBertaEmbeddings(AnnotatorModel,
     """
 
     name = "RoBertaEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/embeddings/roberta_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/roberta_sentence_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for RoBertaSentenceEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaSentenceEmbeddings(AnnotatorModel,
@@ -114,6 +115,8 @@ class RoBertaSentenceEmbeddings(AnnotatorModel,
     """
 
     name = "RoBertaSentenceEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/embeddings/sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/sentence_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for SentenceEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentenceEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasStorageRef):
@@ -93,6 +94,8 @@ class SentenceEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasStorageRef)
     """
 
     name = "SentenceEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.WORD_EMBEDDINGS]
 
     @keyword_only
     def __init__(self):

--- a/python/sparknlp/annotator/embeddings/universal_sentence_encoder.py
+++ b/python/sparknlp/annotator/embeddings/universal_sentence_encoder.py
@@ -14,6 +14,7 @@
 """Contains classes for the UniversalSentenceEncoder."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class UniversalSentenceEncoder(AnnotatorModel,
@@ -119,6 +120,8 @@ class UniversalSentenceEncoder(AnnotatorModel,
     """
 
     name = "UniversalSentenceEncoder"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     loadSP = Param(Params._dummy(), "loadSP",
                    "Whether to load SentencePiece ops file which is required only by multi-lingual models. "

--- a/python/sparknlp/annotator/embeddings/word2vec.py
+++ b/python/sparknlp/annotator/embeddings/word2vec.py
@@ -15,6 +15,7 @@
 
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Word2VecApproach(AnnotatorApproach, HasStorageRef, HasEnableCachingProperties):
@@ -100,6 +101,7 @@ class Word2VecApproach(AnnotatorApproach, HasStorageRef, HasEnableCachingPropert
     >>> dataset = spark.read.text(path).toDF("text")
     >>> pipelineModel = pipeline.fit(dataset)
     """
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     vectorSize = Param(Params._dummy(),
                        "vectorSize",
@@ -213,6 +215,7 @@ class Word2VecApproach(AnnotatorApproach, HasStorageRef, HasEnableCachingPropert
     def _create_model(self, java_model):
         return Word2VecModel(java_model=java_model)
 
+
 class Word2VecModel(AnnotatorModel, HasStorageRef, HasEmbeddingsProperties):
     """Word2Vec model that creates vector representations of words in a text
     corpus.
@@ -294,6 +297,8 @@ class Word2VecModel(AnnotatorModel, HasStorageRef, HasEmbeddingsProperties):
     +--------------------------------------------------------------------------------+
     """
     name = "Word2VecModel"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     vectorSize = Param(Params._dummy(),
                        "vectorSize",

--- a/python/sparknlp/annotator/embeddings/word_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/word_embeddings.py
@@ -15,6 +15,7 @@
 
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class WordEmbeddings(AnnotatorApproach, HasEmbeddingsProperties, HasStorage):
@@ -113,6 +114,8 @@ class WordEmbeddings(AnnotatorApproach, HasEmbeddingsProperties, HasStorage):
     """
 
     name = "WordEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     writeBufferSize = Param(Params._dummy(),
                             "writeBufferSize",
@@ -249,7 +252,10 @@ class WordEmbeddingsModel(AnnotatorModel, HasEmbeddingsProperties, HasStorageMod
     """
 
     name = "WordEmbeddingsModel"
+
     databases = ['EMBEDDINGS']
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     readCacheSize = Param(Params._dummy(),
                           "readCacheSize",

--- a/python/sparknlp/annotator/embeddings/xlm_roberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlm_roberta_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for XlmRoBertaEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaEmbeddings(AnnotatorModel,
@@ -146,6 +147,8 @@ class XlmRoBertaEmbeddings(AnnotatorModel,
     """
 
     name = "XlmRoBertaEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/embeddings/xlm_roberta_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlm_roberta_sentence_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for XlmRoBertaSentenceEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaSentenceEmbeddings(AnnotatorModel,
@@ -117,6 +118,8 @@ class XlmRoBertaSentenceEmbeddings(AnnotatorModel,
     """
 
     name = "XlmRoBertaSentenceEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     maxSentenceLength = Param(Params._dummy(),
                               "maxSentenceLength",

--- a/python/sparknlp/annotator/embeddings/xlnet_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlnet_embeddings.py
@@ -14,6 +14,7 @@
 """Contains classes for XlnetEmbeddings."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlnetEmbeddings(AnnotatorModel,
@@ -150,6 +151,8 @@ class XlnetEmbeddings(AnnotatorModel,
     """
 
     name = "XlnetEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",

--- a/python/sparknlp/annotator/er/entity_ruler.py
+++ b/python/sparknlp/annotator/er/entity_ruler.py
@@ -128,6 +128,8 @@ class EntityRulerApproach(AnnotatorApproach, HasStorage):
 
     inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
+    optionalInputAnnotatorTypes = [AnnotatorType.TOKEN]
+
     patternsResource = Param(Params._dummy(),
                              "patternsResource",
                              "Resource in JSON or CSV format to map entities to patterns",

--- a/python/sparknlp/annotator/er/entity_ruler.py
+++ b/python/sparknlp/annotator/er/entity_ruler.py
@@ -14,6 +14,7 @@
 """Contains classes for the EntityRuler."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class EntityRulerApproach(AnnotatorApproach, HasStorage):
@@ -125,6 +126,8 @@ class EntityRulerApproach(AnnotatorApproach, HasStorage):
     """
     name = "EntityRulerApproach"
 
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
+
     patternsResource = Param(Params._dummy(),
                              "patternsResource",
                              "Resource in JSON or CSV format to map entities to patterns",
@@ -225,6 +228,8 @@ class EntityRulerModel(AnnotatorModel, HasStorageModel):
     """
     name = "EntityRulerModel"
     database = ['ENTITY_PATTERNS']
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
+    optionalInputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.er.EntityRulerModel", java_model=None):
         super(EntityRulerModel, self).__init__(

--- a/python/sparknlp/annotator/graph_extraction.py
+++ b/python/sparknlp/annotator/graph_extraction.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 """Contains classes for GraphExtraction."""
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class GraphExtraction(AnnotatorModel):
@@ -141,6 +142,10 @@ class GraphExtraction(AnnotatorModel):
     GraphFinisher : to output the paths in a more generic format, like RDF
     """
     name = "GraphExtraction"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN, AnnotatorType.NAMED_ENTITY]
+
+    optionalInputAnnotatorTypes = [AnnotatorType.DEPENDENCY, AnnotatorType.LABELED_DEPENDENCY]
 
     relationshipTypes = Param(Params._dummy(),
                               "relationshipTypes",

--- a/python/sparknlp/annotator/keyword_extraction/yake_keyword_extraction.py
+++ b/python/sparknlp/annotator/keyword_extraction/yake_keyword_extraction.py
@@ -15,6 +15,7 @@
 
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class YakeKeywordExtraction(AnnotatorModel):
@@ -151,6 +152,8 @@ class YakeKeywordExtraction(AnnotatorModel):
     +---------------------+-------------------+
     """
     name = "YakeKeywordExtraction"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     @keyword_only
     def __init__(self):

--- a/python/sparknlp/annotator/ld_dl/language_detector_dl.py
+++ b/python/sparknlp/annotator/ld_dl/language_detector_dl.py
@@ -14,6 +14,7 @@
 """Contains classes for LanguageDetectorDL."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LanguageDetectorDL(AnnotatorModel, HasStorageRef, HasEngine):
@@ -96,6 +97,8 @@ class LanguageDetectorDL(AnnotatorModel, HasStorageRef, HasEngine):
     +------+
     """
     name = "LanguageDetectorDL"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.ld.dl.LanguageDetectorDL", java_model=None):
         super(LanguageDetectorDL, self).__init__(

--- a/python/sparknlp/annotator/lemmatizer.py
+++ b/python/sparknlp/annotator/lemmatizer.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 """Contains classes for the Lemmatizer."""
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Lemmatizer(AnnotatorApproach):
@@ -86,6 +87,8 @@ class Lemmatizer(AnnotatorApproach):
     |[Peter, Pipers, employees, are, pick, peck, of, pickle, pepper, .]|
     +------------------------------------------------------------------+
     """
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
+
     dictionary = Param(Params._dummy(),
                        "dictionary",
                        "lemmatizer external dictionary." +

--- a/python/sparknlp/annotator/lemmatizer.py
+++ b/python/sparknlp/annotator/lemmatizer.py
@@ -179,6 +179,7 @@ class Lemmatizer(AnnotatorApproach):
             opts["valueDelimiter"] = value_delimiter
         return self._set(dictionary=ExternalResource(path, read_as, opts))
 
+
 class LemmatizerModel(AnnotatorModel):
     """Instantiated Model of the Lemmatizer.
 
@@ -214,6 +215,8 @@ class LemmatizerModel(AnnotatorModel):
     ...     .setOutputCol("lemma")
     """
     name = "LemmatizerModel"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.LemmatizerModel", java_model=None):
         super(LemmatizerModel, self).__init__(

--- a/python/sparknlp/annotator/matcher/big_text_matcher.py
+++ b/python/sparknlp/annotator/matcher/big_text_matcher.py
@@ -15,6 +15,7 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.matcher.text_matcher import TextMatcherModel
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BigTextMatcher(AnnotatorApproach, HasStorage):
@@ -81,6 +82,8 @@ class BigTextMatcher(AnnotatorApproach, HasStorage):
     |[chunk, 53, 59, laborum, [sentence -> 0, chunk -> 1], []]           |
     +--------------------------------------------------------------------+
     """
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     entities = Param(Params._dummy(),
                      "entities",
@@ -182,6 +185,7 @@ class BigTextMatcherModel(AnnotatorModel, HasStorageModel):
     """
     name = "BigTextMatcherModel"
     databases = ['TMVOCAB', 'TMEDGES', 'TMNODES']
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     caseSensitive = Param(Params._dummy(),
                           "caseSensitive",

--- a/python/sparknlp/annotator/matcher/big_text_matcher.py
+++ b/python/sparknlp/annotator/matcher/big_text_matcher.py
@@ -83,7 +83,7 @@ class BigTextMatcher(AnnotatorApproach, HasStorage):
     +--------------------------------------------------------------------+
     """
 
-    inputAnnotatorTypes = [AnnotatorType.TOKEN]
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     entities = Param(Params._dummy(),
                      "entities",

--- a/python/sparknlp/annotator/matcher/date_matcher.py
+++ b/python/sparknlp/annotator/matcher/date_matcher.py
@@ -14,6 +14,7 @@
 """Contains classes for the DateMatcher."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DateMatcherUtils(Params):
@@ -159,6 +160,7 @@ class DateMatcherUtils(Params):
         """
         return self._set(anchorDateDay=value)
 
+
 class DateMatcher(AnnotatorModel, DateMatcherUtils):
     """Matches standard date formats into a provided format
     Reads from different forms of date and time expressions and converts them
@@ -250,6 +252,8 @@ class DateMatcher(AnnotatorModel, DateMatcherUtils):
     """
 
     name = "DateMatcher"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     @keyword_only
     def __init__(self):

--- a/python/sparknlp/annotator/matcher/multi_date_matcher.py
+++ b/python/sparknlp/annotator/matcher/multi_date_matcher.py
@@ -15,6 +15,7 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.matcher.date_matcher import DateMatcherUtils
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class MultiDateMatcher(AnnotatorModel, DateMatcherUtils):
@@ -93,6 +94,8 @@ class MultiDateMatcher(AnnotatorModel, DateMatcherUtils):
     """
 
     name = "MultiDateMatcher"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     @keyword_only
     def __init__(self):

--- a/python/sparknlp/annotator/matcher/regex_matcher.py
+++ b/python/sparknlp/annotator/matcher/regex_matcher.py
@@ -15,6 +15,7 @@
 
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RegexMatcher(AnnotatorApproach):
@@ -80,6 +81,8 @@ class RegexMatcher(AnnotatorApproach):
     +--------------------------------------------------------------------------------------------+
     """
 
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
+
     strategy = Param(Params._dummy(),
                      "strategy",
                      "MATCH_FIRST|MATCH_ALL|MATCH_COMPLETE",
@@ -130,6 +133,7 @@ class RegexMatcher(AnnotatorApproach):
     def _create_model(self, java_model):
         return RegexMatcherModel(java_model=java_model)
 
+
 class RegexMatcherModel(AnnotatorModel):
     """Instantiated model of the RegexMatcher.
 
@@ -146,6 +150,8 @@ class RegexMatcherModel(AnnotatorModel):
     ----------
     None
     """
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.RegexMatcherModel", java_model=None):
         super(RegexMatcherModel, self).__init__(

--- a/python/sparknlp/annotator/matcher/text_matcher.py
+++ b/python/sparknlp/annotator/matcher/text_matcher.py
@@ -15,6 +15,7 @@
 
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class TextMatcher(AnnotatorApproach):
@@ -89,6 +90,8 @@ class TextMatcher(AnnotatorApproach):
     --------
     BigTextMatcher : to match large amounts of text
     """
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     entities = Param(Params._dummy(),
                      "entities",

--- a/python/sparknlp/annotator/n_gram_generator.py
+++ b/python/sparknlp/annotator/n_gram_generator.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 """Contains classes for the NGramGenerator."""
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NGramGenerator(AnnotatorModel):
@@ -83,6 +84,8 @@ class NGramGenerator(AnnotatorModel):
     """
 
     name = "NGramGenerator"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     @keyword_only
     def __init__(self):

--- a/python/sparknlp/annotator/ner/ner_crf.py
+++ b/python/sparknlp/annotator/ner/ner_crf.py
@@ -15,6 +15,7 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.ner.ner_approach import NerApproach
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NerCrfApproach(AnnotatorApproach, NerApproach):
@@ -129,6 +130,8 @@ class NerCrfApproach(AnnotatorApproach, NerApproach):
     NerDLApproach : for a deep learning based approach
     NerConverter : to further process the results
     """
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN, AnnotatorType.POS, AnnotatorType.WORD_EMBEDDINGS]
 
     l2 = Param(Params._dummy(), "l2", "L2 regularization coefficient", TypeConverters.toFloat)
 
@@ -248,6 +251,7 @@ class NerCrfApproach(AnnotatorApproach, NerApproach):
             includeConfidence=False
         )
 
+
 class NerCrfModel(AnnotatorModel):
     """Extracts Named Entities based on a CRF Model.
 
@@ -343,6 +347,8 @@ class NerCrfModel(AnnotatorModel):
     NerConverter : to further process the results
     """
     name = "NerCrfModel"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN, AnnotatorType.POS, AnnotatorType.WORD_EMBEDDINGS]
 
     includeConfidence = Param(Params._dummy(), "includeConfidence",
                               "external features is a delimited text. needs 'delimiter' in options",

--- a/python/sparknlp/annotator/ner/ner_dl.py
+++ b/python/sparknlp/annotator/ner/ner_dl.py
@@ -18,6 +18,7 @@ import sys
 from sparknlp.annotator.param import EvaluationDLParams
 from sparknlp.common import *
 from sparknlp.annotator.ner.ner_approach import NerApproach
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NerDLApproach(AnnotatorApproach, NerApproach, EvaluationDLParams):
@@ -157,6 +158,8 @@ class NerDLApproach(AnnotatorApproach, NerApproach, EvaluationDLParams):
     NerCrfApproach : for a generic CRF approach
     NerConverter : to further process the results
     """
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN, AnnotatorType.WORD_EMBEDDINGS]
 
     lr = Param(Params._dummy(), "lr", "Learning Rate", TypeConverters.toFloat)
 
@@ -466,6 +469,8 @@ class NerDLModel(AnnotatorModel, HasStorageRef, HasBatchedAnnotate, HasEngine):
     NerConverter : to further process the results
     """
     name = "NerDLModel"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN, AnnotatorType.WORD_EMBEDDINGS]
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.ner.dl.NerDLModel", java_model=None):
         super(NerDLModel, self).__init__(

--- a/python/sparknlp/annotator/ner/ner_overwriter.py
+++ b/python/sparknlp/annotator/ner/ner_overwriter.py
@@ -14,6 +14,7 @@
 """Contains classes for the NerOverwriter."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NerOverwriter(AnnotatorModel):
@@ -114,6 +115,8 @@ class NerOverwriter(AnnotatorModel):
     +---------------------------------------------------------+
     """
     name = "NerOverwriter"
+
+    inputAnnotatorTypes = [AnnotatorType.NAMED_ENTITY]
 
     @keyword_only
     def __init__(self):

--- a/python/sparknlp/annotator/normalizer.py
+++ b/python/sparknlp/annotator/normalizer.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 """Contains classes for the Normalizer."""
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Normalizer(AnnotatorApproach):
@@ -78,6 +79,7 @@ class Normalizer(AnnotatorApproach):
     |[john, and, peter, are, brothers, however, they, dont, support, each, other, that, much]|
     +----------------------------------------------------------------------------------------+
     """
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     cleanupPatterns = Param(Params._dummy(),
                             "cleanupPatterns",
@@ -201,6 +203,7 @@ class NormalizerModel(AnnotatorModel):
     lowercase
         whether to convert strings to lowercase
     """
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     cleanupPatterns = Param(Params._dummy(),
                             "cleanupPatterns",

--- a/python/sparknlp/annotator/pos/perceptron.py
+++ b/python/sparknlp/annotator/pos/perceptron.py
@@ -14,6 +14,7 @@
 """Contains classes for the Perceptron Annotator."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class PerceptronApproach(AnnotatorApproach):
@@ -99,6 +100,9 @@ class PerceptronApproach(AnnotatorApproach):
     |[NNP, NNP, CD, JJ, NNP, NNP, ,, MD, VB, DT, CD, .]|
     +--------------------------------------------------+
     """
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN, AnnotatorType.DOCUMENT]
+
     posCol = Param(Params._dummy(),
                    "posCol",
                    "column of Array of POS tags that match tokens",
@@ -149,6 +153,7 @@ class PerceptronApproach(AnnotatorApproach):
 
     def _create_model(self, java_model):
         return PerceptronModel(java_model=java_model)
+
 
 class PerceptronModel(AnnotatorModel):
     """Averaged Perceptron model to tag words part-of-speech. Sets a POS tag to
@@ -223,6 +228,8 @@ class PerceptronModel(AnnotatorModel):
     +-------------------------------------------+
     """
     name = "PerceptronModel"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN, AnnotatorType.DOCUMENT]
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.pos.perceptron.PerceptronModel", java_model=None):
         super(PerceptronModel, self).__init__(

--- a/python/sparknlp/annotator/sentence/sentence_detector.py
+++ b/python/sparknlp/annotator/sentence/sentence_detector.py
@@ -14,6 +14,7 @@
 """Contains classes for the SentenceDetector."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentenceDetectorParams:
@@ -162,6 +163,8 @@ class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
 
     name = 'SentenceDetector'
 
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
+
     # this one is exclusive to this detector
     detectLists = Param(Params._dummy(),
                         "detectLists",
@@ -284,3 +287,6 @@ class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
             minLength=0,
             maxLength=99999
         )
+
+    def getInputAnnotatorTypes(self):
+        return self.inputAnnotatorTypes

--- a/python/sparknlp/annotator/sentence/sentence_detector_dl.py
+++ b/python/sparknlp/annotator/sentence/sentence_detector_dl.py
@@ -14,6 +14,7 @@
 """Contains classes for SentenceDetectorDl."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentenceDetectorDLApproach(AnnotatorApproach):
@@ -93,6 +94,8 @@ class SentenceDetectorDLApproach(AnnotatorApproach):
     """
 
     name = "SentenceDetectorDLApproach"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     modelArchitecture = Param(Params._dummy(),
                               "modelArchitecture",
@@ -297,6 +300,8 @@ class SentenceDetectorDLModel(AnnotatorModel, HasEngine):
     +----------------------------+
     """
     name = "SentenceDetectorDLModel"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     modelArchitecture = Param(Params._dummy(), "modelArchitecture", "Model architecture (CNN)",
                               typeConverter=TypeConverters.toString)

--- a/python/sparknlp/annotator/sentiment/sentiment_detector.py
+++ b/python/sparknlp/annotator/sentiment/sentiment_detector.py
@@ -14,6 +14,7 @@
 """Contains classes for the SentimentDetector."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentimentDetector(AnnotatorApproach):
@@ -97,6 +98,9 @@ class SentimentDetector(AnnotatorApproach):
     --------
     ViveknSentimentApproach : for an alternative approach to sentiment extraction
     """
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN, AnnotatorType.DOCUMENT]
+
     dictionary = Param(Params._dummy(),
                        "dictionary",
                        "path for dictionary to sentiment analysis",
@@ -160,6 +164,7 @@ class SentimentDetector(AnnotatorApproach):
     def _create_model(self, java_model):
         return SentimentDetectorModel(java_model=java_model)
 
+
 class SentimentDetectorModel(AnnotatorModel):
     """Rule based sentiment detector, which calculates a score based on
     predefined keywords.
@@ -184,6 +189,8 @@ class SentimentDetectorModel(AnnotatorModel):
     None
     """
     name = "SentimentDetectorModel"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN, AnnotatorType.DOCUMENT]
 
     positiveMultiplier = Param(Params._dummy(),
                                "positiveMultiplier",

--- a/python/sparknlp/annotator/sentiment/vivekn_sentiment.py
+++ b/python/sparknlp/annotator/sentiment/vivekn_sentiment.py
@@ -15,6 +15,7 @@
 
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ViveknSentimentApproach(AnnotatorApproach):
@@ -96,6 +97,9 @@ class ViveknSentimentApproach(AnnotatorApproach):
     |[negative]     |
     +---------------+
     """
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN, AnnotatorType.DOCUMENT]
+
     sentimentCol = Param(Params._dummy(),
                          "sentimentCol",
                          "column with the sentiment result of every row. Must be 'positive' or 'negative'",

--- a/python/sparknlp/annotator/seq2seq/gpt2_transformer.py
+++ b/python/sparknlp/annotator/seq2seq/gpt2_transformer.py
@@ -14,6 +14,7 @@
 """Contains classes for the GPT2Transformer."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class GPT2Transformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):
@@ -134,6 +135,8 @@ class GPT2Transformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):
     """
 
     name = "GPT2Transformer"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     task = Param(Params._dummy(), "task", "Transformer's task, e.g. 'is it true that'>",
                  typeConverter=TypeConverters.toString)

--- a/python/sparknlp/annotator/seq2seq/marian_transformer.py
+++ b/python/sparknlp/annotator/seq2seq/marian_transformer.py
@@ -14,6 +14,7 @@
 """Contains classes for the MarianTransformer."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class MarianTransformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):
@@ -119,6 +120,8 @@ class MarianTransformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):
     """
 
     name = "MarianTransformer"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",

--- a/python/sparknlp/annotator/seq2seq/t5_transformer.py
+++ b/python/sparknlp/annotator/seq2seq/t5_transformer.py
@@ -14,6 +14,7 @@
 """Contains classes for the T5Transformer."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class T5Transformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):
@@ -147,6 +148,8 @@ class T5Transformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):
     """
 
     name = "T5Transformer"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",

--- a/python/sparknlp/annotator/spell_check/context_spell_checker.py
+++ b/python/sparknlp/annotator/spell_check/context_spell_checker.py
@@ -14,6 +14,7 @@
 """Contains classes for the ContextSpellChecker."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ContextSpellCheckerApproach(AnnotatorApproach):
@@ -137,6 +138,8 @@ class ContextSpellCheckerApproach(AnnotatorApproach):
     """
 
     name = "ContextSpellCheckerApproach"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     languageModelClasses = Param(Params._dummy(),
                                  "languageModelClasses",
@@ -569,6 +572,8 @@ class ContextSpellCheckerModel(AnnotatorModel, HasEngine):
     NorvigSweetingModel, SymmetricDeleteModel: For alternative approaches to spell checking
     """
     name = "ContextSpellCheckerModel"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     wordMaxDistance = Param(Params._dummy(),
                             "wordMaxDistance",

--- a/python/sparknlp/annotator/spell_check/norvig_sweeting.py
+++ b/python/sparknlp/annotator/spell_check/norvig_sweeting.py
@@ -14,6 +14,7 @@
 """Contains classes for the NorvigSweeting spell checker."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NorvigSweetingApproach(AnnotatorApproach):
@@ -114,6 +115,8 @@ class NorvigSweetingApproach(AnnotatorApproach):
     SymmetricDeleteApproach : for an alternative approach to spell checking
     ContextSpellCheckerApproach : for a DL based approach
     """
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
+
     dictionary = Param(Params._dummy(),
                        "dictionary",
                        "dictionary needs 'tokenPattern' regex in dictionary for separating words",
@@ -242,6 +245,7 @@ class NorvigSweetingApproach(AnnotatorApproach):
     def _create_model(self, java_model):
         return NorvigSweetingModel(java_model=java_model)
 
+
 class NorvigSweetingModel(AnnotatorModel):
     """This annotator retrieves tokens and makes corrections automatically if
     not found in an English dictionary.
@@ -321,6 +325,8 @@ class NorvigSweetingModel(AnnotatorModel):
     ContextSpellCheckerModel : for a DL based approach
     """
     name = "NorvigSweetingModel"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.spell.norvig.NorvigSweetingModel", java_model=None):
         super(NorvigSweetingModel, self).__init__(

--- a/python/sparknlp/annotator/spell_check/symmetric_delete.py
+++ b/python/sparknlp/annotator/spell_check/symmetric_delete.py
@@ -14,6 +14,7 @@
 """Contains classes for SymmetricDelete."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SymmetricDeleteApproach(AnnotatorApproach):
@@ -92,6 +93,8 @@ class SymmetricDeleteApproach(AnnotatorApproach):
     NorvigSweetingApproach : for an alternative approach to spell checking
     ContextSpellCheckerApproach : for a DL based approach
     """
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
+
     corpus = Param(Params._dummy(),
                    "corpus",
                    "folder or file with text that teaches about the language",
@@ -188,6 +191,7 @@ class SymmetricDeleteApproach(AnnotatorApproach):
     def _create_model(self, java_model):
         return SymmetricDeleteModel(java_model=java_model)
 
+
 class SymmetricDeleteModel(AnnotatorModel):
     """Symmetric Delete spelling correction algorithm.
 
@@ -258,6 +262,8 @@ class SymmetricDeleteModel(AnnotatorModel):
     ContextSpellCheckerModel : for a DL based approach
     """
     name = "SymmetricDeleteModel"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.spell.symmetric.SymmetricDeleteModel",
                  java_model=None):

--- a/python/sparknlp/annotator/stemmer.py
+++ b/python/sparknlp/annotator/stemmer.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 """Contains classes for the Stemmer."""
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Stemmer(AnnotatorModel):
@@ -62,6 +63,8 @@ class Stemmer(AnnotatorModel):
     |[peter, piper, employe, ar, pick, peck, of, pickl, pepper, .]|
     +-------------------------------------------------------------+
     """
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     language = Param(Params._dummy(), "language", "stemmer algorithm", typeConverter=TypeConverters.toString)
 

--- a/python/sparknlp/annotator/stop_words_cleaner.py
+++ b/python/sparknlp/annotator/stop_words_cleaner.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 """Contains classes for the StopWordsCleaner."""
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class StopWordsCleaner(AnnotatorModel):
@@ -95,6 +96,8 @@ class StopWordsCleaner(AnnotatorModel):
     """
 
     name = "StopWordsCleaner"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.StopWordsCleaner", java_model=None):

--- a/python/sparknlp/annotator/token/chunk_tokenizer.py
+++ b/python/sparknlp/annotator/token/chunk_tokenizer.py
@@ -15,6 +15,7 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.token.tokenizer import Tokenizer, TokenizerModel
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ChunkTokenizer(Tokenizer):
@@ -79,12 +80,15 @@ class ChunkTokenizer(Tokenizer):
     """
     name = 'ChunkTokenizer'
 
+    inputAnnotatorTypes = [AnnotatorType.CHUNK]
+
     @keyword_only
     def __init__(self):
         super(Tokenizer, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ChunkTokenizer")
 
     def _create_model(self, java_model):
         return ChunkTokenizerModel(java_model=java_model)
+
 
 class ChunkTokenizerModel(TokenizerModel):
     """Instantiated model of the ChunkTokenizer.
@@ -103,6 +107,8 @@ class ChunkTokenizerModel(TokenizerModel):
     None
     """
     name = 'ChunkTokenizerModel'
+
+    inputAnnotatorTypes = [AnnotatorType.CHUNK]
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.ChunkTokenizerModel", java_model=None):

--- a/python/sparknlp/annotator/token/recursive_tokenizer.py
+++ b/python/sparknlp/annotator/token/recursive_tokenizer.py
@@ -14,6 +14,7 @@
 """Contains classes for the RecursiveTokenizer."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RecursiveTokenizer(AnnotatorApproach):
@@ -81,6 +82,8 @@ class RecursiveTokenizer(AnnotatorApproach):
     +------------------------------------------------------------------+
     """
     name = 'RecursiveTokenizer'
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     prefixes = Param(Params._dummy(),
                      "prefixes",
@@ -171,6 +174,7 @@ class RecursiveTokenizer(AnnotatorApproach):
     def _create_model(self, java_model):
         return RecursiveTokenizerModel(java_model=java_model)
 
+
 class RecursiveTokenizerModel(AnnotatorModel):
     """Instantiated model of the RecursiveTokenizer.
 
@@ -188,6 +192,8 @@ class RecursiveTokenizerModel(AnnotatorModel):
     None
     """
     name = 'RecursiveTokenizerModel'
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.RecursiveTokenizerModel", java_model=None):
         super(RecursiveTokenizerModel, self).__init__(

--- a/python/sparknlp/annotator/token/regex_tokenizer.py
+++ b/python/sparknlp/annotator/token/regex_tokenizer.py
@@ -15,6 +15,7 @@
 
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RegexTokenizer(AnnotatorModel):
@@ -80,6 +81,8 @@ class RegexTokenizer(AnnotatorModel):
     """
 
     name = "RegexTokenizer"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     @keyword_only
     def __init__(self):

--- a/python/sparknlp/annotator/token/token2_chunk.py
+++ b/python/sparknlp/annotator/token/token2_chunk.py
@@ -15,6 +15,7 @@
 
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Token2Chunk(AnnotatorModel):
@@ -66,6 +67,8 @@ class Token2Chunk(AnnotatorModel):
     +------------------------------------------+
     """
     name = "Token2Chunk"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
 
     def __init__(self):
         super(Token2Chunk, self).__init__(classname="com.johnsnowlabs.nlp.annotators.Token2Chunk")

--- a/python/sparknlp/annotator/token/tokenizer.py
+++ b/python/sparknlp/annotator/token/tokenizer.py
@@ -15,6 +15,7 @@
 
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Tokenizer(AnnotatorApproach):
@@ -87,6 +88,10 @@ class Tokenizer(AnnotatorApproach):
     +-----------------------------------------------------------------------+
     """
 
+    name = 'Tokenizer'
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
+
     targetPattern = Param(Params._dummy(),
                           "targetPattern",
                           "pattern to grab from text as token candidates. Defaults \S+",
@@ -146,8 +151,6 @@ class Tokenizer(AnnotatorApproach):
                       "maxLength",
                       "Set the maximum allowed length for each token",
                       typeConverter=TypeConverters.toInt)
-
-    name = 'Tokenizer'
 
     @keyword_only
     def __init__(self):
@@ -429,6 +432,7 @@ class Tokenizer(AnnotatorApproach):
     def _create_model(self, java_model):
         return TokenizerModel(java_model=java_model)
 
+
 class TokenizerModel(AnnotatorModel):
     """Tokenizes raw text into word pieces, tokens. Identifies tokens with
     tokenization open standards. A few rules will help customizing it if
@@ -452,6 +456,8 @@ class TokenizerModel(AnnotatorModel):
         Character list used to separate from the inside of tokens
     """
     name = "TokenizerModel"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     exceptions = Param(Params._dummy(),
                        "exceptions",

--- a/python/sparknlp/annotator/ws/word_segmenter.py
+++ b/python/sparknlp/annotator/ws/word_segmenter.py
@@ -14,6 +14,7 @@
 """Contains classes for the WordSegmenter."""
 
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class WordSegmenterApproach(AnnotatorApproach):
@@ -98,6 +99,8 @@ class WordSegmenterApproach(AnnotatorApproach):
     >>> pipelineModel = pipeline.fit(trainingDataSet)
     """
     name = "WordSegmenterApproach"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     posCol = Param(Params._dummy(),
                    "posCol",
@@ -319,6 +322,8 @@ class WordSegmenterModel(AnnotatorModel):
     +--------------------------------------------------------+
     """
     name = "WordSegmenterModel"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     enableRegexTokenizer = Param(Params._dummy(),
                                  "enableRegexTokenizer",

--- a/python/sparknlp/base/chunk2_doc.py
+++ b/python/sparknlp/base/chunk2_doc.py
@@ -14,6 +14,8 @@
 """Contains classes for Chunk2Doc."""
 
 from pyspark import keyword_only
+
+from sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.internal import AnnotatorTransformer
 
 from sparknlp.common import AnnotatorProperties
@@ -71,6 +73,8 @@ class Chunk2Doc(AnnotatorTransformer, AnnotatorProperties):
     """
 
     name = "Chunk2Doc"
+
+    inputAnnotatorTypes = [AnnotatorType.CHUNK]
 
     @keyword_only
     def __init__(self):

--- a/python/sparknlp/base/doc2_chunk.py
+++ b/python/sparknlp/base/doc2_chunk.py
@@ -15,6 +15,8 @@
 
 from pyspark import keyword_only
 from pyspark.ml.param import TypeConverters, Params, Param
+
+from sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.internal import AnnotatorTransformer
 
 from sparknlp.common import AnnotatorProperties
@@ -84,6 +86,7 @@ class Doc2Chunk(AnnotatorTransformer, AnnotatorProperties):
     --------
     Chunk2Doc : for converting `CHUNK` annotations to `DOCUMENT`
     """
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     chunkCol = Param(Params._dummy(), "chunkCol", "column that contains string. Must be part of DOCUMENT", typeConverter=TypeConverters.toString)
     startCol = Param(Params._dummy(), "startCol", "column that has a reference of where chunk begins", typeConverter=TypeConverters.toString)

--- a/python/sparknlp/base/table_assembler.py
+++ b/python/sparknlp/base/table_assembler.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 """Contains classes for the TableAssembler."""
 from sparknlp.common import *
+from sparknlp.common.annotator_type import AnnotatorType
 
 
 class TableAssembler(AnnotatorModel):
@@ -79,6 +80,8 @@ class TableAssembler(AnnotatorModel):
     +-----------------------------------------------+
 """
     name = "TableAssembler"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
 
     inputFormat = Param(
         Params._dummy(),

--- a/python/sparknlp/base/token_assembler.py
+++ b/python/sparknlp/base/token_assembler.py
@@ -15,6 +15,8 @@
 
 from pyspark import keyword_only
 from pyspark.ml.param import TypeConverters, Params, Param
+
+from sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.internal import AnnotatorTransformer
 
 from sparknlp.common import AnnotatorProperties
@@ -94,6 +96,9 @@ class TokenAssembler(AnnotatorTransformer, AnnotatorProperties):
     """
 
     name = "TokenAssembler"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
+
     preservePosition = Param(Params._dummy(), "preservePosition", "whether to preserve the actual position of the tokens or reduce them to one space", typeConverter=TypeConverters.toBoolean)
 
     @keyword_only

--- a/python/sparknlp/common/__init__.py
+++ b/python/sparknlp/common/__init__.py
@@ -21,3 +21,4 @@ from sparknlp.common.read_as import *
 from sparknlp.common.recursive_annotator_approach import *
 from sparknlp.common.storage import *
 from sparknlp.common.utils import *
+from sparknlp.common.annotator_type import *

--- a/python/sparknlp/common/annotator_properties.py
+++ b/python/sparknlp/common/annotator_properties.py
@@ -46,19 +46,37 @@ class AnnotatorProperties(Params):
             Input columns for the annotator
         """
         if type(value[0]) == str or type(value[0]) == list:
-            expected_columns = len(self.inputAnnotatorTypes) + len(self.optionalInputAnnotatorTypes)
-            if expected_columns == 1:
-                if len(value) == 1 and type(value[0]) == list:
-                    return self._set(inputCols=[value[0][0]])
-                else:
-                    return self._set(inputCols=[value[0]])
+            self.inputColsValidation(value)
+            if len(value) == 1 and type(value[0]) == list:
+                return self._set(inputCols=value[0])
             else:
-                if len(value) == 1 and type(value[0]) == list:
-                    return self._set(inputCols=value[0])
-                else:
-                    return self._set(inputCols=list(value))
+                return self._set(inputCols=list(value))
         else:
-            TypeError("InputCols datatype not supported. It must be either str or list")
+            raise TypeError("InputCols datatype not supported. It must be either str or list")
+
+    def inputColsValidation(self, value):
+        actual_columns = len(value)
+        if type(value[0]) == list:
+            actual_columns = len(value[0])
+
+        expected_columns = len(self.inputAnnotatorTypes)
+
+        if len(self.optionalInputAnnotatorTypes) == 0:
+            if actual_columns != expected_columns:
+                raise TypeError(
+                    f"setInputCols in {self.uid} expecting {expected_columns} columns. "
+                    f"Provided column amount: {actual_columns}. "
+                    f"Which should be columns from the following annotators: {self.inputAnnotatorTypes}")
+        else:
+            expected_columns = expected_columns + len(self.optionalInputAnnotatorTypes)
+            print(f"expected_columns: {expected_columns}")
+            print(f"actual_columns: {actual_columns}")
+            print(f"len(self.inputAnnotatorTypes): {actual_columns}")
+            if not (actual_columns == len(self.inputAnnotatorTypes) or actual_columns == expected_columns):
+                raise TypeError(
+                    f"setInputCols in {self.uid} expecting at least {len(self.inputAnnotatorTypes)} columns. "
+                    f"Provided column amount: {actual_columns}. "
+                    f"Which should be columns from at least the following annotators: {self.inputAnnotatorTypes}")
 
     def getInputCols(self):
         """Gets current column names of input annotations."""
@@ -95,4 +113,3 @@ class AnnotatorProperties(Params):
         RecursivePipeline.
         """
         return self.getOrDefault(self.lazyAnnotator)
-

--- a/python/sparknlp/common/annotator_properties.py
+++ b/python/sparknlp/common/annotator_properties.py
@@ -69,9 +69,6 @@ class AnnotatorProperties(Params):
                     f"Which should be columns from the following annotators: {self.inputAnnotatorTypes}")
         else:
             expected_columns = expected_columns + len(self.optionalInputAnnotatorTypes)
-            print(f"expected_columns: {expected_columns}")
-            print(f"actual_columns: {actual_columns}")
-            print(f"len(self.inputAnnotatorTypes): {actual_columns}")
             if not (actual_columns == len(self.inputAnnotatorTypes) or actual_columns == expected_columns):
                 raise TypeError(
                     f"setInputCols in {self.uid} expecting at least {len(self.inputAnnotatorTypes)} columns. "

--- a/python/sparknlp/common/annotator_properties.py
+++ b/python/sparknlp/common/annotator_properties.py
@@ -17,14 +17,20 @@ from pyspark.ml.param import TypeConverters, Params, Param
 
 
 class AnnotatorProperties(Params):
+
+    inputAnnotatorTypes = []
+    optionalInputAnnotatorTypes = []
+
     inputCols = Param(Params._dummy(),
                       "inputCols",
                       "previous annotations columns, if renamed",
                       typeConverter=TypeConverters.toListString)
+
     outputCol = Param(Params._dummy(),
                       "outputCol",
                       "output annotation column. can be left default.",
                       typeConverter=TypeConverters.toString)
+
     lazyAnnotator = Param(Params._dummy(),
                           "lazyAnnotator",
                           "Whether this AnnotatorModel acts as lazy in RecursivePipelines",
@@ -39,10 +45,20 @@ class AnnotatorProperties(Params):
         *value : str
             Input columns for the annotator
         """
-        if len(value) == 1 and type(value[0]) == list:
-            return self._set(inputCols=value[0])
+        if type(value[0]) == str or type(value[0]) == list:
+            expected_columns = len(self.inputAnnotatorTypes) + len(self.optionalInputAnnotatorTypes)
+            if expected_columns == 1:
+                if len(value) == 1 and type(value[0]) == list:
+                    return self._set(inputCols=[value[0][0]])
+                else:
+                    return self._set(inputCols=[value[0]])
+            else:
+                if len(value) == 1 and type(value[0]) == list:
+                    return self._set(inputCols=value[0])
+                else:
+                    return self._set(inputCols=list(value))
         else:
-            return self._set(inputCols=list(value))
+            TypeError("InputCols datatype not supported. It must be either str or list")
 
     def getInputCols(self):
         """Gets current column names of input annotations."""

--- a/python/sparknlp/common/annotator_type.py
+++ b/python/sparknlp/common/annotator_type.py
@@ -1,0 +1,37 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+class AnnotatorType(object):
+    AUDIO = "audio"
+    DOCUMENT = "document"
+    IMAGE = "image"
+    TOKEN = "token"
+    WORDPIECE = "wordpiece"
+    WORD_EMBEDDINGS = "word_embeddings"
+    SENTENCE_EMBEDDINGS = "sentence_embeddings"
+    CATEGORY = "category"
+    DATE = "date"
+    ENTITY = "entity"
+    SENTIMENT = "sentiment"
+    POS = "pos"
+    CHUNK = "chunk"
+    NAMED_ENTITY = "named_entity"
+    NEGEX = "negex"
+    DEPENDENCY = "dependency"
+    LABELED_DEPENDENCY = "labeled_dependency"
+    LANGUAGE = "language"
+    NODE = "node"
+    TABLE = "table"
+    DUMMY = "dummy"

--- a/python/test/annotator/er/entity_ruler_test.py
+++ b/python/test/annotator/er/entity_ruler_test.py
@@ -40,5 +40,28 @@ class EntityRulerTestSpec(unittest.TestCase):
         pipeline = Pipeline(stages=[document_assembler, tokenizer, entity_ruler])
         model = pipeline.fit(self.data)
         result = model.transform(self.data)
-        assert result.select("entity").count() > 0
+        self.assertTrue(result.select("entity").count() > 0)
+
+
+@pytest.mark.fast
+class EntityRulerOneColumnTestSpec(unittest.TestCase):
+
+    def setUp(self):
+        self.data = SparkContextForTest.spark.createDataFrame([["John Snow lives in Winterfell"]]).toDF("text")
+        self.path = os.getcwd() + "/../src/test/resources/entity-ruler/keywords_only.json"
+
+    def runTest(self):
+        document_assembler = DocumentAssembler().setInputCol("text").setOutputCol("document")
+
+        entity_ruler = EntityRulerApproach() \
+            .setInputCols("document") \
+            .setOutputCol("entity") \
+            .setPatternsResource(self.path)
+
+        pipeline = Pipeline(stages=[document_assembler, entity_ruler])
+        model = pipeline.fit(self.data)
+        result = model.transform(self.data)
+        self.assertTrue(result.select("entity").count() > 0)
+
+
 

--- a/python/test/common/annotator_properties_test.py
+++ b/python/test/common/annotator_properties_test.py
@@ -31,24 +31,14 @@ class AnnotatorPropertiesTest(unittest.TestCase):
             .setOutputCol("sentence_title")
 
         sentence_desc = SentenceDetector() \
-            .setInputCols(["document_desc", "document_title"]) \
+            .setInputCols("document_desc") \
             .setOutputCol("sentence_desc")
-
-        sentence_title_2 = SentenceDetector() \
-            .setInputCols("document_title") \
-            .setOutputCol("sentence_title_2")
-
-        sentence_title_3 = SentenceDetector() \
-            .setInputCols("document_title", "document_desc") \
-            .setOutputCol("sentence_title_3")
 
         pipeline = Pipeline(stages=[
             document_assembler_title,
             document_assembler_desc,
             sentence_title,
             sentence_desc,
-            sentence_title_2,
-            sentence_title_3
         ])
 
         result_df = pipeline.fit(self.data).transform(self.data)
@@ -59,8 +49,29 @@ class AnnotatorPropertiesTest(unittest.TestCase):
         sentence_desc_output = result_df.select("sentence_desc.result").collect()[0][0][0]
         self.assertEqual(sentence_desc_output, self.desc)
 
-        sentence_title_2_output = result_df.select("sentence_title_2.result").collect()[0][0][0]
-        self.assertEqual(sentence_title_2_output, self.title)
+@pytest.mark.fast
+class AnnotatorPropertiesTestInvalidNumberOfColumns(unittest.TestCase):
 
-        sentence_title_3_output = result_df.select("sentence_title_3.result").collect()[0][0][0]
-        self.assertEqual(sentence_title_3_output, self.title)
+    def setUp(self):
+        self.array_input = ["document_desc", "document_title"]
+        self.tuple_input = ("document_desc", "document_title")
+
+    def runTest(self):
+
+        self.assertRaises(TypeError, SentenceDetector().setInputCols, self.array_input)
+
+        self.assertRaises(TypeError, SentenceDetector().setInputCols, self.tuple_input)
+
+
+@pytest.mark.fast
+class AnnotatorPropertiesTestInvalidInput(unittest.TestCase):
+
+    def setUp(self):
+        self.dict_input = {"document_desc": "document_title"}
+        self.int_input = 4
+
+    def runTest(self):
+
+        self.assertRaises(TypeError, SentenceDetector().setInputCols, self.dict_input)
+
+        self.assertRaises(TypeError, SentenceDetector().setInputCols, self.int_input)

--- a/python/test/common/annotator_properties_test.py
+++ b/python/test/common/annotator_properties_test.py
@@ -1,0 +1,66 @@
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.util import SparkContextForTest
+
+
+@pytest.mark.fast
+class AnnotatorPropertiesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.title = "Neopets - The gaming website for all your needs."
+        self.desc = "Peter Pipers employees are picking pecks of pickled peppers"
+        self.data = SparkContextForTest.spark \
+            .createDataFrame([[self.title, self.desc]]).toDF("title", "description")
+
+    def runTest(self):
+
+        document_assembler_title = DocumentAssembler() \
+            .setInputCol("title") \
+            .setOutputCol("document_title")
+
+        document_assembler_desc = DocumentAssembler() \
+            .setInputCol("description") \
+            .setOutputCol("document_desc")
+
+        sentence_title = SentenceDetector() \
+            .setInputCols(["document_title"]) \
+            .setOutputCol("sentence_title")
+
+        sentence_desc = SentenceDetector() \
+            .setInputCols(["document_desc", "document_title"]) \
+            .setOutputCol("sentence_desc")
+
+        sentence_title_2 = SentenceDetector() \
+            .setInputCols("document_title") \
+            .setOutputCol("sentence_title_2")
+
+        sentence_title_3 = SentenceDetector() \
+            .setInputCols("document_title", "document_desc") \
+            .setOutputCol("sentence_title_3")
+
+        pipeline = Pipeline(stages=[
+            document_assembler_title,
+            document_assembler_desc,
+            sentence_title,
+            sentence_desc,
+            sentence_title_2,
+            sentence_title_3
+        ])
+
+        result_df = pipeline.fit(self.data).transform(self.data)
+
+        sentence_title_output = result_df.select("sentence_title.result").collect()[0][0][0]
+        self.assertEqual(sentence_title_output, self.title)
+
+        sentence_desc_output = result_df.select("sentence_desc.result").collect()[0][0][0]
+        self.assertEqual(sentence_desc_output, self.desc)
+
+        sentence_title_2_output = result_df.select("sentence_title_2.result").collect()[0][0][0]
+        self.assertEqual(sentence_title_2_output, self.title)
+
+        sentence_title_3_output = result_df.select("sentence_title_3.result").collect()[0][0][0]
+        self.assertEqual(sentence_title_3_output, self.title)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds inputAnnotatorTypes in Python to identify annotators that expect only one column. This allows handling more than one-column inputs in annotators that only process one column by taking only the first one and ignoring the other columns.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Check issue #12981 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- Local Unit Tests
- Google Colab

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
