### PR TITLE
SPARKNLP-734 Enable params argument in spark_nlp.start()

### DIFF
--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -67,6 +67,9 @@ def start(gpu=False,
           m1=False,
           aarch64=False,
           memory="16G",
+          cache_folder="",
+          log_folder="",
+          cluster_tmp_dir="",
           params=None,
           real_time_output=False,
           output_level=1):
@@ -157,6 +160,13 @@ def start(gpu=False,
         else:
             spark_jars_packages = spark_nlp_config.maven_spark3
 
+        if cache_folder != '':
+            builder.config("spark.jsl.settings.pretrained.cache_folder", cache_folder)
+        if log_folder != '':
+            builder.config("spark.jsl.settings.annotator.log_folder", log_folder)
+        if cluster_tmp_dir != '':
+            builder.config("spark.jsl.settings.storage.cluster_tmp_dir", cluster_tmp_dir)
+
         if params.get("spark.jars.packages") is None:
             builder.config("spark.jars.packages", spark_jars_packages)
 
@@ -190,6 +200,13 @@ def start(gpu=False,
                     spark_jars_packages = spark_nlp_config.maven_gpu_spark3
                 else:
                     spark_jars_packages = spark_nlp_config.maven_spark3
+
+                if cache_folder != '':
+                    spark_conf.set("spark.jsl.settings.pretrained.cache_folder", cache_folder)
+                if log_folder != '':
+                    spark_conf.set("spark.jsl.settings.annotator.log_folder", log_folder)
+                if cluster_tmp_dir != '':
+                    spark_conf.set("spark.jsl.settings.storage.cluster_tmp_dir", cluster_tmp_dir)
 
                 if params.get("spark.jars.packages") is None:
                     spark_conf.set("spark.jars.packages", spark_jars_packages)

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -67,9 +67,7 @@ def start(gpu=False,
           m1=False,
           aarch64=False,
           memory="16G",
-          cache_folder="",
-          log_folder="",
-          cluster_tmp_dir="",
+          params=None,
           real_time_output=False,
           output_level=1):
     """Starts a PySpark instance with default parameters for Spark NLP.
@@ -122,6 +120,11 @@ def start(gpu=False,
     """
     current_version = "4.2.8"
 
+    if params is None:
+        params = {}
+    if '_instantiatedSession' in dir(SparkSession) and SparkSession._instantiatedSession is not None:
+        print('Warning::Spark Session already created, some configs may not take.')
+
     class SparkNLPConfig:
 
         def __init__(self):
@@ -146,20 +149,23 @@ def start(gpu=False,
             .config("spark.driver.maxResultSize", spark_nlp_config.driver_max_result_size)
 
         if m1:
-            builder.config("spark.jars.packages", spark_nlp_config.maven_m1)
+            spark_jars_packages = spark_nlp_config.maven_m1
         elif aarch64:
-            builder.config("spark.jars.packages", spark_nlp_config.maven_aarch64)
+            spark_jars_packages = spark_nlp_config.maven_aarch64
         elif gpu:
-            builder.config("spark.jars.packages", spark_nlp_config.maven_gpu_spark3)
+            spark_jars_packages = spark_nlp_config.maven_gpu_spark3
         else:
-            builder.config("spark.jars.packages", spark_nlp_config.maven_spark3)
+            spark_jars_packages = spark_nlp_config.maven_spark3
 
-        if cache_folder != '':
-            builder.config("spark.jsl.settings.pretrained.cache_folder", cache_folder)
-        if log_folder != '':
-            builder.config("spark.jsl.settings.annotator.log_folder", log_folder)
-        if cluster_tmp_dir != '':
-            builder.config("spark.jsl.settings.storage.cluster_tmp_dir", cluster_tmp_dir)
+        if params.get("spark.jars.packages") is None:
+            builder.config("spark.jars.packages", spark_jars_packages)
+
+        for key, value in params.items():
+            if key == "spark.jars.packages":
+                packages = spark_jars_packages + "," + value
+                builder.config(key, packages)
+            else:
+                builder.config(key, value)
 
         return builder.getOrCreate()
 
@@ -177,20 +183,23 @@ def start(gpu=False,
                 spark_conf.set("spark.driver.maxResultSize", spark_nlp_config.driver_max_result_size)
 
                 if m1:
-                    spark_conf.set("spark.jars.packages", spark_nlp_config.maven_m1)
+                    spark_jars_packages = spark_nlp_config.maven_m1
                 elif aarch64:
-                    spark_conf.set("spark.jars.packages", spark_nlp_config.maven_aarch64)
+                    spark_jars_packages = spark_nlp_config.maven_aarch64
                 elif gpu:
-                    spark_conf.set("spark.jars.packages", spark_nlp_config.maven_gpu_spark3)
+                    spark_jars_packages = spark_nlp_config.maven_gpu_spark3
                 else:
-                    spark_conf.set("spark.jars.packages", spark_nlp_config.maven_spark3)
+                    spark_jars_packages = spark_nlp_config.maven_spark3
 
-                if cache_folder != '':
-                    spark_conf.config("spark.jsl.settings.pretrained.cache_folder", cache_folder)
-                if log_folder != '':
-                    spark_conf.config("spark.jsl.settings.annotator.log_folder", log_folder)
-                if cluster_tmp_dir != '':
-                    spark_conf.config("spark.jsl.settings.storage.cluster_tmp_dir", cluster_tmp_dir)
+                if params.get("spark.jars.packages") is None:
+                    spark_conf.set("spark.jars.packages", spark_jars_packages)
+
+                for key, value in params.items():
+                    if key == "spark.jars.packages":
+                        packages = spark_jars_packages + "," + value
+                        spark_conf.set(key, packages)
+                    else:
+                        spark_conf.set(key, value)
 
                 # Make the py4j JVM stdout and stderr available without buffering
                 popen_kwargs = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change adds param argument to `sparknlp.start()`. With this change arguments such as `cache_folder`,  `log_folder`, and  `cluster_tmp_dir` can be defined in a single params argument instead of a dedicated argument. For example:

```
params = {
    "spark.jsl.settings.pretrained.cache_folder": "s3://my_bucket/my_models",
    "spark.hadoop.fs.s3a.access.key": AWS_ACCESS_KEY_ID,
    "spark.hadoop.fs.s3a.secret.key": AWS_SECRET_ACCESS_KEY,
    "spark.hadoop.fs.s3a.session.token": AWS_SESSION_TOKEN,
    "spark.jsl.settings.aws.region": "my_region"
}

spark = sparknlp.start(params=params)
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Other JSL libraries have a param argument to set spark configurations. This change sync open-source spark-nlp to have the same behavior.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Google Colab:
- [sparknlp.start with params](https://colab.research.google.com/drive/1I3e31PpVCaQ6OeoFKO8mmFS-ad0WnXBb?usp=sharing)
- [sparknlp.start without params](https://drive.google.com/file/d/1-hMAroJBeLBaprnwv2Yc8akeJ7pl3MuC/view?usp=sharing) 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
