### PR TITLE
SPARKNLP-713 Modifies Default Values GraphExtraction

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/GraphExtraction.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/GraphExtraction.scala
@@ -530,14 +530,17 @@ class GraphExtraction(override val uid: String)
   private def extractGraphsFromEntities(
       annotationsInfo: AnnotationsInfo,
       graph: GraphBuilder): Seq[Annotation] = {
+
     var rootIndices: Array[Int] = Array()
+    var sourceDependencies: Array[DependencyInfo] = Array()
 
     if ($(rootTokens).isEmpty) {
-      val sourceDependency =
-        annotationsInfo.dependencyData.filter(dependencyInfo => dependencyInfo.headIndex == 0)
-      rootIndices = Array(annotationsInfo.dependencyData.indexOf(sourceDependency.head) + 1)
+      sourceDependencies = annotationsInfo.dependencyData
+        .filter(dependencyInfo => dependencyInfo.headIndex == 0)
+        .toArray
+      rootIndices = Array(annotationsInfo.dependencyData.indexOf(sourceDependencies.head) + 1)
     } else {
-      val sourceDependencies = $(rootTokens).flatMap(rootToken =>
+      sourceDependencies = $(rootTokens).flatMap(rootToken =>
         annotationsInfo.dependencyData.filter(_.token == rootToken))
       rootIndices = sourceDependencies.map(sourceDependency =>
         annotationsInfo.dependencyData.indexOf(sourceDependency) + 1)
@@ -547,7 +550,37 @@ class GraphExtraction(override val uid: String)
       getEntitiesData(annotationsInfo.nerEntities, annotationsInfo.dependencyData)
     val annotatedPaths = rootIndices.flatMap(rootIndex =>
       getAnnotatedPaths(entitiesPairData, graph, rootIndex, annotationsInfo))
+
+    if (annotatedPaths.isEmpty && $(rootTokens).nonEmpty) {
+      println(
+        s"[WARN] Not found paths between given roots: [${$(rootTokens).mkString(",")}] and" +
+          s" entities pairs: ${entitiesPairData.map(x => x.entities).mkString(",")}.\n" +
+          s"This could mean there are no more labeled tokens below the given roots or NER didn't label any token.\n" +
+          s"$entitiesWarnMessage")
+    }
+
+    if (annotatedPaths.isEmpty && $(rootTokens).isEmpty) {
+      println(
+        s"[WARN] Not found paths between the root [${sourceDependencies.head.token}] and " +
+          s" entities pairs ${entitiesPairData.map(x => x.entities).mkString(",")}.\n" +
+          s"This could mean there are no more labeled tokens below the root or NER didn't label any token.\n" +
+          s"$entitiesWarnMessage")
+    }
+
     annotatedPaths
+  }
+
+  private def entitiesWarnMessage: String = {
+    val notebooksURI =
+      "https://github.com/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/annotation/english/"
+    val relationshipTypesNotebook =
+      s"$notebooksURI/graph-extraction/graph_extraction_roots_paths.ipynb"
+    val displayNotebook = s"$notebooksURI/graph-extraction/graph_extraction_helper_display.ipynb"
+    val message =
+      s"You can try using relationshipTypes parameter, check this notebook: $relationshipTypesNotebook \n" +
+        s"You can also use spark-nlp-display to visualize Dependency Parser and NER output to help identify the kind of relations you can extract" +
+        s", check this notebook: $displayNotebook"
+    message
   }
 
   private def extractGraphsFromRelationships(

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/GraphExtraction.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/GraphExtraction.scala
@@ -318,10 +318,10 @@ class GraphExtraction(override val uid: String)
 
   setDefault(
     entityTypes -> Array(),
-    explodeEntities -> false,
+    explodeEntities -> true,
     maxSentenceSize -> 1000,
     minSentenceSize -> 2,
-    mergeEntities -> false,
+    mergeEntities -> true,
     rootTokens -> Array(),
     relationshipTypes -> Array(),
     includeEdges -> true,

--- a/src/test/scala/com/johnsnowlabs/nlp/GraphFinisherTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/GraphFinisherTest.scala
@@ -27,8 +27,6 @@ import scala.collection.mutable
 
 class GraphFinisherTest extends AnyFlatSpec with SparkSessionTest with GraphExtractionFixture {
 
-  spark.conf.set("spark.sql.crossJoin.enabled", "true")
-
   import spark.implicits._
 
   private val textDataSet = Seq("Bruce Wayne lives in Gotham").toDS.toDF("text")
@@ -50,6 +48,8 @@ class GraphFinisherTest extends AnyFlatSpec with SparkSessionTest with GraphExtr
       .setInputCols("document", "token", "entities")
       .setOutputCol("graph")
       .setRelationshipTypes(Array("sees-PER"))
+      .setMergeEntities(false)
+      .setExplodeEntities(false)
     val finisher = new GraphFinisher().setInputCol("graph").setOutputCol("finisher")
     val pipeline = new Pipeline().setStages(Array(graphExtractor, finisher))
     val expectedGraph = List(
@@ -66,12 +66,14 @@ class GraphFinisherTest extends AnyFlatSpec with SparkSessionTest with GraphExtr
     assert(actualGraph == expectedGraph)
   }
 
-  it should "output graph in RDF format as string" in {
+  it should "output graph in RDF format as string" taggedAs FastTest in {
     val testDataSet = getDeepEntities(spark, tokenizerWithSentencePipeline)
     val graphExtractor = new GraphExtraction()
       .setInputCols("document", "token", "entities")
       .setOutputCol("graph")
       .setRelationshipTypes(Array("sees-PER"))
+      .setMergeEntities(false)
+      .setExplodeEntities(false)
     val finisher =
       new GraphFinisher().setInputCol("graph").setOutputCol("finisher").setOutputAsArray(false)
     val expectedGraph = List(
@@ -93,6 +95,8 @@ class GraphFinisherTest extends AnyFlatSpec with SparkSessionTest with GraphExtr
       .setInputCols("document", "token", "entities")
       .setOutputCol("graph")
       .setRelationshipTypes(Array("sees-PER"))
+      .setMergeEntities(false)
+      .setExplodeEntities(false)
     val finisher = new GraphFinisher()
       .setInputCol("graph")
       .setOutputCol("finisher")
@@ -120,6 +124,7 @@ class GraphFinisherTest extends AnyFlatSpec with SparkSessionTest with GraphExtr
       .setInputCols("sentence", "token", "entities")
       .setOutputCol("graph")
       .setExplodeEntities(true)
+      .setMergeEntities(false)
     val finisher = new GraphFinisher()
       .setInputCol("graph")
       .setOutputCol("finisher")

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/GraphExtractionTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/GraphExtractionTest.scala
@@ -33,8 +33,6 @@ import scala.collection.mutable
 
 class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphExtractionFixture {
 
-  spark.conf.set("spark.sql.crossJoin.enabled", "true")
-
   "Graph Extraction" should "return dependency graphs between all entities" taggedAs FastTest in {
 
     val testDataSet = getUniqueEntitiesDataSet(spark, tokenizerWithSentencePipeline)
@@ -42,6 +40,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setInputCols("sentence", "token", "entities")
       .setOutputCol("graph")
       .setExplodeEntities(true)
+      .setMergeEntities(false)
       .setIncludeEdges(false)
     val expectedGraph = Array(
       Seq(
@@ -87,6 +86,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setExplodeEntities(true)
       .setEntityTypes(Array("ORG-LOC"))
       .setIncludeEdges(false)
+      .setMergeEntities(false)
     val expectedGraph = Array(
       Seq(
         Annotation(
@@ -113,6 +113,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setExplodeEntities(true)
       .setEntityTypes(Array("ORG-LOC", "ORG-TIME"))
       .setIncludeEdges(false)
+      .setMergeEntities(false)
     val expectedGraph = Array(
       Seq(
         Annotation(
@@ -148,6 +149,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setExplodeEntities(true)
       .setEntityTypes(Array("ORG-LOC"))
       .setIncludeEdges(false)
+      .setMergeEntities(false)
     val expectedGraph = Array(
       Seq(
         Annotation(
@@ -184,6 +186,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setExplodeEntities(true)
       .setEntityTypes(Array("LOC-LOC"))
       .setIncludeEdges(false)
+      .setMergeEntities(false)
     val expectedGraph = Array(
       Seq(
         Annotation(
@@ -210,6 +213,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setExplodeEntities(true)
       .setEntityTypes(Array("LOC-TIME"))
       .setIncludeEdges(false)
+      .setMergeEntities(false)
     val expectedGraph = Array(
       Seq(
         Annotation(
@@ -247,6 +251,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setEntityTypes(Array("LOC-TIME"))
       .setMinSentenceSize(33)
       .setIncludeEdges(false)
+      .setMergeEntities(false)
     val expectedGraph = Array(
       Seq(
         Annotation(
@@ -274,6 +279,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setEntityTypes(Array("ORG-LOC"))
       .setMaxSentenceSize(5)
       .setIncludeEdges(false)
+      .setMergeEntities(false)
     val expectedGraph = Array(Seq(Annotation(NODE, 0, 0, "", Map())))
 
     val graphDataSet = graphExtractor.transform(testDataSet)
@@ -289,6 +295,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setOutputCol("graph")
       .setMergeEntities(true)
       .setRelationshipTypes(Array("person-PER", "person-LOC"))
+      .setMergeEntities(false)
 
     val graphDataSet = graphExtractor.transform(testDataSet)
     graphDataSet.show(false)
@@ -303,6 +310,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setEntityTypes(Array("PER-LOC"))
       .setRootTokens(Array("goes"))
       .setIncludeEdges(false)
+      .setMergeEntities(false)
     val expectedGraph = Array(
       Seq(
         Annotation(
@@ -327,7 +335,8 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setInputCols("document", "token", "entities")
       .setOutputCol("graph")
       .setRelationshipTypes(Array("sees-PER"))
-
+      .setExplodeEntities(false)
+      .setMergeEntities(false)
     val expectedGraph = Array(
       Seq(Annotation(
         NODE,
@@ -352,6 +361,8 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setInputCols("document", "token", "entities")
       .setOutputCol("graph")
       .setRelationshipTypes(Array("whatever-PER"))
+      .setExplodeEntities(false)
+      .setMergeEntities(false)
 
     val graphDataSet = graphExtractor.transform(testDataSet)
 
@@ -371,6 +382,8 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setOutputCol("graph")
       .setRelationshipTypes(Array("goes-PER", "goes-LOC"))
       .setIncludeEdges(false)
+      .setExplodeEntities(false)
+      .setMergeEntities(false)
     val expectedGraph = Array(
       Seq(
         Annotation(
@@ -398,6 +411,8 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setInputCols("document", "token", "entities")
       .setOutputCol("graph")
       .setRelationshipTypes(Array("polymorphisms-GENE", "polymorphisms-DISEASE"))
+      .setExplodeEntities(false)
+      .setMergeEntities(false)
     val expectedGraph = Array(
       Seq(
         Annotation(
@@ -429,6 +444,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setInputCols("sentence", "token", "entities")
       .setOutputCol("graph")
       .setExplodeEntities(true)
+      .setMergeEntities(false)
     val expectedGraph = Array(
       Seq(
         Annotation(
@@ -471,7 +487,6 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setInputCols("sentence", "token", "entities")
       .setOutputCol("graph")
       .setExplodeEntities(true)
-      .setMergeEntities(true)
       .setMergeEntitiesIOBFormat("IOB")
       .setIncludeEdges(false)
     val expectedGraph = Array(
@@ -545,6 +560,7 @@ class GraphExtractionTest extends AnyFlatSpec with SparkSessionTest with GraphEx
       .setInputCols("document", "token", "ner")
       .setOutputCol("graph")
       .setRelationshipTypes(Array("lad-PER", "lad-LOC"))
+      .setMergeEntities(false)
 
     val graphFinisher = new GraphFinisher()
       .setInputCol("graph")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Modifies default values of `explodeEntities` and `mergeEntities` parameters
2. Adds a warning message when there are empty paths to better guide the user on how to configure `GraphExtraction` to output meaningful relationships.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Defining these parameters by default to true, makes this annotator to have and output, avoiding users to think it does not work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- Local Tests
- Google Colab [notebook](https://colab.research.google.com/drive/1ev7nu39IDr05YlUF-QMmST-dNvjwqY1A?usp=sharing)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
