### PR TITLE
SPARKNLP-669 Adding missing inputAnnotatorTypes

### DIFF
--- a/python/sparknlp/annotator/audio/wav2vec2_for_ctc.py
+++ b/python/sparknlp/annotator/audio/wav2vec2_for_ctc.py
@@ -15,7 +15,6 @@
 """Contains classes concerning Wav2Vec2ForCTC."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Wav2Vec2ForCTC(AnnotatorModel,

--- a/python/sparknlp/annotator/chunker.py
+++ b/python/sparknlp/annotator/chunker.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the Chunker."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Chunker(AnnotatorModel):

--- a/python/sparknlp/annotator/classifier_dl/albert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/albert_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class AlbertForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/albert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/albert_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes concerning AlbertForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class AlbertForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/albert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/albert_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for AlbertForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class AlbertForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/bert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/bert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for BertForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/bert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for BertForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/classifier_dl.py
@@ -16,7 +16,6 @@
 from sparknlp.annotator.param import EvaluationDLParams, ClassifierEncoder
 from sparknlp.base import DocumentAssembler
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEncoder):

--- a/python/sparknlp/annotator/classifier_dl/deberta_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/deberta_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DeBertaForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/deberta_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/deberta_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for DeBertaForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DeBertaForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DistilBertForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for DistilBertForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DistilBertForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for DistilBertForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DistilBertForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/longformer_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/longformer_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LongformerForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/longformer_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/longformer_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for LongformerForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LongformerForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/longformer_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/longformer_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for LongformerForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LongformerForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
@@ -16,7 +16,6 @@
 from sparknlp.annotator.param import EvaluationDLParams, ClassifierEncoder
 from sparknlp.annotator.classifier_dl import ClassifierDLModel
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class MultiClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEncoder):

--- a/python/sparknlp/annotator/classifier_dl/roberta_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/roberta_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/roberta_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/roberta_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for RoBertaForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/roberta_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/roberta_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for RoBertaForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/sentiment_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/sentiment_dl.py
@@ -15,7 +15,6 @@
 
 from sparknlp.annotator.param import EvaluationDLParams, ClassifierEncoder
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentimentDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEncoder):

--- a/python/sparknlp/annotator/classifier_dl/tapas_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/tapas_for_question_answering.py
@@ -14,7 +14,6 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.classifier_dl import BertForQuestionAnswering
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class TapasForQuestionAnswering(BertForQuestionAnswering):

--- a/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for XlmRoBertaForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for XlmRoBertaForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/xlnet_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlnet_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for XlnetForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlnetForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/xlnet_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlnet_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for XlnetForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlnetForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/coref/spanbert_coref.py
+++ b/python/sparknlp/annotator/coref/spanbert_coref.py
@@ -14,7 +14,6 @@
 """Contains classes for the SpanBertCorefModel."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SpanBertCorefModel(AnnotatorModel,

--- a/python/sparknlp/annotator/cv/vit_for_image_classification.py
+++ b/python/sparknlp/annotator/cv/vit_for_image_classification.py
@@ -15,7 +15,6 @@
 """Contains classes concerning ViTForImageClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ViTForImageClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/dependency/dependency_parser.py
+++ b/python/sparknlp/annotator/dependency/dependency_parser.py
@@ -14,7 +14,6 @@
 """Contains classes for the DependencyParser."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DependencyParserApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/dependency/typed_dependency_parser.py
+++ b/python/sparknlp/annotator/dependency/typed_dependency_parser.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class TypedDependencyParserApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/document_normalizer.py
+++ b/python/sparknlp/annotator/document_normalizer.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the DocumentNormalizer"""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DocumentNormalizer(AnnotatorModel):

--- a/python/sparknlp/annotator/embeddings/albert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/albert_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes concerning AlbertEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class AlbertEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/bert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bert_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for BertEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/bert_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bert_sentence_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for BertSentenceEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertSentenceEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/camembert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/camembert_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for CamemBertEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class CamemBertEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/chunk_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/chunk_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for ChunkEmbeddings"""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ChunkEmbeddings(AnnotatorModel):

--- a/python/sparknlp/annotator/embeddings/distil_bert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/distil_bert_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for DistilBertEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DistilBertEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/doc2vec.py
+++ b/python/sparknlp/annotator/embeddings/doc2vec.py
@@ -14,7 +14,6 @@
 """Contains classes for Doc2Vec."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Doc2VecApproach(AnnotatorApproach, HasStorageRef, HasEnableCachingProperties):

--- a/python/sparknlp/annotator/embeddings/elmo_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/elmo_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for ElmoEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ElmoEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/longformer_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/longformer_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for LongformerEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LongformerEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/roberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/roberta_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for RoBertaEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/roberta_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/roberta_sentence_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for RoBertaSentenceEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaSentenceEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/sentence_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for SentenceEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentenceEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasStorageRef):

--- a/python/sparknlp/annotator/embeddings/universal_sentence_encoder.py
+++ b/python/sparknlp/annotator/embeddings/universal_sentence_encoder.py
@@ -14,7 +14,6 @@
 """Contains classes for the UniversalSentenceEncoder."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class UniversalSentenceEncoder(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/word2vec.py
+++ b/python/sparknlp/annotator/embeddings/word2vec.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Word2VecApproach(AnnotatorApproach, HasStorageRef, HasEnableCachingProperties):

--- a/python/sparknlp/annotator/embeddings/word_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/word_embeddings.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class WordEmbeddings(AnnotatorApproach, HasEmbeddingsProperties, HasStorage):

--- a/python/sparknlp/annotator/embeddings/xlm_roberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlm_roberta_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for XlmRoBertaEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/xlm_roberta_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlm_roberta_sentence_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for XlmRoBertaSentenceEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaSentenceEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/xlnet_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlnet_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for XlnetEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlnetEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/er/entity_ruler.py
+++ b/python/sparknlp/annotator/er/entity_ruler.py
@@ -14,7 +14,6 @@
 """Contains classes for the EntityRuler."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class EntityRulerApproach(AnnotatorApproach, HasStorage):

--- a/python/sparknlp/annotator/graph_extraction.py
+++ b/python/sparknlp/annotator/graph_extraction.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for GraphExtraction."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class GraphExtraction(AnnotatorModel):

--- a/python/sparknlp/annotator/keyword_extraction/yake_keyword_extraction.py
+++ b/python/sparknlp/annotator/keyword_extraction/yake_keyword_extraction.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class YakeKeywordExtraction(AnnotatorModel):

--- a/python/sparknlp/annotator/ld_dl/language_detector_dl.py
+++ b/python/sparknlp/annotator/ld_dl/language_detector_dl.py
@@ -14,7 +14,6 @@
 """Contains classes for LanguageDetectorDL."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LanguageDetectorDL(AnnotatorModel, HasStorageRef, HasEngine):

--- a/python/sparknlp/annotator/lemmatizer.py
+++ b/python/sparknlp/annotator/lemmatizer.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the Lemmatizer."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Lemmatizer(AnnotatorApproach):

--- a/python/sparknlp/annotator/matcher/big_text_matcher.py
+++ b/python/sparknlp/annotator/matcher/big_text_matcher.py
@@ -15,7 +15,6 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.matcher.text_matcher import TextMatcherModel
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BigTextMatcher(AnnotatorApproach, HasStorage):
@@ -162,6 +161,7 @@ class BigTextMatcher(AnnotatorApproach, HasStorage):
         tokenizer_model._transfer_params_to_java()
         return self._set(tokenizer_model._java_obj)
 
+
 class BigTextMatcherModel(AnnotatorModel, HasStorageModel):
     """Instantiated model of the BigTextMatcher.
 
@@ -185,7 +185,7 @@ class BigTextMatcherModel(AnnotatorModel, HasStorageModel):
     """
     name = "BigTextMatcherModel"
     databases = ['TMVOCAB', 'TMEDGES', 'TMNODES']
-    inputAnnotatorTypes = [AnnotatorType.TOKEN]
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     caseSensitive = Param(Params._dummy(),
                           "caseSensitive",

--- a/python/sparknlp/annotator/matcher/date_matcher.py
+++ b/python/sparknlp/annotator/matcher/date_matcher.py
@@ -14,7 +14,6 @@
 """Contains classes for the DateMatcher."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DateMatcherUtils(Params):

--- a/python/sparknlp/annotator/matcher/multi_date_matcher.py
+++ b/python/sparknlp/annotator/matcher/multi_date_matcher.py
@@ -15,7 +15,6 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.matcher.date_matcher import DateMatcherUtils
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class MultiDateMatcher(AnnotatorModel, DateMatcherUtils):

--- a/python/sparknlp/annotator/matcher/regex_matcher.py
+++ b/python/sparknlp/annotator/matcher/regex_matcher.py
@@ -14,7 +14,6 @@
 """Contains classes for the RegexMatcher."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RegexMatcher(AnnotatorApproach):

--- a/python/sparknlp/annotator/matcher/text_matcher.py
+++ b/python/sparknlp/annotator/matcher/text_matcher.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class TextMatcher(AnnotatorApproach):

--- a/python/sparknlp/annotator/n_gram_generator.py
+++ b/python/sparknlp/annotator/n_gram_generator.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the NGramGenerator."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NGramGenerator(AnnotatorModel):

--- a/python/sparknlp/annotator/ner/ner_converter.py
+++ b/python/sparknlp/annotator/ner/ner_converter.py
@@ -77,6 +77,8 @@ class NerConverter(AnnotatorModel):
     """
     name = 'NerConverter'
 
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN, AnnotatorType.NAMED_ENTITY]
+
     whiteList = Param(
         Params._dummy(),
         "whiteList",

--- a/python/sparknlp/annotator/ner/ner_crf.py
+++ b/python/sparknlp/annotator/ner/ner_crf.py
@@ -15,7 +15,6 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.ner.ner_approach import NerApproach
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NerCrfApproach(AnnotatorApproach, NerApproach):

--- a/python/sparknlp/annotator/ner/ner_dl.py
+++ b/python/sparknlp/annotator/ner/ner_dl.py
@@ -18,7 +18,6 @@ import sys
 from sparknlp.annotator.param import EvaluationDLParams
 from sparknlp.common import *
 from sparknlp.annotator.ner.ner_approach import NerApproach
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NerDLApproach(AnnotatorApproach, NerApproach, EvaluationDLParams):

--- a/python/sparknlp/annotator/ner/ner_overwriter.py
+++ b/python/sparknlp/annotator/ner/ner_overwriter.py
@@ -14,7 +14,6 @@
 """Contains classes for the NerOverwriter."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NerOverwriter(AnnotatorModel):

--- a/python/sparknlp/annotator/normalizer.py
+++ b/python/sparknlp/annotator/normalizer.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the Normalizer."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Normalizer(AnnotatorApproach):

--- a/python/sparknlp/annotator/pos/perceptron.py
+++ b/python/sparknlp/annotator/pos/perceptron.py
@@ -14,7 +14,6 @@
 """Contains classes for the Perceptron Annotator."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class PerceptronApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/sentence/sentence_detector.py
+++ b/python/sparknlp/annotator/sentence/sentence_detector.py
@@ -14,7 +14,6 @@
 """Contains classes for the SentenceDetector."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentenceDetectorParams:
@@ -287,6 +286,3 @@ class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
             minLength=0,
             maxLength=99999
         )
-
-    def getInputAnnotatorTypes(self):
-        return self.inputAnnotatorTypes

--- a/python/sparknlp/annotator/sentence/sentence_detector_dl.py
+++ b/python/sparknlp/annotator/sentence/sentence_detector_dl.py
@@ -14,7 +14,6 @@
 """Contains classes for SentenceDetectorDl."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentenceDetectorDLApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/sentiment/sentiment_detector.py
+++ b/python/sparknlp/annotator/sentiment/sentiment_detector.py
@@ -14,7 +14,6 @@
 """Contains classes for the SentimentDetector."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentimentDetector(AnnotatorApproach):

--- a/python/sparknlp/annotator/sentiment/vivekn_sentiment.py
+++ b/python/sparknlp/annotator/sentiment/vivekn_sentiment.py
@@ -158,6 +158,7 @@ class ViveknSentimentApproach(AnnotatorApproach):
     def _create_model(self, java_model):
         return ViveknSentimentModel(java_model=java_model)
 
+
 class ViveknSentimentModel(AnnotatorModel):
     """Sentiment analyser inspired by the algorithm by Vivek Narayanan.
 
@@ -190,6 +191,8 @@ class ViveknSentimentModel(AnnotatorModel):
     https://github.com/vivekn/sentiment/
     """
     name = "ViveknSentimentModel"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN, AnnotatorType.DOCUMENT]
 
     importantFeatureRatio = Param(Params._dummy(),
                                   "importantFeatureRatio",

--- a/python/sparknlp/annotator/seq2seq/gpt2_transformer.py
+++ b/python/sparknlp/annotator/seq2seq/gpt2_transformer.py
@@ -14,7 +14,6 @@
 """Contains classes for the GPT2Transformer."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class GPT2Transformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):

--- a/python/sparknlp/annotator/seq2seq/marian_transformer.py
+++ b/python/sparknlp/annotator/seq2seq/marian_transformer.py
@@ -14,7 +14,6 @@
 """Contains classes for the MarianTransformer."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class MarianTransformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):

--- a/python/sparknlp/annotator/seq2seq/t5_transformer.py
+++ b/python/sparknlp/annotator/seq2seq/t5_transformer.py
@@ -14,7 +14,6 @@
 """Contains classes for the T5Transformer."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class T5Transformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):

--- a/python/sparknlp/annotator/spell_check/context_spell_checker.py
+++ b/python/sparknlp/annotator/spell_check/context_spell_checker.py
@@ -14,7 +14,6 @@
 """Contains classes for the ContextSpellChecker."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ContextSpellCheckerApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/spell_check/norvig_sweeting.py
+++ b/python/sparknlp/annotator/spell_check/norvig_sweeting.py
@@ -14,7 +14,6 @@
 """Contains classes for the NorvigSweeting spell checker."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NorvigSweetingApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/spell_check/symmetric_delete.py
+++ b/python/sparknlp/annotator/spell_check/symmetric_delete.py
@@ -14,7 +14,6 @@
 """Contains classes for SymmetricDelete."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SymmetricDeleteApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/stemmer.py
+++ b/python/sparknlp/annotator/stemmer.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the Stemmer."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Stemmer(AnnotatorModel):

--- a/python/sparknlp/annotator/stop_words_cleaner.py
+++ b/python/sparknlp/annotator/stop_words_cleaner.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the StopWordsCleaner."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class StopWordsCleaner(AnnotatorModel):

--- a/python/sparknlp/annotator/token/chunk_tokenizer.py
+++ b/python/sparknlp/annotator/token/chunk_tokenizer.py
@@ -15,7 +15,6 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.token.tokenizer import Tokenizer, TokenizerModel
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ChunkTokenizer(Tokenizer):

--- a/python/sparknlp/annotator/token/recursive_tokenizer.py
+++ b/python/sparknlp/annotator/token/recursive_tokenizer.py
@@ -14,7 +14,6 @@
 """Contains classes for the RecursiveTokenizer."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RecursiveTokenizer(AnnotatorApproach):

--- a/python/sparknlp/annotator/token/regex_tokenizer.py
+++ b/python/sparknlp/annotator/token/regex_tokenizer.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RegexTokenizer(AnnotatorModel):

--- a/python/sparknlp/annotator/token/token2_chunk.py
+++ b/python/sparknlp/annotator/token/token2_chunk.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Token2Chunk(AnnotatorModel):

--- a/python/sparknlp/annotator/token/tokenizer.py
+++ b/python/sparknlp/annotator/token/tokenizer.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Tokenizer(AnnotatorApproach):

--- a/python/sparknlp/annotator/ws/word_segmenter.py
+++ b/python/sparknlp/annotator/ws/word_segmenter.py
@@ -14,7 +14,6 @@
 """Contains classes for the WordSegmenter."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class WordSegmenterApproach(AnnotatorApproach):

--- a/python/sparknlp/base/audio_assembler.py
+++ b/python/sparknlp/base/audio_assembler.py
@@ -15,6 +15,7 @@
 
 from pyspark import keyword_only
 from pyspark.ml.param import TypeConverters, Params, Param
+
 from sparknlp.internal import AnnotatorTransformer
 
 

--- a/python/sparknlp/base/chunk2_doc.py
+++ b/python/sparknlp/base/chunk2_doc.py
@@ -15,10 +15,9 @@
 
 from pyspark import keyword_only
 
+from sparknlp.common import AnnotatorProperties
 from sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.internal import AnnotatorTransformer
-
-from sparknlp.common import AnnotatorProperties
 
 
 class Chunk2Doc(AnnotatorTransformer, AnnotatorProperties):

--- a/python/sparknlp/base/doc2_chunk.py
+++ b/python/sparknlp/base/doc2_chunk.py
@@ -16,10 +16,9 @@
 from pyspark import keyword_only
 from pyspark.ml.param import TypeConverters, Params, Param
 
-from sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.internal import AnnotatorTransformer
 
-from sparknlp.common import AnnotatorProperties
+from sparknlp.common import AnnotatorProperties, AnnotatorType
 
 
 class Doc2Chunk(AnnotatorTransformer, AnnotatorProperties):

--- a/python/sparknlp/base/table_assembler.py
+++ b/python/sparknlp/base/table_assembler.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the TableAssembler."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class TableAssembler(AnnotatorModel):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding missing inputAnnotatorTypes in Python and removing redundant imports

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Check issue #13133 and #13131

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Local Tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
