### PR TITLE
SPARKNLP-473-implement-camembert-for-sequence-classification-annotator

### DIFF
--- a/python/sparknlp/annotator/classifier_dl/__init__.py
+++ b/python/sparknlp/annotator/classifier_dl/__init__.py
@@ -41,4 +41,4 @@ from sparknlp.annotator.classifier_dl.xlnet_for_sequence_classification import *
 from sparknlp.annotator.classifier_dl.xlnet_for_token_classification import *
 from sparknlp.annotator.classifier_dl.camembert_for_token_classification import *
 from sparknlp.annotator.classifier_dl.tapas_for_question_answering import *
-
+from sparknlp.annotator.classifier_dl.camembert_for_sequence_classification import *

--- a/python/sparknlp/annotator/classifier_dl/camembert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/camembert_for_sequence_classification.py
@@ -1,0 +1,212 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Contains classes for CamemBertForSequenceClassification."""
+
+from sparknlp.common import *
+
+
+class CamemBertForSequenceClassification(AnnotatorModel,
+                                         HasCaseSensitiveProperties,
+                                         HasBatchedAnnotate,
+                                         HasClassifierActivationProperties,
+                                         HasEngine):
+    """CamemBertForSequenceClassification can load CamemBERT Models with a sequence
+    classification/regression head on top (a linear layer on top of the pooled output) e.g. for
+    multi-class document classification tasks.
+
+    Pretrained models can be loaded with :meth:`.pretrained` of the companion
+    object:
+
+    >>> sequence_classifier = CamemBertForSequenceClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label")
+
+    The default model is ``"camembert_base_sequence_classifier_allocine"``, if no
+    name is provided.
+
+    For available pretrained models please see the `Models Hub
+    <https://nlp.johnsnowlabs.com/models?task=Text+Classification>`__.
+    To see which models are compatible and how to import them see
+    `Import Transformers into Spark NLP 🚀
+    <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT, TOKEN``    ``CATEGORY``
+    ====================== ======================
+
+    Parameters
+    ----------
+    batchSize
+        Batch size. Large values allows faster processing but requires more
+        memory, by default 8
+    caseSensitive
+        Whether to ignore case in tokens for embeddings matching, by default
+        True
+    configProtoBytes
+        ConfigProto from tensorflow, serialized into byte array.
+    maxSentenceLength
+        Max sentence length to process, by default 128
+    coalesceSentences
+        Instead of 1 class per sentence (if inputCols is `sentence`) output
+        1 class per document by averaging probabilities in all sentences, by
+        default False.
+    activation
+        Whether to calculate logits via Softmax or Sigmoid, by default
+        `"softmax"`.
+
+    Examples
+    --------
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("token")
+    >>> sequenceClassifier = CamemBertForSequenceClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label") \\
+    ...     .setCaseSensitive(True)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     tokenizer,
+    ...     sequenceClassifier
+    ... ])
+    >>> data = spark.createDataFrame([["george washington est allé à washington"]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.select("class.result").show(truncate=False)
+    +------------------------------+
+    |result                        |
+    +------------------------------+
+    |[I-PER, I-PER, O, O, O, I-LOC]|
+    +------------------------------+
+    """
+    name = "CamemBertForSequenceClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
+
+    maxSentenceLength = Param(Params._dummy(),
+                              "maxSentenceLength",
+                              "Max sentence length to process",
+                              typeConverter=TypeConverters.toInt)
+
+    configProtoBytes = Param(Params._dummy(),
+                             "configProtoBytes",
+                             "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
+                             TypeConverters.toListInt)
+
+    coalesceSentences = Param(Params._dummy(), "coalesceSentences",
+                              "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
+                              TypeConverters.toBoolean)
+
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
+
+    def setConfigProtoBytes(self, b):
+        """Sets configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[int]
+            ConfigProto from tensorflow, serialized into byte array
+        """
+        return self._set(configProtoBytes=b)
+
+    def setMaxSentenceLength(self, value):
+        """Sets max sentence length to process, by default 128.
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
+        return self._set(maxSentenceLength=value)
+
+    def setCoalesceSentences(self, value):
+        """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
+        Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
+        into the model and averaging all the probabilities for the entire document instead of probabilities per sentence. (Default: true)
+
+        Parameters
+        ----------
+        value : bool
+            If the output of all sentences will be averaged to one output
+        """
+        return self._set(coalesceSentences=value)
+
+    @keyword_only
+    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForSequenceClassification",
+                 java_model=None):
+        super(CamemBertForSequenceClassification, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        self._setDefault(
+            batchSize=8,
+            maxSentenceLength=128,
+            caseSensitive=True,
+            coalesceSentences=False,
+            activation="softmax"
+        )
+
+    @staticmethod
+    def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        CamemBertForSequenceClassification
+            The restored model
+        """
+        from sparknlp.internal import _CamemBertForSequenceClassification
+        jModel = _CamemBertForSequenceClassification(folder, spark_session._jsparkSession)._java_obj
+        return CamemBertForSequenceClassification(java_model=jModel)
+
+    @staticmethod
+    def pretrained(name="camembert_base_sequence_classifier_allocine", lang="fr", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default
+            "camembert_base_sequence_classifier_allocine"
+        lang : str, optional
+            Language of the pretrained model, by default "fr"
+        remote_loc : str, optional
+            Optional remote address of the resource, by default None. Will use
+            Spark NLPs repositories otherwise.
+
+        Returns
+        -------
+        CamemBertForSequenceClassification
+            The restored model
+        """
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(CamemBertForSequenceClassification, name, lang, remote_loc)

--- a/python/sparknlp/internal/__init__.py
+++ b/python/sparknlp/internal/__init__.py
@@ -291,24 +291,28 @@ class _CoNLLGeneratorExportFromTargetAndPipeline(ExtendedJavaWrapper):
         elif type(pipeline) == str:
             pipeline = PipelineModel.load(pipeline)._to_java()
         if type(target) == DataFrame:
-            super(_CoNLLGeneratorExportFromTargetAndPipeline, self).__init__("com.johnsnowlabs.util.CoNLLGenerator.exportConllFiles",
-                                                        target._jdf, pipeline, output_path)
+            super(_CoNLLGeneratorExportFromTargetAndPipeline, self).__init__(
+                "com.johnsnowlabs.util.CoNLLGenerator.exportConllFiles",
+                target._jdf, pipeline, output_path)
         else:
-            super(_CoNLLGeneratorExportFromTargetAndPipeline, self).__init__("com.johnsnowlabs.util.CoNLLGenerator.exportConllFiles",
-                                                        spark._jsparkSession, target, pipeline, output_path)
+            super(_CoNLLGeneratorExportFromTargetAndPipeline, self).__init__(
+                "com.johnsnowlabs.util.CoNLLGenerator.exportConllFiles",
+                spark._jsparkSession, target, pipeline, output_path)
 
 
 class _CoNLLGeneratorExportFromDataFrameAndField(ExtendedJavaWrapper):
 
     def __init__(self, dataframe, output_path, metadata_sentence_key):
         super(_CoNLLGeneratorExportFromDataFrameAndField, self).__init__(
-            "com.johnsnowlabs.util.CoNLLGenerator.exportConllFilesFromField", dataframe, output_path, metadata_sentence_key)
+            "com.johnsnowlabs.util.CoNLLGenerator.exportConllFilesFromField", dataframe, output_path,
+            metadata_sentence_key)
 
 
 class _CoNLLGeneratorExportFromDataFrame(ExtendedJavaWrapper):
     def __init__(self, dataframe, output_path):
-        super(_CoNLLGeneratorExportFromDataFrame, self).__init__("com.johnsnowlabs.util.CoNLLGenerator.exportConllFiles",
-                                                                 dataframe, output_path)
+        super(_CoNLLGeneratorExportFromDataFrame, self).__init__(
+            "com.johnsnowlabs.util.CoNLLGenerator.exportConllFiles",
+            dataframe, output_path)
 
 
 class _CoverageResult(ExtendedJavaWrapper):
@@ -435,6 +439,7 @@ class _ResourceHelper_validFile(ExtendedJavaWrapper):
         super(_ResourceHelper_validFile, self).__init__(
             "com.johnsnowlabs.nlp.util.io.ResourceHelper.validFile", path)
 
+
 class _ViTForImageClassification(ExtendedJavaWrapper):
     def __init__(self, path, jspark):
         super(_ViTForImageClassification, self).__init__(
@@ -459,4 +464,11 @@ class _TapasForQuestionAnsweringLoader(ExtendedJavaWrapper):
         super(_TapasForQuestionAnsweringLoader, self).__init__(
             "com.johnsnowlabs.nlp.annotators.classifier.dl.TapasForQuestionAnswering.loadSavedModel",
             path,
+            jspark)
+
+
+class _CamemBertForSequenceClassification(ExtendedJavaWrapper):
+    def __init__(self, path, jspark):
+        super(_CamemBertForSequenceClassification, self).__init__(
+            "com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForSequenceClassification.loadSavedModel", path,
             jspark)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -629,4 +629,11 @@ package object annotator {
       extends ReadablePretrainedTapasForQAModel
       with ReadTapasForQATensorflowModel
 
+  type CamemBertForSequenceClassification =
+    com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForSequenceClassification
+
+  object CamemBertForSequenceClassification
+      extends ReadablePretrainedCamemBertForSequenceModel
+      with ReadCamemBertForSequenceTensorflowModel
+
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForSequenceClassification.scala
@@ -1,0 +1,411 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.ml.tensorflow._
+import com.johnsnowlabs.ml.tensorflow.sentencepiece.{
+  ReadSentencePieceModel,
+  SentencePieceWrapper,
+  WriteSentencePieceModel
+}
+import com.johnsnowlabs.ml.util.LoadExternalModel.{
+  loadSentencePieceAsset,
+  loadTextAsset,
+  modelSanityCheck,
+  notSupportedEngineError
+}
+import com.johnsnowlabs.ml.util.ModelEngine
+import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.serialization.MapFeature
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.param.{BooleanParam, IntArrayParam, IntParam}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.SparkSession
+
+/** CamemBertForSequenceClassification can load CamemBERT Models with sequence
+  * classification/regression head on top (a linear layer on top of the pooled output) e.g. for
+  * multi-class document classification tasks.
+  *
+  * Pretrained models can be loaded with `pretrained` of the companion object:
+  * {{{
+  * val sequenceClassifier = CamemBertForSequenceClassification.pretrained()
+  *   .setInputCols("token", "document")
+  *   .setOutputCol("label")
+  * }}}
+  * The default model is `camembert_base_sequence_classifier_allocine"`, if no name is provided.
+  *
+  * For available pretrained models please see the
+  * [[https://nlp.johnsnowlabs.com/models?task=Text+Classification Models Hub]].
+  *
+  * To see which models are compatible and how to import them see
+  * [[https://github.com/JohnSnowLabs/spark-nlp/discussions/5669]] and to see more extended
+  * examples, see
+  * [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForSequenceClassificationTestSpec.scala CamemBertForSequenceClassification]].
+  *
+  * ==Example==
+  * {{{
+  * import spark.implicits._
+  * import com.johnsnowlabs.nlp.base._
+  * import com.johnsnowlabs.nlp.annotator._
+  * import org.apache.spark.ml.Pipeline
+  *
+  * val documentAssembler = new DocumentAssembler()
+  *   .setInputCol("text")
+  *   .setOutputCol("document")
+  *
+  * val tokenizer = new Tokenizer()
+  *   .setInputCols("document")
+  *   .setOutputCol("token")
+  *
+  * val sequenceClassifier = CamemBertForSequenceClassification.pretrained()
+  *   .setInputCols("token", "document")
+  *   .setOutputCol("label")
+  *   .setCaseSensitive(true)
+  *
+  * val pipeline = new Pipeline().setStages(Array(
+  *   documentAssembler,
+  *   tokenizer,
+  *   sequenceClassifier
+  * ))
+  *
+  * val data = Seq("John Lenon was born in London and lived in Paris. My name is Sarah and I live in London").toDF("text")
+  * val result = pipeline.fit(data).transform(data)
+  *
+  * result.select("label.result").show(false)
+  * +--------------------+
+  * |result              |
+  * +--------------------+
+  * |[neg, neg]          |
+  * |[pos, pos, pos, pos]|
+  * +--------------------+
+  * }}}
+  *
+  * @see
+  *   [[CamemBertForSequenceClassification]] for sequence-level classification
+  * @see
+  *   [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of
+  *   transformer based classifiers
+  * @param uid
+  *   required uid for storing annotator to disk
+  * @groupname anno Annotator types
+  * @groupdesc anno
+  *   Required input and expected output annotator types
+  * @groupname Ungrouped Members
+  * @groupname param Parameters
+  * @groupname setParam Parameter setters
+  * @groupname getParam Parameter getters
+  * @groupname Ungrouped Members
+  * @groupprio param  1
+  * @groupprio anno  2
+  * @groupprio Ungrouped 3
+  * @groupprio setParam  4
+  * @groupprio getParam  5
+  * @groupdesc param
+  *   A list of (hyper-)parameter keys this annotator can take. Users can set and get the
+  *   parameter values through setters and getters, respectively.
+  */
+class CamemBertForSequenceClassification(override val uid: String)
+    extends AnnotatorModel[CamemBertForSequenceClassification]
+    with HasBatchedAnnotate[CamemBertForSequenceClassification]
+    with WriteTensorflowModel
+    with WriteSentencePieceModel
+    with HasCaseSensitiveProperties
+    with HasClassifierActivationProperties
+    with HasEngine {
+
+  /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator
+    * type
+    */
+  def this() = this(Identifiable.randomUID("CamemBertForSequenceClassification"))
+
+  /** Input Annotator Types: DOCUMENT, TOKEN
+    *
+    * @group anno
+    */
+  override val inputAnnotatorTypes: Array[String] =
+    Array(AnnotatorType.DOCUMENT, AnnotatorType.TOKEN)
+
+  /** Output Annotator Types: CATEGORY
+    *
+    * @group anno
+    */
+  override val outputAnnotatorType: AnnotatorType = AnnotatorType.CATEGORY
+
+  /** Labels used to decode predicted IDs back to string tags
+    *
+    * @group param
+    */
+  val labels: MapFeature[String, Int] = new MapFeature(this, "labels")
+
+  /** @group setParam */
+  def setLabels(value: Map[String, Int]): this.type = set(labels, value)
+
+  /** Returns labels used to train this model */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
+
+  /** Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document
+    * by averaging probabilities in all sentences. Due to max sequence length limit in almost all
+    * transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
+    * into the model and averaging all the probabilities for the entire document instead of
+    * probabilities per sentence. (Default: true)
+    *
+    * @group param
+    */
+  val coalesceSentences = new BooleanParam(
+    this,
+    "coalesceSentences",
+    "If sets to true the output of all sentences will be averaged to one output instead of one output per sentence. Default to true.")
+
+  /** @group setParam */
+  def setCoalesceSentences(value: Boolean): this.type = set(coalesceSentences, value)
+
+  /** @group getParam */
+  def getCoalesceSentences: Boolean = $(coalesceSentences)
+
+  /** ConfigProto from tensorflow, serialized into byte array. Get with
+    * `config_proto.SerializeToString()`
+    *
+    * @group param
+    */
+  val configProtoBytes = new IntArrayParam(
+    this,
+    "configProtoBytes",
+    "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
+
+  /** @group setParam */
+  def setConfigProtoBytes(bytes: Array[Int]): CamemBertForSequenceClassification.this.type =
+    set(this.configProtoBytes, bytes)
+
+  /** @group getParam */
+  def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
+
+  /** Max sentence length to process (Default: `128`)
+    *
+    * @group param
+    */
+  val maxSentenceLength =
+    new IntParam(this, "maxSentenceLength", "Max sentence length to process")
+
+  /** @group setParam */
+  def setMaxSentenceLength(value: Int): this.type = {
+    require(
+      value <= 512,
+      "CamemBERT models do not support sequences longer than 512 because of trainable positional embeddings.")
+    require(value >= 1, "The maxSentenceLength must be at least 1")
+    set(maxSentenceLength, value)
+    this
+  }
+
+  /** @group getParam */
+  def getMaxSentenceLength: Int = $(maxSentenceLength)
+
+  /** It contains TF model signatures for the laded saved model
+    *
+    * @group param
+    */
+  val signatures = new MapFeature[String, String](model = this, name = "signatures")
+
+  /** @group setParam */
+  def setSignatures(value: Map[String, String]): this.type = {
+    if (get(signatures).isEmpty)
+      set(signatures, value)
+    this
+  }
+
+  /** @group getParam */
+  def getSignatures: Option[Map[String, String]] = get(this.signatures)
+
+  private var _model: Option[Broadcast[TensorflowCamemBertClassification]] = None
+
+  /** @group setParam */
+  def setModelIfNotSet(
+      spark: SparkSession,
+      tensorflowWrapper: TensorflowWrapper,
+      spp: SentencePieceWrapper): CamemBertForSequenceClassification = {
+    if (_model.isEmpty) {
+      _model = Some(
+        spark.sparkContext.broadcast(
+          new TensorflowCamemBertClassification(
+            tensorflowWrapper,
+            spp,
+            configProtoBytes = getConfigProtoBytes,
+            tags = $$(labels),
+            signatures = getSignatures)))
+    }
+
+    this
+  }
+
+  /** @group getParam */
+  def getModelIfNotSet: TensorflowCamemBertClassification = _model.get.value
+
+  /** Whether to lowercase tokens or not
+    *
+    * @group setParam
+    */
+  override def setCaseSensitive(value: Boolean): this.type = {
+    if (get(caseSensitive).isEmpty)
+      set(this.caseSensitive, value)
+    this
+  }
+
+  setDefault(
+    batchSize -> 8,
+    maxSentenceLength -> 128,
+    caseSensitive -> true,
+    coalesceSentences -> false)
+
+  /** takes a document and annotations and produces new annotations of this annotator's annotation
+    * type
+    *
+    * @param batchedAnnotations
+    *   Annotations that correspond to inputAnnotationCols generated by previous annotators if any
+    * @return
+    *   any number of annotations processed for every input annotation. Not necessary one to one
+    *   relationship
+    */
+  override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
+    batchedAnnotations.map(annotations => {
+      val sentences = SentenceSplit.unpack(annotations).toArray
+      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+
+      if (tokenizedSentences.nonEmpty) {
+        getModelIfNotSet.predictSequence(
+          tokenizedSentences,
+          sentences,
+          $(batchSize),
+          $(maxSentenceLength),
+          $(caseSensitive),
+          $(coalesceSentences),
+          $$(labels),
+          $(activation))
+      } else {
+        Seq.empty[Annotation]
+      }
+    })
+  }
+
+  override def onWrite(path: String, spark: SparkSession): Unit = {
+    super.onWrite(path, spark)
+    writeTensorflowModelV2(
+      path,
+      spark,
+      getModelIfNotSet.tensorflowWrapper,
+      "_camembert_classification",
+      CamemBertForSequenceClassification.tfFile,
+      configProtoBytes = getConfigProtoBytes)
+    writeSentencePieceModel(
+      path,
+      spark,
+      getModelIfNotSet.spp,
+      "_camembert",
+      CamemBertForSequenceClassification.sppFile)
+  }
+}
+
+trait ReadablePretrainedCamemBertForSequenceModel
+    extends ParamsAndFeaturesReadable[CamemBertForSequenceClassification]
+    with HasPretrained[CamemBertForSequenceClassification] {
+  override val defaultModelName: Some[String] = Some(
+    "camembert_base_sequence_classifier_allocine")
+  override val defaultLang: String = "fr"
+
+  /** Java compliant-overrides */
+  override def pretrained(): CamemBertForSequenceClassification = super.pretrained()
+
+  override def pretrained(name: String): CamemBertForSequenceClassification =
+    super.pretrained(name)
+
+  override def pretrained(name: String, lang: String): CamemBertForSequenceClassification =
+    super.pretrained(name, lang)
+
+  override def pretrained(
+      name: String,
+      lang: String,
+      remoteLoc: String): CamemBertForSequenceClassification =
+    super.pretrained(name, lang, remoteLoc)
+}
+
+trait ReadCamemBertForSequenceTensorflowModel
+    extends ReadTensorflowModel
+    with ReadSentencePieceModel {
+  this: ParamsAndFeaturesReadable[CamemBertForSequenceClassification] =>
+
+  override val tfFile: String = "camembert_classification_tensorflow"
+  override val sppFile: String = "camembert_spp"
+
+  def readTensorflow(
+      instance: CamemBertForSequenceClassification,
+      path: String,
+      spark: SparkSession): Unit = {
+
+    val tf =
+      readTensorflowModel(path, spark, "_camembert_classification_tf", initAllTables = false)
+    val spp = readSentencePieceModel(path, spark, "_camembert_spp", sppFile)
+    instance.setModelIfNotSet(spark, tf, spp)
+  }
+
+  addReader(readTensorflow)
+
+  def loadSavedModel(
+      modelPath: String,
+      spark: SparkSession): CamemBertForSequenceClassification = {
+
+    val (localModelPath, detectedEngine) = modelSanityCheck(modelPath)
+
+    val spModel = loadSentencePieceAsset(localModelPath, "sentencepiece.bpe.model")
+    val labels = loadTextAsset(localModelPath, "labels.txt").zipWithIndex.toMap
+
+    val annotatorModel = new CamemBertForSequenceClassification()
+      .setLabels(labels)
+
+    annotatorModel.set(annotatorModel.engine, detectedEngine)
+
+    detectedEngine match {
+      case ModelEngine.tensorflow =>
+        val (wrapper, signatures) =
+          TensorflowWrapper.read(localModelPath, zipped = false, useBundle = true)
+
+        val _signatures = signatures match {
+          case Some(s) => s
+          case None => throw new Exception("Cannot load signature definitions from model!")
+        }
+
+        /** the order of setSignatures is important if we use getSignatures inside
+          * setModelIfNotSet
+          */
+        annotatorModel
+          .setSignatures(_signatures)
+          .setModelIfNotSet(spark, wrapper, spModel)
+
+      case _ =>
+        throw new Exception(notSupportedEngineError)
+    }
+
+    annotatorModel
+  }
+}
+
+/** This is the companion object of [[CamemBertForSequenceClassification]]. Please refer to that
+  * class for the documentation.
+  */
+object CamemBertForSequenceClassification
+    extends ReadablePretrainedCamemBertForSequenceModel
+    with ReadCamemBertForSequenceTensorflowModel

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -682,7 +682,8 @@ object PythonResourceDownloader {
     "Wav2Vec2ForCTC" -> Wav2Vec2ForCTC,
     "CamemBertForTokenClassification" -> CamemBertForTokenClassification,
     "TableAssembler" -> TableAssembler,
-    "TapasForQuestionAnswering" -> TapasForQuestionAnswering)
+    "TapasForQuestionAnswering" -> TapasForQuestionAnswering,
+    "CamemBertForSequenceClassification" -> CamemBertForSequenceClassification)
 
   def downloadModel(
       readerStr: String,

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForSequenceClassificationTestSpec.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.nlp.annotator._
+import com.johnsnowlabs.nlp.base._
+import com.johnsnowlabs.nlp.training.CoNLL
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.SlowTest
+import com.johnsnowlabs.util.Benchmark
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.functions.{col, explode, size}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class CamemBertForSequenceClassificationTestSpec extends AnyFlatSpec {
+
+  import ResourceHelper.spark.implicits._
+
+  "CamemBertForSequenceClassification" should "correctly load custom model with extracted signatures" taggedAs SlowTest in {
+
+    val ddd = Seq(
+      "Je t'apprécie beaucoup. Je t'aime.",
+      "Cette banque est très bien, mais elle n'offre pas les services de paiements sans contact.",
+      "J'aime me promener en forêt même si ça me donne mal aux pieds.",
+      "Je pensais lire un livre nul, mais finalement je l'ai trouvé super !")
+      .toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val classifier = CamemBertForSequenceClassification
+      .pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(false)
+      .setCoalesceSentences(false)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, classifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("label").show(20, truncate = false)
+    pipelineDF.select("document.result", "label.result").show(20, truncate = false)
+    pipelineDF
+      .withColumn("doc_size", size(col("document")))
+      .withColumn("label_size", size(col("label")))
+      .where(col("doc_size") =!= col("label_size"))
+      .select("doc_size", "label_size", "document.result", "label.result")
+      .show(20, truncate = false)
+
+    val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"label.result")).count.toInt
+
+    println(s"total tokens: $totalDocs")
+    println(s"total embeddings: $totalLabels")
+
+    assert(totalDocs == totalLabels)
+  }
+
+  "CamemBertForSequenceClassification" should "be saved and loaded correctly" taggedAs SlowTest in {
+
+    import ResourceHelper.spark.implicits._
+
+    val ddd = Seq(
+      "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London",
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21").toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val classifier = CamemBertForSequenceClassification
+      .pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, classifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("label.result").show(false)
+
+    Benchmark.time("Time to save CamemBertForSequenceClassification pipeline model") {
+      pipelineModel.write.overwrite().save("./tmp_forsequence_pipeline")
+    }
+
+    Benchmark.time("Time to save CamemBertForSequenceClassification model") {
+      pipelineModel.stages.last
+        .asInstanceOf[CamemBertForSequenceClassification]
+        .write
+        .overwrite()
+        .save("./tmp_forsequence_model")
+    }
+
+    val loadedPipelineModel = PipelineModel.load("./tmp_forsequence_pipeline")
+    loadedPipelineModel.transform(ddd).select("label.result").show(false)
+
+    val loadedSequenceModel = CamemBertForSequenceClassification.load("./tmp_forsequence_model")
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
+
+  }
+
+  "CamemBertForSequenceClassification" should "benchmark test" taggedAs SlowTest in {
+
+    val conll = CoNLL()
+    val training_data =
+      conll.readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.train")
+
+    val classifier = CamemBertForSequenceClassification
+      .pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("class")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(classifier))
+
+    val pipelineDF = pipeline.fit(training_data).transform(training_data).cache()
+    Benchmark.time("Time to save pipeline results") {
+      pipelineDF.write.mode("overwrite").parquet("./tmp_sequence_classifier")
+    }
+
+    pipelineDF.select("label").show(2, false)
+    pipelineDF.select("document.result", "label.result").show(2, false)
+
+    // only works if it's softmax - one label per row
+    pipelineDF
+      .withColumn("doc_size", size(col("document")))
+      .withColumn("label_size", size(col("class")))
+      .where(col("doc_size") =!= col("label_size"))
+      .select("doc_size", "label_size", "document.result", "class.result")
+      .show(20, false)
+
+    val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"class.result")).count.toInt
+
+    println(s"total docs: $totalDocs")
+    println(s"total classes: $totalLabels")
+
+    assert(totalDocs == totalLabels)
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassificationTestSpec.scala
@@ -153,7 +153,7 @@ class XlmRoBertaForSequenceClassificationTestSpec extends AnyFlatSpec {
     pipelineDF.select("label").show(2, false)
     pipelineDF.select("document.result", "label.result").show(2, false)
 
-    // only works if it's softmax - one lable per row
+    // only works if it's softmax - one label per row
     pipelineDF
       .withColumn("doc_size", size(col("document")))
       .withColumn("label_size", size(col("class")))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

CamemBertForSequenceClassification can load CamemBERT Models with sequence classification/regression head on top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
