### PR TITLE
SPARKNLP-703 Fix Finisher outputAnnotatorType Issue

### DIFF
--- a/python/sparknlp/base/light_pipeline.py
+++ b/python/sparknlp/base/light_pipeline.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Contains classes for the LightPipeline."""
+
+from sparknlp.internal import AnnotatorTransformer
 from sparknlp.base.multi_document_assembler import MultiDocumentAssembler
 
 import sparknlp.internal as _internal
@@ -92,7 +94,8 @@ class LightPipeline:
                 output_cols = stage.getOutputCols()
                 for output_col in output_cols:
                     annotator_types[output_col] = stage.outputAnnotatorType
-            else:
+            elif isinstance(stage, AnnotatorApproach) or isinstance(stage, AnnotatorModel) or\
+                    isinstance(stage, AnnotatorTransformer):
                 if stage.outputAnnotatorType is not None:
                     annotator_types[stage.getOutputCol()] = stage.outputAnnotatorType
         return annotator_types

--- a/python/sparknlp/base/light_pipeline.py
+++ b/python/sparknlp/base/light_pipeline.py
@@ -93,7 +93,8 @@ class LightPipeline:
                 for output_col in output_cols:
                     annotator_types[output_col] = stage.outputAnnotatorType
             else:
-                annotator_types[stage.getOutputCol()] = stage.outputAnnotatorType
+                if stage.outputAnnotatorType is not None:
+                    annotator_types[stage.getOutputCol()] = stage.outputAnnotatorType
         return annotator_types
 
     def _annotationFromJava(self, java_annotations):

--- a/python/sparknlp/internal/annotator_transformer.py
+++ b/python/sparknlp/internal/annotator_transformer.py
@@ -22,6 +22,9 @@ from sparknlp.internal.annotator_java_ml import AnnotatorJavaMLReadable
 
 
 class AnnotatorTransformer(JavaTransformer, AnnotatorJavaMLReadable, JavaMLWritable, ParamsGettersSetters):
+
+    outputAnnotatorType = None
+
     @keyword_only
     def __init__(self, classname):
         super(AnnotatorTransformer, self).__init__()

--- a/python/test/pretrained/pretrained_pipeline_test.py
+++ b/python/test/pretrained/pretrained_pipeline_test.py
@@ -123,3 +123,16 @@ class PretrainedPipelineAudioInputTest(unittest.TestCase):
         for result in annotations_result:
             self.assertTrue(len(result) > 0)
 
+
+@pytest.mark.slow
+class PretrainedPipelineWithFinisher(unittest.TestCase):
+
+    def setUp(self):
+        self.pipeline = PretrainedPipeline("distilbert_base_token_classifier_masakhaner_pipeline", "xx")
+
+    def runTest(self):
+        text = "Hello from John Snow Labs ! "
+        annotations_result = self.pipeline.fullAnnotate(text)
+
+        for result in annotations_result:
+            self.assertTrue(len(result) > 0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change adds `outputAnnotatorType` to `AnnotatorTransformer` to avoid loading `outputAnnotatorType` attribute when components don't use it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pretrained Pipelines or Light Pipelines that use a stage that does not use `outputAnnotatorType` data, raises the following error:
```
AttributeError: 'Finisher' object has no attribute 'getOutputCol'
```
This change will solve two issues:
1) Any pipeline that uses `Finisher`, `GraphFinisher` or `EmbeddingsFinisher`
2) When PipelineModel is part of stages


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

- Local Tests
- Google Colab:
   - [Finisher Issue Notebook](https://colab.research.google.com/drive/1coAmaqk4A1YvQ6Md38jjXDehHnPyJCID?usp=sharing)
   - [PipelineModel Issue Notebook](https://colab.research.google.com/drive/1K_5vhKJ11aJxpYioJbH8sFadWyHhiXIf?usp=sharing)
    
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
