### PR TITLE
SPARKNLP-474 Introducing CamemBERT for Question Answering annotator

### DIFF
--- a/python/sparknlp/annotator/classifier_dl/__init__.py
+++ b/python/sparknlp/annotator/classifier_dl/__init__.py
@@ -42,3 +42,4 @@ from sparknlp.annotator.classifier_dl.xlnet_for_token_classification import *
 from sparknlp.annotator.classifier_dl.camembert_for_token_classification import *
 from sparknlp.annotator.classifier_dl.tapas_for_question_answering import *
 from sparknlp.annotator.classifier_dl.camembert_for_sequence_classification import *
+from sparknlp.annotator.classifier_dl.camembert_for_question_answering import *

--- a/python/sparknlp/annotator/classifier_dl/camembert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/camembert_for_question_answering.py
@@ -16,9 +16,9 @@ from sparknlp.common import *
 
 
 class CamemBertForQuestionAnswering(AnnotatorModel,
-                                     HasCaseSensitiveProperties,
-                                     HasBatchedAnnotate,
-                                     HasEngine):
+                                    HasCaseSensitiveProperties,
+                                    HasBatchedAnnotate,
+                                    HasEngine):
     """CamemBertForQuestionAnswering can load CamemBERT Models with a span classification head on top for extractive
     question-answering tasks like SQuAD (a linear layer on top of the hidden-states output to compute span start
     logits and span end logits).

--- a/python/sparknlp/annotator/classifier_dl/camembert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/camembert_for_sequence_classification.py
@@ -191,8 +191,8 @@ class CamemBertForSequenceClassification(AnnotatorModel,
         CamemBertForSequenceClassification
             The restored model
         """
-        from sparknlp.internal import _CamemBertForSequenceClassification
-        jModel = _CamemBertForSequenceClassification(folder, spark_session._jsparkSession)._java_obj
+        from sparknlp.internal import _CamemBertForSequenceClassificationLoader
+        jModel = _CamemBertForSequenceClassificationLoader(folder, spark_session._jsparkSession)._java_obj
         return CamemBertForSequenceClassification(java_model=jModel)
 
     @staticmethod

--- a/python/sparknlp/internal/__init__.py
+++ b/python/sparknlp/internal/__init__.py
@@ -452,9 +452,9 @@ class _Wav2Vec2ForCTC(ExtendedJavaWrapper):
             "com.johnsnowlabs.nlp.annotators.audio.Wav2Vec2ForCTC.loadSavedModel", path, jspark)
 
 
-class _CamemBertForTokenClassification(ExtendedJavaWrapper):
+class _CamemBertForTokenClassificationLoader(ExtendedJavaWrapper):
     def __init__(self, path, jspark):
-        super(_CamemBertForTokenClassification, self).__init__(
+        super(_CamemBertForTokenClassificationLoader, self).__init__(
             "com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForTokenClassification.loadSavedModel", path,
             jspark)
 
@@ -467,8 +467,15 @@ class _TapasForQuestionAnsweringLoader(ExtendedJavaWrapper):
             jspark)
 
 
-class _CamemBertForSequenceClassification(ExtendedJavaWrapper):
+class _CamemBertForSequenceClassificationLoader(ExtendedJavaWrapper):
     def __init__(self, path, jspark):
-        super(_CamemBertForSequenceClassification, self).__init__(
+        super(_CamemBertForSequenceClassificationLoader, self).__init__(
             "com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForSequenceClassification.loadSavedModel", path,
+            jspark)
+
+
+class _CamemBertQuestionAnsweringLoader(ExtendedJavaWrapper):
+    def __init__(self, path, jspark):
+        super(_CamemBertQuestionAnsweringLoader, self).__init__(
+            "com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForQuestionAnswering.loadSavedModel", path,
             jspark)

--- a/python/test/annotator/classifier_dl/camembert_for_question_aswering_test.py
+++ b/python/test/annotator/classifier_dl/camembert_for_question_aswering_test.py
@@ -1,0 +1,50 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class CamemBertForQuestionAnsweringTestSpec(unittest.TestCase):
+    def setUp(self):
+        self.spark = SparkContextForTest.spark
+        self.question = "Où est-ce que je vis?"
+        self.context = "Mon nom est Wolfgang et je vis à Berlin"
+        self.inputDataset = self.spark.createDataFrame([[self.question, self.context]]) \
+            .toDF("question", "context")
+
+    def runTest(self):
+        document_assembler = MultiDocumentAssembler() \
+            .setInputCols("question", "context") \
+            .setOutputCols("document_question", "document_context")
+
+        qa_classifier = CamemBertForQuestionAnswering.pretrained() \
+            .setInputCols("document_question", "document_context") \
+            .setOutputCol("answer") \
+            .setCaseSensitive(True) \
+            .setMaxSentenceLength(512)
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            qa_classifier
+        ])
+
+        model = pipeline.fit(self.inputDataset)
+        model.transform(self.inputDataset).show()
+        light_pipeline = LightPipeline(model)
+        annotations_result = light_pipeline.fullAnnotate(self.question, self.context)

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowCamemBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowCamemBertClassification.scala
@@ -55,7 +55,9 @@ class TensorflowCamemBertClassification(
   protected val sentenceStartTokenId: Int = spp.getSppModel.pieceToId("<s>") + pieceIdOffset
   protected val sentenceEndTokenId: Int = spp.getSppModel.pieceToId("</s>") + pieceIdOffset
   protected val sentencePadTokenId: Int = spp.getSppModel.pieceToId("<pad>") + pieceIdOffset
-  protected val sentencePieceDelimiterId: Int = spp.getSppModel.pieceToId("▁") + pieceIdOffset
+  // unlike other models the delimiter id is correct and does not need pieceIdOffset
+  // subtracting pieceIdOffset here to make up for adding it later in SP class
+  protected val sentencePieceDelimiterId: Int = spp.getSppModel.pieceToId("▁") - pieceIdOffset
 
   def tokenizeWithAlignment(
       sentences: Seq[TokenizedSentence],
@@ -87,8 +89,8 @@ class TensorflowCamemBertClassification(
       new SentencepieceEncoder(
         spp,
         caseSensitive,
-        sentencePieceDelimiterId - 1,
-        pieceIdOffset = 1)
+        sentencePieceDelimiterId,
+        pieceIdOffset = pieceIdOffset)
 
     val sentences = docs.map { s => Sentence(s.result, s.begin, s.end, 0) }
 
@@ -226,27 +228,29 @@ class TensorflowCamemBertClassification(
     val maxSentenceLength = batch.map(encodedSentence => encodedSentence.length).max
     val batchLength = batch.length
 
-    val tokenBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
-    val maskBuffers: IntDataBuffer = tensors.createIntBuffer(batchLength * maxSentenceLength)
+    val tokenBuffers: LongDataBuffer = tensors.createLongBuffer(batchLength * maxSentenceLength)
+    val maskBuffers: LongDataBuffer = tensors.createLongBuffer(batchLength * maxSentenceLength)
 
     // [nb of encoded sentences , maxSentenceLength]
     val shape = Array(batch.length.toLong, maxSentenceLength)
 
+    // [nb of encoded sentences , maxSentenceLength]
     batch.zipWithIndex
       .foreach { case (sentence, idx) =>
+        val sentenceLong = sentence.map(x => x.toLong)
         val offset = idx * maxSentenceLength
-        tokenBuffers.offset(offset).write(sentence)
+        tokenBuffers.offset(offset).write(sentenceLong)
         maskBuffers
           .offset(offset)
-          .write(sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
+          .write(sentence.map(x => if (x == sentencePadTokenId) 0L else 1L))
       }
 
     val runner = tensorflowWrapper
       .getTFSessionWithSignature(configProtoBytes = configProtoBytes, initAllTables = false)
       .runner
 
-    val tokenTensors = tensors.createIntBufferTensor(shape, tokenBuffers)
-    val maskTensors = tensors.createIntBufferTensor(shape, maskBuffers)
+    val tokenTensors = tensors.createLongBufferTensor(shape, tokenBuffers)
+    val maskTensors = tensors.createLongBufferTensor(shape, maskBuffers)
 
     runner
       .feed(

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -634,7 +634,7 @@ package object annotator {
 
   object CamemBertForSequenceClassification
       extends ReadablePretrainedCamemBertForSequenceModel
-      with ReadCamemBertForSequenceDLModel
+      with ReadCamemBertForSequenceTensorflowModel
 
   type CamemBertForQuestionAnswering =
     com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForQuestionAnswering

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -634,6 +634,13 @@ package object annotator {
 
   object CamemBertForSequenceClassification
       extends ReadablePretrainedCamemBertForSequenceModel
-      with ReadCamemBertForSequenceTensorflowModel
+      with ReadCamemBertForSequenceDLModel
+
+  type CamemBertForQuestionAnswering =
+    com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForQuestionAnswering
+
+  object CamemBertForQuestionAnswering
+      extends ReadablePretrainedCamemBertForQAModel
+      with ReadCamemBertForQADLModel
 
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForQuestionAnswering.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForQuestionAnswering.scala
@@ -272,6 +272,7 @@ trait ReadablePretrainedCamemBertForQAModel
     extends ParamsAndFeaturesReadable[CamemBertForQuestionAnswering]
     with HasPretrained[CamemBertForQuestionAnswering] {
   override val defaultModelName: Some[String] = Some("camembert_base_qa_fquad")
+  override val defaultLang: String = "fr"
 
   /** Java compliant-overrides */
   override def pretrained(): CamemBertForQuestionAnswering =

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForQuestionAnswering.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForQuestionAnswering.scala
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.ml.tensorflow._
+import com.johnsnowlabs.ml.tensorflow.sentencepiece.{
+  ReadSentencePieceModel,
+  SentencePieceWrapper,
+  WriteSentencePieceModel
+}
+import com.johnsnowlabs.ml.util.LoadExternalModel.{
+  loadSentencePieceAsset,
+  modelSanityCheck,
+  notSupportedEngineError
+}
+import com.johnsnowlabs.ml.util.ModelEngine
+import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.serialization.MapFeature
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.param.{IntArrayParam, IntParam}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.SparkSession
+
+/** CamemBertForQuestionAnswering can load CamemBERT Models with a span classification head on top
+  * for extractive question-answering tasks like SQuAD (a linear layer on top of the hidden-states
+  * output to compute span start logits and span end logits).
+  *
+  * Pretrained models can be loaded with `pretrained` of the companion object:
+  * {{{
+  * val spanClassifier = CamemBertForQuestionAnswering.pretrained()
+  *   .setInputCols(Array("document_question", "document_context"))
+  *   .setOutputCol("answer")
+  * }}}
+  * The default model is `"camembert_base_qa_fquad"`, if no name is provided.
+  *
+  * For available pretrained models please see the
+  * [[https://nlp.johnsnowlabs.com/models?task=Question+Answering Models Hub]].
+  *
+  * To see which models are compatible and how to import them see
+  * [[https://github.com/JohnSnowLabs/spark-nlp/discussions/5669]] and to see more extended
+  * examples, see
+  * [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForQuestionAnsweringTestSpec.scala CamemBertForQuestionAnsweringTestSpec]].
+  *
+  * ==Example==
+  * {{{
+  * import spark.implicits._
+  * import com.johnsnowlabs.nlp.base._
+  * import com.johnsnowlabs.nlp.annotator._
+  * import org.apache.spark.ml.Pipeline
+  *
+  * val document = new MultiDocumentAssembler()
+  *   .setInputCols("question", "context")
+  *   .setOutputCols("document_question", "document_context")
+  *
+  * val questionAnswering = CamemBertForQuestionAnswering.pretrained()
+  *   .setInputCols(Array("document_question", "document_context"))
+  *   .setOutputCol("answer")
+  *   .setCaseSensitive(true)
+  *
+  * val pipeline = new Pipeline().setStages(Array(
+  *   document,
+  *   questionAnswering
+  * ))
+  *
+  * val data = Seq("What's my name?", "My name is Clara and I live in Berkeley.").toDF("question", "context")
+  * val result = pipeline.fit(data).transform(data)
+  *
+  * result.select("label.result").show(false)
+  * +---------------------+
+  * |result               |
+  * +---------------------+
+  * |[Clara]              |
+  * ++--------------------+
+  * }}}
+  *
+  * @see
+  *   [[CamemBertForQuestionAnswering]] for sequence-level classification
+  * @see
+  *   [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of
+  *   transformer based classifiers
+  * @param uid
+  *   required uid for storing annotator to disk
+  * @groupname anno Annotator types
+  * @groupdesc anno
+  *   Required input and expected output annotator types
+  * @groupname Ungrouped Members
+  * @groupname param Parameters
+  * @groupname setParam Parameter setters
+  * @groupname getParam Parameter getters
+  * @groupname Ungrouped Members
+  * @groupprio param  1
+  * @groupprio anno  2
+  * @groupprio Ungrouped 3
+  * @groupprio setParam  4
+  * @groupprio getParam  5
+  * @groupdesc param
+  *   A list of (hyper-)parameter keys this annotator can take. Users can set and get the
+  *   parameter values through setters and getters, respectively.
+  */
+class CamemBertForQuestionAnswering(override val uid: String)
+    extends AnnotatorModel[CamemBertForQuestionAnswering]
+    with HasBatchedAnnotate[CamemBertForQuestionAnswering]
+    with WriteTensorflowModel
+    with WriteSentencePieceModel
+    with HasCaseSensitiveProperties
+    with HasEngine {
+
+  /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator
+    * type
+    */
+  def this() = this(Identifiable.randomUID("CamemBertForQuestionAnswering"))
+
+  /** Input Annotator Types: DOCUMENT, DOCUMENT
+    *
+    * @group anno
+    */
+  override val inputAnnotatorTypes: Array[String] =
+    Array(AnnotatorType.DOCUMENT, AnnotatorType.DOCUMENT)
+
+  /** Output Annotator Types: CHUNK
+    *
+    * @group anno
+    */
+  override val outputAnnotatorType: AnnotatorType = AnnotatorType.CHUNK
+
+  /** ConfigProto from tensorflow, serialized into byte array. Get with
+    * `config_proto.SerializeToString()`
+    *
+    * @group param
+    */
+  val configProtoBytes = new IntArrayParam(
+    this,
+    "configProtoBytes",
+    "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
+
+  /** @group setParam */
+  def setConfigProtoBytes(bytes: Array[Int]): CamemBertForQuestionAnswering.this.type =
+    set(this.configProtoBytes, bytes)
+
+  /** @group getParam */
+  def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
+
+  /** Max sentence length to process (Default: `128`)
+    *
+    * @group param
+    */
+  val maxSentenceLength =
+    new IntParam(this, "maxSentenceLength", "Max sentence length to process")
+
+  /** @group setParam */
+  def setMaxSentenceLength(value: Int): this.type = {
+    require(
+      value <= 512,
+      "CamemBERT models do not support sequences longer than 512 because of trainable positional embeddings.")
+    require(value >= 1, "The maxSentenceLength must be at least 1")
+    set(maxSentenceLength, value)
+    this
+  }
+
+  /** @group getParam */
+  def getMaxSentenceLength: Int = $(maxSentenceLength)
+
+  /** It contains TF model signatures for the laded saved model
+    *
+    * @group param
+    */
+  val signatures = new MapFeature[String, String](model = this, name = "signatures")
+
+  /** @group setParam */
+  def setSignatures(value: Map[String, String]): this.type = {
+    if (get(signatures).isEmpty)
+      set(signatures, value)
+    this
+  }
+
+  /** @group getParam */
+  def getSignatures: Option[Map[String, String]] = get(this.signatures)
+
+  private var _model: Option[Broadcast[TensorflowCamemBertClassification]] = None
+
+  /** @group setParam */
+  def setModelIfNotSet(
+      spark: SparkSession,
+      tensorflowWrapper: TensorflowWrapper,
+      spp: SentencePieceWrapper): CamemBertForQuestionAnswering = {
+    if (_model.isEmpty) {
+      _model = Some(
+        spark.sparkContext.broadcast(
+          new TensorflowCamemBertClassification(
+            tensorflowWrapper,
+            spp,
+            configProtoBytes = getConfigProtoBytes,
+            tags = Map.empty[String, Int],
+            signatures = getSignatures)))
+    }
+
+    this
+  }
+
+  /** @group getParam */
+  def getModelIfNotSet: TensorflowCamemBertClassification = _model.get.value
+
+  /** Whether to lowercase tokens or not (Default: `true`).
+    *
+    * @group setParam
+    */
+  override def setCaseSensitive(value: Boolean): this.type = set(this.caseSensitive, value)
+
+  setDefault(batchSize -> 8, maxSentenceLength -> 128, caseSensitive -> true)
+
+  /** takes a document and annotations and produces new annotations of this annotator's annotation
+    * type
+    *
+    * @param batchedAnnotations
+    *   Annotations that correspond to inputAnnotationCols generated by previous annotators if any
+    * @return
+    *   any number of annotations processed for every input annotation. Not necessary one to one
+    *   relationship
+    */
+  override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
+    batchedAnnotations.map(annotations => {
+
+      val documents = annotations
+        .filter(_.annotatorType == AnnotatorType.DOCUMENT)
+        .toSeq
+
+      if (documents.nonEmpty) {
+        getModelIfNotSet.predictSpan(
+          documents,
+          $(maxSentenceLength),
+          $(caseSensitive),
+          MergeTokenStrategy.sentencePiece)
+      } else {
+        Seq.empty[Annotation]
+      }
+    })
+  }
+
+  override def onWrite(path: String, spark: SparkSession): Unit = {
+    super.onWrite(path, spark)
+    writeTensorflowModelV2(
+      path,
+      spark,
+      getModelIfNotSet.tensorflowWrapper,
+      "_camembert_classification",
+      CamemBertForQuestionAnswering.tfFile,
+      configProtoBytes = getConfigProtoBytes)
+    writeSentencePieceModel(
+      path,
+      spark,
+      getModelIfNotSet.spp,
+      "_camembert",
+      CamemBertForQuestionAnswering.sppFile)
+  }
+}
+
+trait ReadablePretrainedCamemBertForQAModel
+    extends ParamsAndFeaturesReadable[CamemBertForQuestionAnswering]
+    with HasPretrained[CamemBertForQuestionAnswering] {
+  override val defaultModelName: Some[String] = Some("camembert_base_qa_fquad")
+
+  /** Java compliant-overrides */
+  override def pretrained(): CamemBertForQuestionAnswering =
+    super.pretrained()
+
+  override def pretrained(name: String): CamemBertForQuestionAnswering =
+    super.pretrained(name)
+
+  override def pretrained(name: String, lang: String): CamemBertForQuestionAnswering =
+    super.pretrained(name, lang)
+
+  override def pretrained(
+      name: String,
+      lang: String,
+      remoteLoc: String): CamemBertForQuestionAnswering =
+    super.pretrained(name, lang, remoteLoc)
+}
+
+trait ReadCamemBertForQADLModel extends ReadTensorflowModel with ReadSentencePieceModel {
+  this: ParamsAndFeaturesReadable[CamemBertForQuestionAnswering] =>
+
+  override val tfFile: String = "camembert_classification_tensorflow"
+  override val sppFile: String = "camembert_spp"
+
+  def readTensorflow(
+      instance: CamemBertForQuestionAnswering,
+      path: String,
+      spark: SparkSession): Unit = {
+
+    val tf =
+      readTensorflowModel(path, spark, "_camembert_classification_tf", initAllTables = false)
+    val spp = readSentencePieceModel(path, spark, "_camembert_spp", sppFile)
+    instance.setModelIfNotSet(spark, tf, spp)
+  }
+
+  addReader(readTensorflow)
+
+  def loadSavedModel(modelPath: String, spark: SparkSession): CamemBertForQuestionAnswering = {
+
+    val (localModelPath, detectedEngine) = modelSanityCheck(modelPath)
+
+    val spModel = loadSentencePieceAsset(localModelPath, "sentencepiece.bpe.model")
+
+    /*Universal parameters for all engines*/
+    val annotatorModel = new CamemBertForQuestionAnswering()
+
+    annotatorModel.set(annotatorModel.engine, detectedEngine)
+
+    detectedEngine match {
+      case ModelEngine.tensorflow =>
+        val (wrapper, signatures) =
+          TensorflowWrapper.read(localModelPath, zipped = false, useBundle = true)
+
+        val _signatures = signatures match {
+          case Some(s) => s
+          case None => throw new Exception("Cannot load signature definitions from model!")
+        }
+
+        /** the order of setSignatures is important if we use getSignatures inside
+          * setModelIfNotSet
+          */
+        annotatorModel
+          .setSignatures(_signatures)
+          .setModelIfNotSet(spark, wrapper, spModel)
+
+      case _ =>
+        throw new Exception(notSupportedEngineError)
+    }
+
+    annotatorModel
+  }
+}
+
+/** This is the companion object of [[CamemBertForQuestionAnswering]]. Please refer to that class
+  * for the documentation.
+  */
+object CamemBertForQuestionAnswering
+    extends ReadablePretrainedCamemBertForQAModel
+    with ReadCamemBertForQADLModel

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -695,7 +695,8 @@ object PythonResourceDownloader {
     "CamemBertForTokenClassification" -> CamemBertForTokenClassification,
     "TableAssembler" -> TableAssembler,
     "TapasForQuestionAnswering" -> TapasForQuestionAnswering,
-    "CamemBertForSequenceClassification" -> CamemBertForSequenceClassification)
+    "CamemBertForSequenceClassification" -> CamemBertForSequenceClassification,
+    "CamemBertForQuestionAnswering" -> CamemBertForQuestionAnswering)
 
   def downloadModel(
       readerStr: String,

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForQuestionAnsweringTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForQuestionAnsweringTestSpec.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.nlp.base._
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.SlowTest
+import com.johnsnowlabs.util.Benchmark
+import org.apache.spark.ml.Pipeline
+import org.scalatest.flatspec.AnyFlatSpec
+
+class CamemBertForQuestionAnsweringTestSpec extends AnyFlatSpec {
+
+  import ResourceHelper.spark.implicits._
+
+  "CamemBertForQuestionAnswering" should "correctly load custom model with extracted signatures" taggedAs SlowTest in {
+
+    val fquadContext =
+      """L'idée selon laquelle une planète inconnue
+        |pourrait exister entre les orbites de Mars et
+        |Jupiter fut proposée pour la première fois par
+        |Johann Elert Bode en 1768. Ses suggestions étaient
+        |basées sur la loi de Titius-Bode, une théorie
+        |désormais obsolète proposée par Johann Daniel
+        |Titius en 1766,. Selon cette loi, le demi-grand
+        |axe de cette planète aurait été d'environ 2,8 ua.
+        |La découverte d'Uranus par William Herschel en
+        |1781 accrut la confiance dans la loi de Titius-
+        |Bode et, en 1800, vingt-quatre astronomes
+        |expérimentés combinèrent leurs efforts et
+        |entreprirent une recherche méthodique de la
+        |planète proposée,. Le groupe était dirigé par
+        |Franz Xaver von Zach. Bien qu'ils n'aient pas
+        |découvert Cérès, ils trouvèrent néanmoins
+        |plusieurs autres astéroïdes.""".stripMargin
+
+    val ddd = Seq(
+      (
+        "Quel astronome a émit l'idée en premier d'une planète entre les orbites de Mars et Jupiter ?",
+        fquadContext),
+      ("Quel astronome découvrit Uranus ?", fquadContext),
+      ("Quelles furent les découvertes finales des vingt-quatre astronomes ?", fquadContext),
+      ("Où est-ce que je vis?", "Mon nom est Wolfgang et je vis à Berlin"))
+      .toDF("question", "context")
+      .repartition(1)
+
+    val document = new MultiDocumentAssembler()
+      .setInputCols("question", "context")
+      .setOutputCols("document_question", "document_context")
+
+    val questionAnswering = CamemBertForQuestionAnswering
+      .pretrained()
+      .setInputCols(Array("document_question", "document_context"))
+      .setOutputCol("answer")
+      .setCaseSensitive(true)
+      .setMaxSentenceLength(512)
+
+    val pipeline = new Pipeline().setStages(Array(document, questionAnswering))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.show(false)
+    pipelineDF.select("answer").show(false)
+    pipelineDF.select("answer.result").show(false)
+
+  }
+
+  "CamemBertForQuestionAnswering" should "benchmark test" taggedAs SlowTest in {
+
+    val data = ResourceHelper.spark.read
+      .option("header", "true")
+      .option("escape", "\"")
+      .csv("src/test/resources/squad/validation-squad-sample.csv")
+      .sample(0.1)
+
+    println(data.count())
+    data.show(5)
+
+    val document = new MultiDocumentAssembler()
+      .setInputCols("question", "context")
+      .setOutputCols("document_question", "document_context")
+
+    val questionAnswering = CamemBertForQuestionAnswering
+      .pretrained()
+      .setInputCols(Array("document_question", "document_context"))
+      .setOutputCol("answer")
+      .setCaseSensitive(true)
+      .setMaxSentenceLength(512)
+
+    val pipeline = new Pipeline().setStages(Array(document, questionAnswering))
+
+    val pipelineModel = pipeline.fit(data)
+    val pipelineDF = pipelineModel.transform(data)
+
+    Benchmark.time("Time to show CamemBertForQuestionAnswering results") {
+      pipelineDF.select("answer").show(10, false)
+    }
+
+    Benchmark.time("Time to save CamemBertForQuestionAnswering results") {
+      pipelineDF
+        .select("answer.result")
+        .write
+        .mode("overwrite")
+        .parquet("./tmp_question_answering")
+    }
+
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

CamemBertForQuestionAnswering can load CamemBERT Models with a span classification head on top for extractive question-answering tasks like SQuAD (a linear layer on top of the hidden-states output to compute span start logits and span end logits).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
