### PR TITLE
Sparknlp 740 rename refactor m 1 to silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Spark NLP: State-of-the-Art Natural Language Processing
+
 <p align="center">
     <a href="https://github.com/JohnSnowLabs/spark-nlp/actions" alt="build">
         <img src="https://github.com/JohnSnowLabs/spark-nlp/workflows/build/badge.svg" /></a>
@@ -16,21 +17,33 @@
         <img src="https://static.pepy.tech/personalized-badge/spark-nlp?period=total&units=international_system&left_color=grey&right_color=orange&left_text=pip%20downloads" /></a>
 </p>
 
-Spark NLP is a state-of-the-art Natural Language Processing library built on top of Apache Spark. It provides **simple**, **performant** & **accurate** NLP annotations for machine learning pipelines that **scale** easily in a distributed environment.
+Spark NLP is a state-of-the-art Natural Language Processing library built on top of Apache Spark. It provides **simple
+**, **performant** & **accurate** NLP annotations for machine learning pipelines that **scale** easily in a distributed
+environment.
 Spark NLP comes with **11000+** pretrained **pipelines** and **models** in more than **200+** languages.
-It also offers tasks such as **Tokenization**, **Word Segmentation**, **Part-of-Speech Tagging**, Word and Sentence **Embeddings**, **Named Entity Recognition**, **Dependency Parsing**, **Spell Checking**, **Text Classification**, **Sentiment Analysis**, **Token Classification**, **Machine Translation** (+180 languages), **Summarization**, **Question Answering**, **Table Question Answering**, **Text Generation**, **Image Classification**, **Automatic Speech Recognition**, and many more [NLP tasks](#features).
+It also offers tasks such as **Tokenization**, **Word Segmentation**, **Part-of-Speech Tagging**, Word and Sentence *
+*Embeddings**, **Named Entity Recognition**, **Dependency Parsing**, **Spell Checking**, **Text Classification**, *
+*Sentiment Analysis**, **Token Classification**, **Machine Translation** (+180 languages), **Summarization**, **Question
+Answering**, **Table Question Answering**, **Text Generation**, **Image Classification**, **Automatic Speech Recognition
+**, and many more [NLP tasks](#features).
 
-**Spark NLP** is the only open-source NLP library in **production** that offers state-of-the-art transformers such as **BERT**, **CamemBERT**, **ALBERT**, **ELECTRA**, **XLNet**, **DistilBERT**, **RoBERTa**, **DeBERTa**, **XLM-RoBERTa**, **Longformer**, **ELMO**, **Universal Sentence Encoder**, **Google T5**, **MarianMT**, **GPT2**, and **Vision Transformers (ViT)** not only to **Python** and **R**, but also to **JVM** ecosystem (**Java**, **Scala**, and **Kotlin**) at **scale** by extending **Apache Spark** natively.
+**Spark NLP** is the only open-source NLP library in **production** that offers state-of-the-art transformers such as *
+*BERT**, **CamemBERT**, **ALBERT**, **ELECTRA**, **XLNet**, **DistilBERT**, **RoBERTa**, **DeBERTa**, **XLM-RoBERTa**, *
+*Longformer**, **ELMO**, **Universal Sentence Encoder**, **Google T5**, **MarianMT**, **GPT2**, and **Vision
+Transformers (ViT)** not only to **Python** and **R**, but also to **JVM** ecosystem (**Java**, **Scala**, and **Kotlin
+**) at **scale** by extending **Apache Spark** natively.
 
 ## Project's website
 
-Take a look at our official Spark NLP page: [http://nlp.johnsnowlabs.com/](http://nlp.johnsnowlabs.com/) for user documentation and examples
+Take a look at our official Spark NLP page: [http://nlp.johnsnowlabs.com/](http://nlp.johnsnowlabs.com/) for user
+documentation and examples
 
 ## Community support
 
 - [Slack](https://www.johnsnowlabs.com/slack-redirect/) For live discussion with the Spark NLP community and the team
 - [GitHub](https://github.com/JohnSnowLabs/spark-nlp) Bug reports, feature requests, and contributions
-- [Discussions](https://github.com/JohnSnowLabs/spark-nlp/discussions) Engage with other community members, share ideas, and show off how you use Spark NLP!
+- [Discussions](https://github.com/JohnSnowLabs/spark-nlp/discussions) Engage with other community members, share ideas,
+  and show off how you use Spark NLP!
 - [Medium](https://medium.com/spark-nlp) Spark NLP articles
 - [YouTube](https://www.youtube.com/channel/UCmFOjlpYEhxf_wJUDuz6xxQ/videos) Spark NLP video tutorials
 
@@ -44,25 +57,25 @@ Take a look at our official Spark NLP page: [http://nlp.johnsnowlabs.com/](http:
 - [Databricks Support](#databricks-support)
 - [EMR Support](#emr-support)
 - [Using Spark NLP](#usage)
-  - [Packages Cheatsheet](#packages-cheatsheet)
-  - [Spark Packages](#spark-packages)
-  - [Scala](#scala)
-    - [Maven](#maven)
-    - [SBT](#sbt)
-  - [Python](#python)
-    - [Pip/Conda](#pipconda)
-  - [Compiled JARs](#compiled-jars)
-  - [Apache Zeppelin](#apache-zeppelin)
-  - [Jupyter Notebook](#jupyter-notebook-python)
-  - [Google Colab Notebook](#google-colab-notebook)
-  - [Kaggle Kernel](#kaggle-kernel)
-  - [Databricks Cluster](#databricks-cluster)
-  - [EMR Cluster](#emr-cluster)
-  - [GCP Dataproc](#gcp-dataproc)
-  - [Spark NLP Configuration](#spark-nlp-configuration)
+    - [Packages Cheatsheet](#packages-cheatsheet)
+    - [Spark Packages](#spark-packages)
+    - [Scala](#scala)
+        - [Maven](#maven)
+        - [SBT](#sbt)
+    - [Python](#python)
+        - [Pip/Conda](#pipconda)
+    - [Compiled JARs](#compiled-jars)
+    - [Apache Zeppelin](#apache-zeppelin)
+    - [Jupyter Notebook](#jupyter-notebook-python)
+    - [Google Colab Notebook](#google-colab-notebook)
+    - [Kaggle Kernel](#kaggle-kernel)
+    - [Databricks Cluster](#databricks-cluster)
+    - [EMR Cluster](#emr-cluster)
+    - [GCP Dataproc](#gcp-dataproc)
+    - [Spark NLP Configuration](#spark-nlp-configuration)
 - [Pipelines & Models](#pipelines-and-models)
-  - [Pipelines](#pipelines)
-  - [Models](#models)
+    - [Pipelines](#pipelines)
+    - [Models](#models)
 - [Offline](#offline)
 - [Examples](#examples)
 - [FAQ](#faq)
@@ -141,7 +154,8 @@ Take a look at our official Spark NLP page: [http://nlp.johnsnowlabs.com/](http:
 - Full integration with Spark ML functions
 - +8500 pre-trained models in +200 languages!
 - +3200 pre-trained pipelines in +200 languages!
-- Multi-lingual NER models: Arabic, Bengali, Chinese, Danish, Dutch, English, Finnish, French, German, Hebrew, Italian, Japanese, Korean, Norwegian, Persian, Polish, Portuguese, Russian, Spanish, Swedish, Urdu, and more.
+- Multi-lingual NER models: Arabic, Bengali, Chinese, Danish, Dutch, English, Finnish, French, German, Hebrew, Italian,
+  Japanese, Korean, Norwegian, Persian, Polish, Portuguese, Russian, Spanish, Swedish, Urdu, and more.
 
 ## Requirements
 
@@ -181,9 +195,9 @@ from sparknlp.pretrained import PretrainedPipeline
 import sparknlp
 
 # Start SparkSession with Spark NLP
-# start() functions has 3 parameters: gpu, m1, and memory
+# start() functions has 3 parameters: gpu, apple_silicon, and memory
 # sparknlp.start(gpu=True) will start the session with GPU support
-# sparknlp.start(m1=True) will start the session with macOS M1 support
+# sparknlp.start(apple_silicon=True) will start the session with macOS M1 & M2 support
 # sparknlp.start(memory="16G") to change the default driver memory in SparkSession
 spark = sparknlp.start()
 
@@ -202,21 +216,24 @@ result = pipeline.annotate(text)
 # What's in the pipeline
 list(result.keys())
 Output: ['entities', 'stem', 'checked', 'lemma', 'document',
-'pos', 'token', 'ner', 'embeddings', 'sentence']
+         'pos', 'token', 'ner', 'embeddings', 'sentence']
 
 # Check the results
 result['entities']
 Output: ['Mona Lisa', 'Leonardo', 'Louvre', 'Paris']
 ```
 
-For more examples, you can visit our dedicated [repository](https://github.com/JohnSnowLabs/spark-nlp-workshop) to showcase all Spark NLP use cases!
+For more examples, you can visit our dedicated [repository](https://github.com/JohnSnowLabs/spark-nlp-workshop) to
+showcase all Spark NLP use cases!
 
 ## Apache Spark Support
 
-Spark NLP *4.3.0* has been built on top of Apache Spark 3.2 while fully supports Apache Spark 3.0.x, 3.1.x, 3.2.x, and 3.3.x:
+Spark NLP *4.3.0* has been built on top of Apache Spark 3.2 while fully supports Apache Spark 3.0.x, 3.1.x, 3.2.x, and
+3.3.x:
 
 | Spark NLP | Apache Spark 2.3.x | Apache Spark 2.4.x | Apache Spark 3.0.x | Apache Spark 3.1.x | Apache Spark 3.2.x | Apache Spark 3.3.x |
 |-----------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
+| 4.3.x     | NO                 | NO                 | YES                | YES                | YES                | YES                |
 | 4.2.x     | NO                 | NO                 | YES                | YES                | YES                | YES                |
 | 4.1.x     | NO                 | NO                 | YES                | YES                | YES                | YES                |
 | 4.0.x     | NO                 | NO                 | YES                | YES                | YES                | YES                |
@@ -227,7 +244,8 @@ Spark NLP *4.3.0* has been built on top of Apache Spark 3.2 while fully supports
 | 3.0.x     | YES                | YES                | YES                | YES                | NO                 | NO                 |
 | 2.7.x     | YES                | YES                | NO                 | NO                 | NO                 | NO                 |
 
-NOTE: Starting 4.0.0 release, the default `spark-nlp` and `spark-nlp-gpu` packages are based on Scala 2.12.15 and Apache Spark 3.2 by default.
+NOTE: Starting 4.0.0 release, the default `spark-nlp` and `spark-nlp-gpu` packages are based on Scala 2.12.15 and Apache
+Spark 3.2 by default.
 
 Find out more about `Spark NLP` versions from our [release notes](https://github.com/JohnSnowLabs/spark-nlp/releases).
 
@@ -235,6 +253,7 @@ Find out more about `Spark NLP` versions from our [release notes](https://github
 
 | Spark NLP | Python 3.6 | Python 3.7 | Python 3.8 | Python 3.9 | Scala 2.11 | Scala 2.12 |
 |-----------|------------|------------|------------|------------|------------|------------|
+| 4.3.x     | YES        | YES        | YES        | YES        | NO         | YES        |
 | 4.2.x     | YES        | YES        | YES        | YES        | NO         | YES        |
 | 4.1.x     | YES        | YES        | YES        | YES        | NO         | YES        |
 | 4.0.x     | YES        | YES        | YES        | YES        | NO         | YES        |
@@ -287,7 +306,8 @@ Spark NLP 4.3.0 has been tested and is compatible with the following runtimes:
 - 11.2 ML & GPU
 - 11.3 ML & GPU
 
-NOTE: Spark NLP 4.0.x is based on TensorFlow 2.7.x which is compatible with CUDA11 and cuDNN 8.0.2. The only Databricks runtimes supporting CUDA 11 are 9.x and above as listed under GPU.
+NOTE: Spark NLP 4.x is based on TensorFlow 2.7.x which is compatible with CUDA11 and cuDNN 8.0.2. The only Databricks
+runtimes supporting CUDA 11 are 9.x and above as listed under GPU.
 
 ## EMR Support
 
@@ -311,18 +331,21 @@ NOTE: The EMR 6.1.0 and 6.1.1 are not supported.
 
 This is a cheatsheet for corresponding Spark NLP Maven package to Apache Spark / PySpark major version:
 
-| Apache Spark     | Spark NLP on CPU   | Spark NLP on GPU           | Spark NLP on AArch64 (linux)   | Spark NLP on M1           |
-|------------------|--------------------|----------------------------|--------------------------------|---------------------------|
-| 3.0/3.1/3.2/3.3  | `spark-nlp`        | `spark-nlp-gpu`            | `spark-nlp-aarch64`            | `spark-nlp-m1`            |
-| Start Function   | `sparknlp.start()` | `sparknlp.start(gpu=True)` | `sparknlp.start(aarch64=True)` | `sparknlp.start(m1=True)` |
+| Apache Spark    | Spark NLP on CPU   | Spark NLP on GPU           | Spark NLP on AArch64 (linux)   | Spark NLP on Apple Silicon           |
+|-----------------|--------------------|----------------------------|--------------------------------|--------------------------------------|
+| 3.0/3.1/3.2/3.3 | `spark-nlp`        | `spark-nlp-gpu`            | `spark-nlp-aarch64`            | `spark-nlp-silicon`                  |
+| Start Function  | `sparknlp.start()` | `sparknlp.start(gpu=True)` | `sparknlp.start(aarch64=True)` | `sparknlp.start(apple_silicon=True)` |
 
-NOTE: `M1` and `AArch64` are under `experimental` support. Access and support to these architectures are limited by the community and we had to build most of the dependencies by ourselves to make them compatible. We support these two architectures, however, they may not work in some environments.
+NOTE: `M1/M2` and `AArch64` are under `experimental` support. Access and support to these architectures are limited by the
+community and we had to build most of the dependencies by ourselves to make them compatible. We support these two
+architectures, however, they may not work in some environments.
 
 ## Spark Packages
 
 ### Command line (requires internet connection)
 
-Spark NLP supports all major releases of Apache Spark 3.0.x, Apache Spark 3.1.x, Apache Spark 3.2.x, and Apache Spark 3.3.x.
+Spark NLP supports all major releases of Apache Spark 3.0.x, Apache Spark 3.1.x, Apache Spark 3.2.x, and Apache Spark
+3.3.x.
 
 #### Apache Spark 3.x (3.0.x, 3.1.x, 3.2.x, and 3.3.x - Scala 2.12)
 
@@ -336,7 +359,8 @@ pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0
 spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0
 ```
 
-The `spark-nlp` has been published to the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp).
+The `spark-nlp` has been published to
+the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp).
 
 ```sh
 # GPU
@@ -349,7 +373,8 @@ spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.3.0
 
 ```
 
-The `spark-nlp-gpu` has been published to the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-gpu).
+The `spark-nlp-gpu` has been published to
+the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-gpu).
 
 ```sh
 # AArch64
@@ -362,22 +387,25 @@ spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.3.0
 
 ```
 
-The `spark-nlp-aarch64` has been published to the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-aarch64).
+The `spark-nlp-aarch64` has been published to
+the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-aarch64).
 
 ```sh
-# M1
+# M1/M2 (Apple Silicon)
 
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.3.0
+spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-silicon_2.12:4.3.0
 
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.3.0
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp-silicon_2.12:4.3.0
 
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.3.0
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-silicon_2.12:4.3.0
 
 ```
 
-The `spark-nlp-m1` has been published to the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-m1).
+The `spark-nlp-silicon` has been published to
+the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-silicon).
 
-**NOTE**: In case you are using large pretrained models like UniversalSentenceEncoder, you need to have the following set in your SparkSession:
+**NOTE**: In case you are using large pretrained models like UniversalSentenceEncoder, you need to have the following
+set in your SparkSession:
 
 ```sh
 spark-shell \
@@ -388,7 +416,9 @@ spark-shell \
 
 ## Scala
 
-Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2.x, and 3.3.x versions. Our packages are deployed to Maven central. To add any of our packages as a dependency in your application you can follow these coordinates:
+Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2.x, and 3.3.x versions. Our packages are
+deployed to Maven central. To add any of our packages as a dependency in your application you can follow these
+coordinates:
 
 ### Maven
 
@@ -425,13 +455,13 @@ Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2
 </dependency>
 ```
 
-**spark-nlp-m1:**
+**spark-nlp-silicon:**
 
 ```xml
-<!-- https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-m1 -->
+<!-- https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-silicon -->
 <dependency>
     <groupId>com.johnsnowlabs.nlp</groupId>
-    <artifactId>spark-nlp-m1_2.12</artifactId>
+    <artifactId>spark-nlp-silicon_2.12</artifactId>
     <version>4.3.0</version>
 </dependency>
 ```
@@ -459,16 +489,18 @@ libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-gpu" % "4.3.0"
 libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-aarch64" % "4.3.0"
 ```
 
-**spark-nlp-m1:**
+**spark-nlp-silicon:**
 
 ```sbtshell
-// https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-m1
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-m1" % "4.3.0"
+// https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-silicon
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-silicon" % "4.3.0"
 ```
 
-Maven Central: [https://mvnrepository.com/artifact/com.johnsnowlabs.nlp](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp)
+Maven
+Central: [https://mvnrepository.com/artifact/com.johnsnowlabs.nlp](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp)
 
-If you are interested, there is a simple SBT project for Spark NLP to guide you on how to use it in your projects [Spark NLP SBT Starter](https://github.com/maziyarpanahi/spark-nlp-starter)
+If you are interested, there is a simple SBT project for Spark NLP to guide you on how to use it in your
+projects [Spark NLP SBT Starter](https://github.com/maziyarpanahi/spark-nlp-starter)
 
 ## Python
 
@@ -492,7 +524,8 @@ Conda:
 conda install -c johnsnowlabs spark-nlp
 ```
 
-PyPI [spark-nlp package](https://pypi.org/project/spark-nlp/) / Anaconda [spark-nlp package](https://anaconda.org/JohnSnowLabs/spark-nlp)
+PyPI [spark-nlp package](https://pypi.org/project/spark-nlp/) /
+Anaconda [spark-nlp package](https://anaconda.org/JohnSnowLabs/spark-nlp)
 
 Then you'll have to create a SparkSession either from Spark NLP:
 
@@ -505,17 +538,18 @@ spark = sparknlp.start()
 or manually:
 
 ```python
-spark = SparkSession.builder \
-    .appName("Spark NLP")\
-    .master("local[*]")\
-    .config("spark.driver.memory","16G")\
-    .config("spark.driver.maxResultSize", "0") \
-    .config("spark.kryoserializer.buffer.max", "2000M")\
-    .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0")\
+spark = SparkSession.builder
+    .appName("Spark NLP")
+    .master("local[*]")
+    .config("spark.driver.memory", "16G")
+    .config("spark.driver.maxResultSize", "0")
+    .config("spark.kryoserializer.buffer.max", "2000M")
+    .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0")
     .getOrCreate()
 ```
 
-If using local jars, you can use `spark.jars` instead for comma-delimited jar files. For cluster setups, of course, you'll have to put the jars in a reachable location for all driver and executor nodes.
+If using local jars, you can use `spark.jars` instead for comma-delimited jar files. For cluster setups, of course,
+you'll have to put the jars in a reachable location for all driver and executor nodes.
 
 **Quick example:**
 
@@ -523,14 +557,14 @@ If using local jars, you can use `spark.jars` instead for comma-delimited jar fi
 import sparknlp
 from sparknlp.pretrained import PretrainedPipeline
 
-#create or get Spark Session
+# create or get Spark Session
 
 spark = sparknlp.start()
 
 sparknlp.version()
 spark.version
 
-#download, load and annotate a text by pre-trained pipeline
+# download, load and annotate a text by pre-trained pipeline
 
 pipeline = PretrainedPipeline('recognize_entities_dl', 'en')
 result = pipeline.annotate('The Mona Lisa is a 16th century oil painting created by Leonardo')
@@ -557,12 +591,13 @@ sbt -Dis_gpu=true assembly
 - FAT-JAR for M! on Apache Spark 3.0.x, 3.1.x, 3.2.x, and 3.3.x
 
 ```bash
-sbt -Dis_m1=true assembly
+sbt -Dis_silicon=true assembly
 ```
 
 ### Using the jar manually
 
-If for some reason you need to use the JAR, you can either download the Fat JARs provided here or download it from [Maven Central](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp).
+If for some reason you need to use the JAR, you can either download the Fat JARs provided here or download it
+from [Maven Central](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp).
 
 To add JARs to spark programs use the `--jars` option:
 
@@ -570,7 +605,8 @@ To add JARs to spark programs use the `--jars` option:
 spark-shell --jars spark-nlp.jar
 ```
 
-The preferred way to use the library when running spark programs is using the `--packages` option as specified in the `spark-packages` section.
+The preferred way to use the library when running spark programs is using the `--packages` option as specified in
+the `spark-packages` section.
 
 ## Apache Zeppelin
 
@@ -582,7 +618,8 @@ Use either one of the following options
 com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0
 ```
 
-- Add a path to pre-built jar from [here](#compiled-jars) in the interpreter's library list making sure the jar is available to driver path
+- Add a path to pre-built jar from [here](#compiled-jars) in the interpreter's library list making sure the jar is
+  available to driver path
 
 ### Python in Zeppelin
 
@@ -600,15 +637,18 @@ python.conda install -c johnsnowlabs spark-nlp
 
 Configure Zeppelin properly, use cells with %spark.pyspark or any interpreter name you chose.
 
-Finally, in Zeppelin interpreter settings, make sure you set properly zeppelin.python to the python you want to use and install the pip library with (e.g. `python3`).
+Finally, in Zeppelin interpreter settings, make sure you set properly zeppelin.python to the python you want to use and
+install the pip library with (e.g. `python3`).
 
-An alternative option would be to set `SPARK_SUBMIT_OPTIONS` (zeppelin-env.sh) and make sure `--packages` is there as shown earlier since it includes both scala and python side installation.
+An alternative option would be to set `SPARK_SUBMIT_OPTIONS` (zeppelin-env.sh) and make sure `--packages` is there as
+shown earlier since it includes both scala and python side installation.
 
 ## Jupyter Notebook (Python)
 
 **Recommended:**
 
-The easiest way to get this done on Linux and macOS is to simply install `spark-nlp` and `pyspark` PyPI packages and launch the Jupyter from the same Python environment:
+The easiest way to get this done on Linux and macOS is to simply install `spark-nlp` and `pyspark` PyPI packages and
+launch the Jupyter from the same Python environment:
 
 ```sh
 $ conda create -n sparknlp python=3.8 -y
@@ -622,7 +662,8 @@ Then you can use `python3` kernel to run your code with creating SparkSession vi
 
 **Optional:**
 
-If you are in different operating systems and require to make Jupyter Notebook run by using pyspark, you can follow these steps:
+If you are in different operating systems and require to make Jupyter Notebook run by using pyspark, you can follow
+these steps:
 
 ```bash
 export SPARK_HOME=/path/to/your/spark/folder
@@ -635,11 +676,13 @@ pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0
 
 Alternatively, you can mix in using `--jars` option for pyspark + `pip install spark-nlp`
 
-If not using pyspark at all, you'll have to run the instructions pointed [here](#python-without-explicit-Pyspark-installation)
+If not using pyspark at all, you'll have to run the instructions
+pointed [here](#python-without-explicit-Pyspark-installation)
 
 ## Google Colab Notebook
 
-Google Colab is perhaps the easiest way to get started with spark-nlp. It requires no installation or setup other than having a Google account.
+Google Colab is perhaps the easiest way to get started with spark-nlp. It requires no installation or setup other than
+having a Google account.
 
 Run the following code in Google Colab notebook and start using spark-nlp right away.
 
@@ -658,7 +701,9 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 !wget https://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.3 -s 4.3.0
 ```
 
-[Spark NLP quick start on Google Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/quick_start_google_colab.ipynb) is a live demo on Google Colab that performs named entity recognitions and sentiment analysis by using Spark NLP pretrained pipelines.
+[Spark NLP quick start on Google Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/quick_start_google_colab.ipynb)
+is a live demo on Google Colab that performs named entity recognitions and sentiment analysis by using Spark NLP
+pretrained pipelines.
 
 ## Kaggle Kernel
 
@@ -679,7 +724,8 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 !wget https://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.3 -s 4.3.0
 ```
 
-[Spark NLP quick start on Kaggle Kernel](https://www.kaggle.com/mozzie/spark-nlp-named-entity-recognition) is a live demo on Kaggle Kernel that performs named entity recognitions by using Spark NLP pretrained pipeline.
+[Spark NLP quick start on Kaggle Kernel](https://www.kaggle.com/mozzie/spark-nlp-named-entity-recognition) is a live
+demo on Kaggle Kernel that performs named entity recognitions by using Spark NLP pretrained pipeline.
 
 ## Databricks Cluster
 
@@ -694,17 +740,20 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 
 3. In `Libraries` tab inside your cluster you need to follow these steps:
 
-    3.1. Install New -> PyPI -> `spark-nlp==4.3.0` -> Install
+   3.1. Install New -> PyPI -> `spark-nlp==4.3.0` -> Install
 
-    3.2. Install New -> Maven -> Coordinates -> `com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0` -> Install
+   3.2. Install New -> Maven -> Coordinates -> `com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0` -> Install
 
 4. Now you can attach your notebook to the cluster and use Spark NLP!
 
-NOTE: Databricks' runtimes support different Apache Spark major releases. Please make sure you choose the correct Spark NLP Maven package name (Maven Coordinate) for your runtime from our [Packages Cheatsheet](https://github.com/JohnSnowLabs/spark-nlp#packages-cheatsheet)
+NOTE: Databricks' runtimes support different Apache Spark major releases. Please make sure you choose the correct Spark
+NLP Maven package name (Maven Coordinate) for your runtime from
+our [Packages Cheatsheet](https://github.com/JohnSnowLabs/spark-nlp#packages-cheatsheet)
 
 ## EMR Cluster
 
-To launch EMR clusters with Apache Spark/PySpark and Spark NLP correctly you need to have bootstrap and software configuration.
+To launch EMR clusters with Apache Spark/PySpark and Spark NLP correctly you need to have bootstrap and software
+configuration.
 
 A sample of your bootstrap script
 
@@ -848,16 +897,16 @@ You can use `.config()` during SparkSession creation to set Spark NLP configurat
 ```python
 from pyspark.sql import SparkSession
 
-spark = SparkSession.builder \
-        .master("local[*]") \
-        .config("spark.driver.memory", "16G") \
-        .config("spark.driver.maxResultSize", "0") \
-        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer") \
-        .config("spark.kryoserializer.buffer.max", "2000m") \
-        .config("spark.jsl.settings.pretrained.cache_folder", "sample_data/pretrained") \
-        .config("spark.jsl.settings.storage.cluster_tmp_dir", "sample_data/storage") \
-        .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0") \
-        .getOrCreate()
+spark = SparkSession.builder
+    .master("local[*]")
+    .config("spark.driver.memory", "16G")
+    .config("spark.driver.maxResultSize", "0")
+    .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+    .config("spark.kryoserializer.buffer.max", "2000m")
+    .config("spark.jsl.settings.pretrained.cache_folder", "sample_data/pretrained")
+    .config("spark.jsl.settings.storage.cluster_tmp_dir", "sample_data/storage")
+    .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0")
+    .getOrCreate()
 ```
 
 **spark-shell:**
@@ -934,14 +983,16 @@ spark.conf.set("spark.jsl.settings.aws.region", "my-region")
 
 **MFA Configuration:**
 
-In case your AWS account is configured with MFA. You will need first to get temporal credentials and add session token to the configuration as shown in the examples below
+In case your AWS account is configured with MFA. You will need first to get temporal credentials and add session token
+to the configuration as shown in the examples below
 For logging:
 
 ```bash
 spark.conf.set("spark.jsl.settings.aws.credentials.session_token", "MY_TOKEN")
 ```
 
-An example of a bash script that gets temporal AWS credentials can be found [here](https://github.com/JohnSnowLabs/spark-nlp/blob/master/scripts/aws_tmp_credentials.sh)
+An example of a bash script that gets temporal AWS credentials can be
+found [here](https://github.com/JohnSnowLabs/spark-nlp/blob/master/scripts/aws_tmp_credentials.sh)
 This script requires three arguments:
 
 ```bash
@@ -961,11 +1012,11 @@ import com.johnsnowlabs.nlp.SparkNLP
 SparkNLP.version()
 
 val testData = spark.createDataFrame(Seq(
-(1, "Google has announced the release of a beta version of the popular TensorFlow machine learning library"),
-(2, "Donald John Trump (born June 14, 1946) is the 45th and current president of the United States")
+  (1, "Google has announced the release of a beta version of the popular TensorFlow machine learning library"),
+  (2, "Donald John Trump (born June 14, 1946) is the 45th and current president of the United States")
 )).toDF("id", "text")
 
-val pipeline = PretrainedPipeline("explain_document_dl", lang="en")
+val pipeline = PretrainedPipeline("explain_document_dl", lang = "en")
 
 val annotation = pipeline.transform(testData)
 
@@ -1005,7 +1056,7 @@ of a particular language for you:
 ```scala
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
 
-ResourceDownloader.showPublicPipelines(lang="en")
+ResourceDownloader.showPublicPipelines(lang = "en")
 /*
 +--------------------------------------------+------+---------+
 | Pipeline                                   | lang | version |
@@ -1025,7 +1076,7 @@ Or if we want to check for a particular version:
 ```scala
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
 
-ResourceDownloader.showPublicPipelines(lang="en", version="3.1.0")
+ResourceDownloader.showPublicPipelines(lang = "en", version = "3.1.0")
 /*
 +---------------------------------------+------+---------+
 | Pipeline                              | lang | version |
@@ -1044,7 +1095,8 @@ ResourceDownloader.showPublicPipelines(lang="en", version="3.1.0")
 
 ### Models
 
-**Some selected languages:** `Afrikaans, Arabic, Armenian, Basque, Bengali, Breton, Bulgarian, Catalan, Czech, Dutch, English, Esperanto, Finnish, French, Galician, German, Greek, Hausa, Hebrew, Hindi, Hungarian, Indonesian, Irish, Italian, Japanese, Latin, Latvian, Marathi, Norwegian, Persian, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Somali, Southern Sotho, Spanish, Swahili, Swedish, Tswana, Turkish, Ukrainian, Zulu`
+**Some selected languages:
+** `Afrikaans, Arabic, Armenian, Basque, Bengali, Breton, Bulgarian, Catalan, Czech, Dutch, English, Esperanto, Finnish, French, Galician, German, Greek, Hausa, Hebrew, Hindi, Hungarian, Indonesian, Irish, Italian, Japanese, Latin, Latvian, Marathi, Norwegian, Persian, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Somali, Southern Sotho, Spanish, Swahili, Swedish, Tswana, Turkish, Ukrainian, Zulu`
 
 **Quick online example:**
 
@@ -1057,9 +1109,9 @@ ner_bert = NerDLModel.pretrained('ner_dl_bert')
 
 ```scala
 // load French POS tagger model trained by Universal Dependencies
-val french_pos = PerceptronModel.pretrained("pos_ud_gsd", lang="fr")
+val french_pos = PerceptronModel.pretrained("pos_ud_gsd", lang = "fr")
 // load Italian LemmatizerModel
-val italian_lemma = LemmatizerModel.pretrained("lemma_dxc", lang="it")
+val italian_lemma = LemmatizerModel.pretrained("lemma_dxc", lang = "it")
 ````
 
 **Quick offline example:**
@@ -1068,8 +1120,8 @@ val italian_lemma = LemmatizerModel.pretrained("lemma_dxc", lang="it")
 
 ```scala
 val french_pos = PerceptronModel.load("/tmp/pos_ud_gsd_fr_2.0.2_2.4_1556531457346/")
-      .setInputCols("document", "token")
-      .setOutputCol("pos")
+  .setInputCols("document", "token")
+  .setOutputCol("pos")
 ```
 
 #### Showing Available Models
@@ -1080,7 +1132,7 @@ of a particular Annotator and language for you:
 ```scala
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
 
-ResourceDownloader.showPublicModels(annotator="NerDLModel", lang="en")
+ResourceDownloader.showPublicModels(annotator = "NerDLModel", lang = "en")
 /*
 +---------------------------------------------+------+---------+
 | Model                                       | lang | version |
@@ -1099,7 +1151,7 @@ Or if we want to check for a particular version:
 ```scala
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
 
-ResourceDownloader.showPublicModels(annotator="NerDLModel", lang="en", version="3.1.0")
+ResourceDownloader.showPublicModels(annotator = "NerDLModel", lang = "en", version = "3.1.0")
 /*
 +----------------------------+------+---------+
 | Model                      | lang | version |
@@ -1133,26 +1185,35 @@ XlnetEmbeddings
 
 ## Offline
 
-Spark NLP library and all the pre-trained models/pipelines can be used entirely offline with no access to the Internet. If you are behind a proxy or a firewall with no access to the Maven repository (to download packages) or/and no access to S3 (to automatically download models and pipelines), you can simply follow the instructions to have Spark NLP without any limitations offline:
+Spark NLP library and all the pre-trained models/pipelines can be used entirely offline with no access to the Internet.
+If you are behind a proxy or a firewall with no access to the Maven repository (to download packages) or/and no access
+to S3 (to automatically download models and pipelines), you can simply follow the instructions to have Spark NLP without
+any limitations offline:
 
 - Instead of using the Maven package, you need to load our Fat JAR
-- Instead of using PretrainedPipeline for pretrained pipelines or the `.pretrained()` function to download pretrained models, you will need to manually download your pipeline/model from [Models Hub](https://nlp.johnsnowlabs.com/models), extract it, and load it.
+- Instead of using PretrainedPipeline for pretrained pipelines or the `.pretrained()` function to download pretrained
+  models, you will need to manually download your pipeline/model from [Models Hub](https://nlp.johnsnowlabs.com/models),
+  extract it, and load it.
 
 Example of `SparkSession` with Fat JAR to have Spark NLP offline:
 
 ```python
-spark = SparkSession.builder \
-    .appName("Spark NLP")\
-    .master("local[*]")\
-    .config("spark.driver.memory","16G")\
-    .config("spark.driver.maxResultSize", "0") \
-    .config("spark.kryoserializer.buffer.max", "2000M")\
-    .config("spark.jars", "/tmp/spark-nlp-assembly-4.3.0.jar")\
+spark = SparkSession.builder
+    .appName("Spark NLP")
+    .master("local[*]")
+    .config("spark.driver.memory", "16G")
+    .config("spark.driver.maxResultSize", "0")
+    .config("spark.kryoserializer.buffer.max", "2000M")
+    .config("spark.jars", "/tmp/spark-nlp-assembly-4.3.0.jar")
     .getOrCreate()
 ```
 
-- You can download provided Fat JARs from each [release notes](https://github.com/JohnSnowLabs/spark-nlp/releases), please pay attention to pick the one that suits your environment depending on the device (CPU/GPU) and Apache Spark version (3.0.x, 3.1.x, 3.2.x, and 3.3.x)
-- If you are local, you can load the Fat JAR from your local FileSystem, however, if you are in a cluster setup you need to put the Fat JAR on a distributed FileSystem such as HDFS, DBFS, S3, etc. (i.e., `hdfs:///tmp/spark-nlp-assembly-4.3.0.jar`)
+- You can download provided Fat JARs from each [release notes](https://github.com/JohnSnowLabs/spark-nlp/releases),
+  please pay attention to pick the one that suits your environment depending on the device (CPU/GPU) and Apache Spark
+  version (3.0.x, 3.1.x, 3.2.x, and 3.3.x)
+- If you are local, you can load the Fat JAR from your local FileSystem, however, if you are in a cluster setup you need
+  to put the Fat JAR on a distributed FileSystem such as HDFS, DBFS, S3, etc. (
+  i.e., `hdfs:///tmp/spark-nlp-assembly-4.3.0.jar`)
 
 Example of using pretrained Models and Pipelines in offline:
 
@@ -1160,9 +1221,9 @@ Example of using pretrained Models and Pipelines in offline:
 # instead of using pretrained() for online:
 # french_pos = PerceptronModel.pretrained("pos_ud_gsd", lang="fr")
 # you download this model, extract it, and use .load
-french_pos = PerceptronModel.load("/tmp/pos_ud_gsd_fr_2.0.2_2.4_1556531457346/")\
-      .setInputCols("document", "token")\
-      .setOutputCol("pos")
+french_pos = PerceptronModel.load("/tmp/pos_ud_gsd_fr_2.0.2_2.4_1556531457346/")
+    .setInputCols("document", "token")
+    .setOutputCol("pos")
 
 # example for pipelines
 # instead of using PretrainedPipeline
@@ -1171,12 +1232,16 @@ french_pos = PerceptronModel.load("/tmp/pos_ud_gsd_fr_2.0.2_2.4_1556531457346/")
 PipelineModel.load("/tmp/explain_document_dl_en_2.0.2_2.4_1556530585689/")
 ```
 
-- Since you are downloading and loading models/pipelines manually, this means Spark NLP is not downloading the most recent and compatible models/pipelines for you. Choosing the right model/pipeline is on you
-- If you are local, you can load the model/pipeline from your local FileSystem, however, if you are in a cluster setup you need to put the model/pipeline on a distributed FileSystem such as HDFS, DBFS, S3, etc. (i.e., `hdfs:///tmp/explain_document_dl_en_2.0.2_2.4_1556530585689/`)
+- Since you are downloading and loading models/pipelines manually, this means Spark NLP is not downloading the most
+  recent and compatible models/pipelines for you. Choosing the right model/pipeline is on you
+- If you are local, you can load the model/pipeline from your local FileSystem, however, if you are in a cluster setup
+  you need to put the model/pipeline on a distributed FileSystem such as HDFS, DBFS, S3, etc. (
+  i.e., `hdfs:///tmp/explain_document_dl_en_2.0.2_2.4_1556530585689/`)
 
 ## Examples
 
-Need more **examples**? Check out our dedicated [Spark NLP Showcase](https://github.com/JohnSnowLabs/spark-nlp-workshop) repository to showcase all Spark NLP use cases!
+Need more **examples**? Check out our dedicated [Spark NLP Showcase](https://github.com/JohnSnowLabs/spark-nlp-workshop)
+repository to showcase all Spark NLP use cases!
 
 Also, don't forget to check [Spark NLP in Action](https://nlp.johnsnowlabs.com/demo) built by Streamlit.
 
@@ -1188,7 +1253,8 @@ Also, don't forget to check [Spark NLP in Action](https://nlp.johnsnowlabs.com/d
 
 ## Citation
 
-We have published a [paper](https://www.sciencedirect.com/science/article/pii/S2665963821000063) that you can cite for the Spark NLP library:
+We have published a [paper](https://www.sciencedirect.com/science/article/pii/S2665963821000063) that you can cite for
+the Spark NLP library:
 
 ```bibtex
 @article{KOCAMAN2021100058,

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbtassembly.MergeStrategy
 import M2Resolvers.m2Resolvers
 import Dependencies._
 
-name := getPackageName(is_m1, is_gpu, is_aarch64)
+name := getPackageName(is_silicon, is_gpu, is_aarch64)
 
 organization := "com.johnsnowlabs.nlp"
 
@@ -158,7 +158,7 @@ lazy val typedDependencyParserDependencies = Seq(junit)
 val tensorflowDependencies: Seq[sbt.ModuleID] =
   if (is_gpu.equals("true"))
     Seq(tensorflowGPU)
-  else if (is_m1.equals("true"))
+  else if (is_silicon.equals("true"))
     Seq(tensorflowM1)
   else if (is_aarch64.equals("true"))
     Seq(tensorflowLinuxAarch64)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   /* required for different hardware */
   val is_gpu: String = System.getProperty("is_gpu", "false")
   val is_opt: String = System.getProperty("is_opt", "false")
-  val is_m1: String = System.getProperty("is_m1", "false")
+  val is_silicon: String = System.getProperty("is_silicon", "false")
   val is_aarch64: String = System.getProperty("is_aarch64", "false")
 
   /* only used for unit tests */
@@ -27,11 +27,11 @@ object Dependencies {
   /** ------- Spark version end ------- */
 
   /** Package attributes */
-  def getPackageName(is_m1: String, is_gpu: String, is_aarch64: String): String = {
+  def getPackageName(is_silicon: String, is_gpu: String, is_aarch64: String): String = {
     if (is_gpu.equals("true")) {
       "spark-nlp-gpu"
-    } else if (is_m1.equals("true")) {
-      "spark-nlp-m1"
+    } else if (is_silicon.equals("true")) {
+      "spark-nlp-silicon"
     } else if (is_aarch64.equals("true")) {
       "spark-nlp-aarch64"
     } else {

--- a/python/README.md
+++ b/python/README.md
@@ -1,4 +1,5 @@
 # Spark NLP: State-of-the-Art Natural Language Processing
+
 <p align="center">
     <a href="https://github.com/JohnSnowLabs/spark-nlp/actions" alt="build">
         <img src="https://github.com/JohnSnowLabs/spark-nlp/workflows/build/badge.svg" /></a>
@@ -16,21 +17,33 @@
         <img src="https://static.pepy.tech/personalized-badge/spark-nlp?period=total&units=international_system&left_color=grey&right_color=orange&left_text=pip%20downloads" /></a>
 </p>
 
-Spark NLP is a state-of-the-art Natural Language Processing library built on top of Apache Spark. It provides **simple**, **performant** & **accurate** NLP annotations for machine learning pipelines that **scale** easily in a distributed environment.
+Spark NLP is a state-of-the-art Natural Language Processing library built on top of Apache Spark. It provides **simple
+**, **performant** & **accurate** NLP annotations for machine learning pipelines that **scale** easily in a distributed
+environment.
 Spark NLP comes with **11000+** pretrained **pipelines** and **models** in more than **200+** languages.
-It also offers tasks such as **Tokenization**, **Word Segmentation**, **Part-of-Speech Tagging**, Word and Sentence **Embeddings**, **Named Entity Recognition**, **Dependency Parsing**, **Spell Checking**, **Text Classification**, **Sentiment Analysis**, **Token Classification**, **Machine Translation** (+180 languages), **Summarization**, **Question Answering**, **Table Question Answering**, **Text Generation**, **Image Classification**, **Automatic Speech Recognition**, and many more [NLP tasks](#features).
+It also offers tasks such as **Tokenization**, **Word Segmentation**, **Part-of-Speech Tagging**, Word and Sentence *
+*Embeddings**, **Named Entity Recognition**, **Dependency Parsing**, **Spell Checking**, **Text Classification**, *
+*Sentiment Analysis**, **Token Classification**, **Machine Translation** (+180 languages), **Summarization**, **Question
+Answering**, **Table Question Answering**, **Text Generation**, **Image Classification**, **Automatic Speech Recognition
+**, and many more [NLP tasks](#features).
 
-**Spark NLP** is the only open-source NLP library in **production** that offers state-of-the-art transformers such as **BERT**, **CamemBERT**, **ALBERT**, **ELECTRA**, **XLNet**, **DistilBERT**, **RoBERTa**, **DeBERTa**, **XLM-RoBERTa**, **Longformer**, **ELMO**, **Universal Sentence Encoder**, **Google T5**, **MarianMT**, **GPT2**, and **Vision Transformers (ViT)** not only to **Python** and **R**, but also to **JVM** ecosystem (**Java**, **Scala**, and **Kotlin**) at **scale** by extending **Apache Spark** natively.
+**Spark NLP** is the only open-source NLP library in **production** that offers state-of-the-art transformers such as *
+*BERT**, **CamemBERT**, **ALBERT**, **ELECTRA**, **XLNet**, **DistilBERT**, **RoBERTa**, **DeBERTa**, **XLM-RoBERTa**, *
+*Longformer**, **ELMO**, **Universal Sentence Encoder**, **Google T5**, **MarianMT**, **GPT2**, and **Vision
+Transformers (ViT)** not only to **Python** and **R**, but also to **JVM** ecosystem (**Java**, **Scala**, and **Kotlin
+**) at **scale** by extending **Apache Spark** natively.
 
 ## Project's website
 
-Take a look at our official Spark NLP page: [http://nlp.johnsnowlabs.com/](http://nlp.johnsnowlabs.com/) for user documentation and examples
+Take a look at our official Spark NLP page: [http://nlp.johnsnowlabs.com/](http://nlp.johnsnowlabs.com/) for user
+documentation and examples
 
 ## Community support
 
 - [Slack](https://www.johnsnowlabs.com/slack-redirect/) For live discussion with the Spark NLP community and the team
 - [GitHub](https://github.com/JohnSnowLabs/spark-nlp) Bug reports, feature requests, and contributions
-- [Discussions](https://github.com/JohnSnowLabs/spark-nlp/discussions) Engage with other community members, share ideas, and show off how you use Spark NLP!
+- [Discussions](https://github.com/JohnSnowLabs/spark-nlp/discussions) Engage with other community members, share ideas,
+  and show off how you use Spark NLP!
 - [Medium](https://medium.com/spark-nlp) Spark NLP articles
 - [YouTube](https://www.youtube.com/channel/UCmFOjlpYEhxf_wJUDuz6xxQ/videos) Spark NLP video tutorials
 
@@ -141,7 +154,8 @@ Take a look at our official Spark NLP page: [http://nlp.johnsnowlabs.com/](http:
 - Full integration with Spark ML functions
 - +8500 pre-trained models in +200 languages!
 - +3200 pre-trained pipelines in +200 languages!
-- Multi-lingual NER models: Arabic, Bengali, Chinese, Danish, Dutch, English, Finnish, French, German, Hebrew, Italian, Japanese, Korean, Norwegian, Persian, Polish, Portuguese, Russian, Spanish, Swedish, Urdu, and more.
+- Multi-lingual NER models: Arabic, Bengali, Chinese, Danish, Dutch, English, Finnish, French, German, Hebrew, Italian,
+  Japanese, Korean, Norwegian, Persian, Polish, Portuguese, Russian, Spanish, Swedish, Urdu, and more.
 
 ## Requirements
 
@@ -181,9 +195,9 @@ from sparknlp.pretrained import PretrainedPipeline
 import sparknlp
 
 # Start SparkSession with Spark NLP
-# start() functions has 3 parameters: gpu, m1, and memory
+# start() functions has 3 parameters: gpu, apple_silicon, and memory
 # sparknlp.start(gpu=True) will start the session with GPU support
-# sparknlp.start(m1=True) will start the session with macOS M1 support
+# sparknlp.start(apple_silicon=True) will start the session with macOS M1 & M2 support
 # sparknlp.start(memory="16G") to change the default driver memory in SparkSession
 spark = sparknlp.start()
 
@@ -202,21 +216,24 @@ result = pipeline.annotate(text)
 # What's in the pipeline
 list(result.keys())
 Output: ['entities', 'stem', 'checked', 'lemma', 'document',
-'pos', 'token', 'ner', 'embeddings', 'sentence']
+         'pos', 'token', 'ner', 'embeddings', 'sentence']
 
 # Check the results
 result['entities']
 Output: ['Mona Lisa', 'Leonardo', 'Louvre', 'Paris']
 ```
 
-For more examples, you can visit our dedicated [repository](https://github.com/JohnSnowLabs/spark-nlp-workshop) to showcase all Spark NLP use cases!
+For more examples, you can visit our dedicated [repository](https://github.com/JohnSnowLabs/spark-nlp-workshop) to
+showcase all Spark NLP use cases!
 
 ## Apache Spark Support
 
-Spark NLP *4.3.0* has been built on top of Apache Spark 3.2 while fully supports Apache Spark 3.0.x, 3.1.x, 3.2.x, and 3.3.x:
+Spark NLP *4.3.0* has been built on top of Apache Spark 3.2 while fully supports Apache Spark 3.0.x, 3.1.x, 3.2.x, and
+3.3.x:
 
 | Spark NLP | Apache Spark 2.3.x | Apache Spark 2.4.x | Apache Spark 3.0.x | Apache Spark 3.1.x | Apache Spark 3.2.x | Apache Spark 3.3.x |
 |-----------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
+| 4.3.x     | NO                 | NO                 | YES                | YES                | YES                | YES                |
 | 4.2.x     | NO                 | NO                 | YES                | YES                | YES                | YES                |
 | 4.1.x     | NO                 | NO                 | YES                | YES                | YES                | YES                |
 | 4.0.x     | NO                 | NO                 | YES                | YES                | YES                | YES                |
@@ -227,7 +244,8 @@ Spark NLP *4.3.0* has been built on top of Apache Spark 3.2 while fully supports
 | 3.0.x     | YES                | YES                | YES                | YES                | NO                 | NO                 |
 | 2.7.x     | YES                | YES                | NO                 | NO                 | NO                 | NO                 |
 
-NOTE: Starting 4.0.0 release, the default `spark-nlp` and `spark-nlp-gpu` packages are based on Scala 2.12.15 and Apache Spark 3.2 by default.
+NOTE: Starting 4.0.0 release, the default `spark-nlp` and `spark-nlp-gpu` packages are based on Scala 2.12.15 and Apache
+Spark 3.2 by default.
 
 Find out more about `Spark NLP` versions from our [release notes](https://github.com/JohnSnowLabs/spark-nlp/releases).
 
@@ -235,6 +253,7 @@ Find out more about `Spark NLP` versions from our [release notes](https://github
 
 | Spark NLP | Python 3.6 | Python 3.7 | Python 3.8 | Python 3.9 | Scala 2.11 | Scala 2.12 |
 |-----------|------------|------------|------------|------------|------------|------------|
+| 4.3.x     | YES        | YES        | YES        | YES        | NO         | YES        |
 | 4.2.x     | YES        | YES        | YES        | YES        | NO         | YES        |
 | 4.1.x     | YES        | YES        | YES        | YES        | NO         | YES        |
 | 4.0.x     | YES        | YES        | YES        | YES        | NO         | YES        |
@@ -287,7 +306,8 @@ Spark NLP 4.3.0 has been tested and is compatible with the following runtimes:
 - 11.2 ML & GPU
 - 11.3 ML & GPU
 
-NOTE: Spark NLP 4.0.x is based on TensorFlow 2.7.x which is compatible with CUDA11 and cuDNN 8.0.2. The only Databricks runtimes supporting CUDA 11 are 9.x and above as listed under GPU.
+NOTE: Spark NLP 4.x is based on TensorFlow 2.7.x which is compatible with CUDA11 and cuDNN 8.0.2. The only Databricks
+runtimes supporting CUDA 11 are 9.x and above as listed under GPU.
 
 ## EMR Support
 
@@ -311,18 +331,21 @@ NOTE: The EMR 6.1.0 and 6.1.1 are not supported.
 
 This is a cheatsheet for corresponding Spark NLP Maven package to Apache Spark / PySpark major version:
 
-| Apache Spark     | Spark NLP on CPU   | Spark NLP on GPU           | Spark NLP on AArch64 (linux)   | Spark NLP on M1           |
-|------------------|--------------------|----------------------------|--------------------------------|---------------------------|
-| 3.0/3.1/3.2/3.3  | `spark-nlp`        | `spark-nlp-gpu`            | `spark-nlp-aarch64`            | `spark-nlp-m1`            |
-| Start Function   | `sparknlp.start()` | `sparknlp.start(gpu=True)` | `sparknlp.start(aarch64=True)` | `sparknlp.start(m1=True)` |
+| Apache Spark    | Spark NLP on CPU   | Spark NLP on GPU           | Spark NLP on AArch64 (linux)   | Spark NLP on Apple Silicon           |
+|-----------------|--------------------|----------------------------|--------------------------------|--------------------------------------|
+| 3.0/3.1/3.2/3.3 | `spark-nlp`        | `spark-nlp-gpu`            | `spark-nlp-aarch64`            | `spark-nlp-silicon`                  |
+| Start Function  | `sparknlp.start()` | `sparknlp.start(gpu=True)` | `sparknlp.start(aarch64=True)` | `sparknlp.start(apple_silicon=True)` |
 
-NOTE: `M1` and `AArch64` are under `experimental` support. Access and support to these architectures are limited by the community and we had to build most of the dependencies by ourselves to make them compatible. We support these two architectures, however, they may not work in some environments.
+NOTE: `M1/M2` and `AArch64` are under `experimental` support. Access and support to these architectures are limited by the
+community and we had to build most of the dependencies by ourselves to make them compatible. We support these two
+architectures, however, they may not work in some environments.
 
 ## Spark Packages
 
 ### Command line (requires internet connection)
 
-Spark NLP supports all major releases of Apache Spark 3.0.x, Apache Spark 3.1.x, Apache Spark 3.2.x, and Apache Spark 3.3.x.
+Spark NLP supports all major releases of Apache Spark 3.0.x, Apache Spark 3.1.x, Apache Spark 3.2.x, and Apache Spark
+3.3.x.
 
 #### Apache Spark 3.x (3.0.x, 3.1.x, 3.2.x, and 3.3.x - Scala 2.12)
 
@@ -336,7 +359,8 @@ pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0
 spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0
 ```
 
-The `spark-nlp` has been published to the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp).
+The `spark-nlp` has been published to
+the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp).
 
 ```sh
 # GPU
@@ -349,7 +373,8 @@ spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:4.3.0
 
 ```
 
-The `spark-nlp-gpu` has been published to the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-gpu).
+The `spark-nlp-gpu` has been published to
+the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-gpu).
 
 ```sh
 # AArch64
@@ -362,22 +387,25 @@ spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:4.3.0
 
 ```
 
-The `spark-nlp-aarch64` has been published to the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-aarch64).
+The `spark-nlp-aarch64` has been published to
+the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-aarch64).
 
 ```sh
-# M1
+# M1/M2 (Apple Silicon)
 
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.3.0
+spark-shell --packages com.johnsnowlabs.nlp:spark-nlp-silicon_2.12:4.3.0
 
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.3.0
+pyspark --packages com.johnsnowlabs.nlp:spark-nlp-silicon_2.12:4.3.0
 
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-m1_2.12:4.3.0
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-silicon_2.12:4.3.0
 
 ```
 
-The `spark-nlp-m1` has been published to the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-m1).
+The `spark-nlp-silicon` has been published to
+the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-silicon).
 
-**NOTE**: In case you are using large pretrained models like UniversalSentenceEncoder, you need to have the following set in your SparkSession:
+**NOTE**: In case you are using large pretrained models like UniversalSentenceEncoder, you need to have the following
+set in your SparkSession:
 
 ```sh
 spark-shell \
@@ -388,7 +416,9 @@ spark-shell \
 
 ## Scala
 
-Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2.x, and 3.3.x versions. Our packages are deployed to Maven central. To add any of our packages as a dependency in your application you can follow these coordinates:
+Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2.x, and 3.3.x versions. Our packages are
+deployed to Maven central. To add any of our packages as a dependency in your application you can follow these
+coordinates:
 
 ### Maven
 
@@ -425,14 +455,14 @@ Spark NLP supports Scala 2.12.15 if you are using Apache Spark 3.0.x, 3.1.x, 3.2
 </dependency>
 ```
 
-**spark-nlp-m1:**
+**spark-nlp-silicon:**
 
 ```xml
-<!-- https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-m1 -->
+<!-- https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-silicon -->
 <dependency>
-    <groupId>com.johnsnowlabs.nlp</groupId>
-    <artifactId>spark-nlp-m1_2.12</artifactId>
-    <version>4.3.0</version>
+  <groupId>com.johnsnowlabs.nlp</groupId>
+  <artifactId>spark-nlp-silicon_2.12</artifactId>
+  <version>4.3.0</version>
 </dependency>
 ```
 
@@ -459,16 +489,18 @@ libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-gpu" % "4.3.0"
 libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-aarch64" % "4.3.0"
 ```
 
-**spark-nlp-m1:**
+**spark-nlp-silicon:**
 
 ```sbtshell
-// https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-m1
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-m1" % "4.3.0"
+// https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp-silicon
+libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-silicon" % "4.3.0"
 ```
 
-Maven Central: [https://mvnrepository.com/artifact/com.johnsnowlabs.nlp](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp)
+Maven
+Central: [https://mvnrepository.com/artifact/com.johnsnowlabs.nlp](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp)
 
-If you are interested, there is a simple SBT project for Spark NLP to guide you on how to use it in your projects [Spark NLP SBT Starter](https://github.com/maziyarpanahi/spark-nlp-starter)
+If you are interested, there is a simple SBT project for Spark NLP to guide you on how to use it in your
+projects [Spark NLP SBT Starter](https://github.com/maziyarpanahi/spark-nlp-starter)
 
 ## Python
 
@@ -492,7 +524,8 @@ Conda:
 conda install -c johnsnowlabs spark-nlp
 ```
 
-PyPI [spark-nlp package](https://pypi.org/project/spark-nlp/) / Anaconda [spark-nlp package](https://anaconda.org/JohnSnowLabs/spark-nlp)
+PyPI [spark-nlp package](https://pypi.org/project/spark-nlp/) /
+Anaconda [spark-nlp package](https://anaconda.org/JohnSnowLabs/spark-nlp)
 
 Then you'll have to create a SparkSession either from Spark NLP:
 
@@ -505,17 +538,18 @@ spark = sparknlp.start()
 or manually:
 
 ```python
-spark = SparkSession.builder \
-    .appName("Spark NLP")\
-    .master("local[*]")\
-    .config("spark.driver.memory","16G")\
-    .config("spark.driver.maxResultSize", "0") \
-    .config("spark.kryoserializer.buffer.max", "2000M")\
-    .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0")\
-    .getOrCreate()
+spark = SparkSession.builder
+.appName("Spark NLP")
+.master("local[*]")
+.config("spark.driver.memory", "16G")
+.config("spark.driver.maxResultSize", "0")
+.config("spark.kryoserializer.buffer.max", "2000M")
+.config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0")
+.getOrCreate()
 ```
 
-If using local jars, you can use `spark.jars` instead for comma-delimited jar files. For cluster setups, of course, you'll have to put the jars in a reachable location for all driver and executor nodes.
+If using local jars, you can use `spark.jars` instead for comma-delimited jar files. For cluster setups, of course,
+you'll have to put the jars in a reachable location for all driver and executor nodes.
 
 **Quick example:**
 
@@ -523,14 +557,14 @@ If using local jars, you can use `spark.jars` instead for comma-delimited jar fi
 import sparknlp
 from sparknlp.pretrained import PretrainedPipeline
 
-#create or get Spark Session
+# create or get Spark Session
 
 spark = sparknlp.start()
 
 sparknlp.version()
 spark.version
 
-#download, load and annotate a text by pre-trained pipeline
+# download, load and annotate a text by pre-trained pipeline
 
 pipeline = PretrainedPipeline('recognize_entities_dl', 'en')
 result = pipeline.annotate('The Mona Lisa is a 16th century oil painting created by Leonardo')
@@ -557,12 +591,13 @@ sbt -Dis_gpu=true assembly
 - FAT-JAR for M! on Apache Spark 3.0.x, 3.1.x, 3.2.x, and 3.3.x
 
 ```bash
-sbt -Dis_m1=true assembly
+sbt -Dis_silicon=true assembly
 ```
 
 ### Using the jar manually
 
-If for some reason you need to use the JAR, you can either download the Fat JARs provided here or download it from [Maven Central](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp).
+If for some reason you need to use the JAR, you can either download the Fat JARs provided here or download it
+from [Maven Central](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp).
 
 To add JARs to spark programs use the `--jars` option:
 
@@ -570,7 +605,8 @@ To add JARs to spark programs use the `--jars` option:
 spark-shell --jars spark-nlp.jar
 ```
 
-The preferred way to use the library when running spark programs is using the `--packages` option as specified in the `spark-packages` section.
+The preferred way to use the library when running spark programs is using the `--packages` option as specified in
+the `spark-packages` section.
 
 ## Apache Zeppelin
 
@@ -582,7 +618,8 @@ Use either one of the following options
 com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0
 ```
 
-- Add a path to pre-built jar from [here](#compiled-jars) in the interpreter's library list making sure the jar is available to driver path
+- Add a path to pre-built jar from [here](#compiled-jars) in the interpreter's library list making sure the jar is
+  available to driver path
 
 ### Python in Zeppelin
 
@@ -600,15 +637,18 @@ python.conda install -c johnsnowlabs spark-nlp
 
 Configure Zeppelin properly, use cells with %spark.pyspark or any interpreter name you chose.
 
-Finally, in Zeppelin interpreter settings, make sure you set properly zeppelin.python to the python you want to use and install the pip library with (e.g. `python3`).
+Finally, in Zeppelin interpreter settings, make sure you set properly zeppelin.python to the python you want to use and
+install the pip library with (e.g. `python3`).
 
-An alternative option would be to set `SPARK_SUBMIT_OPTIONS` (zeppelin-env.sh) and make sure `--packages` is there as shown earlier since it includes both scala and python side installation.
+An alternative option would be to set `SPARK_SUBMIT_OPTIONS` (zeppelin-env.sh) and make sure `--packages` is there as
+shown earlier since it includes both scala and python side installation.
 
 ## Jupyter Notebook (Python)
 
 **Recommended:**
 
-The easiest way to get this done on Linux and macOS is to simply install `spark-nlp` and `pyspark` PyPI packages and launch the Jupyter from the same Python environment:
+The easiest way to get this done on Linux and macOS is to simply install `spark-nlp` and `pyspark` PyPI packages and
+launch the Jupyter from the same Python environment:
 
 ```sh
 $ conda create -n sparknlp python=3.8 -y
@@ -622,7 +662,8 @@ Then you can use `python3` kernel to run your code with creating SparkSession vi
 
 **Optional:**
 
-If you are in different operating systems and require to make Jupyter Notebook run by using pyspark, you can follow these steps:
+If you are in different operating systems and require to make Jupyter Notebook run by using pyspark, you can follow
+these steps:
 
 ```bash
 export SPARK_HOME=/path/to/your/spark/folder
@@ -635,11 +676,13 @@ pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0
 
 Alternatively, you can mix in using `--jars` option for pyspark + `pip install spark-nlp`
 
-If not using pyspark at all, you'll have to run the instructions pointed [here](#python-without-explicit-Pyspark-installation)
+If not using pyspark at all, you'll have to run the instructions
+pointed [here](#python-without-explicit-Pyspark-installation)
 
 ## Google Colab Notebook
 
-Google Colab is perhaps the easiest way to get started with spark-nlp. It requires no installation or setup other than having a Google account.
+Google Colab is perhaps the easiest way to get started with spark-nlp. It requires no installation or setup other than
+having a Google account.
 
 Run the following code in Google Colab notebook and start using spark-nlp right away.
 
@@ -658,7 +701,9 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 !wget https://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.3 -s 4.3.0
 ```
 
-[Spark NLP quick start on Google Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/quick_start_google_colab.ipynb) is a live demo on Google Colab that performs named entity recognitions and sentiment analysis by using Spark NLP pretrained pipelines.
+[Spark NLP quick start on Google Colab](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp-workshop/blob/master/jupyter/quick_start_google_colab.ipynb)
+is a live demo on Google Colab that performs named entity recognitions and sentiment analysis by using Spark NLP
+pretrained pipelines.
 
 ## Kaggle Kernel
 
@@ -679,7 +724,8 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 !wget https://setup.johnsnowlabs.com/colab.sh -O - | bash /dev/stdin -p 3.2.3 -s 4.3.0
 ```
 
-[Spark NLP quick start on Kaggle Kernel](https://www.kaggle.com/mozzie/spark-nlp-named-entity-recognition) is a live demo on Kaggle Kernel that performs named entity recognitions by using Spark NLP pretrained pipeline.
+[Spark NLP quick start on Kaggle Kernel](https://www.kaggle.com/mozzie/spark-nlp-named-entity-recognition) is a live
+demo on Kaggle Kernel that performs named entity recognitions by using Spark NLP pretrained pipeline.
 
 ## Databricks Cluster
 
@@ -694,17 +740,20 @@ This script comes with the two options to define `pyspark` and `spark-nlp` versi
 
 3. In `Libraries` tab inside your cluster you need to follow these steps:
 
-    3.1. Install New -> PyPI -> `spark-nlp==4.3.0` -> Install
+   3.1. Install New -> PyPI -> `spark-nlp==4.3.0` -> Install
 
-    3.2. Install New -> Maven -> Coordinates -> `com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0` -> Install
+   3.2. Install New -> Maven -> Coordinates -> `com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0` -> Install
 
 4. Now you can attach your notebook to the cluster and use Spark NLP!
 
-NOTE: Databricks' runtimes support different Apache Spark major releases. Please make sure you choose the correct Spark NLP Maven package name (Maven Coordinate) for your runtime from our [Packages Cheatsheet](https://github.com/JohnSnowLabs/spark-nlp#packages-cheatsheet)
+NOTE: Databricks' runtimes support different Apache Spark major releases. Please make sure you choose the correct Spark
+NLP Maven package name (Maven Coordinate) for your runtime from
+our [Packages Cheatsheet](https://github.com/JohnSnowLabs/spark-nlp#packages-cheatsheet)
 
 ## EMR Cluster
 
-To launch EMR clusters with Apache Spark/PySpark and Spark NLP correctly you need to have bootstrap and software configuration.
+To launch EMR clusters with Apache Spark/PySpark and Spark NLP correctly you need to have bootstrap and software
+configuration.
 
 A sample of your bootstrap script
 
@@ -848,16 +897,16 @@ You can use `.config()` during SparkSession creation to set Spark NLP configurat
 ```python
 from pyspark.sql import SparkSession
 
-spark = SparkSession.builder \
-        .master("local[*]") \
-        .config("spark.driver.memory", "16G") \
-        .config("spark.driver.maxResultSize", "0") \
-        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer") \
-        .config("spark.kryoserializer.buffer.max", "2000m") \
-        .config("spark.jsl.settings.pretrained.cache_folder", "sample_data/pretrained") \
-        .config("spark.jsl.settings.storage.cluster_tmp_dir", "sample_data/storage") \
-        .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0") \
-        .getOrCreate()
+spark = SparkSession.builder
+.master("local[*]")
+.config("spark.driver.memory", "16G")
+.config("spark.driver.maxResultSize", "0")
+.config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+.config("spark.kryoserializer.buffer.max", "2000m")
+.config("spark.jsl.settings.pretrained.cache_folder", "sample_data/pretrained")
+.config("spark.jsl.settings.storage.cluster_tmp_dir", "sample_data/storage")
+.config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:4.3.0")
+.getOrCreate()
 ```
 
 **spark-shell:**
@@ -934,14 +983,16 @@ spark.conf.set("spark.jsl.settings.aws.region", "my-region")
 
 **MFA Configuration:**
 
-In case your AWS account is configured with MFA. You will need first to get temporal credentials and add session token to the configuration as shown in the examples below
+In case your AWS account is configured with MFA. You will need first to get temporal credentials and add session token
+to the configuration as shown in the examples below
 For logging:
 
 ```bash
 spark.conf.set("spark.jsl.settings.aws.credentials.session_token", "MY_TOKEN")
 ```
 
-An example of a bash script that gets temporal AWS credentials can be found [here](https://github.com/JohnSnowLabs/spark-nlp/blob/master/scripts/aws_tmp_credentials.sh)
+An example of a bash script that gets temporal AWS credentials can be
+found [here](https://github.com/JohnSnowLabs/spark-nlp/blob/master/scripts/aws_tmp_credentials.sh)
 This script requires three arguments:
 
 ```bash
@@ -961,11 +1012,11 @@ import com.johnsnowlabs.nlp.SparkNLP
 SparkNLP.version()
 
 val testData = spark.createDataFrame(Seq(
-(1, "Google has announced the release of a beta version of the popular TensorFlow machine learning library"),
-(2, "Donald John Trump (born June 14, 1946) is the 45th and current president of the United States")
+  (1, "Google has announced the release of a beta version of the popular TensorFlow machine learning library"),
+  (2, "Donald John Trump (born June 14, 1946) is the 45th and current president of the United States")
 )).toDF("id", "text")
 
-val pipeline = PretrainedPipeline("explain_document_dl", lang="en")
+val pipeline = PretrainedPipeline("explain_document_dl", lang = "en")
 
 val annotation = pipeline.transform(testData)
 
@@ -1005,7 +1056,7 @@ of a particular language for you:
 ```scala
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
 
-ResourceDownloader.showPublicPipelines(lang="en")
+ResourceDownloader.showPublicPipelines(lang = "en")
 /*
 +--------------------------------------------+------+---------+
 | Pipeline                                   | lang | version |
@@ -1025,7 +1076,7 @@ Or if we want to check for a particular version:
 ```scala
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
 
-ResourceDownloader.showPublicPipelines(lang="en", version="3.1.0")
+ResourceDownloader.showPublicPipelines(lang = "en", version = "3.1.0")
 /*
 +---------------------------------------+------+---------+
 | Pipeline                              | lang | version |
@@ -1044,7 +1095,8 @@ ResourceDownloader.showPublicPipelines(lang="en", version="3.1.0")
 
 ### Models
 
-**Some selected languages:** `Afrikaans, Arabic, Armenian, Basque, Bengali, Breton, Bulgarian, Catalan, Czech, Dutch, English, Esperanto, Finnish, French, Galician, German, Greek, Hausa, Hebrew, Hindi, Hungarian, Indonesian, Irish, Italian, Japanese, Latin, Latvian, Marathi, Norwegian, Persian, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Somali, Southern Sotho, Spanish, Swahili, Swedish, Tswana, Turkish, Ukrainian, Zulu`
+**Some selected languages:
+** `Afrikaans, Arabic, Armenian, Basque, Bengali, Breton, Bulgarian, Catalan, Czech, Dutch, English, Esperanto, Finnish, French, Galician, German, Greek, Hausa, Hebrew, Hindi, Hungarian, Indonesian, Irish, Italian, Japanese, Latin, Latvian, Marathi, Norwegian, Persian, Polish, Portuguese, Romanian, Russian, Slovak, Slovenian, Somali, Southern Sotho, Spanish, Swahili, Swedish, Tswana, Turkish, Ukrainian, Zulu`
 
 **Quick online example:**
 
@@ -1057,9 +1109,9 @@ ner_bert = NerDLModel.pretrained('ner_dl_bert')
 
 ```scala
 // load French POS tagger model trained by Universal Dependencies
-val french_pos = PerceptronModel.pretrained("pos_ud_gsd", lang="fr")
+val french_pos = PerceptronModel.pretrained("pos_ud_gsd", lang = "fr")
 // load Italian LemmatizerModel
-val italian_lemma = LemmatizerModel.pretrained("lemma_dxc", lang="it")
+val italian_lemma = LemmatizerModel.pretrained("lemma_dxc", lang = "it")
 ````
 
 **Quick offline example:**
@@ -1068,8 +1120,8 @@ val italian_lemma = LemmatizerModel.pretrained("lemma_dxc", lang="it")
 
 ```scala
 val french_pos = PerceptronModel.load("/tmp/pos_ud_gsd_fr_2.0.2_2.4_1556531457346/")
-      .setInputCols("document", "token")
-      .setOutputCol("pos")
+        .setInputCols("document", "token")
+        .setOutputCol("pos")
 ```
 
 #### Showing Available Models
@@ -1080,7 +1132,7 @@ of a particular Annotator and language for you:
 ```scala
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
 
-ResourceDownloader.showPublicModels(annotator="NerDLModel", lang="en")
+ResourceDownloader.showPublicModels(annotator = "NerDLModel", lang = "en")
 /*
 +---------------------------------------------+------+---------+
 | Model                                       | lang | version |
@@ -1099,7 +1151,7 @@ Or if we want to check for a particular version:
 ```scala
 import com.johnsnowlabs.nlp.pretrained.ResourceDownloader
 
-ResourceDownloader.showPublicModels(annotator="NerDLModel", lang="en", version="3.1.0")
+ResourceDownloader.showPublicModels(annotator = "NerDLModel", lang = "en", version = "3.1.0")
 /*
 +----------------------------+------+---------+
 | Model                      | lang | version |
@@ -1133,26 +1185,35 @@ XlnetEmbeddings
 
 ## Offline
 
-Spark NLP library and all the pre-trained models/pipelines can be used entirely offline with no access to the Internet. If you are behind a proxy or a firewall with no access to the Maven repository (to download packages) or/and no access to S3 (to automatically download models and pipelines), you can simply follow the instructions to have Spark NLP without any limitations offline:
+Spark NLP library and all the pre-trained models/pipelines can be used entirely offline with no access to the Internet.
+If you are behind a proxy or a firewall with no access to the Maven repository (to download packages) or/and no access
+to S3 (to automatically download models and pipelines), you can simply follow the instructions to have Spark NLP without
+any limitations offline:
 
 - Instead of using the Maven package, you need to load our Fat JAR
-- Instead of using PretrainedPipeline for pretrained pipelines or the `.pretrained()` function to download pretrained models, you will need to manually download your pipeline/model from [Models Hub](https://nlp.johnsnowlabs.com/models), extract it, and load it.
+- Instead of using PretrainedPipeline for pretrained pipelines or the `.pretrained()` function to download pretrained
+  models, you will need to manually download your pipeline/model from [Models Hub](https://nlp.johnsnowlabs.com/models),
+  extract it, and load it.
 
 Example of `SparkSession` with Fat JAR to have Spark NLP offline:
 
 ```python
-spark = SparkSession.builder \
-    .appName("Spark NLP")\
-    .master("local[*]")\
-    .config("spark.driver.memory","16G")\
-    .config("spark.driver.maxResultSize", "0") \
-    .config("spark.kryoserializer.buffer.max", "2000M")\
-    .config("spark.jars", "/tmp/spark-nlp-assembly-4.3.0.jar")\
-    .getOrCreate()
+spark = SparkSession.builder
+.appName("Spark NLP")
+.master("local[*]")
+.config("spark.driver.memory", "16G")
+.config("spark.driver.maxResultSize", "0")
+.config("spark.kryoserializer.buffer.max", "2000M")
+.config("spark.jars", "/tmp/spark-nlp-assembly-4.3.0.jar")
+.getOrCreate()
 ```
 
-- You can download provided Fat JARs from each [release notes](https://github.com/JohnSnowLabs/spark-nlp/releases), please pay attention to pick the one that suits your environment depending on the device (CPU/GPU) and Apache Spark version (3.0.x, 3.1.x, 3.2.x, and 3.3.x)
-- If you are local, you can load the Fat JAR from your local FileSystem, however, if you are in a cluster setup you need to put the Fat JAR on a distributed FileSystem such as HDFS, DBFS, S3, etc. (i.e., `hdfs:///tmp/spark-nlp-assembly-4.3.0.jar`)
+- You can download provided Fat JARs from each [release notes](https://github.com/JohnSnowLabs/spark-nlp/releases),
+  please pay attention to pick the one that suits your environment depending on the device (CPU/GPU) and Apache Spark
+  version (3.0.x, 3.1.x, 3.2.x, and 3.3.x)
+- If you are local, you can load the Fat JAR from your local FileSystem, however, if you are in a cluster setup you need
+  to put the Fat JAR on a distributed FileSystem such as HDFS, DBFS, S3, etc. (
+  i.e., `hdfs:///tmp/spark-nlp-assembly-4.3.0.jar`)
 
 Example of using pretrained Models and Pipelines in offline:
 
@@ -1160,9 +1221,9 @@ Example of using pretrained Models and Pipelines in offline:
 # instead of using pretrained() for online:
 # french_pos = PerceptronModel.pretrained("pos_ud_gsd", lang="fr")
 # you download this model, extract it, and use .load
-french_pos = PerceptronModel.load("/tmp/pos_ud_gsd_fr_2.0.2_2.4_1556531457346/")\
-      .setInputCols("document", "token")\
-      .setOutputCol("pos")
+french_pos = PerceptronModel.load("/tmp/pos_ud_gsd_fr_2.0.2_2.4_1556531457346/")
+.setInputCols("document", "token")
+.setOutputCol("pos")
 
 # example for pipelines
 # instead of using PretrainedPipeline
@@ -1171,12 +1232,16 @@ french_pos = PerceptronModel.load("/tmp/pos_ud_gsd_fr_2.0.2_2.4_1556531457346/")
 PipelineModel.load("/tmp/explain_document_dl_en_2.0.2_2.4_1556530585689/")
 ```
 
-- Since you are downloading and loading models/pipelines manually, this means Spark NLP is not downloading the most recent and compatible models/pipelines for you. Choosing the right model/pipeline is on you
-- If you are local, you can load the model/pipeline from your local FileSystem, however, if you are in a cluster setup you need to put the model/pipeline on a distributed FileSystem such as HDFS, DBFS, S3, etc. (i.e., `hdfs:///tmp/explain_document_dl_en_2.0.2_2.4_1556530585689/`)
+- Since you are downloading and loading models/pipelines manually, this means Spark NLP is not downloading the most
+  recent and compatible models/pipelines for you. Choosing the right model/pipeline is on you
+- If you are local, you can load the model/pipeline from your local FileSystem, however, if you are in a cluster setup
+  you need to put the model/pipeline on a distributed FileSystem such as HDFS, DBFS, S3, etc. (
+  i.e., `hdfs:///tmp/explain_document_dl_en_2.0.2_2.4_1556530585689/`)
 
 ## Examples
 
-Need more **examples**? Check out our dedicated [Spark NLP Showcase](https://github.com/JohnSnowLabs/spark-nlp-workshop) repository to showcase all Spark NLP use cases!
+Need more **examples**? Check out our dedicated [Spark NLP Showcase](https://github.com/JohnSnowLabs/spark-nlp-workshop)
+repository to showcase all Spark NLP use cases!
 
 Also, don't forget to check [Spark NLP in Action](https://nlp.johnsnowlabs.com/demo) built by Streamlit.
 
@@ -1188,7 +1253,8 @@ Also, don't forget to check [Spark NLP in Action](https://nlp.johnsnowlabs.com/d
 
 ## Citation
 
-We have published a [paper](https://www.sciencedirect.com/science/article/pii/S2665963821000063) that you can cite for the Spark NLP library:
+We have published a [paper](https://www.sciencedirect.com/science/article/pii/S2665963821000063) that you can cite for
+the Spark NLP library:
 
 ```bibtex
 @article{KOCAMAN2021100058,

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -64,7 +64,7 @@ embeddings = annotator
 
 
 def start(gpu=False,
-          m1=False,
+          apple_silicon=False,
           aarch64=False,
           memory="16G",
           cache_folder="",
@@ -93,8 +93,8 @@ def start(gpu=False,
     ----------
     gpu : bool, optional
         Whether to enable GPU acceleration (must be set up correctly), by default False
-    m1 : bool, optional
-        Whether to enable M1 support for macOS
+    apple_silicon : bool, optional
+        Whether to enable Apple Silicon support for macOS
     aarch64 : bool, optional
         Whether to enable Linux Aarch64 support
     memory : str, optional
@@ -137,8 +137,8 @@ def start(gpu=False,
             # Spark NLP on CPU or GPU
             self.maven_spark3 = "com.johnsnowlabs.nlp:spark-nlp_2.12:{}".format(current_version)
             self.maven_gpu_spark3 = "com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:{}".format(current_version)
-            # Spark NLP on M1
-            self.maven_m1 = "com.johnsnowlabs.nlp:spark-nlp-m1_2.12:{}".format(current_version)
+            # Spark NLP on Apple Silicon
+            self.maven_silicon = "com.johnsnowlabs.nlp:spark-nlp-silicon_2.12:{}".format(current_version)
             # Spark NLP on Linux Aarch64
             self.maven_aarch64 = "com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:{}".format(current_version)
 
@@ -151,8 +151,8 @@ def start(gpu=False,
             .config("spark.kryoserializer.buffer.max", spark_nlp_config.serializer_max_buffer) \
             .config("spark.driver.maxResultSize", spark_nlp_config.driver_max_result_size)
 
-        if m1:
-            spark_jars_packages = spark_nlp_config.maven_m1
+        if apple_silicon:
+            spark_jars_packages = spark_nlp_config.maven_silicon
         elif aarch64:
             spark_jars_packages = spark_nlp_config.maven_aarch64
         elif gpu:
@@ -192,8 +192,8 @@ def start(gpu=False,
                 spark_conf.set("spark.kryoserializer.buffer.max", spark_nlp_config.serializer_max_buffer)
                 spark_conf.set("spark.driver.maxResultSize", spark_nlp_config.driver_max_result_size)
 
-                if m1:
-                    spark_jars_packages = spark_nlp_config.maven_m1
+                if apple_silicon:
+                    spark_jars_packages = spark_nlp_config.maven_silicon
                 elif aarch64:
                     spark_jars_packages = spark_nlp_config.maven_aarch64
                 elif gpu:

--- a/src/main/scala/com/johnsnowlabs/nlp/MultiDocumentAssembler.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/MultiDocumentAssembler.scala
@@ -27,9 +27,8 @@ import com.johnsnowlabs.nlp.AnnotatorType._
 
 /** Prepares data into a format that is processable by Spark NLP. This is the entry point for
   * every Spark NLP pipeline. The `MultiDocumentAssembler` can read either a `String` column or an
-  * `Array[String]`. Additionally, [[setCleanupMode]] can be used to
-  * pre-process the text (Default: `disabled`). For possible options please refer the parameters
-  * section.
+  * `Array[String]`. Additionally, [[setCleanupMode]] can be used to pre-process the text
+  * (Default: `disabled`). For possible options please refer the parameters section.
   *
   * For more extended examples on document pre-processing see the
   * [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/document-assembler/Loading_Multiple_Documents.ipynb Examples]].

--- a/src/main/scala/com/johnsnowlabs/nlp/SparkNLP.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/SparkNLP.scala
@@ -23,15 +23,15 @@ object SparkNLP {
   val currentVersion = "4.3.0"
   val MavenSpark3 = s"com.johnsnowlabs.nlp:spark-nlp_2.12:$currentVersion"
   val MavenGpuSpark3 = s"com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:$currentVersion"
-  val MavenSparkM1 = s"com.johnsnowlabs.nlp:spark-nlp-m1_2.12:$currentVersion"
+  val MavenSparkSilicon = s"com.johnsnowlabs.nlp:spark-nlp-silicon_2.12:$currentVersion"
   val MavenSparkAarch64 = s"com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:$currentVersion"
 
   /** Start SparkSession with Spark NLP
     *
     * @param gpu
     *   start Spark NLP with GPU
-    * @param m1
-    *   start Spark NLP for Apple M1 systems
+    * @param apple_silicon
+    *   start Spark NLP for Apple M1 & M2 systems
     * @param aarch64
     *   start Spark NLP for Linux Aarch64 systems
     * @param memory
@@ -52,7 +52,7 @@ object SparkNLP {
     */
   def start(
       gpu: Boolean = false,
-      m1: Boolean = false,
+      apple_silicon: Boolean = false,
       aarch64: Boolean = false,
       memory: String = "16G",
       cache_folder: String = "",
@@ -68,8 +68,8 @@ object SparkNLP {
       .config("spark.kryoserializer.buffer.max", "2000M")
       .config("spark.driver.maxResultSize", "0")
 
-    if (m1) {
-      build.config("spark.jars.packages", MavenSparkM1)
+    if (apple_silicon) {
+      build.config("spark.jars.packages", MavenSparkSilicon)
     } else if (aarch64) {
       build.config("spark.jars.packages", MavenSparkAarch64)
     } else if (gpu) {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/audio/HubertForCTC.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/audio/HubertForCTC.scala
@@ -39,7 +39,7 @@ import org.json4s.jackson.JsonMethods._
   * pre-processed an array of floats.
   *
   * Note that this annotator is currently not supported on Apple Silicon processors such as the
-  * M1. This is due to the processor not supporting instructions for XLA.
+  * M1/M2 (Apple Silicon). This is due to the processor not supporting instructions for XLA.
   *
   * Pretrained models can be loaded with `pretrained` of the companion object:
   * {{{

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/audio/Wav2Vec2ForCTC.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/audio/Wav2Vec2ForCTC.scala
@@ -47,7 +47,7 @@ import org.json4s.jackson.JsonMethods._
   * pre-processed an array of floats.
   *
   * Note that this annotator is currently not supported on Apple Silicon processors such as the
-  * M1. This is due to the processor not supporting instructions for XLA.
+  * M1/M2 (Apple Silicon). This is due to the processor not supporting instructions for XLA.
   *
   * Pretrained models can be loaded with `pretrained` of the companion object:
   * {{{

--- a/src/main/scala/com/johnsnowlabs/nlp/training/CoNLL.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/training/CoNLL.scala
@@ -207,8 +207,6 @@ case class CoNLL(
     }
 
     val docs = lines
-
-
       .flatMap { line =>
         val items = line.trim.split(delimiter)
         if (items.nonEmpty && items(0) == "-DOCSTART-") {

--- a/src/test/scala/com/johnsnowlabs/nlp/training/CoNLLTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/training/CoNLLTestSpec.scala
@@ -8,23 +8,28 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 class CoNLLTestSpec extends AnyFlatSpec {
 
-  private val expectedColumnNames: Seq[String] = Seq("document", "sentence", "token", "pos", "label")
-  private val expectedAnnotatorTypes: Seq[String] = Seq("document", "document", "token", "pos", "named_entity")
+  private val expectedColumnNames: Seq[String] =
+    Seq("document", "sentence", "token", "pos", "label")
+  private val expectedAnnotatorTypes: Seq[String] =
+    Seq("document", "document", "token", "pos", "named_entity")
 
   private def assertNamesAndTypes(trainingDataSchema: Seq[StructField]) = {
     val annotatorSchema = trainingDataSchema
     val comparedColumnNames = annotatorSchema.map(_.name).zip(expectedColumnNames)
-    val comparedAnnotationTypes = annotatorSchema.map(_.metadata.getString("annotatorType")).zip(expectedAnnotatorTypes)
+    val comparedAnnotationTypes =
+      annotatorSchema.map(_.metadata.getString("annotatorType")).zip(expectedAnnotatorTypes)
     assert((comparedColumnNames ++ comparedAnnotationTypes).forall(x => x._1 == x._2))
   }
 
   private def assertDocIds(trainingData: Dataset[_], expectedDocIds: Seq[String]) = {
-    val comparedDocIds = trainingData.select("doc_id").collect.map(_.getString(0)).zip(expectedDocIds).toSeq
+    val comparedDocIds =
+      trainingData.select("doc_id").collect.map(_.getString(0)).zip(expectedDocIds).toSeq
     assert(comparedDocIds.forall(x => x._1 == x._2))
   }
 
   "CoNLL" should "read a CoNLL and have the columns in the right order" taggedAs FastTest in {
-    val trainingData = CoNLL().readDataset(ResourceHelper.spark, "src/test/resources/conll/test_conll_docid.txt")
+    val trainingData =
+      CoNLL().readDataset(ResourceHelper.spark, "src/test/resources/conll/test_conll_docid.txt")
     assertNamesAndTypes(trainingData.schema.tail)
   }
 
@@ -34,14 +39,16 @@ class CoNLLTestSpec extends AnyFlatSpec {
   }
 
   "CoNLL" should "read a CoNLL with ids and have the columns in the right order" taggedAs FastTest in {
-    val trainingData = CoNLL(includeDocId = true).readDataset(ResourceHelper.spark, "src/test/resources/conll/test_conll_docid.txt")
+    val trainingData = CoNLL(includeDocId = true)
+      .readDataset(ResourceHelper.spark, "src/test/resources/conll/test_conll_docid.txt")
     val expectedDocIds = Seq("O", "1", "2", "3-1", "3-2")
     assertNamesAndTypes(trainingData.schema.tail.tail)
     assertDocIds(trainingData, expectedDocIds)
   }
 
   "CoNLL" should "read a CoNLL with ids and have the columns in the right order using * pattern" taggedAs FastTest in {
-    val trainingData = CoNLL(includeDocId = true).readDataset(ResourceHelper.spark, "src/test/resources/conll/*")
+    val trainingData =
+      CoNLL(includeDocId = true).readDataset(ResourceHelper.spark, "src/test/resources/conll/*")
     val expectedDocIds = Seq("O", "1", "2", "3-1", "3-2")
     assertNamesAndTypes(trainingData.schema.tail.tail)
     assertDocIds(trainingData, expectedDocIds)


### PR DESCRIPTION
Spark NLP supports `m1` and `m2` under experimental status (still requires CI/CD to build/test before it is GA). We will refactor `m1` to `silicon` and `apple_silicon` to be more generic.