### PR TITLE
SPARKNLP-667: Fix indexing issue for custom pattern

### DIFF
--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala
@@ -295,11 +295,22 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
     }
   }
 
-  "a Tokenizer" should s"be of type ${AnnotatorType.TOKEN}" taggedAs FastTest in {
+  private def assertIndexAlignment(tokens: Seq[Annotation], text: String): Unit = {
+    tokens.foreach { case Annotation(_, start, end, result, _, _) =>
+      val expected = text.substring(start, end + 1)
+      assert(
+        expected == result,
+        s"Extracted Token \'$result\' did not match text($start, $end): \'$expected\'")
+    }
+  }
+
+  behavior of "Tokenizer"
+
+  it should s"be of type ${AnnotatorType.TOKEN}" taggedAs FastTest in {
     assert(tokenizer.outputAnnotatorType == AnnotatorType.TOKEN)
   }
 
-  "a Tokenizer" should s"correctly handle exceptions in sentences and documents" taggedAs FastTest in {
+  it should s"correctly handle exceptions in sentences and documents" taggedAs FastTest in {
 
     val data = DataBuilder.basicDataBuild(targetText0)
 
@@ -319,9 +330,11 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
 
     assert(
       result(11) == Annotation(AnnotatorType.TOKEN, 57, 65, "New York,", Map("sentence" -> "2")))
+
+    assertIndexAlignment(result, targetText0)
   }
 
-  "a Tokenizer" should s"correctly handle exceptionsPath" taggedAs FastTest in {
+  it should s"correctly handle exceptionsPath" taggedAs FastTest in {
 
     val data = DataBuilder.basicDataBuild(targetText0)
 
@@ -341,9 +354,11 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
 
     assert(
       result(11) == Annotation(AnnotatorType.TOKEN, 57, 65, "New York,", Map("sentence" -> "2")))
+
+    assertIndexAlignment(result, targetText0)
   }
 
-  "a Tokenizer" should "correctly tokenize target text on its defaults parameters with composite" taggedAs FastTest in {
+  it should "correctly tokenize target text on its defaults parameters with composite" taggedAs FastTest in {
 
     val data = DataBuilder.basicDataBuild(targetText1)
     val tokenizer = new Tokenizer()
@@ -357,12 +372,10 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected1.mkString("|")}")
     val result2 = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
-    result2.foreach(annotation => {
-      assert(targetText1.slice(annotation.begin, annotation.end + 1) == annotation.result)
-    })
+    assertIndexAlignment(result2, targetText1)
   }
 
-  "a Tokenizer" should "correctly tokenize target text on its defaults parameters with case insensitive composite" taggedAs FastTest in {
+  it should "correctly tokenize target text on its defaults parameters with case insensitive composite" taggedAs FastTest in {
 
     val data = DataBuilder.basicDataBuild(targetText1)
     val tokenizer = new Tokenizer()
@@ -377,12 +390,11 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected1.mkString("|")}")
     val result2 = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
-    result2.foreach(annotation => {
-      assert(targetText1.slice(annotation.begin, annotation.end + 1) == annotation.result)
-    })
+    assertIndexAlignment(result2, targetText1)
+
   }
 
-  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite" taggedAs FastTest in {
+  it should "correctly tokenize target sentences on its defaults parameters with composite" taggedAs FastTest in {
     val data = DataBuilder.basicDataBuild(targetText1)
     val tokenizer = new Tokenizer()
       .setInputCols("document")
@@ -390,13 +402,15 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       .setExceptions(Array("New York"))
       .fit(data)
     val result = getTokenizerOutput[String](tokenizer, data)
+    val resultAnnotation = getTokenizerOutput[Annotation](tokenizer, data, "")
     assert(
       result.sameElements(expected1),
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected1.mkString("|")}")
+    assertIndexAlignment(resultAnnotation, targetText1)
   }
 
-  "a Tokenizer" should "correctly tokenize target sentences with split chars" taggedAs FastTest in {
+  it should "correctly tokenize target sentences with split chars" taggedAs FastTest in {
     val data = DataBuilder.basicDataBuild(targetText1)
     val tokenizer = new Tokenizer()
       .setInputCols("document")
@@ -405,13 +419,16 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       .addSplitChars("-")
       .fit(data)
     val result = getTokenizerOutput[String](tokenizer, data)
+    val resultAnnotation = getTokenizerOutput[Annotation](tokenizer, data, "")
+
     assert(
       result.sameElements(expected1b),
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected1b.mkString("|")}")
+    assertIndexAlignment(resultAnnotation, targetText1)
   }
 
-  "a Tokenizer" should s"correctly tokenize a simple sentence on defaults" taggedAs FastTest in {
+  it should s"correctly tokenize a simple sentence on defaults" taggedAs FastTest in {
     val data = DataBuilder.basicDataBuild(targetText2)
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").fit(data)
     val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
@@ -419,9 +436,10 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       result.sameElements(expected2),
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected2.mkString("|")}")
+    assertIndexAlignment(result, targetText2)
   }
 
-  "a Tokenizer" should s"correctly tokenize a sentence with breaking characters on defaults" taggedAs FastTest in {
+  it should s"correctly tokenize a sentence with breaking characters on defaults" taggedAs FastTest in {
     val data = DataBuilder.basicDataBuild(targetText3)
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").fit(data)
     val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
@@ -429,9 +447,10 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       result.sameElements(expected3),
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected3.mkString("|")}")
+    assertIndexAlignment(result, targetText3)
   }
 
-  "a Tokenizer" should s"correctly tokenize a sentence with breaking characters on shrink cleanup" taggedAs FastTest in {
+  it should s"correctly tokenize a sentence with breaking characters on shrink cleanup" taggedAs FastTest in {
     val data = DataBuilder.basicDataBuild(targetText4)(cleanupMode = "shrink")
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").fit(data)
     val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
@@ -439,9 +458,12 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       result.sameElements(expected4),
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected4.mkString("|")}")
+
+    val cleanedText = Annotation.collect(data, "document").head.head.result
+    assertIndexAlignment(result, cleanedText)
   }
 
-  "a tokenizer" should "split French apostrophe on left" taggedAs FastTest in {
+  it should "split French apostrophe on left" taggedAs FastTest in {
 
     val data = DataBuilder.basicDataBuild("l'une d'un l'un, des l'extrême des l'extreme")
     val documentAssembler = new DocumentAssembler()
@@ -479,7 +501,7 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
 
   }
 
-  "a Tokenizer" should s"correctly tokenize a sentence with breaking characters on shrink_full cleanup" taggedAs FastTest in {
+  it should s"correctly tokenize a sentence with breaking characters on shrink_full cleanup" taggedAs FastTest in {
     val data = DataBuilder.basicDataBuild(targetText5)(cleanupMode = "shrink_full")
     val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token").fit(data)
     val result = getTokenizerOutput[Annotation](tokenizer, data, "annotation")
@@ -489,7 +511,7 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected5.mkString("|")}")
   }
 
-  "a Tokenizer" should s"correctly tokenize cleanup with composite and exceptions" taggedAs FastTest in {
+  it should s"correctly tokenize cleanup with composite and exceptions" taggedAs FastTest in {
     val data = DataBuilder.basicDataBuild(targetText6)(cleanupMode = "shrink_full")
     val tokenizer = new Tokenizer()
       .setInputCols("document")
@@ -502,10 +524,14 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       result.sameElements(expected6),
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected6.mkString("|")}")
+
+    val cleanedText = Annotation.collect(data, "document").head.head.result
+    assertIndexAlignment(result, cleanedText)
   }
 
-  "a Tokenizer" should "correctly tokenize target sentences on its defaults parameters with composite and different target pattern" taggedAs FastTest in {
-    val data = DataBuilder.basicDataBuild("Hello New York and Goodbye")
+  it should "correctly tokenize target sentences on its defaults parameters with composite and different target pattern" taggedAs FastTest in {
+    val text = "Hello New York and Goodbye"
+    val data = DataBuilder.basicDataBuild(text)
     val tokenizer = new Tokenizer()
       .setInputCols("document")
       .setOutputCol("token")
@@ -513,13 +539,15 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       .setExceptions(Array("New York"))
       .fit(data)
     val result = getTokenizerOutput[String](tokenizer, data)
+    val resultAnnotation = getTokenizerOutput[Annotation](tokenizer, data, "")
     assert(
       result.sameElements(Seq("Hello", "New York", "and", "Goodbye")),
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected1.mkString("|")}")
+    assertIndexAlignment(resultAnnotation, text)
   }
 
-  "a spark based tokenizer" should "resolve big data" taggedAs FastTest in {
+  it should "resolve big data" taggedAs FastTest in {
     val data = ContentProvider.parquetData
       .limit(500000)
       .repartition(16)
@@ -540,14 +568,10 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
     info(s"Collected 5000 tokens took ${(new Date().getTime - date1) / 1000.0} seconds")
   }
 
-  val latinBodyData: Dataset[Row] = DataBuilder.basicDataBuild(ContentProvider.latinBody)
+  it should "handle composite tokens with special chars" taggedAs FastTest in {
 
-  "A full Tokenizer pipeline with latin content" should behave like fullTokenizerPipeline(
-    latinBodyData)
-
-  "a tokenizer" should "handle composite tokens with special chars" taggedAs FastTest in {
-
-    val data = DataBuilder.basicDataBuild("Are you kidding me ?!?! what is this for !?")
+    val text = "Are you kidding me ?!?! what is this for !?"
+    val data = DataBuilder.basicDataBuild(text)
     val documentAssembler = new DocumentAssembler()
       .setInputCol("text")
 
@@ -560,10 +584,12 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       .fit(data)
 
     val tokenized = tokenizer.transform(assembled)
-    tokenized.collect()
+    val resultAnnotation = Annotation.collect(tokenized, "token").flatten
+
+    assertIndexAlignment(resultAnnotation, text)
   }
 
-  "a Tokenizer" should "correctly filter out tokens based on setting minimum and maximum lengths" taggedAs FastTest in {
+  it should "correctly filter out tokens based on setting minimum and maximum lengths" taggedAs FastTest in {
     val data = DataBuilder.basicDataBuild("Hello New York and Goodbye")
     val tokenizer = new Tokenizer()
       .setInputCols("document")
@@ -579,9 +605,10 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
         s"\nresult was \n${result.mkString("|")} \nexpected is: \n${expected1.mkString("|")}")
   }
 
-  "a Tokenizer" should "work correctly with multiple split chars" taggedAs FastTest in {
+  it should "work correctly with multiple split chars" taggedAs FastTest in {
+    val text = "Hello big-city-of-lights welcome to the ground###earth."
     val data =
-      DataBuilder.basicDataBuild("Hello big-city-of-lights welcome to the ground###earth.")
+      DataBuilder.basicDataBuild(text)
     val tokenizer = new Tokenizer()
       .setInputCols("document")
       .setOutputCol("token")
@@ -605,11 +632,14 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       result.sameElements(expected),
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("\n")} \nexpected is: \n${expected.mkString("\n")}")
+
+    assertIndexAlignment(result, text)
   }
 
-  "a Tokenizer" should "work correctly with multiple split chars including stars '*'" taggedAs FastTest in {
+  it should "work correctly with multiple split chars including stars '*'" taggedAs FastTest in {
+    val text = "Hello big-city-of-lights welcome to*the ground###earth."
     val data =
-      DataBuilder.basicDataBuild("Hello big-city-of-lights welcome to*the ground###earth.")
+      DataBuilder.basicDataBuild(text)
     val tokenizer = new Tokenizer()
       .setInputCols("document")
       .setOutputCol("token")
@@ -633,11 +663,14 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       result.sameElements(expected),
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("\n")} \nexpected is: \n${expected.mkString("\n")}")
+
+    assertIndexAlignment(result, text)
   }
 
-  "a Tokenizer" should "work correctly with a split pattern" taggedAs FastTest in {
+  it should "work correctly with a split pattern" taggedAs FastTest in {
+    val text = "Hello big-city-of-lights welcome to the ground###earth."
     val data =
-      DataBuilder.basicDataBuild("Hello big-city-of-lights welcome to the ground###earth.")
+      DataBuilder.basicDataBuild(text)
     val tokenizer = new Tokenizer()
       .setInputCols("document")
       .setOutputCol("token")
@@ -660,9 +693,11 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       result.sameElements(expected),
       s"because result tokens differ: " +
         s"\nresult was \n${result.mkString("\n")} \nexpected is: \n${expected.mkString("\n")}")
+
+    assertIndexAlignment(result, text)
   }
 
-  "a Tokenizer" should "benchmark exceptions" taggedAs SlowTest in {
+  it should "benchmark exceptions" taggedAs SlowTest ignore {
     val data = AnnotatorBuilder.getTrainingDataSet("src/test/resources/spell/sherlockholmes.txt")
 
     val documentAssembler = new DocumentAssembler()
@@ -706,9 +741,72 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
 
   }
 
-  "RecursiveTokenizer" should "split suffixes" taggedAs FastTest in {
+  it should "produce correct indexes for split patterns without space" taggedAs FastTest in {
 
-    val data = DataBuilder.basicDataBuild("One, after the\n\nOther, (and) again.\nPO, QAM,")
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols("document")
+      .setOutputCol("token")
+      .setSplitPattern("""\s+|(?=[-.:;*+,\(\)\/$&%\\[\\]])|(?<=[-.:;*+,\(\)\/$&%\\[\\]])""")
+
+    val pipeline = new Pipeline().setStages(
+      Array(
+        documentAssembler,
+        tokenizer))
+
+    val text =
+      "PRIMARY OBJECTIVES:\r\n\r\n      I. Determine the safety and feasibility of the chimeric antigen receptor T cells transduced\r\n      with the anti-CD19 (cluster of differentiation antigen 19 ) vector (referred to as CART-19\r\n      cells).\r\n\r\n      II. Determine duration of in vivo survival of CART-19 cells. RT-PCR (reverse transcription\r\n      polymerase chain reaction) analysis of whole blood will be used to detect and quantify\r\n      survival of CART-19 TCR (T-cell receptor) zeta:CD137 and TCR zeta cells over time.\r\n\r\n      SECONDARY OBJECTIVES:\r\n\r\n      I. For patients with detectable disease, measure anti-tumor response due to CART-19 cell\r\n      infusions.\r\n\r\n      II. To determine if the CD137 transgene is superior to the TCR zeta only transgene as\r\n      measured by the relative engraftment levels of CART-19 TCR zeta:CD137 and TCR zeta cells over\r\n      time.\r\n\r\n      III. Estimate relative trafficking of CART-19 cells to tumor in bone marrow and lymph nodes.\r\n\r\n      IV. For patients with stored or accessible tumor cells (such as patients with active chronic\r\n      lymphocytic leukemia(CLL), acute lymphocytic leukemia (ALL), etc) determine tumor cell\r\n      killing by CART-19 cells in vitro.\r\n\r\n      V. Determine if cellular or humoral host immunity develops against the murine anti-CD19, and\r\n      assess correlation with loss of detectable CART-19 (loss of engraftment).\r\n\r\n      VI. Determine the relative subsets of CART-19 T cells (Tcm, Tem, and Treg).\r\n\r\n      OUTLINE: Patients are assigned to 1 group according to order of enrollment.\r\n\r\n      Patients receive anti-CD19-CAR (coupled with CD137 and CD3 zeta signalling\r\n      domains)vector-transduced autologous T cells on days 0,1, and 2 in the absence of disease\r\n      progression or unacceptable toxicity.\r\n\r\n      After completion of study treatment, patients are followed intensively for 6 months, every 3\r\n      months for 2 years, and annually thereafter for 13 years."
+
+    val data = Seq(text).toDF("text")
+
+    val result = pipeline.fit(data).transform(data)
+
+    val collected =
+      Annotation.collect(result, "token").flatten.toSeq
+
+    assertIndexAlignment(collected, text)
+  }
+
+  it should "produce correct indexes for matches without space" in {
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols("document")
+      .setOutputCol("token")
+      .setSplitPattern("(?=.)") // split at every character
+
+    val text = "abcdef"
+    val data = Seq(text).toDF("text")
+
+    val expected: Array[Annotation] =
+      text.toArray.zipWithIndex.map { case (t: Char, i: Int) =>
+        Annotation("token", begin = i, end = i, t.toString, Map("sentence" -> "0"))
+      }
+
+    val pipeline = new Pipeline().setStages(Array(documentAssembler, tokenizer))
+    val result = pipeline.fit(data).transform(data)
+
+    val resultTokens: Array[Annotation] =
+      Annotation.collect(result, "token").flatten
+
+    assert(expected sameElements resultTokens)
+    assertIndexAlignment(resultTokens, text)
+
+  }
+
+  val latinBodyData: Dataset[Row] = DataBuilder.basicDataBuild(ContentProvider.latinBody)
+
+  "A full Tokenizer pipeline with latin content" should behave like fullTokenizerPipeline(
+    latinBodyData)
+
+  "RecursiveTokenizer" should "split suffixes" taggedAs FastTest in {
+    val text = "One, after the\n\nOther, (and) again.\nPO, QAM,"
+    val data = DataBuilder.basicDataBuild(text)
     val documentAssembler = new DocumentAssembler()
       .setInputCol("text")
       .setOutputCol("doc")
@@ -722,6 +820,7 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
 
     val tokenized = tokenizer.transform(assembled)
     val result = tokenized.select("token").as[Seq[Annotation]].collect.head.map(_.result)
+    val resultAnnotation = Annotation.collect(tokenized, "token").flatten
     val expected = Seq(
       "One",
       ",",
@@ -742,7 +841,7 @@ class TokenizerTestSpec extends AnyFlatSpec with TokenizerBehaviors {
       "QAM",
       ",")
     assert(result.equals(expected))
-
+    assertIndexAlignment(resultAnnotation, text)
   }
 
   "RecursiveTokenizer" should "be serializable as model" taggedAs FastTest in {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes an issue for the Tokenizer, when a custom pattern is used with lookahead/-behinds that have 0 width matches, indexes would not be calculated correctly. This can lead to further issues down a pipeline.

Other changes:

- resolved some warnings
- refactored tokenizer tests and added new index alignment check

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests are passing (and appended with an additional index check), new tests have been added to cover this scenario

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

