### PR TITLE
Doc id conll reader

### DIFF
--- a/python/sparknlp/training/conll.py
+++ b/python/sparknlp/training/conll.py
@@ -65,6 +65,8 @@ class CoNLL(ExtendedJavaWrapper):
         Whether to explode sentences to separate rows, by default True
     delimiter: str, optional
         Delimiter used to separate columns inside CoNLL file
+    includeDocId: bool, optional
+        Whether to try and parse the document id from the third item in the -DOCSTART- line (X if not found)
 
     Examples
     --------
@@ -92,10 +94,12 @@ class CoNLL(ExtendedJavaWrapper):
                  posCol='pos',
                  conllLabelIndex=3,
                  conllPosIndex=1,
+                 conllDocIdCol="doc_id",
                  textCol='text',
                  labelCol='label',
                  explodeSentences=True,
-                 delimiter=' '
+                 delimiter=' ',
+                 includeDocId=False
                  ):
         super(CoNLL, self).__init__("com.johnsnowlabs.nlp.training.CoNLL",
                                     documentCol,
@@ -104,10 +108,12 @@ class CoNLL(ExtendedJavaWrapper):
                                     posCol,
                                     conllLabelIndex,
                                     conllPosIndex,
+                                    conllDocIdCol,
                                     textCol,
                                     labelCol,
                                     explodeSentences,
-                                    delimiter)
+                                    delimiter,
+                                    includeDocId)
 
     def readDataset(self, spark, path, read_as=ReadAs.TEXT, partitions=8, storage_level=pyspark.StorageLevel.DISK_ONLY):
         # ToDo Replace with std pyspark

--- a/python/test/training/conll_test.py
+++ b/python/test/training/conll_test.py
@@ -1,0 +1,26 @@
+import unittest
+
+import pytest
+
+from sparknlp.training import CoNLL
+from test.util import SparkContextForTest
+
+expectedColumnNames = ["document", "sentence", "token", "pos", "label"]
+expectedAnnotatorTypes = ["document", "document", "token", "pos", "named_entity"]
+
+@pytest.mark.fast
+class CoNLLTestSpec(unittest.TestCase):
+    def runTest(self):
+        trainingData = CoNLL().readDataset(SparkContextForTest.spark, "../src/test/resources/conll/test_conll_docid.txt")
+        comparedColumnNames = list(zip(map(lambda x: x.name, trainingData.schema[1:]),expectedColumnNames))
+        comparedAnnotationTypes = list(zip(map(lambda x: x.metadata["annotatorType"], trainingData.schema[1:]), expectedAnnotatorTypes))
+        assert(all([x == y for x, y in (comparedColumnNames +  comparedAnnotationTypes)]))
+
+
+@pytest.mark.fast
+class CoNLLWithIdsTestSpec(unittest.TestCase):
+    def runTest(self):
+        trainingData = CoNLL(includeDocId=True).readDataset(SparkContextForTest.spark, "../src/test/resources/conll/test_conll_docid.txt")
+        expectedDocIds = ["O", "1", "2", "3-1", "3-2"]
+        comparedDocIds = zip(trainingData.select("doc_id").rdd.flatMap(lambda x: x).collect(), expectedDocIds)
+        assert(all([x == y for x, y in comparedDocIds]))

--- a/src/main/scala/com/johnsnowlabs/nlp/training/CoNLL.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/training/CoNLL.scala
@@ -201,7 +201,7 @@ case class CoNLL(
       sentences.clear()
 
       if (result._1.nonEmpty) {
-        Some(doc.toString, sentences.toList, if (includeDocId) docId else None)
+        Some(result._1, result._2, if (includeDocId) docId else None)
       } else
         None
     }

--- a/src/main/scala/com/johnsnowlabs/nlp/training/CoNLL.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/training/CoNLL.scala
@@ -29,7 +29,8 @@ import scala.collection.mutable.ArrayBuffer
 case class CoNLLDocument(
     text: String,
     nerTagged: Seq[NerTaggedSentence],
-    posTagged: Seq[PosTaggedSentence])
+    posTagged: Seq[PosTaggedSentence],
+    docId: Option[String])
 
 /** Helper class to load a CoNLL type dataset for training.
   *
@@ -131,14 +132,19 @@ case class CoNLLDocument(
   *   Index of the column for NER Label in the dataset
   * @param conllPosIndex
   *   Index of the column for the POS tags in the dataset
+  * @param conllDocIdCol
+  *   Name of the column for the text in the dataset
   * @param conllTextCol
-  *   Index of the column for the text in the dataset
+  *   Name of the column for the text in the dataset
   * @param labelCol
   *   Name of the `NAMED_ENTITY` Annotator type column
   * @param explodeSentences
   *   Whether to explode each sentence to a separate row
   * @param delimiter
   *   Delimiter used to separate columns inside CoNLL file
+  * @param includeDocId
+  *   Whether to try and parse the document id from the third item in the -DOCSTART- line (X if
+  *   not found)
   */
 case class CoNLL(
     documentCol: String = "document",
@@ -147,10 +153,12 @@ case class CoNLL(
     posCol: String = "pos",
     conllLabelIndex: Int = 3,
     conllPosIndex: Int = 1,
+    conllDocIdCol: String = "doc_id",
     conllTextCol: String = "text",
     labelCol: String = "label",
     explodeSentences: Boolean = true,
-    delimiter: String = " ") {
+    delimiter: String = " ",
+    includeDocId: Boolean = false) {
   /*
     Reads Dataset in CoNLL format and pack it into docs
    */
@@ -165,6 +173,7 @@ case class CoNLL(
   }
 
   def readLines(lines: Array[String]): Seq[CoNLLDocument] = {
+    var docId: Option[String] = None
     val doc = new StringBuilder()
     val lastSentence = ArrayBuffer.empty[(IndexedTaggedWord, IndexedTaggedWord)]
 
@@ -187,22 +196,26 @@ case class CoNLL(
 
     def closeDocument = {
 
-      val result = (doc.toString, sentences.toList)
+      val result = (doc.toString, sentences.toList, docId)
       doc.clear()
       sentences.clear()
 
-      if (result._1.nonEmpty)
-        Some(result._1, result._2)
-      else
+      if (result._1.nonEmpty) {
+        Some(doc.toString, sentences.toList, if (includeDocId) docId else None)
+      } else
         None
     }
 
     val docs = lines
+
+
       .flatMap { line =>
         val items = line.trim.split(delimiter)
         if (items.nonEmpty && items(0) == "-DOCSTART-") {
           addSentence()
-          closeDocument
+          val closedDoc = closeDocument
+          docId = items.lift(2)
+          closedDoc
         } else if (items.length <= 1) {
           if (!explodeSentences && (doc.nonEmpty && !doc.endsWith(
               System.lineSeparator) && lastSentence.nonEmpty)) {
@@ -233,11 +246,12 @@ case class CoNLL(
 
     addSentence()
 
-    val last = if (doc.nonEmpty) Seq((doc.toString, sentences.toList)) else Seq.empty
+    val last = if (doc.nonEmpty) Seq((doc.toString, sentences.toList, docId)) else Seq.empty
 
-    (docs ++ last).map { case (text, textSentences) =>
-      val (ner, pos) = textSentences.unzip
-      CoNLLDocument(text, ner, pos)
+    (docs ++ last).map {
+      case (text, textSentences: Seq[(NerTaggedSentence, PosTaggedSentence)], docId) =>
+        val (ner, pos) = textSentences.unzip
+        CoNLLDocument(text, ner, pos, docId)
     }
   }
 
@@ -274,6 +288,9 @@ case class CoNLL(
     PosTagged.pack(sentences)
   }
 
+  def removeSurroundingHyphens(text: String) =
+    "-(.+)-".r.findFirstMatchIn(text).map(_.group(1)).getOrElse(text)
+
   val annotationType: ArrayType = ArrayType(Annotation.dataType)
 
   def getAnnotationType(
@@ -290,6 +307,7 @@ case class CoNLL(
   }
 
   def schema: StructType = {
+    val docId = StructField(conllDocIdCol, StringType)
     val text = StructField(conllTextCol, StringType)
     val doc = getAnnotationType(documentCol, AnnotatorType.DOCUMENT)
     val sentence = getAnnotationType(sentenceCol, AnnotatorType.DOCUMENT)
@@ -297,7 +315,10 @@ case class CoNLL(
     val pos = getAnnotationType(posCol, AnnotatorType.POS)
     val label = getAnnotationType(labelCol, AnnotatorType.NAMED_ENTITY)
 
-    StructType(Seq(text, doc, sentence, token, pos, label))
+    if (includeDocId)
+      StructType(Seq(docId, text, doc, sentence, token, pos, label))
+    else
+      StructType(Seq(text, doc, sentence, token, pos, label))
   }
 
   private def coreTransformation(doc: CoNLLDocument) = {
@@ -307,14 +328,22 @@ case class CoNLL(
     val sentences = packSentence(text, doc.nerTagged)
     val tokenized = packTokenized(text, doc.nerTagged)
     val posTagged = packPosTagged(doc.posTagged)
-
     (text, docs, sentences, tokenized, posTagged, labels)
   }
 
+  private def coreTransformationWithDocId(doc: CoNLLDocument) = {
+    val docId = removeSurroundingHyphens(doc.docId.getOrElse("X"))
+    val (text, docs, sentences, tokenized, posTagged, labels) = coreTransformation(doc)
+    (docId, text, docs, sentences, tokenized, posTagged, labels)
+  }
+
   def packDocs(docs: Seq[CoNLLDocument], spark: SparkSession): Dataset[_] = {
-    import spark.implicits._
-    val rows = docs.map(coreTransformation).toDF.rdd
-    spark.createDataFrame(rows, schema)
+    val preDf = if (includeDocId) {
+      spark.createDataFrame(docs.map(coreTransformationWithDocId))
+    } else {
+      spark.createDataFrame(docs.map(coreTransformation))
+    }
+    spark.createDataFrame(preDf.rdd, schema)
   }
 
   def readDataset(
@@ -328,15 +357,16 @@ case class CoNLL(
         .wholeTextFiles(path, minPartitions = parallelism)
         .flatMap { case (_, content) =>
           val lines = content.split(System.lineSeparator)
-          readLines(lines).map(doc => coreTransformation(doc))
+          readLines(lines)
         }
         .persist(storageLevel)
 
-      val df = spark
-        .createDataFrame(rdd)
-        .toDF(conllTextCol, documentCol, sentenceCol, tokenCol, posCol, labelCol)
-
-      spark.createDataFrame(df.rdd, schema)
+      val preDf = if (includeDocId) {
+        spark.createDataFrame(rdd.map(coreTransformationWithDocId))
+      } else {
+        spark.createDataFrame(rdd.map(coreTransformation))
+      }
+      spark.createDataFrame(preDf.rdd, schema)
     } else {
       val er = ExternalResource(path, readAs, Map("format" -> "text"))
       packDocs(readDocs(er), spark)

--- a/src/test/resources/conll/test_conll_docid.txt
+++ b/src/test/resources/conll/test_conll_docid.txt
@@ -1,0 +1,44 @@
+-DOCSTART- POS O NER
+John NNP I-NP PER
+Smith NNP I-NP PER
+works VBZ I-VP O
+at IN I-PP O
+Airbus NNP I-NP ORG
+Germany NNP B-NP LOC
+. . O O
+
+-DOCSTART- POS 1 NER
+John NNP I-NP PER
+Smith NNP I-NP PER
+works VBZ I-VP O
+at IN I-PP O
+Airbus NNP I-NP ORG
+Germany NNP B-NP LOC
+. . O O
+
+-DOCSTART- POS -2- NER
+John NNP I-NP PER
+Smith NNP I-NP PER
+works VBZ I-VP O
+at IN I-PP O
+Airbus NNP I-NP ORG
+Germany NNP B-NP LOC
+. . O O
+
+-DOCSTART- POS -3-1- NER
+John NNP I-NP PER
+Smith NNP I-NP PER
+works VBZ I-VP O
+at IN I-PP O
+Airbus NNP I-NP ORG
+Germany NNP B-NP LOC
+. . O O
+
+-DOCSTART- POS 3-2 NER
+John NNP I-NP PER
+Smith NNP I-NP PER
+works VBZ I-VP O
+at IN I-PP O
+Airbus NNP I-NP ORG
+Germany NNP B-NP LOC
+. . O O

--- a/src/test/scala/com/johnsnowlabs/nlp/training/CoNLLTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/training/CoNLLTestSpec.scala
@@ -1,0 +1,50 @@
+package com.johnsnowlabs.nlp.training
+
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.FastTest
+import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.types.StructField
+import org.scalatest.flatspec.AnyFlatSpec
+
+class CoNLLTestSpec extends AnyFlatSpec {
+
+  private val expectedColumnNames: Seq[String] = Seq("document", "sentence", "token", "pos", "label")
+  private val expectedAnnotatorTypes: Seq[String] = Seq("document", "document", "token", "pos", "named_entity")
+
+  private def assertNamesAndTypes(trainingDataSchema: Seq[StructField]) = {
+    val annotatorSchema = trainingDataSchema
+    val comparedColumnNames = annotatorSchema.map(_.name).zip(expectedColumnNames)
+    val comparedAnnotationTypes = annotatorSchema.map(_.metadata.getString("annotatorType")).zip(expectedAnnotatorTypes)
+    assert((comparedColumnNames ++ comparedAnnotationTypes).forall(x => x._1 == x._2))
+  }
+
+  private def assertDocIds(trainingData: Dataset[_], expectedDocIds: Seq[String]) = {
+    val comparedDocIds = trainingData.select("doc_id").collect.map(_.getString(0)).zip(expectedDocIds).toSeq
+    assert(comparedDocIds.forall(x => x._1 == x._2))
+  }
+
+  "CoNLL" should "read a CoNLL and have the columns in the right order" taggedAs FastTest in {
+    val trainingData = CoNLL().readDataset(ResourceHelper.spark, "src/test/resources/conll/test_conll_docid.txt")
+    assertNamesAndTypes(trainingData.schema.tail)
+  }
+
+  "CoNLL" should "read a CoNLL and have the columns in the right order using * pattern" taggedAs FastTest in {
+    val trainingData = CoNLL().readDataset(ResourceHelper.spark, "src/test/resources/conll/*")
+    assertNamesAndTypes(trainingData.schema.tail)
+  }
+
+  "CoNLL" should "read a CoNLL with ids and have the columns in the right order" taggedAs FastTest in {
+    val trainingData = CoNLL(includeDocId = true).readDataset(ResourceHelper.spark, "src/test/resources/conll/test_conll_docid.txt")
+    val expectedDocIds = Seq("O", "1", "2", "3-1", "3-2")
+    assertNamesAndTypes(trainingData.schema.tail.tail)
+    assertDocIds(trainingData, expectedDocIds)
+  }
+
+  "CoNLL" should "read a CoNLL with ids and have the columns in the right order using * pattern" taggedAs FastTest in {
+    val trainingData = CoNLL(includeDocId = true).readDataset(ResourceHelper.spark, "src/test/resources/conll/*")
+    val expectedDocIds = Seq("O", "1", "2", "3-1", "3-2")
+    assertNamesAndTypes(trainingData.schema.tail.tail)
+    assertDocIds(trainingData, expectedDocIds)
+  }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Supports `doc_id` information through:

```
DOCSTART- -X- -{doc_id}- O
```
i.e.
```
-DOCSTART- -X- -1- O

EU NNP B-NP B-ORG
rejects VBZ B-VP O

-DOCSTART- -X- 2 O

Rare NNP B-NP O
Hendrix NNP I-NP B-PER

-DOCSTART- -X- -3-1- O

China NNP B-NP B-LOC
says VBZ B-VP O

-DOCSTART-

China NNP B-NP B-LOC
says VBZ B-VP O
```
would produce:

```
+------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+
|doc_id|                text|            document|            sentence|               token|                 pos|               label|
+------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+
|     1|EU rejects German...|[{document, 0, 28...|[{document, 0, 47...|[{token, 0, 1, EU...|[{pos, 0, 1, NNP,...|[{named_entity, 0...|
|     2|Rare Hendrix song...|[{document, 0, 97...|[{document, 0, 50...|[{token, 0, 3, Ra...|[{pos, 0, 3, NNP,...|[{named_entity, 0...|
|   3-1|China says Taiwan...|[{document, 0, 13...|[{document, 0, 46...|[{token, 0, 4, Ch...|[{pos, 0, 4, NNP,...|[{named_entity, 0...|
|     X|China says Taiwan...|[{document, 0, 13...|[{document, 0, 46...|[{token, 0, 4, Ch...|[{pos, 0, 4, NNP,...|[{named_entity, 0...|
+------+--------------------+--------------------+--------------------+--------------------+--------------------+--------------------+
```


## Motivation and Context
Flexibility already offered in the implementation of the CoNLL 2003 standard.

## How Has This Been Tested?
All existing tests passing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Code improvements with no or little impact
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
