### PR TITLE
Fix a bug in Vision Transformer annotator that results in NaNs for some models

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowViTClassifier.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowViTClassifier.scala
@@ -127,9 +127,13 @@ class TensorflowViTClassifier(
         val logits = tag(encoded, activation)
 
         batch.zip(logits).map { case (image, score) =>
-          val label =
-            tags.find(_._2 == score.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
 
+          var label =
+            tags.find(_._2 == score.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
+          if (label=="NA"){
+            label =
+              tags.find(_._2 == score.zipWithIndex.maxBy(_._1)._2.toString).map(_._1).getOrElse("NA")
+          }
           val meta = score.zipWithIndex.flatMap(x =>
             Map(tags.take(10).find(_._2 == x._2).map(_._1).toString -> x._1.toString))
 

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowViTClassifier.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowViTClassifier.scala
@@ -127,13 +127,17 @@ class TensorflowViTClassifier(
         val logits = tag(encoded, activation)
 
         batch.zip(logits).map { case (image, score) =>
-
-          var label =
-            tags.find(_._2 == score.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
-          if (label=="NA"){
-            label =
-              tags.find(_._2 == score.zipWithIndex.maxBy(_._1)._2.toString).map(_._1).getOrElse("NA")
-          }
+          val label =
+            tags
+              .find(_._2 == score.zipWithIndex.maxBy(_._1)._2)
+              .map(_._1)
+              .getOrElse(
+                tags
+                  .find(
+                    _._2 == score.zipWithIndex.maxBy(_._1)._2.toString
+                  ) // TODO: We shouldn't compare unrelated types: BigInt and String
+                  .map(_._1)
+                  .getOrElse("NA"))
           val meta = score.zipWithIndex.flatMap(x =>
             Map(tags.take(10).find(_._2 == x._2).map(_._1).toString -> x._1.toString))
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/cv/ViTForImageClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/cv/ViTForImageClassification.scala
@@ -346,6 +346,7 @@ trait ReadViTForImageTensorflowModel extends ReadTensorflowModel {
 
     val (localModelPath, detectedEngine) = modelSanityCheck(modelPath)
 
+    // TODO: sometimes results in [String, BigInt] where BigInt is actually a string
     val labelJsonContent = loadJsonStringAsset(localModelPath, "labels.json")
     val labelJsonMap =
       parse(labelJsonContent, useBigIntForLong = true).values


### PR DESCRIPTION
## Fixes NaN  in VIt predictions
## Description
A lot of the VIT models were prdicting NaNs because in their labels some were saved as BigInts while others were saved as Strings , I added code for corss checking

## How Has This Been Tested?
Tested it locally on models that were predicting Nan before the change


## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)


