### PR TITLE
SPARKNLP-642: Fix indexing issue for regex splits without space

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexTokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexTokenizer.scala
@@ -21,6 +21,8 @@ import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasSimpleAnnotate}
 import org.apache.spark.ml.param.{BooleanParam, IntParam, Param, ParamValidators}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 
+import scala.util.matching.Regex
+
 /** A tokenizer that splits text by a regex pattern.
   *
   * The pattern needs to be set with `setPattern` and this sets the delimiting pattern or how the
@@ -275,9 +277,10 @@ class RegexTokenizer(override val uid: String)
       val tokens = re
         .split(str)
         .map { token =>
+          curPos = str.indexOf(token, curPos)
           val indexedTokens =
             IndexedToken(token, text.start + curPos, text.start + curPos + token.length - 1)
-          curPos += token.length + 1
+          curPos += token.length
           indexedTokens
         }
         .filter(t =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Resolves #13015. 

The RegexTokenizer Annotator outputs wrong indexes if the pattern includes splits that are not followed by a space. This PR resolves this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests passing, additional assertions for index alignment have been added and are also passing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
