### PR TITLE
SPARKNLP-689 Fix inputAnnotatorTypes in TypedDependencyParser

### DIFF
--- a/python/sparknlp/annotator/dependency/typed_dependency_parser.py
+++ b/python/sparknlp/annotator/dependency/typed_dependency_parser.py
@@ -99,7 +99,7 @@ class TypedDependencyParserApproach(AnnotatorApproach):
     >>> pipelineModel = pipeline.fit(emptyDataSet)
     """
 
-    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.POS, AnnotatorType.DEPENDENCY]
+    inputAnnotatorTypes = [AnnotatorType.TOKEN, AnnotatorType.POS, AnnotatorType.DEPENDENCY]
 
     outputAnnotatorType = AnnotatorType.LABELED_DEPENDENCY
 
@@ -264,7 +264,7 @@ class TypedDependencyParserModel(AnnotatorModel):
 
     name = "TypedDependencyParserModel"
 
-    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.POS, AnnotatorType.DEPENDENCY]
+    inputAnnotatorTypes = [AnnotatorType.TOKEN, AnnotatorType.POS, AnnotatorType.DEPENDENCY]
 
     outputAnnotatorType = AnnotatorType.LABELED_DEPENDENCY
 

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/S3ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/S3ResourceDownloader.scala
@@ -42,7 +42,7 @@ class S3ResourceDownloader(
 
   private val repoFolder2Metadata: mutable.Map[String, RepositoryMetadata] =
     mutable.Map[String, RepositoryMetadata]()
-  private val cachePath = new Path(cacheFolder)
+  val cachePath = new Path(cacheFolder)
 
   if (!doesCacheFolderInCloud && !fileSystem.exists(cachePath)) {
     fileSystem.mkdirs(cachePath)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change solves two issues:
1. Corrects inputAnnotatorTypes values in Python
2. Opens cachePath variable access since it is used in other APIs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Keep consistency between Scala and Python implementations

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
