### PR TITLE
SPARKNLP-621: Add string support to RegexMatcher in addition to a file

### DIFF
--- a/docs/en/annotator_entries/RegexMatcher.md
+++ b/docs/en/annotator_entries/RegexMatcher.md
@@ -28,10 +28,17 @@ CHUNK
 {%- endcapture -%}
 
 {%- capture approach_description -%}
-Uses a reference file to match a set of regular expressions and associate them with a provided identifier.
+Uses rules to match a set of regular expressions and associate them with a provided
+identifier.
 
-A dictionary of predefined regular expressions must be provided with `setExternalRules`.
-The dictionary can be set as a delimited text file.
+A rule consists of a regex pattern and an identifier, delimited by a character of choice. An
+example could be `"\d{4}\/\d\d\/\d\d,date"` which will match strings like `"1970/01/01"` to the
+identifier `"date"`.
+
+Rules must be provided by either `setRules` (followed by `setDelimiter`) or an external file.
+
+To use an external file, a dictionary of predefined regular expressions must be provided with
+`setExternalRules`. The dictionary can be set as a delimited text file.
 
 Pretrained pipelines are available for this module, see [Pipelines](https://nlp.johnsnowlabs.com/docs/en/pipelines).
 

--- a/docs/en/annotators.md
+++ b/docs/en/annotators.md
@@ -79,7 +79,7 @@ There are two types of Annotators:
 {% include templates/anno_table_entry.md path="" name="NorvigSweeting Spellchecker" summary="Retrieves tokens and makes corrections automatically if not found in an English dictionary."%}
 {% include templates/anno_table_entry.md path="" name="POSTagger (Part of speech tagger)" summary="Averaged Perceptron model to tag words part-of-speech."%}
 {% include templates/anno_table_entry.md path="" name="RecursiveTokenizer" summary="Tokenizes raw text recursively based on a handful of definable rules."%}
-{% include templates/anno_table_entry.md path="" name="RegexMatcher" summary="Uses a reference file to match a set of regular expressions and associate them with a provided identifier."%}
+{% include templates/anno_table_entry.md path="" name="RegexMatcher" summary="Uses rules to match a set of regular expressions and associate them with a provided identifier."%}
 {% include templates/anno_table_entry.md path="" name="RegexTokenizer" summary="A tokenizer that splits text by a regex pattern."%}
 {% include templates/anno_table_entry.md path="" name="SentenceDetector" summary="Annotator that detects sentence boundaries using regular expressions."%}
 {% include templates/anno_table_entry.md path="" name="SentenceDetectorDL" summary="Detects sentence boundaries using a deep learning approach."%}

--- a/python/sparknlp/annotator/matcher/regex_matcher.py
+++ b/python/sparknlp/annotator/matcher/regex_matcher.py
@@ -13,16 +13,22 @@
 #  limitations under the License.
 """Contains classes for the RegexMatcher."""
 
-
 from sparknlp.common import *
 
 
 class RegexMatcher(AnnotatorApproach):
-    """Uses a reference file to match a set of regular expressions and associate
-    them with a provided identifier.
+    """Uses rules to match a set of regular expressions and associate them with a
+    provided identifier.
 
-    A dictionary of predefined regular expressions must be provided with
-    :meth:`.setExternalRules`. The dictionary can be set in the form of a
+    A rule consists of a regex pattern and an identifier, delimited by a character of
+    choice. An example could be `"\\d{4}\\/\\d\\d\\/\\d\\d,date"` which will match
+    strings like `"1970/01/01"` to the identifier `"date"`.
+
+    Rules must be provided by either :meth:`.setRules` (followed by
+    :meth:`.setDelimiter`) or an external file.
+
+    To use an external file, a dictionary of predefined regular expressions must be
+    provided with :meth:`.setExternalRules`. The dictionary can be set in the form of a
     delimited text file.
 
     Pretrained pipelines are available for this module, see `Pipelines
@@ -42,6 +48,10 @@ class RegexMatcher(AnnotatorApproach):
     strategy
         Can be either MATCH_FIRST|MATCH_ALL|MATCH_COMPLETE, by default
         "MATCH_ALL"
+    rules
+        Regex rules to match the identifier with
+    delimiter
+        Delimiter for rules provided with setRules
     externalRules
         external resource to rules, needs 'delimiter' in options
 
@@ -88,6 +98,14 @@ class RegexMatcher(AnnotatorApproach):
                           "externalRules",
                           "external resource to rules, needs 'delimiter' in options",
                           typeConverter=TypeConverters.identity)
+    rules = Param(Params._dummy(),
+                  "rules",
+                  "Regex rules to match the identifier with",
+                  typeConverter=TypeConverters.toListString)
+    delimiter = Param(Params._dummy(),
+                      "delimiter",
+                      "Delimiter for rules",
+                      typeConverter=TypeConverters.toString)
 
     @keyword_only
     def __init__(self):
@@ -111,6 +129,9 @@ class RegexMatcher(AnnotatorApproach):
     def setExternalRules(self, path, delimiter, read_as=ReadAs.TEXT, options={"format": "text"}):
         """Sets external resource to rules, needs 'delimiter' in options.
 
+        Only one of either parameter `rules` or `externalRules` must be set.
+
+
         Parameters
         ----------
         path : str
@@ -127,8 +148,44 @@ class RegexMatcher(AnnotatorApproach):
             opts["delimiter"] = delimiter
         return self._set(externalRules=ExternalResource(path, read_as, opts))
 
+    def setRules(self, value):
+        """Sets the regex rules to match the identifier with.
+
+        The rules must consist of a regex pattern and an identifier for that pattern. The regex
+        pattern and the identifier must be delimited by a character that will also have to set with
+        `setDelimiter`.
+
+        Only one of either parameter `rules` or `externalRules` must be set.
+
+         Examples
+         --------
+        >>> regexMatcher = RegexMatcher() \\
+        ...     .setRules(["\\d{4}\\/\\d\\d\\/\\d\\d,date", "\\d{2}\\/\\d\\d\\/\\d\\d,short_date"]) \\
+        ...     .setDelimiter(",") \\
+        ...     .setInputCols(["sentence"]) \\
+        ...     .setOutputCol("regex") \\
+        ...     .setStrategy("MATCH_ALL")
+
+        Parameters
+        ----------
+        value : List[str]
+             List of rules
+        """
+        return self._set(rules=value)
+
+    def setDelimiter(self, value):
+        """Sets the delimiter for rules.
+
+        Parameters
+        ----------
+        value : str
+             Delimiter for the rules
+        """
+        return self._set(delimiter=value)
+
     def _create_model(self, java_model):
         return RegexMatcherModel(java_model=java_model)
+
 
 class RegexMatcherModel(AnnotatorModel):
     """Instantiated model of the RegexMatcher.
@@ -154,4 +211,3 @@ class RegexMatcherModel(AnnotatorModel):
         )
 
     name = "RegexMatcherModel"
-

--- a/python/test/annotator/matcher/regex_matcher_test.py
+++ b/python/test/annotator/matcher/regex_matcher_test.py
@@ -41,3 +41,25 @@ class RegexMatcherTestSpec(unittest.TestCase):
         assembled = document_assembler.transform(self.data)
         regex_matcher.fit(assembled).transform(assembled).show()
 
+
+@pytest.mark.fast
+class RegexMatcherWithStringTestSpec(unittest.TestCase):
+    def setUp(self):
+        # This implicitly sets up py4j for us
+        self.data = SparkContextForTest.spark.createDataFrame(
+            [["My first sentence with the first rule. This is my second sentence with ceremonies rule."]], ["text"])
+
+    def runTest(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        rules = ["the\\s\\w+,followed by 'the'", "ceremonies,ceremony"]
+        regex_matcher = RegexMatcher() \
+            .setInputCols(['document']) \
+            .setStrategy("MATCH_ALL") \
+            .setRules(rules) \
+            .setDelimiter(",") \
+            .setOutputCol("regex")
+        assembled = document_assembler.transform(self.data)
+        regex_matcher.fit(assembled).transform(assembled).select("regex").show()


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the feature to define strings instead of files to the RegexMatcher annotator. This will enable users to 
prototype faster, especially on cloud environments.

Resolves #12824.

### Changes

- new parameter `rules` where users can provide an array of rules
- new parameter `delimiter` to split the rules

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New and old tests passing.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

