### PR TITLE
SPARKNLP-675: BigTextMatcher matches entities with overlapping definitions

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/btm/TMEdgesReadWriter.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/btm/TMEdgesReadWriter.scala
@@ -32,4 +32,8 @@ class TMEdgesReadWriter(
     BigInt(content).toByteArray
   }
 
+  override def lookup(index: (Int, Int)): Option[Int] = {
+    super.lookup(index.toString())
+  }
+
 }

--- a/src/test/resources/entity-extractor/test-overlapping.txt
+++ b/src/test/resources/entity-extractor/test-overlapping.txt
@@ -1,0 +1,4 @@
+lung
+lung cancer
+kidney
+kidney cancer


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR fixes an issue with the BigTextMatcher Annotator, where it would not match entities with overlapping definitions. 

For Example, if both `lung` and `lung cancer` are defined, `lung` would not be matched in a given text.

This was due to an abstraction error of one of the subclasses of the BigTextMatcher during construction of the underlying data structure.

Resolves #13168.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Old tests passing and added new test to cover the bug.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
