### PR TITLE
Fixing Visual NLP docs

### DIFF
--- a/docs/en/ocr_object_detection.md
+++ b/docs/en/ocr_object_detection.md
@@ -63,8 +63,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -183,8 +183,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -316,8 +316,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \

--- a/docs/en/ocr_pipeline_components.md
+++ b/docs/en/ocr_pipeline_components.md
@@ -349,6 +349,7 @@ Read PDF document, run OCR and render results to PDF document.
 
 ```python
 from sparkocr.transformers import *
+from sparkocr.enums import PageSegmentationMode
 
 pdfPath = "path to pdf"
 
@@ -393,6 +394,7 @@ with open("test.pdf", "wb") as file:
 ```scala
 import org.apache.spark.ml.Pipeline
 import com.johnsnowlabs.ocr.transformers._
+import com.johnsnowlabs.ocr.OcrContext.implicits._
 
 val pdfPath = "path to pdf"
 
@@ -1691,8 +1693,8 @@ from sparkocr.utils import display_image
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -1712,9 +1714,9 @@ pipeline = PipelineModel(stages=[
 
 result = pipeline.transform(df)
 
-for r in result.select("image", "corrected_image").collect():
+for r in result.select("image", "binarized_image").collect():
     display_image(r.image)
-    display_image(r.corrected_image)
+    display_image(r.binarized_image)
 ```
 
 ```scala
@@ -1802,8 +1804,8 @@ from sparkocr.utils import display_image
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -1811,7 +1813,7 @@ binary_to_image = BinaryToImage() \
     .setOutputCol("image")
 
 adaptive_thresholding = ImageAdaptiveThresholding() \
-    .setInputCol("scaled_image") \
+    .setInputCol("image") \
     .setOutputCol("binarized_image") \
     .setBlockSize(21) \
     .setOffset(73)
@@ -1823,9 +1825,9 @@ pipeline = PipelineModel(stages=[
 
 result = pipeline.transform(df)
 
-for r in result.select("image", "corrected_image").collect():
+for r in result.select("image", "binarized_image").collect():
     display_image(r.image)
-    display_image(r.corrected_image)
+    display_image(r.binarized_image)
 ```
 
 ```scala
@@ -2307,8 +2309,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -2385,18 +2387,18 @@ It supports following operation:
 ```python
 from pyspark.ml import PipelineModel
 from sparkocr.transformers import *
+from sparkocr.enums import MorphologyOperationType
 
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
     .setInputCol("content") \
     .setOutputCol("image") \
-    .setOperation(MorphologyOperationType.OPENING)
 
 adaptive_thresholding = ImageAdaptiveThresholding() \
     .setInputCol("image") \
@@ -2407,7 +2409,8 @@ adaptive_thresholding = ImageAdaptiveThresholding() \
 opening = ImageMorphologyOperation() \
     .setInputCol("corrected_image") \
     .setOutputCol("opening_image") \
-    .setkernelSize(1)
+    .setKernelSize(1) \
+    .setOperation(MorphologyOperationType.OPENING)
 
 pipeline = PipelineModel(stages=[
     binary_to_image,
@@ -2480,18 +2483,18 @@ for r in result.select("image", "corrected_image").collect():
 ```python
 from pyspark.ml import PipelineModel
 from sparkocr.transformers import *
+from sparkocr.enums import MorphologyOperationType
 
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
     .setInputCol("content") \
-    .setOutputCol("image") \
-    .setOperation(MorphologyOperationType.OPENING)
+    .setOutputCol("image")
 
 cropper = ImageCropper() \
     .setInputCol("image") \
@@ -2583,8 +2586,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -2677,8 +2680,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -2690,9 +2693,9 @@ layout_analyzer = ImageLayoutAnalyzer() \
   .setInputCol("image") \
   .setOutputCol("regions")
 
-splitter = ImageSplitRegions()
-  .setInputCol("image")
-  .setRegionCol("regions")
+splitter = ImageSplitRegions() \
+  .setInputCol("image") \
+  .setInputRegionsCol("regions") \
   .setOutputCol("region_image")
 
 # Define pipeline
@@ -2728,7 +2731,7 @@ val layoutAnalyzer = new ImageLayoutAnalyzer()
 
 val splitter = new ImageSplitRegions()
   .setInputCol("image")
-  .setRegionCol("regions")
+  .setInputRegionsCol("regions")
   .setOutputCol("region_image")
 
 // Define pipeline
@@ -2793,8 +2796,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -2823,7 +2826,7 @@ pipeline = PipelineModel(stages=[
     binary_to_image,
     ocr,
     tokenizer,
-    image_with_annotations
+    draw_annotations
 ])
 
 result = pipeline.transform(df)
@@ -2919,8 +2922,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -2934,7 +2937,7 @@ layout_analyzer = ImageLayoutAnalyzer() \
 
 draw = ImageDrawRegions() \
   .setInputCol("image") \
-  .setRegionCol("regions") \
+  .setInputRegionsCol("regions") \
   .setOutputCol("image_with_regions")
 
 # Define pipeline
@@ -2969,7 +2972,7 @@ val layoutAnalyzer = new ImageLayoutAnalyzer()
 
 val draw = new ImageDrawRegions()
   .setInputCol("image")
-  .setRegionCol("regions")
+  .setInputRegionsCol("regions")
   .setOutputCol("image_with_regions")
 
 // Define pipeline
@@ -3052,8 +3055,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -3167,8 +3170,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -3276,8 +3279,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -3371,8 +3374,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \
@@ -4114,8 +4117,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \

--- a/docs/en/ocr_pipeline_components.md
+++ b/docs/en/ocr_pipeline_components.md
@@ -275,7 +275,7 @@ imageToPdf = ImageToPdf() \
 
 # Call transformers
 image_df = binaryToImage.transform(df)
-pdf_df =  pdfToImage.transform(image_df)
+pdf_df =  imageToPdf.transform(image_df)
 
 pdf_df.select("content").show()
 ```
@@ -300,7 +300,7 @@ val imageToPdf = new ImageToPdf()
 
 // Call transformers
 val image_df = binaryToImage.transform(df)
-val pdf_df =  pdfToImage.transform(image_df)
+val pdf_df =  imageToPdf.transform(image_df)
 
 pdf_df.select("content").show()
 ```
@@ -3551,8 +3551,8 @@ from sparkocr.transformers import *
 imagePath = "path to image"
 
 # Read image file as binary file
-df = spark.read 
-    .format("binaryFile")
+df = spark.read \
+    .format("binaryFile") \
     .load(imagePath)
 
 binary_to_image = BinaryToImage() \

--- a/docs/en/ocr_table_recognition.md
+++ b/docs/en/ocr_table_recognition.md
@@ -301,7 +301,7 @@ binary_to_image = BinaryToImage()
 binary_to_image.setImageType(ImageType.TYPE_BYTE_GRAY)
 binary_to_image.setInputCol("content")
 
-cell_detector = TableCellDetector()
+cell_detector = ImageTableCellDetector()
 cell_detector.setInputCol("image")
 cell_detector.setOutputCol("cells")
 cell_detector.setKeepInput(True)
@@ -321,7 +321,7 @@ pipeline = PipelineModel(stages=[
 
 result = pipeline.transform(df)
 
-results.select("table") \
+result.select("table") \
     .withColumn("cells", f.explode(f.col("table.chunks"))) \
     .select([f.col("cells")[i].getField("chunkText").alias(f"col{i}") for i in
              range(0, 7)]) \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

For the pipeline components part:
  Errors in detail:
  
  1. Missing "\\" sign is added in the read part for the given annotators:
  
  - Image Adaptive Binarizer
  - Image Adaptive Thresholding
  - Image Remove Objects
  - Image Morphology Operation
  - Image Cropper
  - Image Layout Analyzer
  - Image Split Regions
     - Both for the reading part and the splitter part
  - Image Draw Annotations
  - Image Draw Regions
  - Image To Text
  - Image To Text v2
  - Image To Text Pdf
  - Image To Hocr
  - Image Brands To Text
  - Hocr Document Assembler
  
  
  2. Minor Typos (wrong variable/attribute names) are fixed for the given annotators:
  
  - Image Adaptive Binarizer (corrected_image is changed to binarized_image)
  - Image Adaptive Thresholding (corrected_image is changed to binarized_image)
  - Image Adaptive Thresholding (scaled_image is changed to image)
  - Image Morphology Operation (.setOperation() is moved to the opening stage of the pipeline)
  - Image Morphology Operation (setkernelSize() is changed to setKernelSize())
  - Image Cropper (setOperation() is deleted from BinaryToImage stage)
  - Image Split Regions (setRegionCol() is changed to setInputRegionsCol())
  - Image Draw Annotations (image_with_annotations is changed to draw_annotations)
  - Image Draw Regions (setRegionCol() is changed to setInputRegionsCol())
  - Pdf To Image ( pdf_df = pdfToImage.transform(image_df) changed to pdf_df = imageToPdf.transform(image_df) )
  
  
  3. Required imports are added for used Enums for the given annotators:
  
  - TextToPdf (from sparkocr.enums import PageSegmentationMode)
  - ImageMorphologyOperation (from sparkocr.enums import MorphologyOperationType)
  - ImageCropper (from sparkocr.enums import MorphologyOperationType)


For the table recognition part:
  Errors in detail:
  
  1. Missing "\\" sign is added in the read part for the given annotators:
  
  - Image Table Detector
  - Image Table Cell Detector
  - Image Cells To Text Table
  
  2. Minor Typos (wrong variable/attribute names) are fixed for the given annotators:
  
  - Image Table Cell Detector ( ImageTableCellDetector is changed to ImageTableCellDetector() )
  -  Image Cells To Text Table ( TableCellDetector is changed to ImageTableCellDetector )
  -  Image Cells To Text Table ( results is changed to result )
  
  3. The Scala and Python example codes were misplaced. In the Scala tab, there is Python code and vice versa. Therefore, the location of the Python and Scala versions are changed for the given annotators:
  
  - Image Table Detector
  - Image Table Cell Detector
  - Image Cells To Text Table


For the visual document understanding part:
  Errors in detail:
  
  1. Missing "\\" sign is added in the read part for the given annotators:
  
  - Visual Document Classifier
  - Visual Document NER
  - Visual Document NERv2
  - Form Relation Extractor
  
  
  2. The Scala and Python example codes were misplaced. In the Scala tab, there is Python code and vice versa. Therefore, the location of the Python and Scala versions are changed for the given annotators:
  
  - Visual Document Classifier
  - Visual Document NER
  - Visual Document NERv2
  - Form Relation Extractor


For the object detection part:
  Errors in detail:

  1. Missing "\" sign is added in the read part for the given annotators:
  
  - Image Handwritten Detector
  - Image Text Detector
  - Image Text DetectorV2


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There were minor typos, wrong variable/attribute names, and missing imports in the example codes. These errors were causing compiler errors. Therefore, the errors are fixed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The errors were in both Python and Scala versions. Appropriate changes are made to fix the issues. Python version is tested in the Colab environment. The Scala version is tested in the VS Code environment. Both tests were run correctly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
