### PR TITLE
SPARKNLP-724 Adding configuration to skip light pipeline validation

### DIFF
--- a/python/sparknlp/base/embeddings_finisher.py
+++ b/python/sparknlp/base/embeddings_finisher.py
@@ -127,7 +127,8 @@ class EmbeddingsFinisher(AnnotatorTransformer):
         super(EmbeddingsFinisher, self).__init__(classname="com.johnsnowlabs.nlp.EmbeddingsFinisher")
         self._setDefault(
             cleanAnnotations=False,
-            outputAsVector=False
+            outputAsVector=False,
+            outputCols=[]
         )
 
     @keyword_only
@@ -187,3 +188,13 @@ class EmbeddingsFinisher(AnnotatorTransformer):
 
         return self._set(outputAsVector=value)
 
+    def getInputCols(self):
+        """Gets input columns name of annotations."""
+        return self.getOrDefault(self.inputCols)
+
+    def getOutputCols(self):
+        """Gets output columns name of annotations."""
+        if len(self.getOrDefault(self.outputCols)) == 0:
+            return ["finished_" + input_col for input_col in self.getInputCols()]
+        else:
+            return self.getOrDefault(self.outputCols)

--- a/python/sparknlp/base/finisher.py
+++ b/python/sparknlp/base/finisher.py
@@ -97,7 +97,6 @@ class Finisher(AnnotatorTransformer):
     includeMetadata = Param(Params._dummy(), "includeMetadata", "annotation metadata format", typeConverter=TypeConverters.toBoolean)
     outputAsArray = Param(Params._dummy(), "outputAsArray", "finisher generates an Array with the results instead of string", typeConverter=TypeConverters.toBoolean)
     parseEmbeddingsVectors = Param(Params._dummy(), "parseEmbeddingsVectors", "whether to include embeddings vectors in the process", typeConverter=TypeConverters.toBoolean)
-
     name = "Finisher"
 
     @keyword_only
@@ -109,7 +108,8 @@ class Finisher(AnnotatorTransformer):
             outputAsArray=True,
             parseEmbeddingsVectors=False,
             valueSplitSymbol="#",
-            annotationSplitSymbol="@"
+            annotationSplitSymbol="@",
+            outputCols=[]
         )
 
     @keyword_only
@@ -204,3 +204,13 @@ class Finisher(AnnotatorTransformer):
         """
         return self._set(parseEmbeddingsVectors=value)
 
+    def getInputCols(self):
+        """Gets input columns name of annotations."""
+        return self.getOrDefault(self.inputCols)
+
+    def getOutputCols(self):
+        """Gets output columns name of annotations."""
+        if len(self.getOrDefault(self.outputCols)) == 0:
+            return ["finished_" + input_col for input_col in self.getInputCols()]
+        else:
+            return self.getOrDefault(self.outputCols)

--- a/python/sparknlp/base/light_pipeline.py
+++ b/python/sparknlp/base/light_pipeline.py
@@ -13,15 +13,12 @@
 #  limitations under the License.
 """Contains classes for the LightPipeline."""
 
-from sparknlp.internal import AnnotatorTransformer
-from sparknlp.base.multi_document_assembler import MultiDocumentAssembler
-
 import sparknlp.internal as _internal
-
 from sparknlp.annotation import Annotation
 from sparknlp.annotation_audio import AnnotationAudio
 from sparknlp.annotation_image import AnnotationImage
 from sparknlp.common import AnnotatorApproach, AnnotatorModel
+from sparknlp.internal import AnnotatorTransformer
 
 
 class LightPipeline:
@@ -71,8 +68,7 @@ class LightPipeline:
         self.parse_embeddings = parse_embeddings
         self._lightPipeline = _internal._LightPipeline(pipelineModel, parse_embeddings).apply()
 
-    def _validateStagesInputCols(self):
-        stages = self.pipeline_model.stages
+    def _validateStagesInputCols(self, stages):
         annotator_types = self._getAnnotatorTypes(stages)
         for stage in stages:
             if isinstance(stage, AnnotatorApproach) or isinstance(stage, AnnotatorModel):
@@ -88,10 +84,20 @@ class LightPipeline:
                                         f" with the right output names and that they have following annotator types:"
                                         f" {input_annotator_types}")
 
+    def _skipPipelineValidation(self, stages):
+        exceptional_pipeline = [stage for stage in stages if self._skipStageValidation(stage)]
+        if len(exceptional_pipeline) >= 1:
+            return True
+        else:
+            return False
+
+    def _skipStageValidation(self, stage):
+        return hasattr(stage, 'skipLPInputColsValidation') and stage.skipLPInputColsValidation
+
     def _getAnnotatorTypes(self, stages):
         annotator_types = {}
         for stage in stages:
-            if isinstance(stage, MultiDocumentAssembler):
+            if hasattr(stage, 'getOutputCols'):
                 output_cols = stage.getOutputCols()
                 for output_col in output_cols:
                     annotator_types[output_col] = stage.outputAnnotatorType
@@ -185,7 +191,10 @@ class LightPipeline:
         Annotation(named_entity, 30, 36, B-LOC, {'word': 'Baghdad'}),
         Annotation(named_entity, 37, 37, O, {'word': '.'})]
         """
-        self._validateStagesInputCols()
+        stages = self.pipeline_model.stages
+        if not self._skipPipelineValidation(stages):
+            print("Before _validateStagesInputCols")
+            self._validateStagesInputCols(stages)
 
         if optional_target == "":
             if self.__isTextInput(target):
@@ -284,7 +293,9 @@ class LightPipeline:
         List[AnnotationImage]
             The result of the annotation
         """
-        self._validateStagesInputCols()
+        stages = self.pipeline_model.stages
+        if not self._skipPipelineValidation(stages):
+            self._validateStagesInputCols(stages)
 
         if type(path_to_image) is str:
             path_to_image = [path_to_image]
@@ -336,7 +347,9 @@ class LightPipeline:
         def reformat(annotations):
             return {k: list(v) for k, v in annotations.items()}
 
-        self._validateStagesInputCols()
+        stages = self.pipeline_model.stages
+        if not self._skipPipelineValidation(stages):
+            self._validateStagesInputCols(stages)
 
         if optional_target == "":
             if type(target) is str:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change introduces a configuration to skip LightPipeline validation for `inputCols` on Python side. 
This toggle should only be used for specific annotators that do not follow the convention of  predefined `inputAnnotatorTypes` and `outputAnnotatorType`.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Check thread https://github.com/JohnSnowLabs/spark-nlp-internal/pull/1482#issuecomment-1384684725

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Unit Tests
- [Google Colab notebook](https://colab.research.google.com/drive/19FJafbdstkO1xKJmexQluzKjVqtJMbDF?usp=sharing)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
