### PR TITLE
SPARKNLP-656 & SPARKNLP-657: Updated Documentation

### DIFF
--- a/docs/en/annotator_entries/ClassifierDL.md
+++ b/docs/en/annotator_entries/ClassifierDL.md
@@ -155,6 +155,38 @@ The ClassifierDL annotator uses a deep learning model (DNNs) we have built insid
 
 For instantiated/pretrained models, see ClassifierDLModel.
 
+Setting a test dataset to monitor model metrics can be done with `.setTestDataset`. The
+method expects a path to a parquet file containing a dataframe that has the same
+required columns as the training dataframe. The pre-processing steps for the training
+dataframe should also be applied to the test dataframe. The following example will show
+how to create the test dataset:
+
+```
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val embeddings = UniversalSentenceEncoder.pretrained()
+  .setInputCols("document")
+  .setOutputCol("sentence_embeddings")
+
+val preProcessingPipeline = new Pipeline().setStages(Array(documentAssembler, embeddings))
+
+val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+preProcessingPipeline
+  .fit(test)
+  .transform(test)
+  .write
+  .mode("overwrite")
+  .parquet("test_data")
+
+val classifier = new ClassifierDLApproach()
+  .setInputCols("sentence_embeddings")
+  .setOutputCol("category")
+  .setLabelColumn("label")
+  .setTestDataset("test_data")
+```
+
 For extended examples of usage, see the Spark NLP Workshop
 [[1] ](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/scala/training/Train%20Multi-Class%20Text%20Classification%20on%20News%20Articles.scala)
 [[2] ](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.Text_Classification_with_ClassifierDL.ipynb)

--- a/docs/en/annotator_entries/SentimentDL.md
+++ b/docs/en/annotator_entries/SentimentDL.md
@@ -145,6 +145,37 @@ For the instantiated/pretrained models, see SentimentDLModel.
     [SentenceEmbeddings](/docs/en/annotators#sentenceembeddings) or other
     sentence based embeddings can be used
 
+Setting a test dataset to monitor model metrics can be done with `.setTestDataset`. The method
+expects a path to a parquet file containing a dataframe that has the same required columns as
+the training dataframe. The pre-processing steps for the training dataframe should also be
+applied to the test dataframe. The following example will show how to create the test dataset:
+
+```
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val embeddings = UniversalSentenceEncoder.pretrained()
+  .setInputCols("document")
+  .setOutputCol("sentence_embeddings")
+
+val preProcessingPipeline = new Pipeline().setStages(Array(documentAssembler, embeddings))
+
+val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+preProcessingPipeline
+  .fit(test)
+  .transform(test)
+  .write
+  .mode("overwrite")
+  .parquet("test_data")
+
+val classifier = new SentimentDLApproach()
+  .setInputCols("sentence_embeddings")
+  .setOutputCol("sentiment")
+  .setLabelColumn("label")
+  .setTestDataset("test_data")
+```
+
 For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb)
 and the [SentimentDLTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLTestSpec.scala).
 {%- endcapture -%}

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -160,7 +160,9 @@ If you are interested, there is a simple SBT project for Spark NLP to guide you 
 
 ## Installation for M1 Macs
 
-Starting from version 4.2.3, Spark NLP has experimental support for M1 macs.
+Starting from version 4.0.0, Spark NLP has experimental support for M1 macs. Note that
+at the moment, only the standard variant of the M1 is supported. Other variants (e.g.
+M1 Pro/Max/Ultra, M2) will most likely not work.
 
 Make sure the following prerequisites are met:
 

--- a/python/sparknlp/annotator/classifier_dl/classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/classifier_dl.py
@@ -29,6 +29,32 @@ class ClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEnco
 
     For instantiated/pretrained models, see :class:`.ClassifierDLModel`.
 
+    Setting a test dataset to monitor model metrics can be done with
+    ``.setTestDataset``. The method expects a path to a parquet file containing a
+    dataframe that has the same required columns as the training dataframe. The
+    pre-processing steps for the training dataframe should also be applied to the test
+    dataframe. The following example will show how to create the test dataset:
+
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> embeddings = UniversalSentenceEncoder.pretrained() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("sentence_embeddings")
+    >>> preProcessingPipeline = Pipeline().setStages([documentAssembler, embeddings])
+    >>> (train, test) = data.randomSplit([0.8, 0.2])
+    >>> preProcessingPipeline \\
+    ...     .fit(test) \\
+    ...     .transform(test)
+    ...     .write \\
+    ...     .mode("overwrite") \\
+    ...     .parquet("test_data")
+    >>> classifier = ClassifierDLApproach() \\
+    ...     .setInputCols(["sentence_embeddings"]) \\
+    ...     .setOutputCol("category") \\
+    ...     .setLabelColumn("label") \\
+    ...     .setTestDataset("test_data")
+
     For extended examples of usage, see the Spark NLP Workshop
     `Spark NLP Workshop  <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.Text_Classification_with_ClassifierDL.ipynb>`__.
 
@@ -40,30 +66,35 @@ class ClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEnco
 
     Parameters
     ----------
-    lr
-        Learning Rate, by default 0.005
     batchSize
         Batch size, by default 64
-    dropout
-        Dropout coefficient, by default 0.5
-    maxEpochs
-        Maximum number of epochs to train, by default 30
     configProtoBytes
         ConfigProto from tensorflow, serialized into byte array.
+    dropout
+        Dropout coefficient, by default 0.5
+    enableOutputLogs
+        Whether to use stdout in addition to Spark logs, by default False
+    evaluationLogExtended
+        Whether logs for validation to be extended: it displays time and evaluation of
+        each label. Default is False.
+    labelColumn
+        Column with label per each token
+    lr
+        Learning Rate, by default 0.005
+    maxEpochs
+        Maximum number of epochs to train, by default 30
+    outputLogsPath
+        Folder path to save training logs
+    randomSeed
+        Random seed for shuffling
+    testDataset
+        Path to test dataset. If set used to calculate statistic on it during training.
     validationSplit
         Choose the proportion of training dataset to be validated against the
         model on each Epoch. The value should be between 0.0 and 1.0 and by
         default it is 0.0 and off.
-    enableOutputLogs
-        Whether to use stdout in addition to Spark logs, by default False
-    outputLogsPath
-        Folder path to save training logs
-    labelColumn
-        Column with label per each token
     verbose
         Level of verbosity during training
-    randomSeed
-        Random seed for shuffling
 
     Notes
     -----

--- a/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
@@ -43,6 +43,31 @@ class MultiClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, Classifie
     :class:`.BertSentenceEmbeddings`, :class:`.SentenceEmbeddings` or other
     sentence embeddings.
 
+    Setting a test dataset to monitor model metrics can be done with
+    ``.setTestDataset``. The method expects a path to a parquet file containing a
+    dataframe that has the same required columns as the training dataframe. The
+    pre-processing steps for the training dataframe should also be applied to the test
+    dataframe. The following example will show how to create the test dataset:
+
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> embeddings = UniversalSentenceEncoder.pretrained() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("sentence_embeddings")
+    >>> preProcessingPipeline = Pipeline().setStages([documentAssembler, embeddings])
+    >>> (train, test) = data.randomSplit([0.8, 0.2])
+    >>> preProcessingPipeline \\
+    ...     .fit(test) \\
+    ...     .transform(test)
+    ...     .write \\
+    ...     .mode("overwrite") \\
+    ...     .parquet("test_data")
+    >>> mulitClassifier = MultiClassifierDLApproach() \\
+    ...     .setInputCols(["sentence_embeddings"]) \\
+    ...     .setOutputCol("category") \\
+    ...     .setLabelColumn("label") \\
+    ...     .setTestDataset("test_data")
 
     For extended examples of usage, see the `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb>`__.
 
@@ -54,32 +79,39 @@ class MultiClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, Classifie
 
     Parameters
     ----------
-    lr
-        Learning Rate, by default 0.001
     batchSize
         Batch size, by default 64
-    maxEpochs
-        Maximum number of epochs to train, by default 10
     configProtoBytes
         ConfigProto from tensorflow, serialized into byte array.
-    validationSplit
-        Choose the proportion of training dataset to be validated against the
-        model on each Epoch. The value should be between 0.0 and 1.0 and by
-        default it is 0.0 and off, by default 0.0
     enableOutputLogs
         Whether to use stdout in addition to Spark logs, by default False
-    outputLogsPath
-        Folder path to save training logs
+    enableOutputLogs
+        Whether to use stdout in addition to Spark logs.
+    evaluationLogExtended
+        Whether logs for validation to be extended: it displays time and evaluation of
+        each label. Default is False.
     labelColumn
         Column with label per each token
-    verbose
-        Level of verbosity during training
+    lr
+        Learning Rate, by default 0.001
+    maxEpochs
+        Maximum number of epochs to train, by default 10
+    outputLogsPath
+        Folder path to save training logs
     randomSeed
         Random seed, by default 44
     shufflePerEpoch
         whether to shuffle the training data on each Epoch, by default False
+    testDataset
+        Path to test dataset. If set used to calculate statistic on it during training.
     threshold
         The minimum threshold for each label to be accepted, by default 0.5
+    validationSplit
+        Choose the proportion of training dataset to be validated against the
+        model on each Epoch. The value should be between 0.0 and 1.0 and by
+        default it is 0.0 and off, by default 0.0
+    verbose
+        Level of verbosity during training
 
     Notes
     -----

--- a/python/sparknlp/annotator/param/evaluation_dl_params.py
+++ b/python/sparknlp/annotator/param/evaluation_dl_params.py
@@ -97,8 +97,26 @@ class EvaluationDLParams(ParamsGettersSetters):
         return self._set(outputLogsPath=p)
 
     def setTestDataset(self, path, read_as=ReadAs.SPARK, options={"format": "parquet"}):
-        """Sets Path to test dataset. If set used to calculate statistic on it
-        during training.
+        """Path to a parquet file of a test dataset. If set, it is used to calculate
+        statistics on it during training.
+
+        The parquet file must be a dataframe that has the same columns as the model that
+        is being trained. For example, if the model needs as input `DOCUMENT`, `TOKEN`,
+        `WORD_EMBEDDINGS` (Features) and `NAMED_ENTITY` (label) then these columns also
+        need to be present while saving the dataframe. The pre-processing steps for the
+        training dataframe should also be applied to the test dataframe.
+
+        An example on how to create such a parquet file could be:
+
+        >>> # assuming preProcessingPipeline
+        >>> (train, test) = data.randomSplit([0.8, 0.2])
+        >>> preProcessingPipeline
+        ...     .fit(test)
+        ...     .transform(test)
+        ...     .write
+        ...     .mode("overwrite")
+        ...     .parquet("test_data")
+        >>> annotator.setTestDataset("test_data")
 
         Parameters
         ----------

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLApproach.scala
@@ -46,6 +46,37 @@ import scala.util.Random
   *     [[com.johnsnowlabs.nlp.embeddings.SentenceEmbeddings SentenceEmbeddings]] can be used for
   *     the `inputCol`.
   *
+  * Setting a test dataset to monitor model metrics can be done with `.setTestDataset`. The method
+  * expects a path to a parquet file containing a dataframe that has the same required columns as
+  * the training dataframe. The pre-processing steps for the training dataframe should also be
+  * applied to the test dataframe. The following example will show how to create the test dataset:
+  *
+  * {{{
+  * val documentAssembler = new DocumentAssembler()
+  *   .setInputCol("text")
+  *   .setOutputCol("document")
+  *
+  * val embeddings = UniversalSentenceEncoder.pretrained()
+  *   .setInputCols("document")
+  *   .setOutputCol("sentence_embeddings")
+  *
+  * val preProcessingPipeline = new Pipeline().setStages(Array(documentAssembler, embeddings))
+  *
+  * val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+  * preProcessingPipeline
+  *   .fit(test)
+  *   .transform(test)
+  *   .write
+  *   .mode("overwrite")
+  *   .parquet("test_data")
+  *
+  * val classifier = new ClassifierDLApproach()
+  *   .setInputCols("sentence_embeddings")
+  *   .setOutputCol("category")
+  *   .setLabelColumn("label")
+  *   .setTestDataset("test_data")
+  * }}}
+  *
   * For extended examples of usage, see the Spark NLP Workshop
   * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/scala/training/Train%20Multi-Class%20Text%20Classification%20on%20News%20Articles.scala [1]]]
   * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.Text_Classification_with_ClassifierDL.ipynb [2]]]

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MultiClassifierDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MultiClassifierDLApproach.scala
@@ -59,6 +59,37 @@ import scala.util.Random
   *     [[com.johnsnowlabs.nlp.embeddings.SentenceEmbeddings SentenceEmbeddings]] can be used for
   *     the `inputCol`.
   *
+  * Setting a test dataset to monitor model metrics can be done with `.setTestDataset`. The method
+  * expects a path to a parquet file containing a dataframe that has the same required columns as
+  * the training dataframe. The pre-processing steps for the training dataframe should also be
+  * applied to the test dataframe. The following example will show how to create the test dataset:
+  *
+  * {{{
+  * val documentAssembler = new DocumentAssembler()
+  *   .setInputCol("text")
+  *   .setOutputCol("document")
+  *
+  * val embeddings = UniversalSentenceEncoder.pretrained()
+  *   .setInputCols("document")
+  *   .setOutputCol("sentence_embeddings")
+  *
+  * val preProcessingPipeline = new Pipeline().setStages(Array(documentAssembler, embeddings))
+  *
+  * val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+  * preProcessingPipeline
+  *   .fit(test)
+  *   .transform(test)
+  *   .write
+  *   .mode("overwrite")
+  *   .parquet("test_data")
+  *
+  * val mulitClassifier = new MultiClassifierDLApproach()
+  *   .setInputCols("sentence_embeddings")
+  *   .setOutputCol("category")
+  *   .setLabelColumn("label")
+  *   .setTestDataset("test_data")
+  * }}}
+  *
   * For extended examples of usage, see the
   * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb Spark NLP Workshop]]
   * and the

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLApproach.scala
@@ -47,6 +47,37 @@ import scala.util.Random
   *     [[com.johnsnowlabs.nlp.embeddings.SentenceEmbeddings SentenceEmbeddings]] can be used for
   *     the `inputCol`.
   *
+  * Setting a test dataset to monitor model metrics can be done with `.setTestDataset`. The method
+  * expects a path to a parquet file containing a dataframe that has the same required columns as
+  * the training dataframe. The pre-processing steps for the training dataframe should also be
+  * applied to the test dataframe. The following example will show how to create the test dataset:
+  *
+  * {{{
+  * val documentAssembler = new DocumentAssembler()
+  *   .setInputCol("text")
+  *   .setOutputCol("document")
+  *
+  * val embeddings = UniversalSentenceEncoder.pretrained()
+  *   .setInputCols("document")
+  *   .setOutputCol("sentence_embeddings")
+  *
+  * val preProcessingPipeline = new Pipeline().setStages(Array(documentAssembler, embeddings))
+  *
+  * val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+  * preProcessingPipeline
+  *   .fit(test)
+  *   .transform(test)
+  *   .write
+  *   .mode("overwrite")
+  *   .parquet("test_data")
+  *
+  * val classifier = new SentimentDLApproach()
+  *   .setInputCols("sentence_embeddings")
+  *   .setOutputCol("sentiment")
+  *   .setLabelColumn("label")
+  *   .setTestDataset("test_data")
+  * }}}
+  *
   * For extended examples of usage, see the
   * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb Spark NLP Workshop]]
   * and the

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -59,6 +59,43 @@ import scala.util.Random
   *     [[com.johnsnowlabs.nlp.embeddings.BertEmbeddings BertEmbeddings]] for BERT based
   *     embeddings).
   *
+  * Setting a test dataset to monitor model metrics can be done with `.setTestDataset`. The method
+  * expects a path to a parquet file containing a dataframe that has the same required columns as
+  * the training dataframe. The pre-processing steps for the training dataframe should also be
+  * applied to the test dataframe. The following example will show how to create the test dataset
+  * with a CoNLL dataset:
+  *
+  * {{{
+  * val documentAssembler = new DocumentAssembler()
+  *   .setInputCol("text")
+  *   .setOutputCol("document")
+  *
+  * val embeddings = WordEmbeddingsModel
+  *   .pretrained()
+  *   .setInputCols("document", "token")
+  *   .setOutputCol("embeddings")
+  *
+  * val preProcessingPipeline = new Pipeline().setStages(Array(documentAssembler, embeddings))
+  *
+  * val conll = CoNLL()
+  * val Array(train, test) = conll
+  *   .readDataset(spark, "src/test/resources/conll2003/eng.train")
+  *   .randomSplit(Array(0.8, 0.2))
+  *
+  * preProcessingPipeline
+  *   .fit(test)
+  *   .transform(test)
+  *   .write
+  *   .mode("overwrite")
+  *   .parquet("test_data")
+  *
+  * val nerTagger = new NerDLApproach()
+  *   .setInputCols("document", "token", "embeddings")
+  *   .setLabelColumn("label")
+  *   .setOutputCol("ner")
+  *   .setTestDataset("test_data")
+  * }}}
+  *
   * For extended examples of usage, see the
   * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/tree/master/jupyter/training/english/dl-ner Spark NLP Workshop]]
   * and the

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/param/EvaluationDLParams.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/param/EvaluationDLParams.scala
@@ -62,7 +62,8 @@ trait EvaluationDLParams extends Params {
   val outputLogsPath =
     new Param[String](this, "outputLogsPath", "Folder path to save training logs")
 
-  /** Path to test dataset. If set, it is used to calculate statistics on it during training.
+  /** Path to a parquet file of a test dataset. If set, it is used to calculate statistics on it
+    * during training.
     *
     * @group param
     */
@@ -114,7 +115,30 @@ trait EvaluationDLParams extends Params {
   def setOutputLogsPath(path: String): this.type =
     set(this.outputLogsPath, path)
 
-  /** Path to test dataset. If set, it is used to calculate statistics on it during training.
+  /** Path to a parquet file of a test dataset. If set, it is used to calculate statistics on it
+    * during training.
+    *
+    * The parquet file must be a dataframe that has the same columns as the model that is being
+    * trained. For example, if the model needs as input `DOCUMENT`, `TOKEN`, `WORD_EMBEDDINGS`
+    * (Features) and `NAMED_ENTITY` (label) then these columns also need to be present while
+    * saving the dataframe. The pre-processing steps for the training dataframe should also be
+    * applied to the test dataframe.
+    *
+    * An example on how to create such a parquet file could be:
+    *
+    * {{{
+    * // assuming preProcessingPipeline
+    * val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+    *
+    * preProcessingPipeline
+    *   .fit(test)
+    *   .transform(test)
+    *   .write
+    *   .mode("overwrite")
+    *   .parquet("test_data")
+    *
+    * annotator.setTestDataset("test_data")
+    * }}}
     *
     * @group setParam
     */
@@ -124,7 +148,32 @@ trait EvaluationDLParams extends Params {
       options: Map[String, String] = Map("format" -> "parquet")): this.type =
     set(testDataset, ExternalResource(path, readAs, options))
 
-  /** Path to test dataset. If set, it is used to calculate statistics on it during training.
+  /** ExternalResource to a parquet file of a test dataset. If set, it is used to calculate
+    * statistics on it during training.
+    *
+    * When using an ExternalResource, only parquet files are accepted for this function.
+    *
+    * The parquet file must be a dataframe that has the same columns as the model that is being
+    * trained. For example, if the model needs as input `DOCUMENT`, `TOKEN`, `WORD_EMBEDDINGS`
+    * (Features) and `NAMED_ENTITY` (label) then these columns also need to be present while
+    * saving the dataframe. The pre-processing steps for the training dataframe should also be
+    * applied to the test dataframe.
+    *
+    * An example on how to create such a parquet file could be:
+    *
+    * {{{
+    * // assuming preProcessingPipeline
+    * val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+    *
+    * preProcessingPipeline
+    *   .fit(test)
+    *   .transform(test)
+    *   .write
+    *   .mode("overwrite")
+    *   .parquet("test_data")
+    *
+    * annotator.setTestDataset("test_data")
+    * }}}
     *
     * @group setParam
     */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR updates the documentation so it is more clear how to use `setTestDataset` in `*DLApproach` annotators.

In addition installation instructions for M1 machines were also updated.

Resolves #13070 and #13079.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No code changes.