### PR TITLE
SPARKNLP-728 Avoid Copying Existing Models on S3/GCP

### DIFF
--- a/src/main/scala/com/johnsnowlabs/client/aws/AWSGateway.scala
+++ b/src/main/scala/com/johnsnowlabs/client/aws/AWSGateway.scala
@@ -109,8 +109,20 @@ class AWSGateway(
       client.getObjectMetadata(bucket, s3FilePath)
       true
     } catch {
-      case e: AmazonServiceException => if (e.getStatusCode == 404) false else throw e
+      case exception: AmazonServiceException =>
+        if (exception.getStatusCode == 404) false else throw exception
     }
+  }
+
+  def doesS3FolderExist(bucket: String, s3FilePath: String): Boolean = {
+    try {
+      val listObjects = client.listObjectsV2(bucket, s3FilePath)
+      listObjects.getObjectSummaries.size() > 0
+    } catch {
+      case exception: AmazonServiceException =>
+        if (exception.getStatusCode == 404) false else throw exception
+    }
+
   }
 
   def getS3Object(bucket: String, s3FilePath: String, tmpFile: File): ObjectMetadata = {

--- a/src/main/scala/com/johnsnowlabs/client/gcp/GCPGateway.scala
+++ b/src/main/scala/com/johnsnowlabs/client/gcp/GCPGateway.scala
@@ -2,13 +2,14 @@ package com.johnsnowlabs.client.gcp
 
 import com.google.cloud.storage.{BlobId, BlobInfo, Storage, StorageOptions}
 import com.johnsnowlabs.util.{ConfigHelper, ConfigLoader}
+import org.sparkproject.guava.collect.Iterables
 
 import java.io.InputStream
 
 class GCPGateway(
     projectId: String = ConfigLoader.getConfigStringValue(ConfigHelper.gcpProjectId)) {
 
-  lazy val storageClient: Storage = {
+  private lazy val storageClient: Storage = {
     if (projectId == null || projectId.isEmpty) {
       throw new UnsupportedOperationException(
         "projectId argument is mandatory to create GCP Storage client.")
@@ -26,6 +27,17 @@ class GCPGateway(
     val blobInfo = BlobInfo.newBuilder(blobId).build
 
     storageClient.createFrom(blobInfo, inputStream)
+  }
+
+  def doesFolderExist(bucket: String, prefix: String): Boolean = {
+    val storage = StorageOptions.newBuilder.setProjectId(projectId).build.getService
+    val blobs = storage.list(
+      bucket,
+      Storage.BlobListOption.prefix(prefix),
+      Storage.BlobListOption.currentDirectory)
+
+    val blobsSize = Iterables.size(blobs.iterateAll())
+    blobsSize > 0
   }
 
 }

--- a/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
@@ -75,4 +75,12 @@ object ConfigHelper {
     sparkSession.sparkContext.hadoopConfiguration.get("hadoop.tmp.dir")
   }
 
+  def getHadoopS3Config: (String, String, String) = {
+    val accessKey = sparkSession.sparkContext.hadoopConfiguration.get("fs.s3a.access.key")
+    val secretKey = sparkSession.sparkContext.hadoopConfiguration.get("fs.s3a.secret.key")
+    val sessionToken = sparkSession.sparkContext.hadoopConfiguration.get("fs.s3a.session.token")
+
+    (accessKey, secretKey, sessionToken)
+  }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change introduces an enhancement when loading models from S3 or GCP. Which consists in checking if a model already exists in a bucket before copying from models hub to an external bucket.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current implementation always copies models from models hub when `cache_pretained` is configure for S3 or GCP. This behavior is inefficient and makes an unnecessary usage of bandwidth and network resources.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Google Colab Notebooks
- Loading models from S3 
- [Loading models from GCP](https://colab.research.google.com/drive/15FrX1JstZMM6c2GfYYGc2EhXn-UUv-MG?usp=sharing)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
