### PR TITLE
SPARKNLP-682 Refactoring Error Handling Resource Downloader 

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -109,8 +109,8 @@ object ResourceDownloader {
     Version.parse(Build.version)
   }
 
-  var defaultDownloader: ResourceDownloader =
-    new S3ResourceDownloader(s3Bucket, s3Path, cacheFolder, "default")
+  var privateDownloader: ResourceDownloader =
+    new S3ResourceDownloader(s3Bucket, s3Path, cacheFolder, "private")
   var publicDownloader: ResourceDownloader =
     new S3ResourceDownloader(s3Bucket, s3Path, cacheFolder, "public")
   var communityDownloader: ResourceDownloader =
@@ -119,7 +119,7 @@ object ResourceDownloader {
   /** Reset the cache and recreate ResourceDownloader S3 credentials */
   def resetResourceDownloader(): Unit = {
     cache.empty
-    this.defaultDownloader = new S3ResourceDownloader(s3Bucket, s3Path, cacheFolder, "default")
+    this.privateDownloader = new S3ResourceDownloader(s3Bucket, s3Path, cacheFolder, "private")
   }
 
   /** List all pretrained models in public name_lang */
@@ -341,7 +341,9 @@ object ResourceDownloader {
       lang: Option[String] = None,
       version: Option[Version] = None): List[String] = {
     val resourceList = new ListBuffer[String]()
-    val resourceMetaData = defaultDownloader.downloadMetadataIfNeed(folder)
+
+    val resourceMetaData = getResourceMetadata(folder)
+
     for (meta <- resourceMetaData) {
       val isSameResourceType =
         meta.category.getOrElse(ResourceType.NOT_DEFINED).toString.equals(resourceType.toString)
@@ -386,7 +388,9 @@ object ResourceDownloader {
     listPretrainedResources(folder, resourceType, lang = Some(lang), version = Some(version))
 
   def listAvailableAnnotators(folder: String = publicLoc): List[String] = {
-    val resourceMetaData = defaultDownloader.downloadMetadataIfNeed(folder)
+
+    val resourceMetaData = getResourceMetadata(folder)
+
     resourceMetaData
       .map(_.annotator.getOrElse(""))
       .toSet
@@ -395,6 +399,14 @@ object ResourceDownloader {
       }
       .toList
       .sorted
+  }
+
+  private def getResourceMetadata(location: String): List[ResourceMetadata] = {
+    location match {
+      case this.publicLoc => publicDownloader.downloadMetadataIfNeed(location)
+      case loc if loc.startsWith("@") => communityDownloader.downloadMetadataIfNeed(location)
+      case _ => privateDownloader.downloadMetadataIfNeed(location)
+    }
   }
 
   def showAvailableAnnotators(folder: String = publicLoc): Unit = {
@@ -440,7 +452,7 @@ object ResourceDownloader {
           request.sparkVersion)
         communityDownloader.download(updatedRequest)
       } else {
-        defaultDownloader.download(request)
+        privateDownloader.download(request)
       }
     }
 
@@ -470,7 +482,7 @@ object ResourceDownloader {
 
     require(
       path.isDefined,
-      s"Was not found appropriate resource to download for request: $request with downloader: $defaultDownloader")
+      s"Was not found appropriate resource to download for request: $request with downloader: $privateDownloader")
     println("Download done! Loading the resource.")
     path.get
   }
@@ -489,7 +501,7 @@ object ResourceDownloader {
     } else if (folder.startsWith("@")) {
       communityDownloader.downloadAndUnzipFile(model)
     } else {
-      defaultDownloader.downloadAndUnzipFile(model)
+      privateDownloader.downloadAndUnzipFile(model)
     }
   }
 
@@ -540,7 +552,7 @@ object ResourceDownloader {
   }
 
   def clearCache(request: ResourceRequest): Unit = {
-    defaultDownloader.clearCache(request)
+    privateDownloader.clearCache(request)
     publicDownloader.clearCache(request)
     communityDownloader.clearCache(request)
     cache.remove(request)
@@ -556,7 +568,7 @@ object ResourceDownloader {
       size = communityDownloader.getDownloadSize(
         ResourceRequest(resourceRequest.name, resourceRequest.language, actualLoc))
     } else {
-      size = defaultDownloader.getDownloadSize(resourceRequest)
+      size = privateDownloader.getDownloadSize(resourceRequest)
     }
     size match {
       case Some(downloadBytes) => FileHelper.getHumanReadableFileSize(downloadBytes)

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/S3ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/S3ResourceDownloader.scala
@@ -40,9 +40,9 @@ class S3ResourceDownloader(
     region: String = "us-east-1")
     extends ResourceDownloader {
 
-  val repoFolder2Metadata: mutable.Map[String, RepositoryMetadata] =
+  private val repoFolder2Metadata: mutable.Map[String, RepositoryMetadata] =
     mutable.Map[String, RepositoryMetadata]()
-  val cachePath = new Path(cacheFolder)
+  private val cachePath = new Path(cacheFolder)
 
   if (!doesCacheFolderInCloud && !fileSystem.exists(cachePath)) {
     fileSystem.mkdirs(cachePath)
@@ -50,7 +50,7 @@ class S3ResourceDownloader(
 
   lazy val awsGateway = new AWSGateway(region = region, credentialsType = credentialsType)
 
-  def doesCacheFolderInCloud(): Boolean = {
+  private def doesCacheFolderInCloud(): Boolean = {
     cacheFolder.startsWith("s3") || cacheFolder.startsWith("gs")
   }
 
@@ -272,8 +272,8 @@ class S3ResourceDownloader(
       val tmpFileName = Files.createTempFile(s3File, "").toString
       val tmpFile = new File(tmpFileName)
 
-      val newStrfilePath: String = s3FilePath.toString
-      val mybucket: String = bucket.toString
+      val newStrfilePath: String = s3FilePath
+      val mybucket: String = bucket
       // 2. Download content to tmp file
       awsGateway.getS3Object(mybucket, newStrfilePath, tmpFile)
 

--- a/src/test/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloaderMetaSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloaderMetaSpec.scala
@@ -26,18 +26,18 @@ class ResourceDownloaderMetaSpec extends AnyFlatSpec with BeforeAndAfter {
   val resourcePath = "src/test/resources/resource-downloader/test_metadata.json"
   val mockResourceDownloader: MockResourceDownloader = new MockResourceDownloader(resourcePath)
 
-  val realDefaultDownloader: ResourceDownloader = ResourceDownloader.defaultDownloader
+  val realPrivateDownloader: ResourceDownloader = ResourceDownloader.privateDownloader
   val realPublicDownloader: ResourceDownloader = ResourceDownloader.publicDownloader
   val realCommunityDownloader: ResourceDownloader = ResourceDownloader.communityDownloader
 
   before {
-    ResourceDownloader.defaultDownloader = mockResourceDownloader
+    ResourceDownloader.privateDownloader = mockResourceDownloader
     ResourceDownloader.publicDownloader = mockResourceDownloader
     ResourceDownloader.communityDownloader = mockResourceDownloader
   }
 
   after {
-    ResourceDownloader.defaultDownloader = realDefaultDownloader
+    ResourceDownloader.privateDownloader = realPrivateDownloader
     ResourceDownloader.publicDownloader = realPublicDownloader
     ResourceDownloader.communityDownloader = realCommunityDownloader
   }
@@ -184,7 +184,7 @@ class ResourceDownloaderMetaSpec extends AnyFlatSpec with BeforeAndAfter {
 
   }
   it should "should download a model and unzip file" taggedAs SlowTest in {
-    ResourceDownloader.defaultDownloader = realDefaultDownloader
+    ResourceDownloader.privateDownloader = realPrivateDownloader
     ResourceDownloader.publicDownloader = realPublicDownloader
     ResourceDownloader.communityDownloader = realCommunityDownloader
     ResourceDownloader.downloadModelDirectly(
@@ -192,7 +192,7 @@ class ResourceDownloaderMetaSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   it should "be able to list from online metadata" in {
-    ResourceDownloader.defaultDownloader = realDefaultDownloader
+    ResourceDownloader.privateDownloader = realPrivateDownloader
     ResourceDownloader.publicDownloader = realPublicDownloader
     ResourceDownloader.communityDownloader = realCommunityDownloader
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change removes getObjectFromS3 allowing AWS SDK to rise the correspondent error. 
In addition, this change refactors ResourceDownloader to reflect the intention of each credential type on the downloader.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Attempting the public credentials on a private folder will throw access errors. The result is that users will continue to try different credentials over, and over just to realize that the issue was a wrong/nonexistent path. We should report the error properly here, and stop, instead of attempting public access.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

- Local Tests
- Google Colan [notebook](https://colab.research.google.com/drive/11EXU_RGnOhKnU92wa_xh_xjul8wjhFDY?usp=sharing)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
