### PR TITLE
SPARKNLP-743: Add parameter to SparkNLP.start

### DIFF
--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -107,11 +107,13 @@ def start(gpu=False,
         for WordEmbeddings. By default, this locations is the location of
         `hadoop.tmp.dir` set via Hadoop configuration for Apache Spark. NOTE: `S3` is
         not supported and it must be local, HDFS, or DBFS.
+    params : dict, optional
+        Custom parameters to set for the Spark configuration, by default None.
     cluster_tmp_dir : str, optional
         The location to save logs from annotators during training. If not set, it will
         be in the users home directory under `annotator_logs`.
     real_time_output : bool, optional
-        Whether to output in real time, by default False
+        Whether to read and print JVM output in real time, by default False
     output_level : int, optional
         Output level for logs, by default 1
 

--- a/src/test/java/com/johnsnowlabs/nlp/GeneralAnnotationsTest.java
+++ b/src/test/java/com/johnsnowlabs/nlp/GeneralAnnotationsTest.java
@@ -27,6 +27,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import scala.collection.immutable.HashMap;
 
 import java.util.LinkedList;
 
@@ -46,14 +47,13 @@ public class GeneralAnnotationsTest {
         Pipeline pipeline = new Pipeline();
         pipeline.setStages(new PipelineStage[]{document, tokenizer});
 
-        SparkSession spark = com.johnsnowlabs.nlp.SparkNLP.start(
-                false,
+        SparkSession spark = com.johnsnowlabs.nlp.SparkNLP.start(false,
                 false,
                 false,
                 "16G",
                 "",
                 "",
-                "");
+                "", new HashMap<>());
 
         LinkedList<String> text = new java.util.LinkedList<>();
 

--- a/src/test/scala/com/johnsnowlabs/nlp/SparkNLPTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/SparkNLPTestSpec.scala
@@ -1,0 +1,27 @@
+package com.johnsnowlabs.nlp
+
+import com.johnsnowlabs.tags.SlowTest
+import com.johnsnowlabs.util.ConfigHelper.{awsJavaSdkVersion, hadoopAwsVersion}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class SparkNLPTestSpec extends AnyFlatSpec {
+
+  behavior of "SparkNLPTestSpec"
+
+  it should "start with extra parameters" taggedAs SlowTest ignore {
+    val extraParams: Map[String, String] = Map(
+      "spark.jars.packages" -> ("org.apache.hadoop:hadoop-aws:" + hadoopAwsVersion + ",com.amazonaws:aws-java-sdk:" + awsJavaSdkVersion),
+      "spark.hadoop.fs.s3a.path.style.access" -> "true")
+
+    val spark = SparkNLP.start(params = extraParams)
+
+    assert(spark.conf.get("spark.hadoop.fs.s3a.path.style.access") == "true")
+
+    Seq(
+      "com.johnsnowlabs.nlp:spark-nlp",
+      "org.apache.hadoop:hadoop-aws",
+      "com.amazonaws:aws-java-sdk").foreach { pkg =>
+      assert(spark.conf.get("spark.jars.packages").contains(pkg))
+    }
+  }
+}


### PR DESCRIPTION
- Added params parameter which can supply custom configurations to the SparkSession

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds additional parameters that are available in the python version but not in the Scala version.
- added the `params` parameter, that enables users to add extra spark configurations easily
- python parameters `real_time_output` and `output_level` do not apply, as they forward the output of the JVMs to the python program

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a new test (ignore for CI) for SparkNLP start

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
