### PR TITLE
Removed duplicated method definition (ContextSpellCheckerApproach)

### DIFF
--- a/python/sparknlp/annotator/spell_check/context_spell_checker.py
+++ b/python/sparknlp/annotator/spell_check/context_spell_checker.py
@@ -393,18 +393,6 @@ class ContextSpellCheckerApproach(AnnotatorApproach):
         """
         return self._set(weightedDistPath=path)
 
-    def setWeightedDistPath(self, path):
-        """Sets the path to the file containing the weights for the levenshtein
-        distance.
-
-        Parameters
-        ----------
-        path : str
-            Path to the file containing the weights for the levenshtein
-            distance.
-        """
-        return self._set(weightedDistPath=path)
-
     def setMaxWindowLen(self, length):
         """Sets the maximum size for the window used to remember history prior
         to every correction.


### PR DESCRIPTION
Removed the duplicated definition of method `setWeightedDistPath` from `ContextSpellCheckerApproach`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
