### PR TITLE
Fix to white space in cache_pretrained

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/util/LoadExternalModel.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/util/LoadExternalModel.scala
@@ -68,7 +68,7 @@ object LoadExternalModel {
     require(f.isDirectory, s"Folder $modelPath is not folder")
 
     /*Check if the assets path is correct*/
-    val assetsPath = Paths.get(modelPath, "/assets").toString
+    val assetsPath = Paths.get(modelPath, "assets").toString
     val assetsPathFile = new File(assetsPath)
     require(assetsPathFile.exists, s"Folder $assetsPath not found")
     require(assetsPathFile.isDirectory, s"Folder $assetsPath is not folder")
@@ -108,7 +108,7 @@ object LoadExternalModel {
   }
 
   def loadTextAsset(assetPath: String, assetName: String): Array[String] = {
-    val assetFile = checkAndCreateFile(assetPath + "/assets", assetName)
+    val assetFile = checkAndCreateFile(Paths.get(assetPath, "assets").toString, assetName)
 
     // Convert to URL first to access correct file protocol
     val assetResource =
@@ -124,7 +124,7 @@ object LoadExternalModel {
     *   SentencePieceWrapper
     */
   def loadSentencePieceAsset(assetPath: String, assetName: String): SentencePieceWrapper = {
-    val assetFile = checkAndCreateFile(assetPath + "/assets", assetName)
+    val assetFile = checkAndCreateFile(Paths.get(assetPath, "assets").toString, assetName)
     SentencePieceWrapper.read(assetFile.toString)
   }
 
@@ -136,7 +136,7 @@ object LoadExternalModel {
     *   JSON as String to be parsed later
     */
   def loadJsonStringAsset(assetPath: String, assetName: String): String = {
-    val assetFile = checkAndCreateFile(assetPath + "/assets", assetName)
+    val assetFile = checkAndCreateFile(Paths.get(assetPath, "assets").toString, assetName)
     val vocabStream = ResourceHelper.getResourceStream(assetFile.getAbsolutePath)
     Source.fromInputStream(vocabStream).mkString
   }

--- a/src/main/scala/com/johnsnowlabs/util/ConfigLoader.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigLoader.scala
@@ -36,8 +36,8 @@ object ConfigLoader {
     getConfigInfo(ConfigHelper.pretrainedS3BucketKey, "auxdata.johnsnowlabs.com") ++
       getConfigInfo(ConfigHelper.pretrainedCommunityS3BucketKey, "community.johnsnowlabs.com") ++
       getConfigInfo(ConfigHelper.pretrainedS3PathKey, "") ++
-      getConfigInfo(ConfigHelper.pretrainedCacheFolder, homeDirectory + "/cache_pretrained") ++
-      getConfigInfo(ConfigHelper.annotatorLogFolder, homeDirectory + "/annotator_logs") ++
+      getConfigInfo(ConfigHelper.pretrainedCacheFolder, java.nio.file.Paths.get(homeDirectory, "cache_pretrained").toString) ++
+      getConfigInfo(ConfigHelper.annotatorLogFolder, java.nio.file.Paths.get(homeDirectory, "annotator_logs").toString) ++
       getConfigInfo(ConfigHelper.accessKeyId, "") ++
       getConfigInfo(ConfigHelper.secretAccessKey, "") ++
       getConfigInfo(ConfigHelper.sessionToken, "") ++


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When using `ResourceDownloader` in a Windows environment where the user folder contains white space, the downloader raises an error 

```java
java.net.URISyntaxException: Illegal character in path at index 20: file:/C:/Users/User Name/cache_pretrained/  
```

I used the `java.nio.file.Paths` module to propose a fix, but it needs to be further tested.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Crashes the process of all pipelines.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No tests were made.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
