### PR TITLE
SPARKNLP-733: Fix loadSavedModel for private buckets

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -21,7 +21,7 @@ import com.johnsnowlabs.nlp.annotators._
 import com.johnsnowlabs.nlp.annotators.audio.{HubertForCTC, Wav2Vec2ForCTC}
 import com.johnsnowlabs.nlp.annotators.classifier.dl._
 import com.johnsnowlabs.nlp.annotators.coref.SpanBertCorefModel
-import com.johnsnowlabs.nlp.annotators.cv.{ViTForImageClassification, SwinForImageClassification}
+import com.johnsnowlabs.nlp.annotators.cv.{SwinForImageClassification, ViTForImageClassification}
 import com.johnsnowlabs.nlp.annotators.er.EntityRulerModel
 import com.johnsnowlabs.nlp.annotators.ld.dl.LanguageDetectorDL
 import com.johnsnowlabs.nlp.annotators.ner.crf.NerCrfModel
@@ -47,7 +47,7 @@ import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.SparkFiles
 import org.apache.spark.ml.util.DefaultParamsReadable
 import org.apache.spark.ml.{PipelineModel, PipelineStage}
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 import java.io.File
 import java.net.URI
@@ -83,7 +83,7 @@ trait ResourceDownloader {
 
 object ResourceDownloader {
 
-  private val logger = LoggerFactory.getLogger(this.getClass.toString)
+  private val logger: Logger = LoggerFactory.getLogger(this.getClass.toString)
 
   val fileSystem: FileSystem = OutputHelper.getFileSystem
 
@@ -98,7 +98,8 @@ object ResourceDownloader {
 
   val publicLoc = "public/models"
 
-  private val cache = mutable.Map[ResourceRequest, PipelineStage]()
+  private val cache: mutable.Map[ResourceRequest, PipelineStage] =
+    mutable.Map[ResourceRequest, PipelineStage]()
 
   lazy val sparkVersion: Version = {
     val spark_version = ResourceHelper.spark.version
@@ -589,9 +590,14 @@ object ResourceDownloader {
 
     val (bucketName, keyPrefix) = ResourceHelper.parseS3URI(path)
 
-    val tmpDirectory = SparkFiles.getRootDirectory()
+    val (accessKey, secretKey, sessionToken) = ConfigHelper.getHadoopS3Config
+    val privateS3Defined = accessKey != null && secretKey != null && sessionToken != null
 
-    val awsGateway = new AWSGateway()
+    val awsGateway =
+      if (privateS3Defined) new AWSGateway(accessKey, secretKey, sessionToken)
+      else new AWSGateway(credentialsType = "public")
+
+    val tmpDirectory = SparkFiles.getRootDirectory()
     awsGateway.downloadFilesFromDirectory(bucketName, keyPrefix, new File(tmpDirectory))
 
     Paths.get(tmpDirectory, keyPrefix).toUri

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -77,8 +77,8 @@ object ResourceHelper {
       .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .config("spark.kryoserializer.buffer.max", "1000M")
       .config("spark.driver.maxResultSize", "0")
-      .config(ConfigHelper.awsExternalAccessKeyId, awsAccessKeyId)
-      .config(ConfigHelper.awsExternalSecretAccessKey, awsSecretAccessKey)
+      .config("spark.hadoop.fs.s3a.access.key", awsAccessKeyId)
+      .config("spark.hadoop.fs.s3a.secret.key", awsSecretAccessKey)
       .config(ConfigHelper.awsExternalRegion, region)
       .config(
         "spark.hadoop.fs.s3a.aws.credentials.provider",
@@ -93,7 +93,7 @@ object ResourceHelper {
       require(
         awsSessionToken.isDefined,
         "AWS Session token needs to be provided for TemporaryAWSCredentialsProvider.")
-      sparkSession.config(ConfigHelper.awsExternalSessionToken, awsSessionToken.get)
+      sparkSession.config("spark.hadoop.fs.s3a.session.token", awsSessionToken.get)
     }
 
     sparkSession.getOrCreate()

--- a/src/test/scala/com/johnsnowlabs/util/ResourceHelperTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/util/ResourceHelperTestSpec.scala
@@ -213,18 +213,22 @@ class ResourceHelperTestSpec extends AnyFlatSpec {
       awsSecretAccessKey,
       awsSessionToken = Some(awsSessionToken))
 
-    val s3FolderPath = "s3://sparknlp-test/tf-hub-bert/model"
+    val s3FolderPath = "s3://sparknlp-test/public/tf-hub-bert/model"
+    val s3FolderPathPrivate = "s3://sparknlp-test/tf-hub-bert/model"
 
     val resourcePath = "src/test/resources/tf-hub-bert/model"
 
     val resourceFolderContent: Array[String] = new File(resourcePath).listFiles().map(_.getName)
 
     val localPath = ResourceHelper.copyToLocal(s3FolderPath)
-    new File(localPath).listFiles().foreach { f: File =>
-      assert(
-        resourceFolderContent.contains(f.getName),
-        s"File $f missing in copied temporary folder $localPath.")
-    }
+    val localPathForPrivateBucket = ResourceHelper.copyToLocal(s3FolderPathPrivate)
+
+    Seq(localPath, localPathForPrivateBucket).foreach(path =>
+      new File(path).listFiles().foreach { f: File =>
+        assert(
+          resourceFolderContent.contains(f.getName),
+          s"File $f missing in copied temporary folder $localPath.")
+      })
 
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR fixes an issue, where a private bucket S3 would fail to download, when using loadSavedModel.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran relevant tests with a public and private S3 bucket. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
