### PR TITLE
Spark NLP 424-release-candidate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,28 @@
 ========
+4.2.4
+========
+----------------
+New Features & Enhancements
+----------------
+* Introduce support for GCP storage to be allowed as `cache_pretrained` directory for keeping all downloaded models and pipelines
+* Update to TensorFlow 2.7.4 with bug and CVEs fixes
+* Update documentation on how to use `testDataset` param in NerDLApproach, ClassifierDLApproach, MultiClassifierDLApproach, and SentimentDLApproach
+* Update installation instructions for Apple M1 chip
+* Improve error handling while importing external TensorFlow models into Spark NLP
+* Improve error messages when importing external models from remote storages like DBFS, S3, and HDFS
+* Add support for future decoder-encoder models (2 separate models)
+
+----------------
+Bug Fixes
+----------------
+* Add missing setPreservePosition in NerConverter
+* Add missing inputAnnotatorTypes to BigTextMatcher, ViveknSentimentModel, and NerConverter annotators
+* Fix all wrong example codes provided for LemmatizerModel in Models Hub
+* Fix provided notebook to import Longformer models from HF: https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/transformers/HuggingFace%20in%20Spark%20NLP%20-%20Longformer.ipynb
+* Fix the t5_grammar_error_corrector model to be compatible with Spark NLP 4.0+
+
+
+========
 4.2.3
 ========
 ----------------
@@ -17,7 +41,6 @@ regexMatcher = RegexMatcher() \
       .setOutputCol("regex") \
       .setStrategy("MATCH_ALL")
 ```
-*
 
 ----------------
 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ To use Spark NLP you need the following requirements:
 
 **GPU (optional):**
 
-Spark NLP 4.2.3 is built with TensorFlow 2.7.1 and the following NVIDIA® software are only required for GPU support:
+Spark NLP 4.2.4 is built with TensorFlow 2.7.1 and the following NVIDIA® software are only required for GPU support:
 
 - NVIDIA® GPU drivers version 450.80.02 or higher
 - CUDA® Toolkit 11.2
@@ -168,7 +168,7 @@ $ java -version
 $ conda create -n sparknlp python=3.7 -y
 $ conda activate sparknlp
 # spark-nlp by default is based on pyspark 3.x
-$ pip install spark-nlp==4.2.3 pyspark==3.2.1
+$ pip install spark-nlp==4.2.4 pyspark==3.2.1
 ```
 
 In Python console or Jupyter `Python3` kernel:
@@ -213,7 +213,7 @@ For more examples, you can visit our dedicated [repository](https://github.com/J
 
 ## Apache Spark Support
 
-Spark NLP *4.2.3* has been built on top of Apache Spark 3.2 while fully supports Apache Spark 3.0.x, 3.1.x, 3.2.x, and 3.3.x:
+Spark NLP *4.2.4* has been built on top of Apache Spark 3.2 while fully supports Apache Spark 3.0.x, 3.1.x, 3.2.x, and 3.3.x:
 
 | Spark NLP | Apache Spark 2.3.x | Apache Spark 2.4.x | Apache Spark 3.0.x | Apache Spark 3.1.x | Apache Spark 3.2.x | Apache Spark 3.3.x |
 |-----------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
@@ -247,7 +247,7 @@ Find out more about `Spark NLP` versions from our [release notes](https://github
 
 ## Databricks Support
 
-Spark NLP 4.2.3 has been tested and is compatible with the following runtimes:
+Spark NLP 4.2.4 has been tested and is compatible with the following runtimes:
 
 **CPU:**
 
@@ -288,7 +288,7 @@ NOTE: Spark NLP 4.0.x is based on TensorFlow 2.7.x which is compatible with CUDA
 
 ## EMR Support
 
-Spark NLP 4.2.3 has been tested and is compatible with the following EMR releases:
+Spark NLP 4.2.4 has been tested and is compatible with the following EMR releases:
 
 - emr-6.2.0
 - emr-6.3.0
@@ -326,11 +326,11 @@ Spark NLP supports all major releases of Apache Spark 3.0.x, Apache Spark 3.1.x,
 ```sh
 # CPU
 
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+spark-shell --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 The `spark-nlp` has been published to the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp).
@@ -338,11 +338,11 @@ The `spark-nlp` has been published to the [Maven Repository](https://mvnreposito
 ```sh
 # GPU
 
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.2.3
+spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.2.4
 
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.2.3
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.2.4
 
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.2.3
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.2.4
 
 ```
 
@@ -351,11 +351,11 @@ The `spark-nlp-gpu` has been published to the [Maven Repository](https://mvnrepo
 ```sh
 # AArch64
 
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.2.3
+spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.2.4
 
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.2.3
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.2.4
 
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.2.3
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.2.4
 
 ```
 
@@ -364,11 +364,11 @@ The `spark-nlp-aarch64` has been published to the [Maven Repository](https://mvn
 ```sh
 # M1
 
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.2.3
+spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.2.4
 
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.2.3
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.2.4
 
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.2.3
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.2.4
 
 ```
 
@@ -380,7 +380,7 @@ The `spark-nlp-m1` has been published to the [Maven Repository](https://mvnrepos
 spark-shell \
   --driver-memory 16g \
   --conf spark.kryoserializer.buffer.max=2000M \
-  --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+  --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 ## Scala
@@ -396,7 +396,7 @@ Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -407,7 +407,7 @@ Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp-gpu_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -418,7 +418,7 @@ Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp-aarch64_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -429,7 +429,7 @@ Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp-m1_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -439,28 +439,28 @@ Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2
 
 ```sbtshell
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp" % "4.2.4"
 ```
 
 **spark-nlp-gpu:**
 
 ```sbtshell
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-gpu
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-gpu" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-gpu" % "4.2.4"
 ```
 
 **spark-nlp-aarch64:**
 
 ```sbtshell
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-aarch64
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-aarch64" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-aarch64" % "4.2.4"
 ```
 
 **spark-nlp-m1:**
 
 ```sbtshell
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-m1
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-m1" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-m1" % "4.2.4"
 ```
 
 Maven Central: [https://mvnrepository.com/artifact/com.johnsnowlabs.nlp](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp)
@@ -480,7 +480,7 @@ If you installed pyspark through pip/conda, you can install `spark-nlp` through 
 Pip:
 
 ```bash
-pip install spark-nlp==4.2.3
+pip install spark-nlp==4.2.4
 ```
 
 Conda:
@@ -508,7 +508,7 @@ spark = SparkSession.builder \
     .config("spark.driver.memory","16G")\
     .config("spark.driver.maxResultSize", "0") \
     .config("spark.kryoserializer.buffer.max", "2000M")\
-    .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3")\
+    .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4")\
     .getOrCreate()
 ```
 
@@ -576,7 +576,7 @@ Use either one of the following options
 - Add the following Maven Coordinates to the interpreter's library list
 
 ```bash
-com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 - Add a path to pre-built jar from [here](#compiled-jars) in the interpreter's library list making sure the jar is available to driver path
@@ -586,7 +586,7 @@ com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
 Apart from the previous step, install the python module through pip
 
 ```bash
-pip install spark-nlp==4.2.3
+pip install spark-nlp==4.2.4
 ```
 
 Or you can install `spark-nlp` from inside Zeppelin by using Conda:
@@ -611,7 +611,7 @@ The easiest way to get this done on Linux and macOS is to simply install `spark-
 $ conda create -n sparknlp python=3.8 -y
 $ conda activate sparknlp
 # spark-nlp by default is based on pyspark 3.x
-$ pip install spark-nlp==4.2.3 pyspark==3.2.1 jupyter
+$ pip install spark-nlp==4.2.4 pyspark==3.2.1 jupyter
 $ jupyter notebook
 ```
 
@@ -627,7 +627,7 @@ export PYSPARK_PYTHON=python3
 export PYSPARK_DRIVER_PYTHON=jupyter
 export PYSPARK_DRIVER_PYTHON_OPTS=notebook
 
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 Alternatively, you can mix in using `--jars` option for pyspark + `pip install spark-nlp`
@@ -652,7 +652,7 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 # -s is for spark-nlp
 # -g will enable upgrading libcudnn8 to 8.1.0 on Google Colab for GPU usage
 # by default they are set to the latest
-!wget https://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.1 -s 4.2.3
+!wget https://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.1 -s 4.2.4
 ```
 
 [Spark NLP quick start on Google Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/quick_start_google_colab.ipynb) is a live demo on Google Colab that performs named entity recognitions and sentiment analysis by using Spark NLP pretrained pipelines.
@@ -673,7 +673,7 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 # -s is for spark-nlp
 # -g will enable upgrading libcudnn8 to 8.1.0 on Kaggle for GPU usage
 # by default they are set to the latest
-!wget https://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.1 -s 4.2.3
+!wget https://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.1 -s 4.2.4
 ```
 
 [Spark NLP quick start on Kaggle Kernel](https://www.kaggle.com/mozzie/spark-nlp-named-entity-recognition) is a live demo on Kaggle Kernel that performs named entity recognitions by using Spark NLP pretrained pipeline.
@@ -691,9 +691,9 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 
 3. In `Libraries` tab inside your cluster you need to follow these steps:
 
-    3.1. Install New -> PyPI -> `spark-nlp==4.2.3` -> Install
+    3.1. Install New -> PyPI -> `spark-nlp==4.2.4` -> Install
 
-    3.2. Install New -> Maven -> Coordinates -> `com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3` -> Install
+    3.2. Install New -> Maven -> Coordinates -> `com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4` -> Install
 
 4. Now you can attach your notebook to the cluster and use Spark NLP!
 
@@ -741,7 +741,7 @@ A sample of your software configuration in JSON on S3 (must be public access):
       "spark.kryoserializer.buffer.max": "2000M",
       "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
       "spark.driver.maxResultSize": "0",
-      "spark.jars.packages": "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3"
+      "spark.jars.packages": "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4"
     }
 }]
 ```
@@ -750,7 +750,7 @@ A sample of AWS CLI to launch EMR cluster:
 
 ```.sh
 aws emr create-cluster \
---name "Spark NLP 4.2.3" \
+--name "Spark NLP 4.2.4" \
 --release-label emr-6.2.0 \
 --applications Name=Hadoop Name=Spark Name=Hive \
 --instance-type m4.4xlarge \
@@ -814,7 +814,7 @@ gcloud dataproc clusters create ${CLUSTER_NAME} \
   --enable-component-gateway \
   --metadata 'PIP_PACKAGES=spark-nlp spark-nlp-display google-cloud-bigquery google-cloud-storage' \
   --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/python/pip-install.sh \
-  --properties spark:spark.serializer=org.apache.spark.serializer.KryoSerializer,spark:spark.driver.maxResultSize=0,spark:spark.kryoserializer.buffer.max=2000M,spark:spark.jars.packages=com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+  --properties spark:spark.serializer=org.apache.spark.serializer.KryoSerializer,spark:spark.driver.maxResultSize=0,spark:spark.kryoserializer.buffer.max=2000M,spark:spark.jars.packages=com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 2. On an existing one, you need to install spark-nlp and spark-nlp-display packages from PyPI.
@@ -853,7 +853,7 @@ spark = SparkSession.builder \
         .config("spark.kryoserializer.buffer.max", "2000m") \
         .config("spark.jsl.settings.pretrained.cache_folder", "sample_data/pretrained") \
         .config("spark.jsl.settings.storage.cluster_tmp_dir", "sample_data/storage") \
-        .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3") \
+        .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4") \
         .getOrCreate()
 ```
 
@@ -867,7 +867,7 @@ spark-shell \
   --conf spark.kryoserializer.buffer.max=2000M \
   --conf spark.jsl.settings.pretrained.cache_folder="sample_data/pretrained" \
   --conf spark.jsl.settings.storage.cluster_tmp_dir="sample_data/storage" \
-  --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+  --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 **pyspark:**
@@ -880,7 +880,7 @@ pyspark \
   --conf spark.kryoserializer.buffer.max=2000M \
   --conf spark.jsl.settings.pretrained.cache_folder="sample_data/pretrained" \
   --conf spark.jsl.settings.storage.cluster_tmp_dir="sample_data/storage" \
-  --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+  --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 **Databricks:**
@@ -1144,12 +1144,12 @@ spark = SparkSession.builder \
     .config("spark.driver.memory","16G")\
     .config("spark.driver.maxResultSize", "0") \
     .config("spark.kryoserializer.buffer.max", "2000M")\
-    .config("spark.jars", "/tmp/spark-nlp-assembly-4.2.3.jar")\
+    .config("spark.jars", "/tmp/spark-nlp-assembly-4.2.4.jar")\
     .getOrCreate()
 ```
 
 - You can download provided Fat JARs from each [release notes](https://github.com/JohnSnowLabs/spark-nlp/releases), please pay attention to pick the one that suits your environment depending on the device (CPU/GPU) and Apache Spark version (3.0.x, 3.1.x, 3.2.x, and 3.3.x)
-- If you are local, you can load the Fat JAR from your local FileSystem, however, if you are in a cluster setup you need to put the Fat JAR on a distributed FileSystem such as HDFS, DBFS, S3, etc. (i.e., `hdfs:///tmp/spark-nlp-assembly-4.2.3.jar`)
+- If you are local, you can load the Fat JAR from your local FileSystem, however, if you are in a cluster setup you need to put the Fat JAR on a distributed FileSystem such as HDFS, DBFS, S3, etc. (i.e., `hdfs:///tmp/spark-nlp-assembly-4.2.4.jar`)
 
 Example of using pretrained Models and Pipelines in offline:
 

--- a/build.sbt
+++ b/build.sbt
@@ -143,8 +143,12 @@ lazy val utilDependencies = Seq(
     exclude ("commons-configuration", "commons-configuration"),
   liblevenshtein
     exclude ("com.google.guava", "guava")
-    exclude ("org.apache.commons", "commons-lang3"),
-  greex)
+    exclude ("org.apache.commons", "commons-lang3")
+    exclude ("com.google.code.findbugs", "annotations")
+    exclude ("org.slf4j", "slf4j-api"),
+  gcpStorage,
+  greex
+)
 
 lazy val typedDependencyParserDependencies = Seq(junit)
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := getPackageName(is_m1, is_gpu, is_aarch64)
 
 organization := "com.johnsnowlabs.nlp"
 
-version := "4.2.3"
+version := "4.2.4"
 
 (ThisBuild / scalaVersion) := scalaVer
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: "spark-nlp"
-  version: 4.2.3
+  version: 4.2.4
 
 app:
   entry: spark-nlp
   summary: Natural Language Understanding Library for Apache Spark.
 
 source:
-    fn: spark-nlp-4.2.3.tar.gz
+    fn: spark-nlp-4.2.4.tar.gz
     url: https://files.pythonhosted.org/packages/09/81/d5644f8ff89839da85b1ef70cf38ca0cab2fc12041d724c5e794a47c14f5/spark-nlp-4.2.3.tar.gz
     sha256: 430aa24d0e325138140ef92b6e7c4c797838e9eee14aaf636af08276956549f9
 build:

--- a/docs/_layouts/landing.html
+++ b/docs/_layouts/landing.html
@@ -201,22 +201,22 @@ article_header:
                   <div class="highlight-box">
     {% highlight bash %}
     # Install Spark NLP from PyPI
-    $ pip install spark-nlp==4.2.3 pyspark==3.3.0
+    $ pip install spark-nlp==4.2.4 pyspark==3.3.0
 
     # Install Spark NLP from Anaconda/Conda
     $ conda install -c johnsnowlabs spark-nlp
 
     # Load Spark NLP with Spark Shell
-    $ spark-shell --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+    $ spark-shell --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 
     # Load Spark NLP with PySpark
-    $ pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+    $ pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 
     # Load Spark NLP with Spark Submit
-    $ spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+    $ spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 
     # Load Spark NLP as an external Fat JAR
-    $ spark-shell --jars spark-nlp-assembly-4.2.3.jar
+    $ spark-shell --jars spark-nlp-assembly-4.2.4.jar
     {% endhighlight %}
                     </div>
                 </div>

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_alksnis_lt_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_alksnis_lt_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
     .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_alksnis", "lt")\ 
-    .setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
     .setOutputCol("lemma")
     
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
     .setOutputCol("token")
     
 val lemma = LemmatizerModel.pretrained("lemma_alksnis", "lt")
-    .setInputCols("sentence", "token")
+.setInputCols("token")
     .setOutputCol("lemma")
     
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_alpino_nl_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_alpino_nl_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_alpino", "nl")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_alpino", "nl")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_ancora_ca_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_ancora_ca_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ancora", "ca")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ancora", "ca")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_arcosg_gd_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_arcosg_gd_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_arcosg", "gd")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_arcosg", "gd")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_atis_en_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_atis_en_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_atis", "en")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_atis", "en")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_atis_tr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_atis_tr_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_atis", "tr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -71,7 +71,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_atis", "tr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_boun_tr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_boun_tr_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_boun", "tr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_boun", "tr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_btb_bg_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_btb_bg_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_btb", "bg")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_btb", "bg")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_cac_cs_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_cac_cs_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_cac", "cs")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_cac", "cs")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_ccg_cy_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_ccg_cy_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ccg", "cy")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ccg", "cy")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_csui_id_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_csui_id_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_csui", "id")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_csui", "id")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_ctg_gl_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_ctg_gl_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ctg", "gl")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ctg", "gl")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_ddt_da_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_ddt_da_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ddt", "da")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ddt", "da")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_esl_en_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_esl_en_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_esl", "en")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_esl", "en")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_farpahc_fo_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_farpahc_fo_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_farpahc", "fo")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_farpahc", "fo")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_gdt_el_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_gdt_el_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gdt", "el")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gdt", "el")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsd_de_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsd_de_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gsd", "de")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -71,7 +71,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gsd", "de")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsd_es_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsd_es_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gsd", "es")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -71,7 +71,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gsd", "es")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsd_fr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsd_fr_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gsd", "fr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -71,7 +71,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gsd", "fr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsd_ja_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsd_ja_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gsd", "ja")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -71,7 +71,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gsd", "ja")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsd_pt_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsd_pt_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gsd", "pt")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -71,7 +71,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gsd", "pt")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsd_zh_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsd_zh_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gsd", "zh")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -71,7 +71,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gsd", "zh")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsdluw_ja_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsdluw_ja_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gsdluw", "ja")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gsdluw", "ja")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsdsimp_zh_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_gsdsimp_zh_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gsdsimp", "zh")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gsdsimp", "zh")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_gum_en_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_gum_en_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gum", "en")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gum", "en")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_hdt_de_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_hdt_de_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_hdt", "de")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_hdt", "de")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_hdtb_hi_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_hdtb_hi_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_hdtb", "hi")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_hdtb", "hi")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_htb_he_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_htb_he_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_htb", "he")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_htb", "he")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_idt_ga_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_idt_ga_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_idt", "ga")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_idt", "ga")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_isdt_it_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_isdt_it_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_isdt", "it")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_isdt", "it")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_ittb_la_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_ittb_la_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ittb", "la")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ittb", "la")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_iu_uk_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_iu_uk_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_iu", "uk")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_iu", "uk")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_kyoto_lzh_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_kyoto_lzh_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_kyoto", "lzh")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_kyoto", "lzh")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_lassysmall_nl_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_lassysmall_nl_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_lassysmall", "nl")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_lassysmall", "nl")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_lvtb_lv_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_lvtb_lv_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_lvtb", "lv")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_lvtb", "lv")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_modern_is_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_modern_is_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_modern", "is")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_modern", "is")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_nonstandard_ro_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_nonstandard_ro_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_nonstandard", "ro")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_nonstandard", "ro")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_nsc_pcm_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_nsc_pcm_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_nsc", "pcm")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_nsc", "pcm")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_nynorsklia_no_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_nynorsklia_no_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_nynorsklia", "no")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_nynorsklia", "no")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_parisstories_fr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_parisstories_fr_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_parisstories", "fr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_parisstories", "fr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_partut_en_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_partut_en_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_partut", "en")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -71,7 +71,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_partut", "en")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_partut_fr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_partut_fr_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_partut", "fr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -71,7 +71,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_partut", "fr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_partut_it_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_partut_it_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_partut", "it")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_partut", "it")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_pdb_pl_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_pdb_pl_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_pdb", "pl")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_pdb", "pl")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_pdt_cs_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_pdt_cs_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_pdt", "cs")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_pdt", "cs")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_perdt_fa_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_perdt_fa_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_perdt", "fa")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_perdt", "fa")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_perseus_grc_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_perseus_grc_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_perseus", "grc")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_perseus", "grc")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_perseus_la_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_perseus_la_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_perseus", "la")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -71,7 +71,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_perseus", "la")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_proiel_cu_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_proiel_cu_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_proiel", "cu")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -71,7 +71,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_proiel", "cu")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_proiel_got_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_proiel_got_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_proiel", "got")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -71,7 +71,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_proiel", "got")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_rhapsodie_fr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_rhapsodie_fr_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_rhapsodie", "fr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_rhapsodie", "fr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_rnc_orv_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_rnc_orv_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_rnc", "orv")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_rnc", "orv")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_rrt_ro_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_rrt_ro_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_rrt", "ro")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_rrt", "ro")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_sagt_qtd_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_sagt_qtd_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_sagt", "qtd")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_sagt", "qtd")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_scriptorium_cop_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_scriptorium_cop_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_scriptorium", "cop")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_scriptorium", "cop")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_sequoia_fr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_sequoia_fr_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_sequoia", "fr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_sequoia", "fr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_seraji_fa_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_seraji_fa_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_seraji", "fa")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_seraji", "fa")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_set_hr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_set_hr_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_set", "hr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_set", "hr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_simonero_ro_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_simonero_ro_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_simonero", "ro")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_simonero", "ro")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_srcmf_fro_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_srcmf_fro_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_srcmf", "fro")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_srcmf", "fro")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_ssj_sl_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_ssj_sl_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ssj", "sl")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ssj", "sl")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_syntagrus_ru_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_syntagrus_ru_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_syntagrus", "ru")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_syntagrus", "ru")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_szeged_hu_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_szeged_hu_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_szeged", "hu")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_szeged", "hu")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_taiga_ru_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_taiga_ru_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_taiga", "ru")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_taiga", "ru")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_talbanken_sv_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_talbanken_sv_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_talbanken", "sv")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_talbanken", "sv")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_tourism_tr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_tourism_tr_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_tourism", "tr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_tourism", "tr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_ttb_ta_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_ttb_ta_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ttb", "ta")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ttb", "ta")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_udante_la_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_udante_la_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_udante", "la")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_udante", "la")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_udt_ug_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_udt_ug_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_udt", "ug")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_udt", "ug")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_vit_it_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_vit_it_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_vit", "it")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_vit", "it")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_vtb_vi_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_vtb_vi_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_vtb", "vi")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_vtb", "vi")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-03-31-lemma_wtb_wo_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-03-31-lemma_wtb_wo_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_wtb", "wo")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -72,7 +72,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_wtb", "wo")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_afribooms_af_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_afribooms_af_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_afribooms", "af")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_afribooms", "af")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_ancora_es_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_ancora_es_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ancora", "es")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -69,7 +69,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ancora", "es")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_armtdp_hy_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_armtdp_hy_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_armtdp", "hy")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_armtdp", "hy")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_armtdp_hyw_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_armtdp_hyw_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_armtdp", "hyw")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -69,7 +69,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_armtdp", "hyw")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_bdt_eu_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_bdt_eu_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_bdt", "eu")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_bdt", "eu")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_bokmaal_no_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_bokmaal_no_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
     .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_bokmaal", "no")\ 
-    .setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
     .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
     .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_bokmaal", "no")
-    .setInputCols("sentence", "token")
+.setInputCols("token")
     .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_bosque_pt_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_bosque_pt_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_bosque", "pt")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_bosque", "pt")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_cltt_cs_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_cltt_cs_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_cltt", "cs")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_cltt", "cs")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_edt_et_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_edt_et_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_edt", "et")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_edt", "et")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_ewt_en_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_ewt_en_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ewt", "en")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -69,7 +69,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ewt", "en")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_ewt_et_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_ewt_et_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ewt", "et")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ewt", "et")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_fictree_cs_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_fictree_cs_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_fictree", "cs")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_fictree", "cs")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_framenet_tr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_framenet_tr_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_framenet", "tr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_framenet", "tr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_ftb_fi_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_ftb_fi_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ftb", "fi")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ftb", "fi")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_ftb_fr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_ftb_fr_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ftb", "fr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -69,7 +69,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ftb", "fr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_giella_sme_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_giella_sme_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_giella", "sme")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_giella", "sme")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_gsd_id_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_gsd_id_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gsd", "id")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -69,7 +69,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gsd", "id")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_gsd_ko_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_gsd_ko_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gsd", "ko")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gsd", "ko")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_gsd_ru_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_gsd_ru_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_gsd", "ru")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -69,7 +69,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_gsd", "ru")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_hiencs_qhe_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_hiencs_qhe_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_hiencs", "qhe")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_hiencs", "qhe")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_hse_be_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_hse_be_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_hse", "be")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_hse", "be")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_icepahc_is_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_icepahc_is_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_icepahc", "is")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_icepahc", "is")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_imst_tr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_imst_tr_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_imst", "tr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_imst", "tr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_kaist_ko_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_kaist_ko_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_kaist", "ko")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_kaist", "ko")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_kenet_tr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_kenet_tr_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_kenet", "tr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_kenet", "tr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_lfg_pl_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_lfg_pl_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_lfg", "pl")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_lfg", "pl")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_lines_en_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_lines_en_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_lines", "en")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -69,7 +69,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_lines", "en")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_lines_sv_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_lines_sv_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_lines", "sv")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_lines", "sv")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_llct_la_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_llct_la_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_llct", "la")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_llct", "la")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_mtg_te_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_mtg_te_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_mtg", "te")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_mtg", "te")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_mudt_mt_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_mudt_mt_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_mudt", "mt")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_mudt", "mt")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_nynorsk_no_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_nynorsk_no_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_nynorsk", "no")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_nynorsk", "no")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_padt_ar_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_padt_ar_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_padt", "ar")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_padt", "ar")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_penn_tr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_penn_tr_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_penn", "tr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_penn", "tr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_postwita_it_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_postwita_it_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_postwita", "it")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_postwita", "it")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_proiel_grc_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_proiel_grc_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_proiel", "grc")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_proiel", "grc")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_proiel_la_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_proiel_la_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_proiel", "la")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -69,7 +69,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_proiel", "la")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_set_sr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_set_sr_3_0.md
@@ -45,7 +45,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_set", "sr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -69,7 +69,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_set", "sr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_snk_sk_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_snk_sk_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_snk", "sk")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_snk", "sk")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_sst_sl_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_sst_sl_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_sst", "sl")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_sst", "sl")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_tdt_fi_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_tdt_fi_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_tdt", "fi")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_tdt", "fi")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_torot_orv_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_torot_orv_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_torot", "orv")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_torot", "orv")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_treegal_gl_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_treegal_gl_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_treegal", "gl")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_treegal", "gl")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_twittiro_it_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_twittiro_it_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_twittiro", "it")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_twittiro", "it")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_udtb_ur_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_udtb_ur_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_udtb", "ur")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_udtb", "ur")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_ufal_mr_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_ufal_mr_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_ufal", "mr")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_ufal", "mr")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/_posts/maziyarpanahi/2022-05-01-lemma_vedic_sa_3_0.md
+++ b/docs/_posts/maziyarpanahi/2022-05-01-lemma_vedic_sa_3_0.md
@@ -46,7 +46,7 @@ tokenizer = Tokenizer()\
 .setOutputCol("token") 
 
 lemma = LemmatizerModel.pretrained("lemma_vedic", "sa")\ 
-.setInputCols(["sentence", "token"])\ 
+.setInputCols(["token"])\
 .setOutputCol("lemma")
 
 pipeline = Pipeline(stages=[document, sentence, tokenizer, lemma])
@@ -70,7 +70,7 @@ val tokenizer = new Tokenizer()
 .setOutputCol("token")
 
 val lemma = LemmatizerModel.pretrained("lemma_vedic", "sa")
-.setInputCols("sentence", "token")
+.setInputCols("token")
 .setOutputCol("lemma")
 
 val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, lemma))

--- a/docs/en/annotator_entries/ClassifierDL.md
+++ b/docs/en/annotator_entries/ClassifierDL.md
@@ -155,6 +155,38 @@ The ClassifierDL annotator uses a deep learning model (DNNs) we have built insid
 
 For instantiated/pretrained models, see ClassifierDLModel.
 
+Setting a test dataset to monitor model metrics can be done with `.setTestDataset`. The
+method expects a path to a parquet file containing a dataframe that has the same
+required columns as the training dataframe. The pre-processing steps for the training
+dataframe should also be applied to the test dataframe. The following example will show
+how to create the test dataset:
+
+```
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val embeddings = UniversalSentenceEncoder.pretrained()
+  .setInputCols("document")
+  .setOutputCol("sentence_embeddings")
+
+val preProcessingPipeline = new Pipeline().setStages(Array(documentAssembler, embeddings))
+
+val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+preProcessingPipeline
+  .fit(test)
+  .transform(test)
+  .write
+  .mode("overwrite")
+  .parquet("test_data")
+
+val classifier = new ClassifierDLApproach()
+  .setInputCols("sentence_embeddings")
+  .setOutputCol("category")
+  .setLabelColumn("label")
+  .setTestDataset("test_data")
+```
+
 For extended examples of usage, see the Spark NLP Workshop
 [[1] ](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/scala/training/Train%20Multi-Class%20Text%20Classification%20on%20News%20Articles.scala)
 [[2] ](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.Text_Classification_with_ClassifierDL.ipynb)

--- a/docs/en/annotator_entries/MultiClassifierDL.md
+++ b/docs/en/annotator_entries/MultiClassifierDL.md
@@ -186,7 +186,7 @@ preProcessingPipeline
   .mode("overwrite")
   .parquet("test_data")
 
-val mulitClassifier = new MultiClassifierDLApproach()
+val multiClassifier = new MultiClassifierDLApproach()
   .setInputCols("sentence_embeddings")
   .setOutputCol("category")
   .setLabelColumn("label")

--- a/docs/en/annotator_entries/SentimentDL.md
+++ b/docs/en/annotator_entries/SentimentDL.md
@@ -145,6 +145,37 @@ For the instantiated/pretrained models, see SentimentDLModel.
     [SentenceEmbeddings](/docs/en/annotators#sentenceembeddings) or other
     sentence based embeddings can be used
 
+Setting a test dataset to monitor model metrics can be done with `.setTestDataset`. The method
+expects a path to a parquet file containing a dataframe that has the same required columns as
+the training dataframe. The pre-processing steps for the training dataframe should also be
+applied to the test dataframe. The following example will show how to create the test dataset:
+
+```
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val embeddings = UniversalSentenceEncoder.pretrained()
+  .setInputCols("document")
+  .setOutputCol("sentence_embeddings")
+
+val preProcessingPipeline = new Pipeline().setStages(Array(documentAssembler, embeddings))
+
+val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+preProcessingPipeline
+  .fit(test)
+  .transform(test)
+  .write
+  .mode("overwrite")
+  .parquet("test_data")
+
+val classifier = new SentimentDLApproach()
+  .setInputCols("sentence_embeddings")
+  .setOutputCol("sentiment")
+  .setLabelColumn("label")
+  .setTestDataset("test_data")
+```
+
 For extended examples of usage, see the [Spark NLP Workshop](https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb)
 and the [SentimentDLTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLTestSpec.scala).
 {%- endcapture -%}

--- a/docs/en/concepts.md
+++ b/docs/en/concepts.md
@@ -62,7 +62,7 @@ $ java -version
 $ conda create -n sparknlp python=3.7 -y
 $ conda activate sparknlp
 # spark-nlp by default is based on pyspark 3.x
-$ pip install spark-nlp==4.2.3 pyspark==3.2.1 jupyter
+$ pip install spark-nlp==4.2.4 pyspark==3.2.1 jupyter
 $ jupyter notebook
 ```
 

--- a/docs/en/examples.md
+++ b/docs/en/examples.md
@@ -16,7 +16,7 @@ $ java -version
 # should be Java 8 (Oracle or OpenJDK)
 $ conda create -n sparknlp python=3.7 -y
 $ conda activate sparknlp
-$ pip install spark-nlp==4.2.3 pyspark==3.2.1
+$ pip install spark-nlp==4.2.4 pyspark==3.2.1
 ```
 
 ## Google Colab Notebook
@@ -36,7 +36,7 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 # -p is for pyspark
 # -s is for spark-nlp
 # by default they are set to the latest
-!bash colab.sh -p 3.2.1 -s 4.2.3
+!bash colab.sh -p 3.2.1 -s 4.2.4
 ```
 
 [Spark NLP quick start on Google Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/quick_start_google_colab.ipynb) is a live demo on Google Colab that performs named entity recognitions and sentiment analysis by using Spark NLP pretrained pipelines.

--- a/docs/en/hardware_acceleration.md
+++ b/docs/en/hardware_acceleration.md
@@ -49,7 +49,7 @@ Since the new Transformer models such as BERT for Word and Sentence embeddings a
 | DeBERTa Large     |        +477%(5.8x)        |
 | Longformer Base   |         +52%(1.5x)        |
 
-Spark NLP 4.2.3 is built with TensorFlow 2.7.1 and the following NVIDIA® software are only required for GPU support:
+Spark NLP 4.2.4 is built with TensorFlow 2.7.1 and the following NVIDIA® software are only required for GPU support:
 
 - NVIDIA® GPU drivers version 450.80.02 or higher
 - CUDA® Toolkit 11.2

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -160,7 +160,9 @@ If you are interested, there is a simple SBT project for Spark NLP to guide you 
 
 ## Installation for M1 Macs
 
-Starting from version 4.2.3, Spark NLP has experimental support for M1 macs.
+Starting from version 4.0.0, Spark NLP has experimental support for M1 macs. Note that
+at the moment, only the standard variant of the M1 is supported. Other variants (e.g.
+M1 Pro/Max/Ultra, M2) will most likely not work.
 
 Make sure the following prerequisites are met:
 

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -5,7 +5,7 @@ seotitle: Spark NLP
 title: Installation
 permalink: /docs/en/install
 key: docs-install
-modify_date: "2022-08-23"
+modify_date: "2022-11-28"
 show_nav: true
 sidebar:
     nav: sparknlp
@@ -15,22 +15,22 @@ sidebar:
 
 ```bash
 # Install Spark NLP from PyPI
-pip install spark-nlp==4.2.3
+pip install spark-nlp==4.2.4
 
 # Install Spark NLP from Anacodna/Conda
 conda install -c johnsnowlabs spark-nlp
 
 # Load Spark NLP with Spark Shell
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+spark-shell --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 
 # Load Spark NLP with PySpark
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 
 # Load Spark NLP with Spark Submit
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 
 # Load Spark NLP as external JAR after compiling and building Spark NLP by `sbt assembly`
-spark-shell --jars spark-nlp-assembly-4.2.3.jar
+spark-shell --jars spark-nlp-assembly-4.2.4.jar
 ```
 
 ## Python
@@ -45,7 +45,7 @@ $ java -version
 # should be Java 8 (Oracle or OpenJDK)
 $ conda create -n sparknlp python=3.8 -y
 $ conda activate sparknlp
-$ pip install spark-nlp==4.2.3 pyspark==3.2.1
+$ pip install spark-nlp==4.2.4 pyspark==3.2.1
 ```
 
 Of course you will need to have jupyter installed in your system:
@@ -72,7 +72,7 @@ spark = SparkSession.builder \
     .config("spark.driver.memory","16G")\
     .config("spark.driver.maxResultSize", "0") \
     .config("spark.kryoserializer.buffer.max", "2000M")\
-    .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3")\
+    .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4")\
     .getOrCreate()
 ```
 
@@ -87,7 +87,7 @@ spark = SparkSession.builder \
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -98,7 +98,7 @@ spark = SparkSession.builder \
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp-gpu_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -109,7 +109,7 @@ spark = SparkSession.builder \
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp-m1_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -120,7 +120,7 @@ spark = SparkSession.builder \
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp-aarch64_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -130,28 +130,28 @@ spark = SparkSession.builder \
 
 ```scala
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp" % "4.2.4"
 ```
 
 **spark-nlp-gpu:**
 
 ```scala
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-gpu
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-gpu" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-gpu" % "4.2.4"
 ```
 
 **spark-nlp-m1:**
 
 ```scala
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-m1
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-m1" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-m1" % "4.2.4"
 ```
 
 **spark-nlp-aarch64:**
 
 ```scala
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-aarch64
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-aarch64" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-aarch64" % "4.2.4"
 ```
 
 Maven Central: [https://mvnrepository.com/artifact/com.johnsnowlabs.nlp](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp)
@@ -199,7 +199,7 @@ maven coordinates like these:
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp-m1_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -207,7 +207,7 @@ or in case of sbt:
 
 ```scala
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-m1" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-m1" % "4.2.4"
 ```
 
 If everything went well, you can now start Spark NLP with the `m1` flag set to `true`:
@@ -240,7 +240,7 @@ spark = sparknlp.start(m1=True)
 
 ## Installation for Linux Aarch64 Systems
 
-Starting from version 4.2.3, Spark NLP supports Linux systems running on an aarch64
+Starting from version 4.2.4, Spark NLP supports Linux systems running on an aarch64
 processor architecture. The necessary dependencies have been built on Ubuntu 16.04, so a
 recent system with an environment of at least that will be needed.
 
@@ -284,7 +284,7 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 # -p is for pyspark
 # -s is for spark-nlp
 # by default they are set to the latest
-!wget http://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.1 -s 4.2.3
+!wget http://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.1 -s 4.2.4
 ```
 
 [Spark NLP quick start on Google Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/quick_start_google_colab.ipynb) is a live demo on Google Colab that performs named entity recognitions and sentiment analysis by using Spark NLP pretrained pipelines.
@@ -303,7 +303,7 @@ Run the following code in Kaggle Kernel and start using spark-nlp right away.
 
 ## Databricks Support
 
-Spark NLP 4.2.3 has been tested and is compatible with the following runtimes:
+Spark NLP 4.2.4 has been tested and is compatible with the following runtimes:
 
 **CPU:**
 
@@ -354,7 +354,7 @@ NOTE: Spark NLP 4.0.x is based on TensorFlow 2.7.x which is compatible with CUDA
 
     3.1. Install New -> PyPI -> `spark-nlp` -> Install
 
-    3.2. Install New -> Maven -> Coordinates -> `com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3` -> Install
+    3.2. Install New -> Maven -> Coordinates -> `com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4` -> Install
 
 4. Now you can attach your notebook to the cluster and use Spark NLP!
 
@@ -370,7 +370,7 @@ Note: You can import these notebooks by using their URLs.
 
 ## EMR Support
 
-Spark NLP 4.2.3 has been tested and is compatible with the following EMR releases:
+Spark NLP 4.2.4 has been tested and is compatible with the following EMR releases:
 
 - emr-6.2.0
 - emr-6.3.0
@@ -424,7 +424,7 @@ A sample of your software configuration in JSON on S3 (must be public access):
       "spark.kryoserializer.buffer.max": "2000M",
       "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
       "spark.driver.maxResultSize": "0",
-      "spark.jars.packages": "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3"
+      "spark.jars.packages": "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4"
     }
 }
 ]
@@ -434,7 +434,7 @@ A sample of AWS CLI to launch EMR cluster:
 
 ```sh
 aws emr create-cluster \
---name "Spark NLP 4.2.3" \
+--name "Spark NLP 4.2.4" \
 --release-label emr-6.2.0 \
 --applications Name=Hadoop Name=Spark Name=Hive \
 --instance-type m4.4xlarge \
@@ -688,7 +688,7 @@ We recommend using `conda` to manage your Python environment on Windows.
 Now you can use the downloaded binary by navigating to `%SPARK_HOME%\bin` and
 running
 
-Either create a conda env for python 3.6, install *pyspark==3.2.1 spark-nlp numpy* and use Jupyter/python console, or in the same conda env you can go to spark bin for *pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3*.
+Either create a conda env for python 3.6, install *pyspark==3.2.1 spark-nlp numpy* and use Jupyter/python console, or in the same conda env you can go to spark bin for *pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4*.
 
 <img class="image image--xl" src="/assets/images/installation/90126972-c03e5500-dd64-11ea-8285-e4f76aa9e543.jpg" style="width:100%; align:center; box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);"/>
 
@@ -714,12 +714,12 @@ spark = SparkSession.builder \
     .config("spark.driver.memory","16G")\
     .config("spark.driver.maxResultSize", "0") \
     .config("spark.kryoserializer.buffer.max", "2000M")\
-    .config("spark.jars", "/tmp/spark-nlp-assembly-4.2.3.jar")\
+    .config("spark.jars", "/tmp/spark-nlp-assembly-4.2.4.jar")\
     .getOrCreate()
 ```
 
 - You can download provided Fat JARs from each [release notes](https://github.com/JohnSnowLabs/spark-nlp/releases), please pay attention to pick the one that suits your environment depending on the device (CPU/GPU) and Apache Spark version (3.x)
-- If you are local, you can load the Fat JAR from your local FileSystem, however, if you are in a cluster setup you need to put the Fat JAR on a distributed FileSystem such as HDFS, DBFS, S3, etc. (i.e., `hdfs:///tmp/spark-nlp-assembly-4.2.3.jar`)
+- If you are local, you can load the Fat JAR from your local FileSystem, however, if you are in a cluster setup you need to put the Fat JAR on a distributed FileSystem such as HDFS, DBFS, S3, etc. (i.e., `hdfs:///tmp/spark-nlp-assembly-4.2.4.jar`)
 
 Example of using pretrained Models and Pipelines in offline:
 

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -169,13 +169,12 @@ Make sure the following prerequisites are met:
 1. An M1 compiled java version needs to be installed. For example to install the Zulu
     Java 11 JDK head to [Download Azul JDKs](https://www.azul.com/downloads/?version=java-11-lts&os=macos&architecture=arm-64-bit&package=jdk) and install that java version.
 
-    Running `java -version` should produce a result, which contains `aarch64`
-    or `mixed mode` as the architecture:
+    To check if the installed java environment is running natively on arm64 and not
+    rosetta, you can run the following commands in your shell:
+
     ```shell
-    johnsnow@m1mac ~ % java -version
-    openjdk version "11.0.13" 2021-10-19 LTS
-    OpenJDK Runtime Environment Zulu11.52+13-CA (build 11.0.13+8-LTS)
-    OpenJDK 64-Bit Server VM Zulu11.52+13-CA (build 11.0.13+8-LTS, mixed mode)
+    johnsnow@m1mac ~ % cat $(which java) | file -
+    /dev/stdin: Mach-O 64-bit executable arm64
     ```
 
     The environment variable `JAVA_HOME` should also be set to this java version. You
@@ -183,7 +182,7 @@ Make sure the following prerequisites are met:
     you can set it by adding `export JAVA_HOME=$(/usr/libexec/java_home)` to your
     `~/.zshrc` file.
 
-### Scala and Java
+### Scala and Java for M1
 
 Adding Spark NLP to your Scala or Java project is easy:
 
@@ -213,14 +212,13 @@ libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-m1" % "4.2.3"
 
 If everything went well, you can now start Spark NLP with the `m1` flag set to `true`:
 
-
 ```scala
 import com.johnsnowlabs.nlp.SparkNLP
 
 val spark = SparkNLP.start(m1 = true)
 ```
 
-### Python
+### Python for M1
 
 First, make sure you have a recent Python 3 installation.
 

--- a/docs/en/spark_nlp.md
+++ b/docs/en/spark_nlp.md
@@ -25,7 +25,7 @@ Spark NLP is built on top of **Apache Spark 3.x**. For using Spark NLP you need:
 
 **GPU (optional):**
 
-Spark NLP 4.2.3 is built with TensorFlow 2.7.1 and the following NVIDIA® software are only required for GPU support:
+Spark NLP 4.2.4 is built with TensorFlow 2.7.1 and the following NVIDIA® software are only required for GPU support:
 
 - NVIDIA® GPU drivers version 450.80.02 or higher
 - CUDA® Toolkit 11.2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,7 @@ object Dependencies {
   val junitVersion = "4.13.2"
   val junit = "junit" % "junit" % junitVersion % Test
 
-  val tensorflowVersion = "0.4.3"
+  val tensorflowVersion = "0.4.4"
 
   val tensorflowGPU = "com.johnsnowlabs.nlp" %% "tensorflow-gpu" % tensorflowVersion
   val tensorflowCPU = "com.johnsnowlabs.nlp" %% "tensorflow-cpu" % tensorflowVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -78,5 +78,8 @@ object Dependencies {
   val tensorflowM1 = "com.johnsnowlabs.nlp" %% "tensorflow-m1" % tensorflowVersion
   val tensorflowLinuxAarch64 = "com.johnsnowlabs.nlp" %% "tensorflow-aarch64" % tensorflowVersion
 
+  val gcpStorageVersion = "2.15.0"
+  val gcpStorage = "com.google.cloud" % "google-cloud-storage" % gcpStorageVersion
+
   /** ------- Dependencies end  ------- */
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,5 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.2")
+
+addDependencyTreePlugin

--- a/python/README.md
+++ b/python/README.md
@@ -152,7 +152,7 @@ To use Spark NLP you need the following requirements:
 
 **GPU (optional):**
 
-Spark NLP 4.2.3 is built with TensorFlow 2.7.1 and the following NVIDIA® software are only required for GPU support:
+Spark NLP 4.2.4 is built with TensorFlow 2.7.1 and the following NVIDIA® software are only required for GPU support:
 
 - NVIDIA® GPU drivers version 450.80.02 or higher
 - CUDA® Toolkit 11.2
@@ -168,7 +168,7 @@ $ java -version
 $ conda create -n sparknlp python=3.7 -y
 $ conda activate sparknlp
 # spark-nlp by default is based on pyspark 3.x
-$ pip install spark-nlp==4.2.3 pyspark==3.2.1
+$ pip install spark-nlp==4.2.4 pyspark==3.2.1
 ```
 
 In Python console or Jupyter `Python3` kernel:
@@ -213,7 +213,7 @@ For more examples, you can visit our dedicated [repository](https://github.com/J
 
 ## Apache Spark Support
 
-Spark NLP *4.2.3* has been built on top of Apache Spark 3.2 while fully supports Apache Spark 3.0.x, 3.1.x, 3.2.x, and 3.3.x:
+Spark NLP *4.2.4* has been built on top of Apache Spark 3.2 while fully supports Apache Spark 3.0.x, 3.1.x, 3.2.x, and 3.3.x:
 
 | Spark NLP | Apache Spark 2.3.x | Apache Spark 2.4.x | Apache Spark 3.0.x | Apache Spark 3.1.x | Apache Spark 3.2.x | Apache Spark 3.3.x |
 |-----------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
@@ -247,7 +247,7 @@ Find out more about `Spark NLP` versions from our [release notes](https://github
 
 ## Databricks Support
 
-Spark NLP 4.2.3 has been tested and is compatible with the following runtimes:
+Spark NLP 4.2.4 has been tested and is compatible with the following runtimes:
 
 **CPU:**
 
@@ -288,7 +288,7 @@ NOTE: Spark NLP 4.0.x is based on TensorFlow 2.7.x which is compatible with CUDA
 
 ## EMR Support
 
-Spark NLP 4.2.3 has been tested and is compatible with the following EMR releases:
+Spark NLP 4.2.4 has been tested and is compatible with the following EMR releases:
 
 - emr-6.2.0
 - emr-6.3.0
@@ -326,11 +326,11 @@ Spark NLP supports all major releases of Apache Spark 3.0.x, Apache Spark 3.1.x,
 ```sh
 # CPU
 
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+spark-shell --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 The `spark-nlp` has been published to the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp).
@@ -338,11 +338,11 @@ The `spark-nlp` has been published to the [Maven Repository](https://mvnreposito
 ```sh
 # GPU
 
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.2.3
+spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.2.4
 
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.2.3
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.2.4
 
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.2.3
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.2.4
 
 ```
 
@@ -351,11 +351,11 @@ The `spark-nlp-gpu` has been published to the [Maven Repository](https://mvnrepo
 ```sh
 # AArch64
 
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.2.3
+spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.2.4
 
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.2.3
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.2.4
 
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.2.3
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.2.4
 
 ```
 
@@ -364,11 +364,11 @@ The `spark-nlp-aarch64` has been published to the [Maven Repository](https://mvn
 ```sh
 # M1
 
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.2.3
+spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.2.4
 
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.2.3
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.2.4
 
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.2.3
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.2.4
 
 ```
 
@@ -380,7 +380,7 @@ The `spark-nlp-m1` has been published to the [Maven Repository](https://mvnrepos
 spark-shell \
   --driver-memory 16g \
   --conf spark.kryoserializer.buffer.max=2000M \
-  --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+  --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 ## Scala
@@ -396,7 +396,7 @@ Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -407,7 +407,7 @@ Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp-gpu_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -418,7 +418,7 @@ Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp-aarch64_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -429,7 +429,7 @@ Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
     <artifactId>spark-nlp-m1_2.12</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
 </dependency>
 ```
 
@@ -439,28 +439,28 @@ Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2
 
 ```sbtshell
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp" % "4.2.4"
 ```
 
 **spark-nlp-gpu:**
 
 ```sbtshell
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-gpu
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-gpu" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-gpu" % "4.2.4"
 ```
 
 **spark-nlp-aarch64:**
 
 ```sbtshell
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-aarch64
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-aarch64" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-aarch64" % "4.2.4"
 ```
 
 **spark-nlp-m1:**
 
 ```sbtshell
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-m1
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-m1" % "4.2.3"
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-m1" % "4.2.4"
 ```
 
 Maven Central: [https://mvnrepository.com/artifact/com.johnsnowlabs.nlp](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp)
@@ -480,7 +480,7 @@ If you installed pyspark through pip/conda, you can install `spark-nlp` through 
 Pip:
 
 ```bash
-pip install spark-nlp==4.2.3
+pip install spark-nlp==4.2.4
 ```
 
 Conda:
@@ -508,7 +508,7 @@ spark = SparkSession.builder \
     .config("spark.driver.memory","16G")\
     .config("spark.driver.maxResultSize", "0") \
     .config("spark.kryoserializer.buffer.max", "2000M")\
-    .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3")\
+    .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4")\
     .getOrCreate()
 ```
 
@@ -576,7 +576,7 @@ Use either one of the following options
 - Add the following Maven Coordinates to the interpreter's library list
 
 ```bash
-com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 - Add a path to pre-built jar from [here](#compiled-jars) in the interpreter's library list making sure the jar is available to driver path
@@ -586,7 +586,7 @@ com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
 Apart from the previous step, install the python module through pip
 
 ```bash
-pip install spark-nlp==4.2.3
+pip install spark-nlp==4.2.4
 ```
 
 Or you can install `spark-nlp` from inside Zeppelin by using Conda:
@@ -611,7 +611,7 @@ The easiest way to get this done on Linux and macOS is to simply install `spark-
 $ conda create -n sparknlp python=3.8 -y
 $ conda activate sparknlp
 # spark-nlp by default is based on pyspark 3.x
-$ pip install spark-nlp==4.2.3 pyspark==3.2.1 jupyter
+$ pip install spark-nlp==4.2.4 pyspark==3.2.1 jupyter
 $ jupyter notebook
 ```
 
@@ -627,7 +627,7 @@ export PYSPARK_PYTHON=python3
 export PYSPARK_DRIVER_PYTHON=jupyter
 export PYSPARK_DRIVER_PYTHON_OPTS=notebook
 
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 Alternatively, you can mix in using `--jars` option for pyspark + `pip install spark-nlp`
@@ -652,7 +652,7 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 # -s is for spark-nlp
 # -g will enable upgrading libcudnn8 to 8.1.0 on Google Colab for GPU usage
 # by default they are set to the latest
-!wget https://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.1 -s 4.2.3
+!wget https://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.1 -s 4.2.4
 ```
 
 [Spark NLP quick start on Google Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/quick_start_google_colab.ipynb) is a live demo on Google Colab that performs named entity recognitions and sentiment analysis by using Spark NLP pretrained pipelines.
@@ -673,7 +673,7 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 # -s is for spark-nlp
 # -g will enable upgrading libcudnn8 to 8.1.0 on Kaggle for GPU usage
 # by default they are set to the latest
-!wget https://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.1 -s 4.2.3
+!wget https://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.1 -s 4.2.4
 ```
 
 [Spark NLP quick start on Kaggle Kernel](https://www.kaggle.com/mozzie/spark-nlp-named-entity-recognition) is a live demo on Kaggle Kernel that performs named entity recognitions by using Spark NLP pretrained pipeline.
@@ -691,9 +691,9 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 
 3. In `Libraries` tab inside your cluster you need to follow these steps:
 
-    3.1. Install New -> PyPI -> `spark-nlp==4.2.3` -> Install
+    3.1. Install New -> PyPI -> `spark-nlp==4.2.4` -> Install
 
-    3.2. Install New -> Maven -> Coordinates -> `com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3` -> Install
+    3.2. Install New -> Maven -> Coordinates -> `com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4` -> Install
 
 4. Now you can attach your notebook to the cluster and use Spark NLP!
 
@@ -741,7 +741,7 @@ A sample of your software configuration in JSON on S3 (must be public access):
       "spark.kryoserializer.buffer.max": "2000M",
       "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
       "spark.driver.maxResultSize": "0",
-      "spark.jars.packages": "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3"
+      "spark.jars.packages": "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4"
     }
 }]
 ```
@@ -750,7 +750,7 @@ A sample of AWS CLI to launch EMR cluster:
 
 ```.sh
 aws emr create-cluster \
---name "Spark NLP 4.2.3" \
+--name "Spark NLP 4.2.4" \
 --release-label emr-6.2.0 \
 --applications Name=Hadoop Name=Spark Name=Hive \
 --instance-type m4.4xlarge \
@@ -814,7 +814,7 @@ gcloud dataproc clusters create ${CLUSTER_NAME} \
   --enable-component-gateway \
   --metadata 'PIP_PACKAGES=spark-nlp spark-nlp-display google-cloud-bigquery google-cloud-storage' \
   --initialization-actions gs://goog-dataproc-initialization-actions-${REGION}/python/pip-install.sh \
-  --properties spark:spark.serializer=org.apache.spark.serializer.KryoSerializer,spark:spark.driver.maxResultSize=0,spark:spark.kryoserializer.buffer.max=2000M,spark:spark.jars.packages=com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+  --properties spark:spark.serializer=org.apache.spark.serializer.KryoSerializer,spark:spark.driver.maxResultSize=0,spark:spark.kryoserializer.buffer.max=2000M,spark:spark.jars.packages=com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 2. On an existing one, you need to install spark-nlp and spark-nlp-display packages from PyPI.
@@ -853,7 +853,7 @@ spark = SparkSession.builder \
         .config("spark.kryoserializer.buffer.max", "2000m") \
         .config("spark.jsl.settings.pretrained.cache_folder", "sample_data/pretrained") \
         .config("spark.jsl.settings.storage.cluster_tmp_dir", "sample_data/storage") \
-        .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3") \
+        .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4") \
         .getOrCreate()
 ```
 
@@ -867,7 +867,7 @@ spark-shell \
   --conf spark.kryoserializer.buffer.max=2000M \
   --conf spark.jsl.settings.pretrained.cache_folder="sample_data/pretrained" \
   --conf spark.jsl.settings.storage.cluster_tmp_dir="sample_data/storage" \
-  --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+  --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 **pyspark:**
@@ -880,7 +880,7 @@ pyspark \
   --conf spark.kryoserializer.buffer.max=2000M \
   --conf spark.jsl.settings.pretrained.cache_folder="sample_data/pretrained" \
   --conf spark.jsl.settings.storage.cluster_tmp_dir="sample_data/storage" \
-  --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.3
+  --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.4
 ```
 
 **Databricks:**
@@ -1144,12 +1144,12 @@ spark = SparkSession.builder \
     .config("spark.driver.memory","16G")\
     .config("spark.driver.maxResultSize", "0") \
     .config("spark.kryoserializer.buffer.max", "2000M")\
-    .config("spark.jars", "/tmp/spark-nlp-assembly-4.2.3.jar")\
+    .config("spark.jars", "/tmp/spark-nlp-assembly-4.2.4.jar")\
     .getOrCreate()
 ```
 
 - You can download provided Fat JARs from each [release notes](https://github.com/JohnSnowLabs/spark-nlp/releases), please pay attention to pick the one that suits your environment depending on the device (CPU/GPU) and Apache Spark version (3.0.x, 3.1.x, 3.2.x, and 3.3.x)
-- If you are local, you can load the Fat JAR from your local FileSystem, however, if you are in a cluster setup you need to put the Fat JAR on a distributed FileSystem such as HDFS, DBFS, S3, etc. (i.e., `hdfs:///tmp/spark-nlp-assembly-4.2.3.jar`)
+- If you are local, you can load the Fat JAR from your local FileSystem, however, if you are in a cluster setup you need to put the Fat JAR on a distributed FileSystem such as HDFS, DBFS, S3, etc. (i.e., `hdfs:///tmp/spark-nlp-assembly-4.2.4.jar`)
 
 Example of using pretrained Models and Pipelines in offline:
 

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -23,7 +23,7 @@ copyright = "2022, John Snow Labs"
 author = "John Snow Labs"
 
 # The full version, including alpha/beta/rc tags
-release = "4.2.3"
+release = "4.2.4"
 pyspark_version = "3.2.1"
 
 # -- General configuration ---------------------------------------------------

--- a/python/setup.py
+++ b/python/setup.py
@@ -41,7 +41,7 @@ setup(
     # project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
 
-    version='4.2.3',  # Required
+    version='4.2.4',  # Required
 
     # This is a one-line description or tagline of what your project does. This
     # corresponds to the 'Summary' metadata field:

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -120,7 +120,7 @@ def start(gpu=False,
         The initiated Spark session.
 
     """
-    current_version = "4.2.3"
+    current_version = "4.2.4"
 
     class SparkNLPConfig:
 
@@ -265,4 +265,4 @@ def version():
     str
         The current Spark NLP version.
     """
-    return '4.2.3'
+    return '4.2.4'

--- a/python/sparknlp/annotator/audio/wav2vec2_for_ctc.py
+++ b/python/sparknlp/annotator/audio/wav2vec2_for_ctc.py
@@ -15,7 +15,6 @@
 """Contains classes concerning Wav2Vec2ForCTC."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Wav2Vec2ForCTC(AnnotatorModel,

--- a/python/sparknlp/annotator/chunker.py
+++ b/python/sparknlp/annotator/chunker.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the Chunker."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Chunker(AnnotatorModel):

--- a/python/sparknlp/annotator/classifier_dl/albert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/albert_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class AlbertForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/albert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/albert_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes concerning AlbertForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class AlbertForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/albert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/albert_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for AlbertForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class AlbertForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/bert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/bert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for BertForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/bert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for BertForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/classifier_dl.py
@@ -16,7 +16,6 @@
 from sparknlp.annotator.param import EvaluationDLParams, ClassifierEncoder
 from sparknlp.base import DocumentAssembler
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEncoder):

--- a/python/sparknlp/annotator/classifier_dl/classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/classifier_dl.py
@@ -29,6 +29,32 @@ class ClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEnco
 
     For instantiated/pretrained models, see :class:`.ClassifierDLModel`.
 
+    Setting a test dataset to monitor model metrics can be done with
+    ``.setTestDataset``. The method expects a path to a parquet file containing a
+    dataframe that has the same required columns as the training dataframe. The
+    pre-processing steps for the training dataframe should also be applied to the test
+    dataframe. The following example will show how to create the test dataset:
+
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> embeddings = UniversalSentenceEncoder.pretrained() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("sentence_embeddings")
+    >>> preProcessingPipeline = Pipeline().setStages([documentAssembler, embeddings])
+    >>> (train, test) = data.randomSplit([0.8, 0.2])
+    >>> preProcessingPipeline \\
+    ...     .fit(test) \\
+    ...     .transform(test)
+    ...     .write \\
+    ...     .mode("overwrite") \\
+    ...     .parquet("test_data")
+    >>> classifier = ClassifierDLApproach() \\
+    ...     .setInputCols(["sentence_embeddings"]) \\
+    ...     .setOutputCol("category") \\
+    ...     .setLabelColumn("label") \\
+    ...     .setTestDataset("test_data")
+
     For extended examples of usage, see the Spark NLP Workshop
     `Spark NLP Workshop  <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.Text_Classification_with_ClassifierDL.ipynb>`__.
 
@@ -40,30 +66,35 @@ class ClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEnco
 
     Parameters
     ----------
-    lr
-        Learning Rate, by default 0.005
     batchSize
         Batch size, by default 64
-    dropout
-        Dropout coefficient, by default 0.5
-    maxEpochs
-        Maximum number of epochs to train, by default 30
     configProtoBytes
         ConfigProto from tensorflow, serialized into byte array.
+    dropout
+        Dropout coefficient, by default 0.5
+    enableOutputLogs
+        Whether to use stdout in addition to Spark logs, by default False
+    evaluationLogExtended
+        Whether logs for validation to be extended: it displays time and evaluation of
+        each label. Default is False.
+    labelColumn
+        Column with label per each token
+    lr
+        Learning Rate, by default 0.005
+    maxEpochs
+        Maximum number of epochs to train, by default 30
+    outputLogsPath
+        Folder path to save training logs
+    randomSeed
+        Random seed for shuffling
+    testDataset
+        Path to test dataset. If set used to calculate statistic on it during training.
     validationSplit
         Choose the proportion of training dataset to be validated against the
         model on each Epoch. The value should be between 0.0 and 1.0 and by
         default it is 0.0 and off.
-    enableOutputLogs
-        Whether to use stdout in addition to Spark logs, by default False
-    outputLogsPath
-        Folder path to save training logs
-    labelColumn
-        Column with label per each token
     verbose
         Level of verbosity during training
-    randomSeed
-        Random seed for shuffling
 
     Notes
     -----

--- a/python/sparknlp/annotator/classifier_dl/deberta_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/deberta_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DeBertaForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/deberta_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/deberta_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for DeBertaForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DeBertaForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DistilBertForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for DistilBertForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DistilBertForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for DistilBertForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DistilBertForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/longformer_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/longformer_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LongformerForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/longformer_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/longformer_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for LongformerForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LongformerForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/longformer_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/longformer_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for LongformerForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LongformerForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
@@ -43,6 +43,31 @@ class MultiClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, Classifie
     :class:`.BertSentenceEmbeddings`, :class:`.SentenceEmbeddings` or other
     sentence embeddings.
 
+    Setting a test dataset to monitor model metrics can be done with
+    ``.setTestDataset``. The method expects a path to a parquet file containing a
+    dataframe that has the same required columns as the training dataframe. The
+    pre-processing steps for the training dataframe should also be applied to the test
+    dataframe. The following example will show how to create the test dataset:
+
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> embeddings = UniversalSentenceEncoder.pretrained() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("sentence_embeddings")
+    >>> preProcessingPipeline = Pipeline().setStages([documentAssembler, embeddings])
+    >>> (train, test) = data.randomSplit([0.8, 0.2])
+    >>> preProcessingPipeline \\
+    ...     .fit(test) \\
+    ...     .transform(test)
+    ...     .write \\
+    ...     .mode("overwrite") \\
+    ...     .parquet("test_data")
+    >>> mulitClassifier = MultiClassifierDLApproach() \\
+    ...     .setInputCols(["sentence_embeddings"]) \\
+    ...     .setOutputCol("category") \\
+    ...     .setLabelColumn("label") \\
+    ...     .setTestDataset("test_data")
 
     For extended examples of usage, see the `Spark NLP Workshop <https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb>`__.
 
@@ -54,32 +79,39 @@ class MultiClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, Classifie
 
     Parameters
     ----------
-    lr
-        Learning Rate, by default 0.001
     batchSize
         Batch size, by default 64
-    maxEpochs
-        Maximum number of epochs to train, by default 10
     configProtoBytes
         ConfigProto from tensorflow, serialized into byte array.
-    validationSplit
-        Choose the proportion of training dataset to be validated against the
-        model on each Epoch. The value should be between 0.0 and 1.0 and by
-        default it is 0.0 and off, by default 0.0
     enableOutputLogs
         Whether to use stdout in addition to Spark logs, by default False
-    outputLogsPath
-        Folder path to save training logs
+    enableOutputLogs
+        Whether to use stdout in addition to Spark logs.
+    evaluationLogExtended
+        Whether logs for validation to be extended: it displays time and evaluation of
+        each label. Default is False.
     labelColumn
         Column with label per each token
-    verbose
-        Level of verbosity during training
+    lr
+        Learning Rate, by default 0.001
+    maxEpochs
+        Maximum number of epochs to train, by default 10
+    outputLogsPath
+        Folder path to save training logs
     randomSeed
         Random seed, by default 44
     shufflePerEpoch
         whether to shuffle the training data on each Epoch, by default False
+    testDataset
+        Path to test dataset. If set used to calculate statistic on it during training.
     threshold
         The minimum threshold for each label to be accepted, by default 0.5
+    validationSplit
+        Choose the proportion of training dataset to be validated against the
+        model on each Epoch. The value should be between 0.0 and 1.0 and by
+        default it is 0.0 and off, by default 0.0
+    verbose
+        Level of verbosity during training
 
     Notes
     -----

--- a/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
@@ -16,7 +16,6 @@
 from sparknlp.annotator.param import EvaluationDLParams, ClassifierEncoder
 from sparknlp.annotator.classifier_dl import ClassifierDLModel
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class MultiClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEncoder):

--- a/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
@@ -62,7 +62,7 @@ class MultiClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, Classifie
     ...     .write \\
     ...     .mode("overwrite") \\
     ...     .parquet("test_data")
-    >>> mulitClassifier = MultiClassifierDLApproach() \\
+    >>> multiClassifier = MultiClassifierDLApproach() \\
     ...     .setInputCols(["sentence_embeddings"]) \\
     ...     .setOutputCol("category") \\
     ...     .setLabelColumn("label") \\

--- a/python/sparknlp/annotator/classifier_dl/roberta_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/roberta_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/roberta_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/roberta_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for RoBertaForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/roberta_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/roberta_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for RoBertaForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/sentiment_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/sentiment_dl.py
@@ -15,7 +15,6 @@
 
 from sparknlp.annotator.param import EvaluationDLParams, ClassifierEncoder
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentimentDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEncoder):

--- a/python/sparknlp/annotator/classifier_dl/tapas_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/tapas_for_question_answering.py
@@ -14,7 +14,6 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.classifier_dl import BertForQuestionAnswering
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class TapasForQuestionAnswering(BertForQuestionAnswering):

--- a/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_question_answering.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaForQuestionAnswering(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for XlmRoBertaForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for XlmRoBertaForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/xlnet_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlnet_for_sequence_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for XlnetForSequenceClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlnetForSequenceClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/classifier_dl/xlnet_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlnet_for_token_classification.py
@@ -14,7 +14,6 @@
 """Contains classes for XlnetForTokenClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlnetForTokenClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/coref/spanbert_coref.py
+++ b/python/sparknlp/annotator/coref/spanbert_coref.py
@@ -14,7 +14,6 @@
 """Contains classes for the SpanBertCorefModel."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SpanBertCorefModel(AnnotatorModel,

--- a/python/sparknlp/annotator/cv/vit_for_image_classification.py
+++ b/python/sparknlp/annotator/cv/vit_for_image_classification.py
@@ -15,7 +15,6 @@
 """Contains classes concerning ViTForImageClassification."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ViTForImageClassification(AnnotatorModel,

--- a/python/sparknlp/annotator/dependency/dependency_parser.py
+++ b/python/sparknlp/annotator/dependency/dependency_parser.py
@@ -14,7 +14,6 @@
 """Contains classes for the DependencyParser."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DependencyParserApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/dependency/typed_dependency_parser.py
+++ b/python/sparknlp/annotator/dependency/typed_dependency_parser.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class TypedDependencyParserApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/document_normalizer.py
+++ b/python/sparknlp/annotator/document_normalizer.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the DocumentNormalizer"""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DocumentNormalizer(AnnotatorModel):

--- a/python/sparknlp/annotator/embeddings/albert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/albert_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes concerning AlbertEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class AlbertEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/bert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bert_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for BertEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/bert_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bert_sentence_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for BertSentenceEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BertSentenceEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/camembert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/camembert_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for CamemBertEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class CamemBertEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/chunk_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/chunk_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for ChunkEmbeddings"""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ChunkEmbeddings(AnnotatorModel):

--- a/python/sparknlp/annotator/embeddings/distil_bert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/distil_bert_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for DistilBertEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DistilBertEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/doc2vec.py
+++ b/python/sparknlp/annotator/embeddings/doc2vec.py
@@ -14,7 +14,6 @@
 """Contains classes for Doc2Vec."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Doc2VecApproach(AnnotatorApproach, HasStorageRef, HasEnableCachingProperties):

--- a/python/sparknlp/annotator/embeddings/elmo_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/elmo_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for ElmoEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ElmoEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/longformer_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/longformer_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for LongformerEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LongformerEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/roberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/roberta_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for RoBertaEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/roberta_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/roberta_sentence_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for RoBertaSentenceEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RoBertaSentenceEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/sentence_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for SentenceEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentenceEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasStorageRef):

--- a/python/sparknlp/annotator/embeddings/universal_sentence_encoder.py
+++ b/python/sparknlp/annotator/embeddings/universal_sentence_encoder.py
@@ -14,7 +14,6 @@
 """Contains classes for the UniversalSentenceEncoder."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class UniversalSentenceEncoder(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/word2vec.py
+++ b/python/sparknlp/annotator/embeddings/word2vec.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Word2VecApproach(AnnotatorApproach, HasStorageRef, HasEnableCachingProperties):

--- a/python/sparknlp/annotator/embeddings/word_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/word_embeddings.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class WordEmbeddings(AnnotatorApproach, HasEmbeddingsProperties, HasStorage):

--- a/python/sparknlp/annotator/embeddings/xlm_roberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlm_roberta_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for XlmRoBertaEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/xlm_roberta_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlm_roberta_sentence_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for XlmRoBertaSentenceEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlmRoBertaSentenceEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/embeddings/xlnet_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlnet_embeddings.py
@@ -14,7 +14,6 @@
 """Contains classes for XlnetEmbeddings."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class XlnetEmbeddings(AnnotatorModel,

--- a/python/sparknlp/annotator/er/entity_ruler.py
+++ b/python/sparknlp/annotator/er/entity_ruler.py
@@ -14,7 +14,6 @@
 """Contains classes for the EntityRuler."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class EntityRulerApproach(AnnotatorApproach, HasStorage):

--- a/python/sparknlp/annotator/graph_extraction.py
+++ b/python/sparknlp/annotator/graph_extraction.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for GraphExtraction."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class GraphExtraction(AnnotatorModel):

--- a/python/sparknlp/annotator/keyword_extraction/yake_keyword_extraction.py
+++ b/python/sparknlp/annotator/keyword_extraction/yake_keyword_extraction.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class YakeKeywordExtraction(AnnotatorModel):

--- a/python/sparknlp/annotator/ld_dl/language_detector_dl.py
+++ b/python/sparknlp/annotator/ld_dl/language_detector_dl.py
@@ -14,7 +14,6 @@
 """Contains classes for LanguageDetectorDL."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class LanguageDetectorDL(AnnotatorModel, HasStorageRef, HasEngine):

--- a/python/sparknlp/annotator/lemmatizer.py
+++ b/python/sparknlp/annotator/lemmatizer.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the Lemmatizer."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Lemmatizer(AnnotatorApproach):

--- a/python/sparknlp/annotator/matcher/big_text_matcher.py
+++ b/python/sparknlp/annotator/matcher/big_text_matcher.py
@@ -15,7 +15,6 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.matcher.text_matcher import TextMatcherModel
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class BigTextMatcher(AnnotatorApproach, HasStorage):
@@ -162,6 +161,7 @@ class BigTextMatcher(AnnotatorApproach, HasStorage):
         tokenizer_model._transfer_params_to_java()
         return self._set(tokenizer_model._java_obj)
 
+
 class BigTextMatcherModel(AnnotatorModel, HasStorageModel):
     """Instantiated model of the BigTextMatcher.
 
@@ -185,7 +185,7 @@ class BigTextMatcherModel(AnnotatorModel, HasStorageModel):
     """
     name = "BigTextMatcherModel"
     databases = ['TMVOCAB', 'TMEDGES', 'TMNODES']
-    inputAnnotatorTypes = [AnnotatorType.TOKEN]
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
 
     caseSensitive = Param(Params._dummy(),
                           "caseSensitive",

--- a/python/sparknlp/annotator/matcher/date_matcher.py
+++ b/python/sparknlp/annotator/matcher/date_matcher.py
@@ -14,7 +14,6 @@
 """Contains classes for the DateMatcher."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class DateMatcherUtils(Params):

--- a/python/sparknlp/annotator/matcher/multi_date_matcher.py
+++ b/python/sparknlp/annotator/matcher/multi_date_matcher.py
@@ -15,7 +15,6 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.matcher.date_matcher import DateMatcherUtils
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class MultiDateMatcher(AnnotatorModel, DateMatcherUtils):

--- a/python/sparknlp/annotator/matcher/regex_matcher.py
+++ b/python/sparknlp/annotator/matcher/regex_matcher.py
@@ -14,7 +14,6 @@
 """Contains classes for the RegexMatcher."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RegexMatcher(AnnotatorApproach):

--- a/python/sparknlp/annotator/matcher/text_matcher.py
+++ b/python/sparknlp/annotator/matcher/text_matcher.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class TextMatcher(AnnotatorApproach):

--- a/python/sparknlp/annotator/n_gram_generator.py
+++ b/python/sparknlp/annotator/n_gram_generator.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the NGramGenerator."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NGramGenerator(AnnotatorModel):

--- a/python/sparknlp/annotator/ner/ner_converter.py
+++ b/python/sparknlp/annotator/ner/ner_converter.py
@@ -80,8 +80,7 @@ class NerConverter(AnnotatorModel):
     """
     name = 'NerConverter'
 
-    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN,
-                           AnnotatorType.NAMED_ENTITY]
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN, AnnotatorType.NAMED_ENTITY]
 
     whiteList = Param(
         Params._dummy(),

--- a/python/sparknlp/annotator/ner/ner_converter.py
+++ b/python/sparknlp/annotator/ner/ner_converter.py
@@ -40,6 +40,9 @@ class NerConverter(AnnotatorModel):
     whiteList
         If defined, list of entities to process. The rest will be ignored. Do
         not include IOB prefix on labels
+    preservePosition
+        Whether to preserve the original position of the tokens in the original document
+        or use the modified tokens, by default `True`
 
     Examples
     --------
@@ -77,11 +80,21 @@ class NerConverter(AnnotatorModel):
     """
     name = 'NerConverter'
 
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN,
+                           AnnotatorType.NAMED_ENTITY]
+
     whiteList = Param(
         Params._dummy(),
         "whiteList",
         "If defined, list of entities to process. The rest will be ignored. Do not include IOB prefix on labels",
         typeConverter=TypeConverters.toListString
+    )
+
+    preservePosition = Param(
+        Params._dummy(),
+        "preservePosition",
+        "Whether to preserve the original position of the tokens in the original document or use the modified tokens",
+        typeConverter=TypeConverters.toBoolean
     )
 
     def setWhiteList(self, entities):
@@ -97,7 +110,20 @@ class NerConverter(AnnotatorModel):
         """
         return self._set(whiteList=entities)
 
+    def setPreservePosition(self, value):
+        """
+        Whether to preserve the original position of the tokens in the original document
+        or use the modified tokens, by default `True`.
+
+        Parameters
+        ----------
+        value : bool
+            Whether to preserve the original position of the tokens in the original
+            document or use the modified tokens
+        """
+        return self._set(preservePosition=value)
+
     @keyword_only
     def __init__(self):
-        super(NerConverter, self).__init__(classname="com.johnsnowlabs.nlp.annotators.ner.NerConverter")
-
+        super(NerConverter, self).__init__(
+            classname="com.johnsnowlabs.nlp.annotators.ner.NerConverter")

--- a/python/sparknlp/annotator/ner/ner_crf.py
+++ b/python/sparknlp/annotator/ner/ner_crf.py
@@ -15,7 +15,6 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.ner.ner_approach import NerApproach
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NerCrfApproach(AnnotatorApproach, NerApproach):

--- a/python/sparknlp/annotator/ner/ner_dl.py
+++ b/python/sparknlp/annotator/ner/ner_dl.py
@@ -18,7 +18,6 @@ import sys
 from sparknlp.annotator.param import EvaluationDLParams
 from sparknlp.common import *
 from sparknlp.annotator.ner.ner_approach import NerApproach
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NerDLApproach(AnnotatorApproach, NerApproach, EvaluationDLParams):

--- a/python/sparknlp/annotator/ner/ner_overwriter.py
+++ b/python/sparknlp/annotator/ner/ner_overwriter.py
@@ -14,7 +14,6 @@
 """Contains classes for the NerOverwriter."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NerOverwriter(AnnotatorModel):

--- a/python/sparknlp/annotator/normalizer.py
+++ b/python/sparknlp/annotator/normalizer.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the Normalizer."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Normalizer(AnnotatorApproach):

--- a/python/sparknlp/annotator/param/evaluation_dl_params.py
+++ b/python/sparknlp/annotator/param/evaluation_dl_params.py
@@ -97,8 +97,26 @@ class EvaluationDLParams(ParamsGettersSetters):
         return self._set(outputLogsPath=p)
 
     def setTestDataset(self, path, read_as=ReadAs.SPARK, options={"format": "parquet"}):
-        """Sets Path to test dataset. If set used to calculate statistic on it
-        during training.
+        """Path to a parquet file of a test dataset. If set, it is used to calculate
+        statistics on it during training.
+
+        The parquet file must be a dataframe that has the same columns as the model that
+        is being trained. For example, if the model needs as input `DOCUMENT`, `TOKEN`,
+        `WORD_EMBEDDINGS` (Features) and `NAMED_ENTITY` (label) then these columns also
+        need to be present while saving the dataframe. The pre-processing steps for the
+        training dataframe should also be applied to the test dataframe.
+
+        An example on how to create such a parquet file could be:
+
+        >>> # assuming preProcessingPipeline
+        >>> (train, test) = data.randomSplit([0.8, 0.2])
+        >>> preProcessingPipeline
+        ...     .fit(test)
+        ...     .transform(test)
+        ...     .write
+        ...     .mode("overwrite")
+        ...     .parquet("test_data")
+        >>> annotator.setTestDataset("test_data")
 
         Parameters
         ----------

--- a/python/sparknlp/annotator/pos/perceptron.py
+++ b/python/sparknlp/annotator/pos/perceptron.py
@@ -14,7 +14,6 @@
 """Contains classes for the Perceptron Annotator."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class PerceptronApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/sentence/sentence_detector.py
+++ b/python/sparknlp/annotator/sentence/sentence_detector.py
@@ -14,7 +14,6 @@
 """Contains classes for the SentenceDetector."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentenceDetectorParams:
@@ -287,6 +286,3 @@ class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
             minLength=0,
             maxLength=99999
         )
-
-    def getInputAnnotatorTypes(self):
-        return self.inputAnnotatorTypes

--- a/python/sparknlp/annotator/sentence/sentence_detector_dl.py
+++ b/python/sparknlp/annotator/sentence/sentence_detector_dl.py
@@ -14,7 +14,6 @@
 """Contains classes for SentenceDetectorDl."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentenceDetectorDLApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/sentiment/sentiment_detector.py
+++ b/python/sparknlp/annotator/sentiment/sentiment_detector.py
@@ -14,7 +14,6 @@
 """Contains classes for the SentimentDetector."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SentimentDetector(AnnotatorApproach):

--- a/python/sparknlp/annotator/sentiment/vivekn_sentiment.py
+++ b/python/sparknlp/annotator/sentiment/vivekn_sentiment.py
@@ -158,6 +158,7 @@ class ViveknSentimentApproach(AnnotatorApproach):
     def _create_model(self, java_model):
         return ViveknSentimentModel(java_model=java_model)
 
+
 class ViveknSentimentModel(AnnotatorModel):
     """Sentiment analyser inspired by the algorithm by Vivek Narayanan.
 
@@ -190,6 +191,8 @@ class ViveknSentimentModel(AnnotatorModel):
     https://github.com/vivekn/sentiment/
     """
     name = "ViveknSentimentModel"
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN, AnnotatorType.DOCUMENT]
 
     importantFeatureRatio = Param(Params._dummy(),
                                   "importantFeatureRatio",

--- a/python/sparknlp/annotator/seq2seq/gpt2_transformer.py
+++ b/python/sparknlp/annotator/seq2seq/gpt2_transformer.py
@@ -14,7 +14,6 @@
 """Contains classes for the GPT2Transformer."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class GPT2Transformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):

--- a/python/sparknlp/annotator/seq2seq/marian_transformer.py
+++ b/python/sparknlp/annotator/seq2seq/marian_transformer.py
@@ -14,7 +14,6 @@
 """Contains classes for the MarianTransformer."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class MarianTransformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):

--- a/python/sparknlp/annotator/seq2seq/t5_transformer.py
+++ b/python/sparknlp/annotator/seq2seq/t5_transformer.py
@@ -14,7 +14,6 @@
 """Contains classes for the T5Transformer."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class T5Transformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):

--- a/python/sparknlp/annotator/spell_check/context_spell_checker.py
+++ b/python/sparknlp/annotator/spell_check/context_spell_checker.py
@@ -14,7 +14,6 @@
 """Contains classes for the ContextSpellChecker."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ContextSpellCheckerApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/spell_check/norvig_sweeting.py
+++ b/python/sparknlp/annotator/spell_check/norvig_sweeting.py
@@ -14,7 +14,6 @@
 """Contains classes for the NorvigSweeting spell checker."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class NorvigSweetingApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/spell_check/symmetric_delete.py
+++ b/python/sparknlp/annotator/spell_check/symmetric_delete.py
@@ -14,7 +14,6 @@
 """Contains classes for SymmetricDelete."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class SymmetricDeleteApproach(AnnotatorApproach):

--- a/python/sparknlp/annotator/stemmer.py
+++ b/python/sparknlp/annotator/stemmer.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the Stemmer."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Stemmer(AnnotatorModel):

--- a/python/sparknlp/annotator/stop_words_cleaner.py
+++ b/python/sparknlp/annotator/stop_words_cleaner.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the StopWordsCleaner."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class StopWordsCleaner(AnnotatorModel):

--- a/python/sparknlp/annotator/token/chunk_tokenizer.py
+++ b/python/sparknlp/annotator/token/chunk_tokenizer.py
@@ -15,7 +15,6 @@
 
 from sparknlp.common import *
 from sparknlp.annotator.token.tokenizer import Tokenizer, TokenizerModel
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class ChunkTokenizer(Tokenizer):

--- a/python/sparknlp/annotator/token/recursive_tokenizer.py
+++ b/python/sparknlp/annotator/token/recursive_tokenizer.py
@@ -14,7 +14,6 @@
 """Contains classes for the RecursiveTokenizer."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RecursiveTokenizer(AnnotatorApproach):

--- a/python/sparknlp/annotator/token/regex_tokenizer.py
+++ b/python/sparknlp/annotator/token/regex_tokenizer.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class RegexTokenizer(AnnotatorModel):

--- a/python/sparknlp/annotator/token/token2_chunk.py
+++ b/python/sparknlp/annotator/token/token2_chunk.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Token2Chunk(AnnotatorModel):

--- a/python/sparknlp/annotator/token/tokenizer.py
+++ b/python/sparknlp/annotator/token/tokenizer.py
@@ -15,7 +15,6 @@
 
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class Tokenizer(AnnotatorApproach):

--- a/python/sparknlp/annotator/ws/word_segmenter.py
+++ b/python/sparknlp/annotator/ws/word_segmenter.py
@@ -14,7 +14,6 @@
 """Contains classes for the WordSegmenter."""
 
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class WordSegmenterApproach(AnnotatorApproach):

--- a/python/sparknlp/base/audio_assembler.py
+++ b/python/sparknlp/base/audio_assembler.py
@@ -15,6 +15,7 @@
 
 from pyspark import keyword_only
 from pyspark.ml.param import TypeConverters, Params, Param
+
 from sparknlp.internal import AnnotatorTransformer
 
 

--- a/python/sparknlp/base/chunk2_doc.py
+++ b/python/sparknlp/base/chunk2_doc.py
@@ -15,10 +15,9 @@
 
 from pyspark import keyword_only
 
+from sparknlp.common import AnnotatorProperties
 from sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.internal import AnnotatorTransformer
-
-from sparknlp.common import AnnotatorProperties
 
 
 class Chunk2Doc(AnnotatorTransformer, AnnotatorProperties):

--- a/python/sparknlp/base/doc2_chunk.py
+++ b/python/sparknlp/base/doc2_chunk.py
@@ -16,10 +16,9 @@
 from pyspark import keyword_only
 from pyspark.ml.param import TypeConverters, Params, Param
 
-from sparknlp.common.annotator_type import AnnotatorType
 from sparknlp.internal import AnnotatorTransformer
 
-from sparknlp.common import AnnotatorProperties
+from sparknlp.common import AnnotatorProperties, AnnotatorType
 
 
 class Doc2Chunk(AnnotatorTransformer, AnnotatorProperties):

--- a/python/sparknlp/base/table_assembler.py
+++ b/python/sparknlp/base/table_assembler.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the TableAssembler."""
 from sparknlp.common import *
-from sparknlp.common.annotator_type import AnnotatorType
 
 
 class TableAssembler(AnnotatorModel):

--- a/python/sparknlp/common/annotator_properties.py
+++ b/python/sparknlp/common/annotator_properties.py
@@ -42,7 +42,7 @@ class AnnotatorProperties(Params):
 
         Parameters
         ----------
-        *value : str
+        *value : List[str]
             Input columns for the annotator
         """
         if type(value[0]) == str or type(value[0]) == list:

--- a/python/test/annotator/ner/ner_converter_test.py
+++ b/python/test/annotator/ner/ner_converter_test.py
@@ -1,0 +1,42 @@
+import unittest
+
+import pytest
+from pyspark.ml import Pipeline
+
+from sparknlp.annotator import *
+from test.util import SparkSessionForTest
+
+
+@pytest.mark.fast
+class NerConverterTestSpec(unittest.TestCase):
+
+    def runTest(self):
+        documentAssembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+        tokenizer = Tokenizer() \
+            .setInputCols(["document"]) \
+            .setOutputCol("token")
+        embeddings = WordEmbeddingsModel.pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("bert")
+        nerTagger = NerDLModel.pretrained() \
+            .setInputCols(["document", "token", "bert"]) \
+            .setOutputCol("ner")
+        pipeline = Pipeline().setStages([
+            documentAssembler,
+            tokenizer,
+            embeddings,
+            nerTagger
+        ])
+        data = SparkSessionForTest.spark.createDataFrame(
+            [["U.N. official Ekeus heads for Baghdad."]]).toDF("text")
+        result = pipeline.fit(data).transform(data)
+
+        converter = NerConverter() \
+            .setInputCols(["document", "token", "ner"]) \
+            .setOutputCol("entities") \
+            .setPreservePosition(False) \
+            .setWhiteList(["ORG", "LOC"])
+
+        converter.transform(result).selectExpr("explode(entities)").show(truncate=False)

--- a/scripts/colab_setup.sh
+++ b/scripts/colab_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #default values for pyspark, spark-nlp, and SPARK_HOME
-SPARKNLP="4.2.3"
+SPARKNLP="4.2.4"
 PYSPARK="3.2.1"
 
 while getopts s:p:g option

--- a/scripts/kaggle_setup.sh
+++ b/scripts/kaggle_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #default values for pyspark, spark-nlp, and SPARK_HOME
-SPARKNLP="4.2.3"
+SPARKNLP="4.2.4"
 PYSPARK="3.2.1"
 
 while getopts s:p:g option

--- a/scripts/sagemaker_setup.sh
+++ b/scripts/sagemaker_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Default values for pyspark, spark-nlp, and SPARK_HOME
-SPARKNLP="4.2.3"
+SPARKNLP="4.2.4"
 PYSPARK="3.2.1"
 
 echo "Setup SageMaker for PySpark $PYSPARK and Spark NLP $SPARKNLP"

--- a/src/main/scala/com/johnsnowlabs/client/gcp/GCPGateway.scala
+++ b/src/main/scala/com/johnsnowlabs/client/gcp/GCPGateway.scala
@@ -1,0 +1,31 @@
+package com.johnsnowlabs.client.gcp
+
+import com.google.cloud.storage.{BlobId, BlobInfo, Storage, StorageOptions}
+import com.johnsnowlabs.util.{ConfigHelper, ConfigLoader}
+
+import java.io.InputStream
+
+class GCPGateway(
+    projectId: String = ConfigLoader.getConfigStringValue(ConfigHelper.gcpProjectId)) {
+
+  lazy val storageClient: Storage = {
+    if (projectId == null || projectId.isEmpty) {
+      throw new UnsupportedOperationException(
+        "projectId argument is mandatory to create GCP Storage client.")
+    }
+
+    StorageOptions.newBuilder.setProjectId(projectId).build.getService
+  }
+
+  def copyFileToGCPStorage(
+      bucket: String,
+      destinationGCPStoragePath: String,
+      inputStream: InputStream): Unit = {
+
+    val blobId = BlobId.of(bucket, destinationGCPStoragePath)
+    val blobInfo = BlobInfo.newBuilder(blobId).build
+
+    storageClient.createFrom(blobInfo, inputStream)
+  }
+
+}

--- a/src/main/scala/com/johnsnowlabs/ml/util/ModelEngine.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/util/ModelEngine.scala
@@ -21,5 +21,8 @@ object ModelEngine {
   val tensorflowModelName = "saved_model.pb"
   val onnx = "onnx"
   val onnxModelName = "model.onnx"
+  val onnxEncoderModel = "encoder_model.onnx"
+  val onnxDecoderModel = "decoder_model.onnx"
+  val onnxDecoderWithPastModel = "decoder_with_past_model.onnx"
   val unk = "unk"
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/SparkNLP.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/SparkNLP.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.SparkSession
 
 object SparkNLP {
 
-  val currentVersion = "4.2.3"
+  val currentVersion = "4.2.4"
   val MavenSpark3 = s"com.johnsnowlabs.nlp:spark-nlp_2.12:$currentVersion"
   val MavenGpuSpark3 = s"com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:$currentVersion"
   val MavenSparkM1 = s"com.johnsnowlabs.nlp:spark-nlp-m1_2.12:$currentVersion"

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLApproach.scala
@@ -46,6 +46,37 @@ import scala.util.Random
   *     [[com.johnsnowlabs.nlp.embeddings.SentenceEmbeddings SentenceEmbeddings]] can be used for
   *     the `inputCol`.
   *
+  * Setting a test dataset to monitor model metrics can be done with `.setTestDataset`. The method
+  * expects a path to a parquet file containing a dataframe that has the same required columns as
+  * the training dataframe. The pre-processing steps for the training dataframe should also be
+  * applied to the test dataframe. The following example will show how to create the test dataset:
+  *
+  * {{{
+  * val documentAssembler = new DocumentAssembler()
+  *   .setInputCol("text")
+  *   .setOutputCol("document")
+  *
+  * val embeddings = UniversalSentenceEncoder.pretrained()
+  *   .setInputCols("document")
+  *   .setOutputCol("sentence_embeddings")
+  *
+  * val preProcessingPipeline = new Pipeline().setStages(Array(documentAssembler, embeddings))
+  *
+  * val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+  * preProcessingPipeline
+  *   .fit(test)
+  *   .transform(test)
+  *   .write
+  *   .mode("overwrite")
+  *   .parquet("test_data")
+  *
+  * val classifier = new ClassifierDLApproach()
+  *   .setInputCols("sentence_embeddings")
+  *   .setOutputCol("category")
+  *   .setLabelColumn("label")
+  *   .setTestDataset("test_data")
+  * }}}
+  *
   * For extended examples of usage, see the Spark NLP Workshop
   * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/scala/training/Train%20Multi-Class%20Text%20Classification%20on%20News%20Articles.scala [1]]]
   * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/tutorials/Certification_Trainings/Public/5.Text_Classification_with_ClassifierDL.ipynb [2]]]

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MultiClassifierDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MultiClassifierDLApproach.scala
@@ -83,7 +83,7 @@ import scala.util.Random
   *   .mode("overwrite")
   *   .parquet("test_data")
   *
-  * val mulitClassifier = new MultiClassifierDLApproach()
+  * val multiClassifier = new MultiClassifierDLApproach()
   *   .setInputCols("sentence_embeddings")
   *   .setOutputCol("category")
   *   .setLabelColumn("label")

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MultiClassifierDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MultiClassifierDLApproach.scala
@@ -59,6 +59,37 @@ import scala.util.Random
   *     [[com.johnsnowlabs.nlp.embeddings.SentenceEmbeddings SentenceEmbeddings]] can be used for
   *     the `inputCol`.
   *
+  * Setting a test dataset to monitor model metrics can be done with `.setTestDataset`. The method
+  * expects a path to a parquet file containing a dataframe that has the same required columns as
+  * the training dataframe. The pre-processing steps for the training dataframe should also be
+  * applied to the test dataframe. The following example will show how to create the test dataset:
+  *
+  * {{{
+  * val documentAssembler = new DocumentAssembler()
+  *   .setInputCol("text")
+  *   .setOutputCol("document")
+  *
+  * val embeddings = UniversalSentenceEncoder.pretrained()
+  *   .setInputCols("document")
+  *   .setOutputCol("sentence_embeddings")
+  *
+  * val preProcessingPipeline = new Pipeline().setStages(Array(documentAssembler, embeddings))
+  *
+  * val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+  * preProcessingPipeline
+  *   .fit(test)
+  *   .transform(test)
+  *   .write
+  *   .mode("overwrite")
+  *   .parquet("test_data")
+  *
+  * val mulitClassifier = new MultiClassifierDLApproach()
+  *   .setInputCols("sentence_embeddings")
+  *   .setOutputCol("category")
+  *   .setLabelColumn("label")
+  *   .setTestDataset("test_data")
+  * }}}
+  *
   * For extended examples of usage, see the
   * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb Spark NLP Workshop]]
   * and the

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLApproach.scala
@@ -47,6 +47,37 @@ import scala.util.Random
   *     [[com.johnsnowlabs.nlp.embeddings.SentenceEmbeddings SentenceEmbeddings]] can be used for
   *     the `inputCol`.
   *
+  * Setting a test dataset to monitor model metrics can be done with `.setTestDataset`. The method
+  * expects a path to a parquet file containing a dataframe that has the same required columns as
+  * the training dataframe. The pre-processing steps for the training dataframe should also be
+  * applied to the test dataframe. The following example will show how to create the test dataset:
+  *
+  * {{{
+  * val documentAssembler = new DocumentAssembler()
+  *   .setInputCol("text")
+  *   .setOutputCol("document")
+  *
+  * val embeddings = UniversalSentenceEncoder.pretrained()
+  *   .setInputCols("document")
+  *   .setOutputCol("sentence_embeddings")
+  *
+  * val preProcessingPipeline = new Pipeline().setStages(Array(documentAssembler, embeddings))
+  *
+  * val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+  * preProcessingPipeline
+  *   .fit(test)
+  *   .transform(test)
+  *   .write
+  *   .mode("overwrite")
+  *   .parquet("test_data")
+  *
+  * val classifier = new SentimentDLApproach()
+  *   .setInputCols("sentence_embeddings")
+  *   .setOutputCol("sentiment")
+  *   .setLabelColumn("label")
+  *   .setTestDataset("test_data")
+  * }}}
+  *
   * For extended examples of usage, see the
   * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb Spark NLP Workshop]]
   * and the

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLApproach.scala
@@ -59,6 +59,43 @@ import scala.util.Random
   *     [[com.johnsnowlabs.nlp.embeddings.BertEmbeddings BertEmbeddings]] for BERT based
   *     embeddings).
   *
+  * Setting a test dataset to monitor model metrics can be done with `.setTestDataset`. The method
+  * expects a path to a parquet file containing a dataframe that has the same required columns as
+  * the training dataframe. The pre-processing steps for the training dataframe should also be
+  * applied to the test dataframe. The following example will show how to create the test dataset
+  * with a CoNLL dataset:
+  *
+  * {{{
+  * val documentAssembler = new DocumentAssembler()
+  *   .setInputCol("text")
+  *   .setOutputCol("document")
+  *
+  * val embeddings = WordEmbeddingsModel
+  *   .pretrained()
+  *   .setInputCols("document", "token")
+  *   .setOutputCol("embeddings")
+  *
+  * val preProcessingPipeline = new Pipeline().setStages(Array(documentAssembler, embeddings))
+  *
+  * val conll = CoNLL()
+  * val Array(train, test) = conll
+  *   .readDataset(spark, "src/test/resources/conll2003/eng.train")
+  *   .randomSplit(Array(0.8, 0.2))
+  *
+  * preProcessingPipeline
+  *   .fit(test)
+  *   .transform(test)
+  *   .write
+  *   .mode("overwrite")
+  *   .parquet("test_data")
+  *
+  * val nerTagger = new NerDLApproach()
+  *   .setInputCols("document", "token", "embeddings")
+  *   .setLabelColumn("label")
+  *   .setOutputCol("ner")
+  *   .setTestDataset("test_data")
+  * }}}
+  *
   * For extended examples of usage, see the
   * [[https://github.com/JohnSnowLabs/spark-nlp-workshop/tree/master/jupyter/training/english/dl-ner Spark NLP Workshop]]
   * and the

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/param/EvaluationDLParams.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/param/EvaluationDLParams.scala
@@ -62,7 +62,8 @@ trait EvaluationDLParams extends Params {
   val outputLogsPath =
     new Param[String](this, "outputLogsPath", "Folder path to save training logs")
 
-  /** Path to test dataset. If set, it is used to calculate statistics on it during training.
+  /** Path to a parquet file of a test dataset. If set, it is used to calculate statistics on it
+    * during training.
     *
     * @group param
     */
@@ -114,7 +115,30 @@ trait EvaluationDLParams extends Params {
   def setOutputLogsPath(path: String): this.type =
     set(this.outputLogsPath, path)
 
-  /** Path to test dataset. If set, it is used to calculate statistics on it during training.
+  /** Path to a parquet file of a test dataset. If set, it is used to calculate statistics on it
+    * during training.
+    *
+    * The parquet file must be a dataframe that has the same columns as the model that is being
+    * trained. For example, if the model needs as input `DOCUMENT`, `TOKEN`, `WORD_EMBEDDINGS`
+    * (Features) and `NAMED_ENTITY` (label) then these columns also need to be present while
+    * saving the dataframe. The pre-processing steps for the training dataframe should also be
+    * applied to the test dataframe.
+    *
+    * An example on how to create such a parquet file could be:
+    *
+    * {{{
+    * // assuming preProcessingPipeline
+    * val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+    *
+    * preProcessingPipeline
+    *   .fit(test)
+    *   .transform(test)
+    *   .write
+    *   .mode("overwrite")
+    *   .parquet("test_data")
+    *
+    * annotator.setTestDataset("test_data")
+    * }}}
     *
     * @group setParam
     */
@@ -124,7 +148,32 @@ trait EvaluationDLParams extends Params {
       options: Map[String, String] = Map("format" -> "parquet")): this.type =
     set(testDataset, ExternalResource(path, readAs, options))
 
-  /** Path to test dataset. If set, it is used to calculate statistics on it during training.
+  /** ExternalResource to a parquet file of a test dataset. If set, it is used to calculate
+    * statistics on it during training.
+    *
+    * When using an ExternalResource, only parquet files are accepted for this function.
+    *
+    * The parquet file must be a dataframe that has the same columns as the model that is being
+    * trained. For example, if the model needs as input `DOCUMENT`, `TOKEN`, `WORD_EMBEDDINGS`
+    * (Features) and `NAMED_ENTITY` (label) then these columns also need to be present while
+    * saving the dataframe. The pre-processing steps for the training dataframe should also be
+    * applied to the test dataframe.
+    *
+    * An example on how to create such a parquet file could be:
+    *
+    * {{{
+    * // assuming preProcessingPipeline
+    * val Array(train, test) = data.randomSplit(Array(0.8, 0.2))
+    *
+    * preProcessingPipeline
+    *   .fit(test)
+    *   .transform(test)
+    *   .write
+    *   .mode("overwrite")
+    *   .parquet("test_data")
+    *
+    * annotator.setTestDataset("test_data")
+    * }}}
     *
     * @group setParam
     */

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -760,4 +760,15 @@ object ResourceHelper {
 
     (bucketName, key)
   }
+
+  def parseGCPStorageURI(gcpStorageURI: String): (String, String) = {
+    val prefix = "gs://"
+    val bucketName = gcpStorageURI.substring(prefix.length).split("/").head
+    val storagePath = gcpStorageURI.substring((prefix + bucketName).length + 1)
+
+    require(bucketName.nonEmpty, "GCP Storage bucket name is empty!")
+
+    (bucketName, storagePath)
+  }
+
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -207,9 +207,10 @@ object ResourceHelper {
         "https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/training/english/dl-ner/mfa_ner_graphs_s3.ipynb")
       throw awsE
     case e: Exception =>
+      val copyToLocalErrorMessage: String =
+        "Please make sure the provided path exists and is accessible while keeping in mind only file:/, hdfs:/, dbfs:/ and s3:/ protocols are supported at the moment."
       println(
-        s"Could not create temporary local directory for provided path $path. " +
-          "Please note that only file:/, hdfs:/, dbfs:/ and s3:/ protocols are supported.")
+        s"$e \n Therefore, could not create temporary local directory for provided path $path. $copyToLocalErrorMessage")
       throw e
   }
 

--- a/src/main/scala/com/johnsnowlabs/util/Build.scala
+++ b/src/main/scala/com/johnsnowlabs/util/Build.scala
@@ -17,5 +17,5 @@
 package com.johnsnowlabs.util
 
 object Build {
-  val version: String = "4.2.3"
+  val version: String = "4.2.4"
 }

--- a/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
@@ -64,6 +64,9 @@ object ConfigHelper {
   val hadoopAwsVersion: String = "3.3.1"
   val awsJavaSdkVersion: String = "1.11.901"
 
+  // Stores info for integration with GCP
+  val gcpProjectId = "spark.jsl.settings.gcp.project_id"
+
   def getConfigValueOrElse(property: String, defaultValue: String): String = {
     sparkSession.conf.get(property, defaultValue)
   }

--- a/src/main/scala/com/johnsnowlabs/util/ConfigLoader.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigLoader.scala
@@ -52,7 +52,8 @@ object ConfigLoader {
       getConfigInfo(ConfigHelper.awsExternalSessionToken, "") ++
       getConfigInfo(ConfigHelper.awsExternalProfileName, "") ++
       getConfigInfo(ConfigHelper.awsExternalS3BucketKey, "") ++
-      getConfigInfo(ConfigHelper.awsExternalRegion, "")
+      getConfigInfo(ConfigHelper.awsExternalRegion, "") ++
+      getConfigInfo(ConfigHelper.gcpProjectId, "")
   }
 
   private def getConfigInfo(property: String, defaultValue: String): Map[String, String] = {


### PR DESCRIPTION
- https://github.com/JohnSnowLabs/spark-nlp/pull/13108
  * SPARKNLP-656: Update documentation regarding testDataset in trainable classifiers
  - updated docs for NerDLApproach, ClassifierDLApproach, MultiClassifierDLApproach, SentimentDLApproach
  * SPARKNLP-657: Updated installation docs for M1
- https://github.com/JohnSnowLabs/spark-nlp/pull/13109
  - Example in error message importing external models
  - Add support for future decoder-encoder models (separate models)
- https://github.com/JohnSnowLabs/spark-nlp/pull/13112
- https://github.com/JohnSnowLabs/spark-nlp/pull/13126
- https://github.com/JohnSnowLabs/spark-nlp/pull/13141
- https://github.com/JohnSnowLabs/spark-nlp/pull/13144
  - BigTextMatcher
  - ViveknSentimentModel
  - NerConverter
- https://github.com/JohnSnowLabs/spark-nlp/pull/13152
- https://github.com/JohnSnowLabs/spark-nlp/pull/13153
- Fix broken notebook to import Longformer models from HF: https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/transformers/HuggingFace%20in%20Spark%20NLP%20-%20Longformer.ipynb
- Fix the `t5_grammar_error_corrector` model to be compatible with Spark NLP 4.0+