### PR TITLE
SPARKNLP-708 Enabling Embeddings output in LightPipeline.fullAnnotate

### DIFF
--- a/python/sparknlp/annotation.py
+++ b/python/sparknlp/annotation.py
@@ -65,12 +65,13 @@ class Annotation:
         return Annotation(self.annotatorType, self.begin, self.end, result, self.metadata, self.embeddings)
 
     def __str__(self):
-        return "Annotation(%s, %i, %i, %s, %s)" % (
+        return "Annotation(%s, %i, %i, %s, %s, %s)" % (
             self.annotatorType,
             self.begin,
             self.end,
             self.result,
-            str(self.metadata)
+            str(self.metadata),
+            str(self.embeddings)
         )
 
     def __repr__(self):

--- a/python/sparknlp/base/light_pipeline.py
+++ b/python/sparknlp/base/light_pipeline.py
@@ -66,6 +66,7 @@ class LightPipeline:
 
     def __init__(self, pipelineModel, parse_embeddings=False):
         self.pipeline_model = pipelineModel
+        self.parse_embeddings = parse_embeddings
         self._lightPipeline = _internal._LightPipeline(pipelineModel, parse_embeddings).apply()
 
     def _validateStagesInputCols(self):
@@ -123,13 +124,17 @@ class LightPipeline:
                                     annotation.metadata())
                 )
             else:
+                if self.parse_embeddings:
+                    embeddings = list(annotation.embeddings())
+                else:
+                    embeddings = []
                 annotations.append(
                     Annotation(annotation.annotatorType(),
                                annotation.begin(),
                                annotation.end(),
                                annotation.result(),
                                annotation.metadata(),
-                               [])
+                               embeddings)
                 )
         return annotations
 

--- a/python/test/base/light_pipeline_test.py
+++ b/python/test/base/light_pipeline_test.py
@@ -17,6 +17,8 @@ import unittest
 import pytest
 
 from pyspark.sql.functions import col
+
+from sparknlp.pretrained import PretrainedPipeline
 from test.util import SparkSessionForTest, SparkContextForTest
 
 from sparknlp.annotator import *
@@ -387,3 +389,20 @@ class LightPipelineWrongInputColsTest(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             light_model.annotate(self.sample_text)
+
+
+@pytest.mark.slow
+class LightPipelineWithEmbeddings(unittest.TestCase):
+
+    def setUp(self):
+        self.pipeline = PretrainedPipeline('onto_recognize_entities_bert_tiny', lang='en')
+
+    def runTest(self):
+        light_pipeline = LightPipeline(self.pipeline.model, parse_embeddings=True)
+        result = light_pipeline.annotate("Hello from John Snow Labs ! ")
+
+        self.assertTrue(len(result["embeddings"]) > 0)
+
+        full_result = light_pipeline.fullAnnotate("Hello from John Snow Labs ! ")[0]
+        self.assertTrue(len(full_result["embeddings"]) > 0)
+

--- a/python/test/pretrained/pretrained_pipeline_test.py
+++ b/python/test/pretrained/pretrained_pipeline_test.py
@@ -122,4 +122,3 @@ class PretrainedPipelineAudioInputTest(unittest.TestCase):
         self.assertEqual(len(annotations_result), len(audios))
         for result in annotations_result:
             self.assertTrue(len(result) > 0)
-

--- a/src/test/scala/com/johnsnowlabs/nlp/LightPipelineTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/LightPipelineTestSpec.scala
@@ -20,7 +20,7 @@ import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.annotators.sda.vivekn.ViveknSentimentApproach
 import com.johnsnowlabs.nlp.annotators.spell.norvig.NorvigSweetingApproach
 import com.johnsnowlabs.nlp.annotators.{Normalizer, Tokenizer}
-import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.nlp.pretrained.PretrainedPipeline
 import com.johnsnowlabs.tags.{FastTest, SlowTest}
 import com.johnsnowlabs.util.Benchmark
 import org.apache.spark.ml.{Pipeline, PipelineModel}
@@ -218,6 +218,20 @@ class LightPipelineTestSpec extends AnyFlatSpec {
     assertThrows[UnsupportedOperationException] {
       lightPipeline.fullAnnotate(Array("1", "2", "3"), Array("1", "2"))
     }
+  }
+
+  it should "output embeddings for LightPipeline" taggedAs SlowTest in {
+    val pipeline = new PretrainedPipeline("onto_recognize_entities_bert_tiny", "en")
+    val lightPipeline = new LightPipeline(pipeline.model, parseEmbeddings = true)
+
+    val result = lightPipeline.annotate("Hello from John Snow Labs ! ")
+
+    assert(result("embeddings").nonEmpty)
+
+    val fullResult = lightPipeline.fullAnnotate("Hello from John Snow Labs ! ")
+    val embeddingsAnnotation = fullResult("embeddings").map(_.asInstanceOf[Annotation]).head
+
+    assert(embeddingsAnnotation.embeddings.nonEmpty)
   }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change enables the output of embeddings for `fullAnnotate` when `parseEmbeddings` argument is set to True.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`parseEmbeddings` argument is used to include embeddings data in the output of a `LightPipeline.` However, it only works in `annotation` method and not in `fullAnnotate` which is wrong. It should work for both methods.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Local Tests
- Google Colab [notebook](https://colab.research.google.com/drive/1zdMaq2yFU-mJKNLwBZr5QPKHhcVrGgGD?usp=sharing)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
