### PR TITLE
SPARKNLP-726 Fix metadata in XXXForSequenceClassification results

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowForClassification.scala
@@ -132,7 +132,7 @@ trait TensorflowForClassification {
       tags: Map[String, Int],
       scores: Array[Float]): Array[(String, String)] = {
     scores.zipWithIndex.flatMap(x =>
-      Map(tags.find(_._2 == x._2).map(_._1).toString -> x._1.toString))
+      Map(tags.find(_._2 == x._2).map(_._1).getOrElse("NA") -> x._1.toString))
   }
 
   def constructAnnotationForSequenceClassifier(


### PR DESCRIPTION
- This will fix the issue with optional key in metadata. This `"Some(POSITIVE)"` will be `"POSITIVE"`


current metadata:
```
+-----------------------------------------------------------------------------------------------+
|label                                                                                          |
+-----------------------------------------------------------------------------------------------+
|[{category, 0, 87, pos, {sentence -> 0, Some(neg) -> 0.13602075, Some(pos) -> 0.8639792}, []}] |
|[{category, 0, 48, pos, {sentence -> 0, Some(neg) -> 0.34219337, Some(pos) -> 0.65780663}, []}]|
|[{category, 0, 47, neg, {sentence -> 0, Some(neg) -> 0.7505674, Some(pos) -> 0.24943262}, []}] |
|[{category, 0, 17, pos, {sentence -> 0, Some(neg) -> 0.31065974, Some(pos) -> 0.6893403}, []}] |
|[{category, 0, 71, neg, {sentence -> 0, Some(neg) -> 0.5079189, Some(pos) -> 0.4920811}, []}]  |
|[{category, 0, 85, neg, {sentence -> 0, Some(neg) -> 0.56631726, Some(pos) -> 0.43368277}, []}]|
+-----------------------------------------------------------------------------------------------+
```

fixed version:
```
+-----------------------------------------------------------------------------------+
|label                                                                              |
+-----------------------------------------------------------------------------------+
|[{category, 0, 87, pos, {sentence -> 0, neg -> 0.13602075, pos -> 0.8639792}, []}] |
|[{category, 0, 48, pos, {sentence -> 0, neg -> 0.34219337, pos -> 0.65780663}, []}]|
|[{category, 0, 47, neg, {sentence -> 0, neg -> 0.7505674, pos -> 0.24943262}, []}] |
|[{category, 0, 17, pos, {sentence -> 0, neg -> 0.31065974, pos -> 0.6893403}, []}] |
|[{category, 0, 71, neg, {sentence -> 0, neg -> 0.5079189, pos -> 0.4920811}, []}]  |
|[{category, 0, 85, neg, {sentence -> 0, neg -> 0.56631726, pos -> 0.43368277}, []}]|
+-----------------------------------------------------------------------------------+
```