### PR TITLE
SPARKNLP-666 use spark 3.3.1 as base

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Python packages (Python 3.7)
         run: |
           python -m pip install --upgrade pip
-          pip install pyspark==3.3.0 numpy pytest
+          pip install pyspark==3.3.1 numpy pytest
       - name: Build Spark NLP on Apache Spark 3.3.0
         run: |
           brew install sbt

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,11 +4,11 @@ object Dependencies {
 
   /** ------- Spark version start ------- */
   /* default spark version to base the APIS */
-  val spark32Ver = "3.2.3"
+  val spark33Ver = "3.3.1"
   /* only used in unit tests */
   val spark30Ver = "3.0.3"
   val spark31Ver = "3.1.3"
-  val spark33Ver = "3.3.1"
+  val spark32Ver = "3.2.3"
 
   /* required for different hardware */
   val is_gpu: String = System.getProperty("is_gpu", "false")
@@ -19,8 +19,8 @@ object Dependencies {
   /* only used for unit tests */
   val is_spark30: String = System.getProperty("is_spark30", "false")
   val is_spark31: String = System.getProperty("is_spark31", "false")
-  val is_spark32: String = System.getProperty("is_spark32", "true")
-  val is_spark33: String = System.getProperty("is_spark33", "false")
+  val is_spark32: String = System.getProperty("is_spark32", "false")
+  val is_spark33: String = System.getProperty("is_spark33", "true")
 
   val sparkVer: String = getSparkVersion(is_spark30, is_spark31, is_spark32, is_spark33)
 
@@ -48,16 +48,16 @@ object Dependencies {
       spark30Ver
     } else if (is_spark31.equals("true")) {
       spark31Ver
-    } else if (is_spark33.equals("true")) {
-      spark33Ver
+    } else if (is_spark32.equals("true")) {
+      spark32Ver
     } else {
       /* default spark version */
-      spark32Ver
+      spark33Ver
     }
   }
 
-  def getJavaTarget(is_spark32: String): String = {
-    if (is_spark32.equals("true")) {
+  def getJavaTarget(is_spark33: String): String = {
+    if (is_spark33.equals("true")) {
       "-target:jvm-1.8"
     } else {
       ""
@@ -103,7 +103,7 @@ object Dependencies {
   val tensorflowM1 = "com.johnsnowlabs.nlp" %% "tensorflow-m1" % tensorflowVersion
   val tensorflowLinuxAarch64 = "com.johnsnowlabs.nlp" %% "tensorflow-aarch64" % tensorflowVersion
 
-  val gcpStorageVersion = "2.15.0"
+  val gcpStorageVersion = "2.16.0"
   val gcpStorage = "com.google.cloud" % "google-cloud-storage" % gcpStorageVersion
 
   /** ------- Dependencies end  ------- */

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,7 +70,7 @@ object Dependencies {
 
   lazy val supportedScalaVersions: Seq[String] = List(scala212)
 
-  val scalaTestVersion = "3.2.9"
+  val scalaTestVersion = "3.2.14"
 
   /** ------- Scala version end ------- */
 

--- a/python/test/annotator/conll_generator_test.py
+++ b/python/test/annotator/conll_generator_test.py
@@ -25,6 +25,6 @@ class CoNLLGeneratorTestSpec(unittest.TestCase):
         self.data = SparkContextForTest.spark.read.load("file:///" + os.getcwd() + "/../src/test/resources/conllgenerator/conllgenerator_nonint_token_metadata.parquet").cache()
 
     def runTest(self):
-        CoNLLGenerator.exportConllFiles(self.data, 'noninttokens2')  # with sentence
-        CoNLLGenerator.exportConllFiles(self.data, 'noninttokensst3', 'section')  # with section
+        CoNLLGenerator.exportConllFiles(self.data, './tmp_noninttokens2')  # with sentence
+        CoNLLGenerator.exportConllFiles(self.data, './tmp_noninttokensst3', 'section')  # with section
 

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,14 @@
+log4j.rootLogger=WARN, STDOUT
+log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender
+log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
+log4j.appender.STDOUT.layout.ConversionPattern=[%5p] %m%n
+
+log4j.logger.AnnotatorLogger=WARN
+log4j.logger.RuleFactory=WARN
+log4j.logger.ChunkAssembler=WARN
+log4j.logger.PerceptronTraining=WARN
+log4j.logger.PragmaticScorer=WARN
+log4j.logger.NorvigApproach=WARN
+log4j.logger.CRF=WARN
+log4j.logger.NerDL=WARN
+log4j.logger.DependencyParserApproach=WARN

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/norvig/NorvigSweetingBehaviors.scala
@@ -159,11 +159,13 @@ trait NorvigSweetingBehaviors { this: AnyFlatSpec =>
       }
 
       val expectedErrorMessage = caught match {
-        case ex: AnalysisException => "need an array field but got string" // Spark 3.x
+        case ex: AnalysisException =>
+          "The deserializer is not supported: need a(n) \"ARRAY\" field but got \"STRING\"." // Spark 3.3.x
         case ex: IllegalArgumentException =>
           "Train dataset must have an array annotation type column" // Spark 2.x
         case _ =>
           new Exception("Unknown exception. Please check Spark version for correct handling.")
+          "Unknown exception. Please check Spark version for correct handling."
       }
 
       assert(caught.getMessage == expectedErrorMessage)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteBehaviors.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteBehaviors.scala
@@ -23,7 +23,7 @@ import com.johnsnowlabs.tags.FastTest
 import com.johnsnowlabs.util.{Benchmark, PipelineModels}
 import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset}
 import org.scalatest.flatspec.AnyFlatSpec
 
 trait SymmetricDeleteBehaviors {
@@ -288,13 +288,14 @@ trait SymmetricDeleteBehaviors {
     "" should "raise an error when dataset without array annotation is used" in {
       val trainDataSet =
         AnnotatorBuilder.getTrainingDataSet("src/test/resources/spell/sherlockholmes.txt")
-      val expectedErrorMessage = "Train dataset must have an array annotation type column"
+      val expectedErrorMessage =
+        "The deserializer is not supported: need a(n) \"ARRAY\" field but got \"STRING\"."
       val spell = new SymmetricDeleteApproach()
         .setInputCols(Array("text"))
         .setOutputCol("spell")
         .setDictionary("src/test/resources/spell/words.txt")
 
-      val caught = intercept[IllegalArgumentException] {
+      val caught = intercept[AnalysisException] {
         spell.fit(trainDataSet)
       }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModelTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/symmetric/SymmetricDeleteModelTestSpec.scala
@@ -74,6 +74,6 @@ class SymmetricDeleteModelTestSpec extends AnyFlatSpec with SymmetricDeleteBehav
 
     it should behave like trainSpellCheckerModelFromFit
 
-    it should behave like raiseErrorWhenWrongColumnIsSent
    */
+  it should behave like raiseErrorWhenWrongColumnIsSent
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/util/CoNLLGeneratorTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/util/CoNLLGeneratorTestSpec.scala
@@ -172,6 +172,6 @@ class CoNLLGeneratorTestSpec extends AnyFlatSpec {
     val df = ResourceHelper.spark.read.load(
       "src/test/resources/conllgenerator/conllgenerator_nonint_token_metadata.parquet")
 
-    CoNLLGenerator.exportConllFiles(df, "./noninttokens")
+    CoNLLGenerator.exportConllFiles(df, "./tmp_noninttokens")
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
No need to update Scala 2.12.15 to something higher, Spark 3.3.1 is still on this version.

- Spark 3.3.1 is now a default package for our APIs
- GCP storage is updated to 2.16.0 from 2.15.0
- Spark 3.3.1 uses log4j2 so we need another file for log4j2
- Test Python by using pyspark 3.3.1 in GA
- Ignore the test directory by adding ignored tmp_
- Fix AnalysisException exception that requires a different caught message

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
