### PR TITLE
SPARKNLP-661: Add missing setPreservePosition in NerConverter

### DIFF
--- a/python/sparknlp/annotator/ner/ner_converter.py
+++ b/python/sparknlp/annotator/ner/ner_converter.py
@@ -40,6 +40,9 @@ class NerConverter(AnnotatorModel):
     whiteList
         If defined, list of entities to process. The rest will be ignored. Do
         not include IOB prefix on labels
+    preservePosition
+        Whether to preserve the original position of the tokens in the original document
+        or use the modified tokens, by default `True`
 
     Examples
     --------
@@ -77,11 +80,21 @@ class NerConverter(AnnotatorModel):
     """
     name = 'NerConverter'
 
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN,
+                           AnnotatorType.NAMED_ENTITY]
+
     whiteList = Param(
         Params._dummy(),
         "whiteList",
         "If defined, list of entities to process. The rest will be ignored. Do not include IOB prefix on labels",
         typeConverter=TypeConverters.toListString
+    )
+
+    preservePosition = Param(
+        Params._dummy(),
+        "preservePosition",
+        "Whether to preserve the original position of the tokens in the original document or use the modified tokens",
+        typeConverter=TypeConverters.toBoolean
     )
 
     def setWhiteList(self, entities):
@@ -97,7 +110,20 @@ class NerConverter(AnnotatorModel):
         """
         return self._set(whiteList=entities)
 
+    def setPreservePosition(self, value):
+        """
+        Whether to preserve the original position of the tokens in the original document
+        or use the modified tokens, by default `True`.
+
+        Parameters
+        ----------
+        value : bool
+            Whether to preserve the original position of the tokens in the original
+            document or use the modified tokens
+        """
+        return self._set(preservePosition=value)
+
     @keyword_only
     def __init__(self):
-        super(NerConverter, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ner.NerConverter")
-
+        super(NerConverter, self).__init__(
+            classname="com.johnsnowlabs.nlp.annotators.ner.NerConverter")

--- a/python/sparknlp/common/annotator_properties.py
+++ b/python/sparknlp/common/annotator_properties.py
@@ -42,7 +42,7 @@ class AnnotatorProperties(Params):
 
         Parameters
         ----------
-        *value : str
+        *value : List[str]
             Input columns for the annotator
         """
         if type(value[0]) == str or type(value[0]) == list:

--- a/python/test/annotator/ner/ner_converter_test.py
+++ b/python/test/annotator/ner/ner_converter_test.py
@@ -1,0 +1,42 @@
+import unittest
+
+import pytest
+from pyspark.ml import Pipeline
+
+from sparknlp.annotator import *
+from test.util import SparkSessionForTest
+
+
+@pytest.mark.fast
+class NerConverterTestSpec(unittest.TestCase):
+
+    def runTest(self):
+        documentAssembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+        tokenizer = Tokenizer() \
+            .setInputCols(["document"]) \
+            .setOutputCol("token")
+        embeddings = WordEmbeddingsModel.pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("bert")
+        nerTagger = NerDLModel.pretrained() \
+            .setInputCols(["document", "token", "bert"]) \
+            .setOutputCol("ner")
+        pipeline = Pipeline().setStages([
+            documentAssembler,
+            tokenizer,
+            embeddings,
+            nerTagger
+        ])
+        data = SparkSessionForTest.spark.createDataFrame(
+            [["U.N. official Ekeus heads for Baghdad."]]).toDF("text")
+        result = pipeline.fit(data).transform(data)
+
+        converter = NerConverter() \
+            .setInputCols(["document", "token", "ner"]) \
+            .setOutputCol("entities") \
+            .setPreservePosition(False) \
+            .setWhiteList(["ORG", "LOC"])
+
+        converter.transform(result).selectExpr("explode(entities)").show(truncate=False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a missing parameter on the Python side for the NerConverter.

- Also adds missing `inputAnnotatorTypes` for NerConverter
- New test added

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New and old tests passing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
