### PR TITLE
SPARKNLP 643 detecting spark version in a safer way

### DIFF
--- a/python/sparknlp/internal/extended_java_wrapper.py
+++ b/python/sparknlp/internal/extended_java_wrapper.py
@@ -16,6 +16,7 @@
 from pyspark import SparkContext
 from pyspark.ml.wrapper import JavaWrapper
 from pyspark.sql import DataFrame
+import re
 
 
 class ExtendedJavaWrapper(JavaWrapper):
@@ -53,7 +54,8 @@ class ExtendedJavaWrapper(JavaWrapper):
         return java_array
 
     def spark_version(self):
-        spark_version = self.sc.version.split(".")
+        cleaned_version = re.findall(r'(?:(\d+\.(?:\d+\.)*\d+))', self.sc.version)
+        spark_version = cleaned_version[0].split(".")
         return int("".join(spark_version))
 
     def getDataFrame(self, spark, jdf):

--- a/python/sparknlp/internal/extended_java_wrapper.py
+++ b/python/sparknlp/internal/extended_java_wrapper.py
@@ -16,7 +16,7 @@
 from pyspark import SparkContext
 from pyspark.ml.wrapper import JavaWrapper
 from pyspark.sql import DataFrame
-import re
+from distutils.version import LooseVersion
 
 
 class ExtendedJavaWrapper(JavaWrapper):
@@ -54,12 +54,10 @@ class ExtendedJavaWrapper(JavaWrapper):
         return java_array
 
     def spark_version(self):
-        cleaned_version = re.findall(r'(?:(\d+\.(?:\d+\.)*\d+))', self.sc.version)
-        spark_version = cleaned_version[0].split(".")
-        return int("".join(spark_version))
+        return self.sc.version
 
     def getDataFrame(self, spark, jdf):
-        if self.spark_version() >= 330:
+        if LooseVersion(self.spark_version()) >= LooseVersion("3.3.0"):
             return DataFrame(jdf, spark._getActiveSessionOrCreate())
         else:
             return DataFrame(jdf, spark._wrapped)


### PR DESCRIPTION
Some environments will have an alphanumeric version of Spark. This PR will make a safer comparison when it comes to whether or not we are in Spark `3.3.0` environment (needed for some operations).

We could use 

```python
cleaned_version = re.findall(r'(?:(\d+\.(?:\d+\.)*\d+))', self.sc.version)
```

or `LooseVersion` from `distutils.version`

```python
LooseVersion(self.spark_version()) >= LooseVersion("3.3.0")
```