### PR TITLE
SPARKNLP 680 Update sbt, sbt-assembly, and GA for Scala unit tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: macos-latest
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
+      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
     name: Build and Test on Apache Spark 3.3.x
 
     steps:
@@ -57,10 +58,10 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.3.0
         run: |
           brew install sbt
-          sbt -mem 4096 -Dis_spark33=true clean assemblyAndCopy
+          sbt -Dis_spark33=true clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.3.x
         run: |
-          sbt -mem 4096 test
+          sbt test
       - name: Upload coverage data to Coveralls
         run: sbt coverageReport coveralls
         env:
@@ -76,6 +77,7 @@ jobs:
     runs-on: macos-latest
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
+      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
     name: Build and Test on Apache Spark 3.2.x
 
     steps:
@@ -97,10 +99,10 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.2.1
         run: |
           brew install sbt
-          sbt -mem 4096 clean assemblyAndCopy
+          sbt clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.2.x
         run: |
-          sbt -mem 4096 coverage test
+          sbt coverage test
       - name: Test Spark NLP in Python - Apache Spark 3.2.x
         run: |
           cd python
@@ -111,6 +113,7 @@ jobs:
     runs-on: macos-latest
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
+      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
     name: Build and Test on Apache Spark 3.1.x
 
     steps:
@@ -132,10 +135,10 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.1.x
         run: |
           brew install sbt
-          sbt -mem 4096 -Dis_spark31=true clean assemblyAndCopy
+          sbt -Dis_spark31=true clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.1.x
         run: |
-          sbt -mem 4096 test
+          sbt test
       - name: Test Spark NLP in Python - Apache Spark 3.1.x
         run: |
           cd python
@@ -146,6 +149,7 @@ jobs:
     runs-on: macos-latest
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
+      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
     name: Build and Test on Apache Spark 3.0.x
 
     steps:
@@ -167,10 +171,10 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.0.x
         run: |
           brew install sbt
-          sbt -mem 4096 -Dis_spark30=true clean assemblyAndCopy
+          sbt -Dis_spark30=true clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.0.x
         run: |
-          sbt -mem 4096 test
+          sbt test
       - name: Test Spark NLP in Python - Apache Spark 3.0.x
         run: |
           cd python

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: macos-latest
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
-      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
+      JAVA_OPTS: "-XX:+UseG1GC"
     name: Build and Test on Apache Spark 3.3.x
 
     steps:
@@ -58,10 +58,10 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.3.0
         run: |
           brew install sbt
-          sbt -Dis_spark33=true clean assemblyAndCopy
+          sbt -Dis_spark33=true -mem 4096 clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.3.x
         run: |
-          sbt test
+          sbt -mem 4096 test
       - name: Upload coverage data to Coveralls
         run: sbt coverageReport coveralls
         env:
@@ -77,7 +77,7 @@ jobs:
     runs-on: macos-latest
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
-      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
+      JAVA_OPTS: "-XX:+UseG1GC"
     name: Build and Test on Apache Spark 3.2.x
 
     steps:
@@ -99,10 +99,10 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.2.1
         run: |
           brew install sbt
-          sbt clean assemblyAndCopy
+          sbt -mem 4096 clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.2.x
         run: |
-          sbt coverage test
+          sbt -mem 4096 coverage test
       - name: Test Spark NLP in Python - Apache Spark 3.2.x
         run: |
           cd python
@@ -113,7 +113,7 @@ jobs:
     runs-on: macos-latest
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
-      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
+      JAVA_OPTS: "-XX:+UseG1GC"
     name: Build and Test on Apache Spark 3.1.x
 
     steps:
@@ -135,10 +135,10 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.1.x
         run: |
           brew install sbt
-          sbt -Dis_spark31=true clean assemblyAndCopy
+          sbt -Dis_spark31=true -mem 4096 clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.1.x
         run: |
-          sbt test
+          sbt -mem 4096 test
       - name: Test Spark NLP in Python - Apache Spark 3.1.x
         run: |
           cd python
@@ -149,7 +149,7 @@ jobs:
     runs-on: macos-latest
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
-      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
+      JAVA_OPTS: "-XX:+UseG1GC"
     name: Build and Test on Apache Spark 3.0.x
 
     steps:
@@ -171,10 +171,10 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.0.x
         run: |
           brew install sbt
-          sbt -Dis_spark30=true clean assemblyAndCopy
+          sbt -Dis_spark30=true -mem 4096 clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.0.x
         run: |
-          sbt test
+          sbt -mem 4096 test
       - name: Test Spark NLP in Python - Apache Spark 3.0.x
         run: |
           cd python

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,10 +58,12 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.3.0
         run: |
           brew install sbt
-          sbt -Dis_spark33=true -mem 4096 clean assemblyAndCopy
+          sbt -Dis_spark33=true clean
+          sbt -Dis_spark33=true compile
+          sbt -mem 4096 -Dis_spark33=true assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.3.x
         run: |
-          sbt -mem 4096 test
+          sbt -mem 4096 -Dis_spark33=true test
       - name: Upload coverage data to Coveralls
         run: sbt coverageReport coveralls
         env:
@@ -99,7 +101,9 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.2.1
         run: |
           brew install sbt
-          sbt -mem 4096 clean assemblyAndCopy
+          sbt clean
+          sbt compile
+          sbt assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.2.x
         run: |
           sbt -mem 4096 coverage test
@@ -135,10 +139,12 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.1.x
         run: |
           brew install sbt
-          sbt -Dis_spark31=true -mem 4096 clean assemblyAndCopy
+          sbt -Dis_spark31=true clean
+          sbt -Dis_spark31=true compile
+          sbt -mem 4096 -Dis_spark31=true assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.1.x
         run: |
-          sbt -mem 4096 test
+          sbt -mem 4096 -Dis_spark31=true test
       - name: Test Spark NLP in Python - Apache Spark 3.1.x
         run: |
           cd python
@@ -171,10 +177,12 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.0.x
         run: |
           brew install sbt
-          sbt -Dis_spark30=true -mem 4096 clean assemblyAndCopy
+          sbt -Dis_spark30=true clean
+          sbt -Dis_spark30=true compile
+          sbt -mem 4096 -Dis_spark30=true assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.0.x
         run: |
-          sbt -mem 4096 test
+          sbt -mem 4096 -Dis_spark30=true test
       - name: Test Spark NLP in Python - Apache Spark 3.0.x
         run: |
           cd python

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,7 +61,7 @@ jobs:
           sbt -mem 4096 -Dis_spark33=true clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.3.x
         run: |
-          sbt -mem 4096 test
+          sbt -mem 4096 coverage test
       - name: Upload coverage data to Coveralls
         run: sbt coverageReport coveralls
         env:
@@ -102,7 +102,7 @@ jobs:
           sbt -mem 4096 clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.2.x
         run: |
-          sbt -mem 4096 coverage test
+          sbt -mem 4096 test
       - name: Test Spark NLP in Python - Apache Spark 3.2.x
         run: |
           cd python

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: macos-latest
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
-      JAVA_OPTS: "-XX:+UseG1GC"
+      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
     name: Build and Test on Apache Spark 3.3.x
 
     steps:
@@ -58,12 +58,10 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.3.0
         run: |
           brew install sbt
-          sbt -Dis_spark33=true clean
-          sbt -Dis_spark33=true compile
-          sbt -mem 4096 -Dis_spark33=true assemblyAndCopy
+          sbt -mem 4096 -Dis_spark33=true clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.3.x
         run: |
-          sbt -mem 4096 -Dis_spark33=true test
+          sbt -mem 4096 test
       - name: Upload coverage data to Coveralls
         run: sbt coverageReport coveralls
         env:
@@ -79,7 +77,7 @@ jobs:
     runs-on: macos-latest
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
-      JAVA_OPTS: "-XX:+UseG1GC"
+      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
     name: Build and Test on Apache Spark 3.2.x
 
     steps:
@@ -101,9 +99,7 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.2.1
         run: |
           brew install sbt
-          sbt clean
-          sbt compile
-          sbt assemblyAndCopy
+          sbt -mem 4096 clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.2.x
         run: |
           sbt -mem 4096 coverage test
@@ -117,7 +113,7 @@ jobs:
     runs-on: macos-latest
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
-      JAVA_OPTS: "-XX:+UseG1GC"
+      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
     name: Build and Test on Apache Spark 3.1.x
 
     steps:
@@ -139,12 +135,10 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.1.x
         run: |
           brew install sbt
-          sbt -Dis_spark31=true clean
-          sbt -Dis_spark31=true compile
-          sbt -mem 4096 -Dis_spark31=true assemblyAndCopy
+          sbt -mem 4096 -Dis_spark31=true clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.1.x
         run: |
-          sbt -mem 4096 -Dis_spark31=true test
+          sbt -mem 4096 test
       - name: Test Spark NLP in Python - Apache Spark 3.1.x
         run: |
           cd python
@@ -155,7 +149,7 @@ jobs:
     runs-on: macos-latest
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
-      JAVA_OPTS: "-XX:+UseG1GC"
+      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
     name: Build and Test on Apache Spark 3.0.x
 
     steps:
@@ -177,12 +171,10 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.0.x
         run: |
           brew install sbt
-          sbt -Dis_spark30=true clean
-          sbt -Dis_spark30=true compile
-          sbt -mem 4096 -Dis_spark30=true assemblyAndCopy
+          sbt -mem 4096 -Dis_spark30=true clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.0.x
         run: |
-          sbt -mem 4096 -Dis_spark30=true test
+          sbt -mem 4096 test
       - name: Test Spark NLP in Python - Apache Spark 3.0.x
         run: |
           cd python

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,6 +34,8 @@ jobs:
   spark33:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip test]')"
     runs-on: macos-latest
+    env:
+      TF_CPP_MIN_LOG_LEVEL: 3
     name: Build and Test on Apache Spark 3.3.x
 
     steps:
@@ -55,10 +57,10 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.3.0
         run: |
           brew install sbt
-          sbt -mem 4096 clean assemblyAndCopy
+          sbt -mem 4096 -Dis_spark33=true clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.3.x
         run: |
-          sbt -mem 4096 coverage test
+          sbt -mem 4096 test
       - name: Upload coverage data to Coveralls
         run: sbt coverageReport coveralls
         env:
@@ -72,6 +74,8 @@ jobs:
   spark32:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip test]')"
     runs-on: macos-latest
+    env:
+      TF_CPP_MIN_LOG_LEVEL: 3
     name: Build and Test on Apache Spark 3.2.x
 
     steps:
@@ -96,7 +100,7 @@ jobs:
           sbt -mem 4096 clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.2.x
         run: |
-          sbt -mem 4096 test
+          sbt -mem 4096 coverage test
       - name: Test Spark NLP in Python - Apache Spark 3.2.x
         run: |
           cd python
@@ -105,6 +109,8 @@ jobs:
   spark31:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip test]')"
     runs-on: macos-latest
+    env:
+      TF_CPP_MIN_LOG_LEVEL: 3
     name: Build and Test on Apache Spark 3.1.x
 
     steps:
@@ -126,7 +132,7 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.1.x
         run: |
           brew install sbt
-          sbt -mem 4096 clean assemblyAndCopy
+          sbt -mem 4096 -Dis_spark31=true clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.1.x
         run: |
           sbt -mem 4096 test
@@ -138,6 +144,8 @@ jobs:
   spark30:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip test]')"
     runs-on: macos-latest
+    env:
+      TF_CPP_MIN_LOG_LEVEL: 3
     name: Build and Test on Apache Spark 3.0.x
 
     steps:
@@ -159,7 +167,7 @@ jobs:
       - name: Build Spark NLP on Apache Spark 3.0.x
         run: |
           brew install sbt
-          sbt -mem 4096 clean assemblyAndCopy
+          sbt -mem 4096 -Dis_spark30=true clean assemblyAndCopy
       - name: Test Spark NLP in Scala - Apache Spark 3.0.x
         run: |
           sbt -mem 4096 test

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ version := "4.2.4"
 
 (ThisBuild / scalacOptions) += "-target:jvm-1.8"
 
+(ThisBuild / javaOptions) += "-Xmx4096m -XX:+UseG1GC"
+
 scalacOptions ++= Seq("-unchecked", "-feature", "-deprecation", "-language:implicitConversions")
 
 (Compile / doc / scalacOptions) ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,9 @@ version := "4.2.4"
 
 (ThisBuild / scalacOptions) += "-target:jvm-1.8"
 
-(ThisBuild / javaOptions) += "-Xmx4096m -XX:+UseG1GC"
+(ThisBuild / javaOptions) += "-Xmx4096m"
+
+(ThisBuild / javaOptions) += "-XX:+UseG1GC"
 
 scalacOptions ++= Seq("-unchecked", "-feature", "-deprecation", "-language:implicitConversions")
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-import Dependencies._
-import Resolvers.m2Resolvers
 import sbtassembly.MergeStrategy
+import M2Resolvers.m2Resolvers
+import Dependencies._
 
 name := getPackageName(is_m1, is_gpu, is_aarch64)
 
@@ -147,8 +147,7 @@ lazy val utilDependencies = Seq(
     exclude ("com.google.code.findbugs", "annotations")
     exclude ("org.slf4j", "slf4j-api"),
   gcpStorage,
-  greex
-)
+  greex)
 
 lazy val typedDependencyParserDependencies = Seq(junit)
 
@@ -182,7 +181,8 @@ lazy val root = (project in file("."))
   ShadeRule.rename("org.apache.http.**" -> "org.apache.httpShaded@1").inAll,
   ShadeRule.rename("com.amazonaws.**" -> "com.amazonaws.ShadedByJSL@1").inAll)
 
-(assembly / assemblyOption) := (assembly / assemblyOption).value.copy(includeScala = false)
+(assembly / assemblyOption) := (assembly / assemblyOption).value.withIncludeScala(includeScala =
+  false)
 
 (assembly / assemblyMergeStrategy) := {
   case PathList("META-INF", "versions", "9", "module-info.class") => MergeStrategy.discard

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,14 +3,26 @@ import sbt._
 object Dependencies {
 
   /** ------- Spark version start ------- */
+  /* default spark version to base the APIS */
   val spark32Ver = "3.2.1"
+  /* only used in unit tests */
+  val spark30Ver = "3.0.3"
+  val spark31Ver = "3.1.3"
+  val spark33Ver = "3.3.1"
 
+  /* required for different hardware */
   val is_gpu: String = System.getProperty("is_gpu", "false")
   val is_opt: String = System.getProperty("is_opt", "false")
   val is_m1: String = System.getProperty("is_m1", "false")
   val is_aarch64: String = System.getProperty("is_aarch64", "false")
 
-  val sparkVer: String = getSparkVersion
+  /* only used for unit tests */
+  val is_spark30: String = System.getProperty("is_spark30", "false")
+  val is_spark31: String = System.getProperty("is_spark31", "false")
+  val is_spark32: String = System.getProperty("is_spark32", "true")
+  val is_spark33: String = System.getProperty("is_spark33", "false")
+
+  val sparkVer: String = getSparkVersion(is_spark30, is_spark31, is_spark32, is_spark33)
 
   /** ------- Spark version end ------- */
 
@@ -27,8 +39,21 @@ object Dependencies {
     }
   }
 
-  def getSparkVersion: String = {
-    spark32Ver
+  def getSparkVersion(
+      is_spark30: String,
+      is_spark31: String,
+      is_spark32: String,
+      is_spark33: String): String = {
+    if (is_spark30.equals("true")) {
+      spark30Ver
+    } else if (is_spark31.equals("true")) {
+      spark31Ver
+    } else if (is_spark33.equals("true")) {
+      spark33Ver
+    } else {
+      /* default spark version */
+      spark32Ver
+    }
   }
 
   def getJavaTarget(is_spark32: String): String = {

--- a/project/M2Resolvers.scala
+++ b/project/M2Resolvers.scala
@@ -1,0 +1,7 @@
+import sbt._
+
+object M2Resolvers {
+  val m2CentralRepo = "Maven Central" at "https://repo1.maven.org/maven2/"
+
+  val m2Resolvers: Seq[MavenRepository] = Seq(m2CentralRepo)
+}

--- a/project/Resolvers.scala
+++ b/project/Resolvers.scala
@@ -1,7 +1,0 @@
-import sbt._
-
-object Resolvers {
-  val m2CentralRepo = "Maven Central"  at "https://repo1.maven.org/maven2/"
-
-  val m2Resolvers = Seq(m2CentralRepo)
-}

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.0.0")

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.0.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.8.0


### PR DESCRIPTION
- now we actually build the whole Spark NLP with a specific Spark major release before testing it in GA (missed this part before)
- updating `sbt-assembly` to `2.0.0`. This has lots of performance improvements which we can benefit from when packaging Fat JARs (4 different architectures, lots of sbt dependencies)
- There is another Resolvers in `sbt` so `sbt._` had a conflict with our object called Resolvers.
- Update `sbt` to `1.8.0` with improvements and bug fixes, but mostly for CVEs fixes:
  -   Updates to Coursier 2.1.0-RC1 to address [https://github.com/advisories/GHSA-wv7w-rj2x-556x](https://github.com/advisories/GHSA-wv7w-rj2x-556x "https://github.com/advisories/GHSA-wv7w-rj2x-556x")
  -   Updates to Ivy 2.3.0-sbt-a8f9eb5bf09d0539ea3658a2c2d4e09755b5133e to address [https://github.com/advisories/GHSA-wv7w-rj2x-556x](https://github.com/advisories/GHSA-wv7w-rj2x-556x "https://github.com/advisories/GHSA-wv7w-rj2x-556x")
- Use the new withIncludeScala in assemblyOption instead of value
