### PR TITLE
Fixed links after the change in example to examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,6 +293,9 @@ venv.bak/
 # mypy
 .mypy_cache/
 
+# VS Code
+**/.vscode
+
 ### SBT ###
 # Simple Build Tool
 # http://www.scala-sbt.org/release/docs/Getting-Started/Directories.html#configuring-version-control

--- a/docs/en/annotator_entries/ChunkEmbeddings.md
+++ b/docs/en/annotator_entries/ChunkEmbeddings.md
@@ -7,7 +7,7 @@ This annotator utilizes WordEmbeddings, BertEmbeddings etc. to generate chunk em
 [Chunker](/docs/en/annotators#chunker), [NGramGenerator](/docs/en/annotators#ngramgenerator),
 or [NerConverter](/docs/en/annotators#nerconverter) outputs.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/embeddings/ChunkEmbeddings.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/embeddings/ChunkEmbeddings.ipynb)
 and the [ChunkEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/Chunker.md
+++ b/docs/en/annotator_entries/Chunker.md
@@ -21,7 +21,7 @@ val chunker = new Chunker()
 When defining the regular expressions, tags enclosed in angle brackets are treated as groups, so here specifically
 `"<NNP>+"` means 1 or more nouns in succession. Additional patterns can also be set with `addRegexParsers`.
 
-For more extended examples see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/chunking/Chunk_Extraction_with_Chunker.ipynb))
+For more extended examples see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/chunking/Chunk_Extraction_with_Chunker.ipynb))
 and the  [ChunkerTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ChunkerTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/ClassifierDL.md
+++ b/docs/en/annotator_entries/ClassifierDL.md
@@ -24,7 +24,7 @@ The default model is `"classifierdl_use_trec6"`, if no name is provided. It uses
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Text+Classification).
 
 For extended examples of usage, see the
-[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb)
+[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb)
 and the [ClassifierDLTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLTestSpec.scala).
 {%- endcapture -%}
 
@@ -188,8 +188,8 @@ val classifier = new ClassifierDLApproach()
 ```
 
 For extended examples of usage, see the Examples
-[[1] ](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/scala/training/Train%20Multi-Class%20Text%20Classification%20on%20News%20Articles.scala)
-[[2] ](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb)
+[[1] ](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/scala/training/Train%20Multi-Class%20Text%20Classification%20on%20News%20Articles.scala)
+[[2] ](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb)
 and the [ClassifierDLTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/ContextSpellChecker.md
+++ b/docs/en/annotator_entries/ContextSpellChecker.md
@@ -26,7 +26,7 @@ val spellChecker = ContextSpellCheckerModel.pretrained()
 The default model is `"spellcheck_dl"`, if no name is provided.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Spell+Check).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb)
 and the [ContextSpellCheckerTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala).
 {%- endcapture -%}
 
@@ -142,7 +142,7 @@ certain number of errors, `ContextSpellChecker` will rank correction sequences a
 For an in-depth explanation of the module see the article [Applying Context Aware Spell Checking in Spark NLP](https://medium.com/spark-nlp/applying-context-aware-spell-checking-in-spark-nlp-3c29c46963bc).
 
 For extended examples of usage, see the article [Training a Contextual Spell Checker for Italian Language](https://towardsdatascience.com/training-a-contextual-spell-checker-for-italian-language-66dda528e4bf),
-the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb)
+the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb)
 and the [ContextSpellCheckerTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/spell/context/ContextSpellCheckerTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/DateMatcher.md
+++ b/docs/en/annotator_entries/DateMatcher.md
@@ -23,7 +23,7 @@ For example `"The 31st of April in the year 2008"` will be converted into `2008/
 
 Pretrained pipelines are available for this module, see [Pipelines](https://nlp.johnsnowlabs.com/docs/en/pipelines).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/MultiDateMatcherMultiLanguage_en.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/MultiDateMatcherMultiLanguage_en.ipynb)
 and the [DateMatcherTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/DateMatcherTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/DependencyParser.md
+++ b/docs/en/annotator_entries/DependencyParser.md
@@ -21,7 +21,7 @@ val dependencyParserApproach = DependencyParserModel.pretrained()
 The default model is `"dependency_conllu"`, if no name is provided.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/graph-extraction/graph_extraction_intro.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/graph-extraction/graph_extraction_intro.ipynb)
 and the [DependencyParserApproachTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/parser/dep/DependencyParserApproachTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/DocumentAssembler.md
+++ b/docs/en/annotator_entries/DocumentAssembler.md
@@ -8,7 +8,7 @@ The `DocumentAssembler` can read either a `String` column or an `Array[String]`.
 can be used to pre-process the text (Default: `disabled`). For possible options please refer the parameters section.
 
 For more extended examples on document pre-processing see the
-[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/document-assembler/Loading_Documents_With_DocumentAssembler.ipynb).
+[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/document-assembler/Loading_Documents_With_DocumentAssembler.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/annotator_entries/DocumentNormalizer.md
+++ b/docs/en/annotator_entries/DocumentNormalizer.md
@@ -8,7 +8,7 @@ Removes all dirty characters from text following one or more input regex pattern
 Can apply not wanted character removal with a specific policy.
 Can apply lower case normalization.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/document-normalizer/document_normalizer_notebook.ipynb
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/document-normalizer/document_normalizer_notebook.ipynb
 ).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/EmbeddingsFinisher.md
+++ b/docs/en/annotator_entries/EmbeddingsFinisher.md
@@ -16,7 +16,7 @@ compatible with Spark ML functions such as LDA, K-mean, Random Forest classifier
 `featureCol`.
 
 For more extended examples see the
-[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/text-similarity/Spark_NLP_Spark_ML_Text_Similarity.ipynb).
+[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-similarity/Spark_NLP_Spark_ML_Text_Similarity.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/annotator_entries/Finisher.md
+++ b/docs/en/annotator_entries/Finisher.md
@@ -7,7 +7,7 @@ Converts annotation results into a format that easier to use. It is useful to ex
 Pipelines. The Finisher outputs annotation(s) values into `String`.
 
 For more extended examples on document pre-processing see the
-[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/model-downloader/Create%20custom%20pipeline%20-%20NerDL.ipynb
+[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/model-downloader/Create%20custom%20pipeline%20-%20NerDL.ipynb
 ).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/LanguageDetectorDL.md
+++ b/docs/en/annotator_entries/LanguageDetectorDL.md
@@ -21,7 +21,7 @@ The default model is `"ld_wiki_tatoeba_cnn_21"`, default language is `"xx"` (mea
 if no values are provided.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Language+Detection).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/language-detection/Language_Detection_and_Indentification.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/language-detection/Language_Detection_and_Indentification.ipynb)
 And the [LanguageDetectorDLTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ld/dl/LanguageDetectorDLTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/Lemmatizer.md
+++ b/docs/en/annotator_entries/Lemmatizer.md
@@ -54,7 +54,7 @@ The dictionary can be set as a delimited text file.
 Pretrained models can be loaded with `LemmatizerModel.pretrained`.
 
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Lemmatization).
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/italian/Train-Lemmatizer-Italian.ipynb).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/italian/Train-Lemmatizer-Italian.ipynb).
 {%- endcapture -%}
 
 {%- capture approach_input_anno -%}

--- a/docs/en/annotator_entries/MultiClassifierDL.md
+++ b/docs/en/annotator_entries/MultiClassifierDL.md
@@ -34,7 +34,7 @@ of the classes the instance can be assigned to.
 Formally, multi-label classification is the problem of finding a model that maps inputs x to binary vectors y
 (assigning a value of 0 or 1 for each element (label) in y).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb)
 and the [MultiClassifierDLTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MultiClassifierDLTestSpec.scala).
 {%- endcapture -%}
 
@@ -193,7 +193,7 @@ val multiClassifier = new MultiClassifierDLApproach()
   .setTestDataset("test_data")
 ```
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb)
 and the [MultiClassifierDLTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MultiClassifierDLTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/MultiDateMatcher.md
+++ b/docs/en/annotator_entries/MultiDateMatcher.md
@@ -16,7 +16,7 @@ Reads the following kind of dates:
 
 For example `"The 31st of April in the year 2008"` will be converted into `2008/04/31`.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/MultiDateMatcherMultiLanguage_en.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/MultiDateMatcherMultiLanguage_en.ipynb)
 and the [MultiDateMatcherTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/MultiDateMatcherTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/MultiDocumentAssembler.md
+++ b/docs/en/annotator_entries/MultiDocumentAssembler.md
@@ -10,7 +10,7 @@ pre-process the text (Default: `disabled`). For possible options please refer th
 section.
 
 For more extended examples on document pre-processing see the
-[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/document-assembler/Loading_Multiple_Documents.ipynb).
+[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/document-assembler/Loading_Multiple_Documents.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/annotator_entries/NGramGenerator.md
+++ b/docs/en/annotator_entries/NGramGenerator.md
@@ -13,7 +13,7 @@ When the input is empty, an empty array is returned.
 When the input array length is less than n (number of elements per n-gram), no n-grams are
 returned.
 
-For more extended examples see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/chunking/NgramGenerator.ipynb)
+For more extended examples see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/chunking/NgramGenerator.ipynb)
 and the [NGramGeneratorTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/NGramGeneratorTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/NerCrf.md
+++ b/docs/en/annotator_entries/NerCrf.md
@@ -24,7 +24,7 @@ val nerTagger = NerCrfModel.pretrained()
 The default model is `"ner_crf"`, if no name is provided.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Named+Entity+Recognition).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/crf-ner/ner_dl_crf.ipynb).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/crf-ner/ner_dl_crf.ipynb).
 {%- endcapture -%}
 
 {%- capture model_input_anno -%}
@@ -175,7 +175,7 @@ Excluding the label, this can be done with for example
 
 Optionally the user can provide an entity dictionary file with setExternalFeatures for better accuracy.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/crf-ner/ner_dl_crf.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/crf-ner/ner_dl_crf.ipynb)
 and the [NerCrfApproachTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/crf/NerCrfApproachTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/NerDL.md
+++ b/docs/en/annotator_entries/NerDL.md
@@ -25,7 +25,7 @@ Note that some pretrained models require specific types of embeddings, depending
 For example, the default model `"ner_dl"` requires the
 [WordEmbeddings](/docs/en/annotators#wordembeddings) `"glove_100d"`.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/model-downloader/Create%20custom%20pipeline%20-%20NerDL.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/model-downloader/Create%20custom%20pipeline%20-%20NerDL.ipynb)
 and the [NerDLSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala).
 {%- endcapture -%}
 
@@ -202,7 +202,7 @@ val nerTagger = new NerDLApproach()
   .setTestDataset("test_data")
 ```
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner)
 and the [NerDLSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/Normalizer.md
+++ b/docs/en/annotator_entries/Normalizer.md
@@ -30,7 +30,7 @@ TOKEN
 Annotator that cleans out tokens. Requires stems, hence tokens.
 Removes all dirty characters from text following a regex pattern and transforms words based on a provided dictionary
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/document-normalizer/document_normalizer_notebook.ipynb).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/document-normalizer/document_normalizer_notebook.ipynb).
 {%- endcapture -%}
 
 {%- capture approach_input_anno -%}

--- a/docs/en/annotator_entries/Perceptron.md
+++ b/docs/en/annotator_entries/Perceptron.md
@@ -20,7 +20,7 @@ The default model is `"pos_anc"`, if no name is provided.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Part+of+Speech+Tagging).
 Additionally, pretrained pipelines are available for this module, see [Pipelines](https://nlp.johnsnowlabs.com/docs/en/pipelines).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/french/Train-Perceptron-French.ipynb).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/french/Train-Perceptron-French.ipynb).
 {%- endcapture -%}
 
 {%- capture model_input_anno -%}
@@ -157,7 +157,7 @@ POS().readDataset(spark, datasetPath).selectExpr("explode(tags) as tags").show(f
                       ...
 ```
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/french/Train-Perceptron-French.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/french/Train-Perceptron-French.ipynb)
 and [PerceptronApproach tests](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/RecursiveTokenizer.md
+++ b/docs/en/annotator_entries/RecursiveTokenizer.md
@@ -36,7 +36,7 @@ Unlike the Tokenizer, the RecursiveTokenizer operates based on these array strin
  - `infixes`: Strings that will be split when found at the middle of token.
  - `whitelist`: Whitelist of strings not to split
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb)
 and the [TokenizerTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/RegexMatcher.md
+++ b/docs/en/annotator_entries/RegexMatcher.md
@@ -42,7 +42,7 @@ To use an external file, a dictionary of predefined regular expressions must be 
 
 Pretrained pipelines are available for this module, see [Pipelines](https://nlp.johnsnowlabs.com/docs/en/pipelines).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/regex-matcher/Matching_Text_with_RegexMatcher.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/regex-matcher/Matching_Text_with_RegexMatcher.ipynb)
 and the [RegexMatcherTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/RegexMatcherTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/SentenceDetector.md
+++ b/docs/en/annotator_entries/SentenceDetector.md
@@ -36,7 +36,7 @@ If only the custom bounds should be used, then the parameter `useCustomBoundsOnl
 Each extracted sentence can be returned in an Array or exploded to separate rows,
 if `explodeSentences` is set to `true`.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/sentence-detection/SentenceDetector_advanced_examples.ipynb).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/sentence-detection/SentenceDetector_advanced_examples.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/annotator_entries/SentenceDetectorDL.md
+++ b/docs/en/annotator_entries/SentenceDetectorDL.md
@@ -20,7 +20,7 @@ For available pretrained models please see the [Models Hub](https://nlp.johnsnow
 Each extracted sentence can be returned in an Array or exploded to separate rows,
 if `explodeSentences` is set to `true`.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/multilingual/SentenceDetectorDL.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/multilingual/SentenceDetectorDL.ipynb)
 and the [SentenceDetectorDLSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLSpec.scala).
 {%- endcapture -%}
 
@@ -168,7 +168,7 @@ using a CNN architecture. We also modified the original implementation a little 
 Each extracted sentence can be returned in an Array or exploded to separate rows,
 if `explodeSentences` is set to `true`.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/multilingual/SentenceDetectorDL.ipynb) and the [SentenceDetectorDLSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLSpec.scala).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/multilingual/SentenceDetectorDL.ipynb) and the [SentenceDetectorDLSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLSpec.scala).
 {%- endcapture -%}
 
 {%- capture approach_input_anno -%}

--- a/docs/en/annotator_entries/SentenceEmbeddings.md
+++ b/docs/en/annotator_entries/SentenceEmbeddings.md
@@ -10,7 +10,7 @@ or document embeddings by either summing up or averaging all the word embeddings
 This can be configured with `setPoolingStrategy`, which either be `"AVERAGE"` or `"SUM"`.
 
 For more extended examples see the
-[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/text-similarity/Spark_NLP_Spark_ML_Text_Similarity.ipynb).
+[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-similarity/Spark_NLP_Spark_ML_Text_Similarity.ipynb).
 and the [SentenceEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/SentenceEmbeddingsTestSpec.scala).
 
 **TIP:** Here is how you can explode and convert these embeddings into `Vectors` or what's known as `Feature` column so it can be used in Spark ML regression or clustering functions:

--- a/docs/en/annotator_entries/SentimentDL.md
+++ b/docs/en/annotator_entries/SentimentDL.md
@@ -21,7 +21,7 @@ The default model is `"sentimentdl_use_imdb"`, if no name is provided. It is eng
 the IMDB dataset.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Sentiment+Analysis).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb)
 and the [SentimentDLTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLTestSpec.scala).
 {%- endcapture -%}
 
@@ -176,7 +176,7 @@ val classifier = new SentimentDLApproach()
   .setTestDataset("test_data")
 ```
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb)
 and the [SentimentDLTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/SentimentDLTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/SentimentDetector.md
+++ b/docs/en/annotator_entries/SentimentDetector.md
@@ -15,7 +15,7 @@ The dictionary can be set as a delimited text file.
 By default, the sentiment score will be assigned labels `"positive"` if the score is `>= 0`, else `"negative"`.
 To retrieve the raw sentiment scores, `enableScore` needs to be set to `true`.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dictionary-sentiment/sentiment.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dictionary-sentiment/sentiment.ipynb)
 and the [SentimentTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/PragmaticSentimentTestSpec.scala).
 {%- endcapture -%}
 
@@ -49,7 +49,7 @@ The dictionary can be set as a delimited text file.
 By default, the sentiment score will be assigned labels `"positive"` if the score is `>= 0`, else `"negative"`.
 To retrieve the raw sentiment scores, `enableScore` needs to be set to `true`.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dictionary-sentiment/sentiment.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dictionary-sentiment/sentiment.ipynb)
 and the [SentimentTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/sda/pragmatic/PragmaticSentimentTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/Stemmer.md
+++ b/docs/en/annotator_entries/Stemmer.md
@@ -4,7 +4,7 @@ Stemmer
 
 {%- capture description -%}
 Returns hard-stems out of words with the objective of retrieving the meaningful part of the word.
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/stemmer/Word_Stemming_with_Stemmer.ipynb).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/stemmer/Word_Stemming_with_Stemmer.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/annotator_entries/StopWordsCleaner.md
+++ b/docs/en/annotator_entries/StopWordsCleaner.md
@@ -19,7 +19,7 @@ val stopWords = StopWordsCleaner.pretrained()
 ```
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Stop+Words+Removal).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/stop-words/StopWordsCleaner.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/stop-words/StopWordsCleaner.ipynb)
 and [StopWordsCleanerTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/StopWordsCleanerTestSpec.scala).
 
 

--- a/docs/en/annotator_entries/TextMatcher.md
+++ b/docs/en/annotator_entries/TextMatcher.md
@@ -33,7 +33,7 @@ Annotator to match exact phrases (by token) provided in a file against a Documen
 A text file of predefined phrases must be provided with `setEntities`.
 
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/text-matcher-pipeline/extractor.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-matcher-pipeline/extractor.ipynb)
 and the [TextMatcherTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/TextMatcherTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/TokenAssembler.md
+++ b/docs/en/annotator_entries/TokenAssembler.md
@@ -8,7 +8,7 @@ lemmatized, normalized, spell checked, etc, in order to use this document annota
 Requires `DOCUMENT` and `TOKEN` type annotations as input.
 
 For more extended examples on document pre-processing see the
-[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/token-assembler/Assembling_Tokens_to_Documents.ipynb).
+[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/token-assembler/Assembling_Tokens_to_Documents.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/annotator_entries/Tokenizer.md
+++ b/docs/en/annotator_entries/Tokenizer.md
@@ -38,7 +38,7 @@ This class represents a non fitted tokenizer. Fitting it will cause the internal
 Identifies tokens with tokenization open standards. A few rules will help customizing it if defaults do not fit user needs.
 
 For extended examples of usage see the
-[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/document-normalizer/document_normalizer_notebook.ipynb)
+[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/document-normalizer/document_normalizer_notebook.ipynb)
 and [Tokenizer test class](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/TokenizerTestSpec.scala)
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/TypedDependencyParser.md
+++ b/docs/en/annotator_entries/TypedDependencyParser.md
@@ -21,7 +21,7 @@ val typedDependencyParser = TypedDependencyParserModel.pretrained()
 The default model is `"dependency_typed_conllu"`, if no name is provided.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/graph-extraction/graph_extraction_intro.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/graph-extraction/graph_extraction_intro.ipynb)
 and the [TypedDependencyModelTestSpec](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/annotators/parser/typdep/TypedDependencyModelTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/ViveknSentiment.md
+++ b/docs/en/annotator_entries/ViveknSentiment.md
@@ -14,7 +14,7 @@ For training your own model, please see the documentation of that class.
 The analyzer requires sentence boundaries to give a score in context.
 Tokenization is needed to make sure tokens are within bounds. Transitivity requirements are also required.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/vivekn-sentiment/VivekNarayanSentimentApproach.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/vivekn-sentiment/VivekNarayanSentimentApproach.ipynb)
 and the [ViveknSentimentTestSpec](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/annotators/sda/vivekn).
 {%- endcapture -%}
 
@@ -49,7 +49,7 @@ Tokenization is needed to make sure tokens are within bounds. Transitivity requi
 
 The training data needs to consist of a column for normalized text and a label column (either `"positive"` or `"negative"`).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/vivekn-sentiment/VivekNarayanSentimentApproach.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/vivekn-sentiment/VivekNarayanSentimentApproach.ipynb)
 and the [ViveknSentimentTestSpec](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/annotators/sda/vivekn).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/WordEmbeddings.md
+++ b/docs/en/annotator_entries/WordEmbeddings.md
@@ -37,7 +37,7 @@ There are also two convenient functions to retrieve the embeddings coverage with
     1.0
     ```
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/quick_start_offline.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/quick_start_offline.ipynb)
 and the [WordEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsTestSpec.scala).
 {%- endcapture -%}
 
@@ -178,7 +178,7 @@ If a token is not found in the dictionary, then the result will be a zero vector
 Statistics about the rate of converted tokens, can be retrieved with`[WordEmbeddingsModel.withCoverageColumn`
 and `WordEmbeddingsModel.overallCoverage`.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/quick_start_offline.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/quick_start_offline.ipynb)
 and the [WordEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsTestSpec.scala).
 {%- endcapture -%}
 

--- a/docs/en/annotator_entries/WordSegmenter.md
+++ b/docs/en/annotator_entries/WordSegmenter.md
@@ -170,7 +170,7 @@ data has to be loaded into a dataframe, where the column is an
 **Tip**: The helper class [POS](/api/com/johnsnowlabs/nlp/training/POS) might be useful to read
 training data into data frames.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/chinese/word_segmentation)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/chinese/word_segmentation)
 and the [WordSegmenterTest](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/WordSegmenterTest.scala).
 
 **References:**

--- a/docs/en/annotator_entries/Yake.md
+++ b/docs/en/annotator_entries/Yake.md
@@ -20,7 +20,7 @@ first sent through a Sentence Boundary Detector and then a tokenizer.
 Note that each keyword will be given a keyword score greater than 0 (The lower the score better the keyword).
 Therefore to filter the keywords, an upper bound for the score can be set with `setThreshold`.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/keyword-extraction/Keyword_Extraction_YAKE.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/keyword-extraction/Keyword_Extraction_YAKE.ipynb)
 and the [YakeTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/keyword/yake/YakeTestSpec.scala).
 
  **Sources** :

--- a/docs/en/third-party-projects.md
+++ b/docs/en/third-party-projects.md
@@ -32,7 +32,7 @@ Comet can easily integrated into the Spark NLP workflow with the a dedicated
 logging class `CometLogger` to log training and evaluation metrics,
 pipeline parameters and NER visualization made with sparknlp-display.
 
-For more information see the [User Guide](/api/python/third_party/Comet.html) and for more examples see the [Spark NLP Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/logging/Comet_SparkNLP_Integration.ipynb).
+For more information see the [User Guide](/api/python/third_party/Comet.html) and for more examples see the [Spark NLP Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/logging/Comet_SparkNLP_Integration.ipynb).
 
 
 | **Python API:** [CometLogger](/api/python/reference/autosummary/sparknlp/logging/comet/index.html#sparknlp.logging.comet.CometLogger) |

--- a/docs/en/training_entries/AlbertForTokenClassification.md
+++ b/docs/en/training_entries/AlbertForTokenClassification.md
@@ -12,7 +12,7 @@ transformers library. After the training process is done, the model checkpoint
 can be loaded by this annotator. This is done with `loadSavedModel` (for loading
 the transformers model) and `load` for the saved Spark NLP model.
 
-For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20AlbertForTokenClassification.ipynb).
+For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20AlbertForTokenClassification.ipynb).
 
 Example for loading a saved transformers model:
 ```python

--- a/docs/en/training_entries/BertForSequenceClassification.md
+++ b/docs/en/training_entries/BertForSequenceClassification.md
@@ -12,7 +12,7 @@ transformers library. After the training process is done, the model checkpoint
 can be loaded by this annotator. This is done with `loadSavedModel` (for loading
 the transformers model) and `load` for the saved Spark NLP model.
 
-For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BertForSequenceClassification.ipynb).
+For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BertForSequenceClassification.ipynb).
 
 Example for loading a saved transformers model:
 ```python

--- a/docs/en/training_entries/BertForTokenClassification.md
+++ b/docs/en/training_entries/BertForTokenClassification.md
@@ -12,7 +12,7 @@ transformers library. After the training process is done, the model checkpoint
 can be loaded by this annotator. This is done with `loadSavedModel` (for loading
 the transformers model) and `load` for the saved Spark NLP model.
 
-For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BertForTokenClassification.ipynb).
+For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BertForTokenClassification.ipynb).
 
 Example for loading a saved transformers model:
 ```python

--- a/docs/en/training_entries/ClassifierDLApproach.md
+++ b/docs/en/training_entries/ClassifierDLApproach.md
@@ -10,8 +10,8 @@ The ClassifierDL annotator uses a deep learning model (DNNs) we have built insid
 100 classes.
 
 For extended examples of usage, see the Examples
-[[1] ](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/scala/training/Train%20Multi-Class%20Text%20Classification%20on%20News%20Articles.scala)
-[[2] ](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb).
+[[1] ](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/scala/training/Train%20Multi-Class%20Text%20Classification%20on%20News%20Articles.scala)
+[[2] ](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/training_entries/ContextSpellCheckerApproach.md
+++ b/docs/en/training_entries/ContextSpellCheckerApproach.md
@@ -15,7 +15,7 @@ certain number of errors, `ContextSpellChecker` will rank correction sequences a
 For an in-depth explanation of the module see the article [Applying Context Aware Spell Checking in Spark NLP](https://medium.com/spark-nlp/applying-context-aware-spell-checking-in-spark-nlp-3c29c46963bc).
 
 For extended examples of usage, see the article [Training a Contextual Spell Checker for Italian Language](https://towardsdatascience.com/training-a-contextual-spell-checker-for-italian-language-66dda528e4bf),
-the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb).
+the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/training_entries/DistilBertForSequenceClassification.md
+++ b/docs/en/training_entries/DistilBertForSequenceClassification.md
@@ -12,7 +12,7 @@ transformers library. After the training process is done, the model checkpoint
 can be loaded by this annotator. This is done with `loadSavedModel` (for loading
 the transformers model) and `load` for the saved Spark NLP model.
 
-For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20DistilBertForSequenceClassification.ipynb).
+For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20DistilBertForSequenceClassification.ipynb).
 
 Example for loading a saved transformers model:
 ```python

--- a/docs/en/training_entries/DistilBertForTokenClassification.md
+++ b/docs/en/training_entries/DistilBertForTokenClassification.md
@@ -11,7 +11,7 @@ transformers library. After the training process is done, the model checkpoint
 can be loaded by this annotator. This is done with `loadSavedModel` (for loading
 the transformers model) and `load` for the saved Spark NLP model.
 
-For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20DistilBertForTokenClassification.ipynb).
+For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20DistilBertForTokenClassification.ipynb).
 
 Example for loading a saved transformers model:
 ```python

--- a/docs/en/training_entries/Lemmatizer.md
+++ b/docs/en/training_entries/Lemmatizer.md
@@ -8,7 +8,7 @@ Retrieves the significant part of a word. A dictionary of predefined lemmas must
 The dictionary can be set as a delimited text file.
 Pretrained models can be loaded with `LemmatizerModel.pretrained`.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/italian/Train-Lemmatizer-Italian.ipynb).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/italian/Train-Lemmatizer-Italian.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/training_entries/MultiClassifierDLApproach.md
+++ b/docs/en/training_entries/MultiClassifierDLApproach.md
@@ -21,7 +21,7 @@ of the classes the instance can be assigned to.
 Formally, multi-label classification is the problem of finding a model that maps inputs x to binary vectors y
 (assigning a value of 0 or 1 for each element (label) in y).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/training_entries/NerCrfApproach.md
+++ b/docs/en/training_entries/NerCrfApproach.md
@@ -18,7 +18,7 @@ Excluding the label, this can be done with for example
 
 Optionally the user can provide an entity dictionary file with `setExternalFeatures` for better accuracy.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/crf-ner/ner_dl_crf.ipynb).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/crf-ner/ner_dl_crf.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/training_entries/NerDLApproach.md
+++ b/docs/en/training_entries/NerDLApproach.md
@@ -16,7 +16,7 @@ Excluding the label, this can be done with for example
   - a [WordEmbeddingsModel](/docs/en/annotators#wordembeddings)
   (any word embeddings can be chosen, e.g. [BertEmbeddings](/docs/en/transformers#bertembeddings) for BERT based embeddings).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/training_entries/PerceptronApproach.md
+++ b/docs/en/training_entries/PerceptronApproach.md
@@ -26,7 +26,7 @@ POS().readDataset(spark, datasetPath).selectExpr("explode(tags) as tags").show(f
                       ...
 ```
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/french/Train-Perceptron-French.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/french/Train-Perceptron-French.ipynb)
 and [PerceptronApproach tests](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron).
 {%- endcapture -%}
 
@@ -158,4 +158,3 @@ python_api_link=python_api_link
 api_link=api_link
 source_link=source_link
 %}
-

--- a/docs/en/training_entries/RoBertaForTokenClassification.md
+++ b/docs/en/training_entries/RoBertaForTokenClassification.md
@@ -12,7 +12,7 @@ transformers library. After the training process is done, the model checkpoint
 can be loaded by this annotator. This is done with `loadSavedModel` (for loading
 the transformers model) and `load` for the saved Spark NLP model.
 
-For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20RoBertaForTokenClassification.ipynb).
+For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20RoBertaForTokenClassification.ipynb).
 
 Example for loading a saved transformers model:
 ```python

--- a/docs/en/training_entries/SentenceDetectorDLApproach.md
+++ b/docs/en/training_entries/SentenceDetectorDLApproach.md
@@ -17,7 +17,7 @@ using a CNN architecture. We also modified the original implementation a little 
 Each extracted sentence can be returned in an Array or exploded to separate rows,
 if `explodeSentences` is set to `true`.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/multilingual/SentenceDetectorDL.ipynb).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/multilingual/SentenceDetectorDL.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/training_entries/SentimentDLApproach.md
+++ b/docs/en/training_entries/SentimentDLApproach.md
@@ -17,7 +17,7 @@ For the instantiated/pretrained models, see SentimentDLModel.
     [BertSentenceEmbeddings](/docs/en/transformers#bertsentenceembeddings), or
     [SentenceEmbeddings](docs/en/annotators#sentenceembeddings) can be used for the `inputCol`.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb).
 {%- endcapture -%}
 
 {%- capture approach_input_anno -%}

--- a/docs/en/training_entries/ViveknSentimentApproach.md
+++ b/docs/en/training_entries/ViveknSentimentApproach.md
@@ -13,7 +13,7 @@ Tokenization is needed to make sure tokens are within bounds. Transitivity requi
 
 The training data needs to consist of a column for normalized text and a label column (either `"positive"` or `"negative"`).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/vivekn-sentiment/VivekNarayanSentimentApproach.ipynb).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/vivekn-sentiment/VivekNarayanSentimentApproach.ipynb).
 {%- endcapture -%}
 
 {%- capture input_anno -%}

--- a/docs/en/training_entries/WordSegmenterApproach.md
+++ b/docs/en/training_entries/WordSegmenterApproach.md
@@ -16,7 +16,7 @@ set with `setPosColumn`.
 
 **Tip**: The helper class [POS](#pos-dataset) might be useful to read training data into data frames.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/chinese/word_segmentation).
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/chinese/word_segmentation).
 {%- endcapture -%}
 
 {%- capture input_anno -%}
@@ -123,4 +123,3 @@ python_api_link=python_api_link
 api_link=api_link
 source_link=source_link
 %}
-

--- a/docs/en/training_entries/XlmRoBertaForTokenClassification.md
+++ b/docs/en/training_entries/XlmRoBertaForTokenClassification.md
@@ -12,7 +12,7 @@ transformers library. After the training process is done, the model checkpoint
 can be loaded by this annotator. This is done with `loadSavedModel` (for loading
 the transformers model) and `load` for the saved Spark NLP model.
 
-For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20XlmRoBertaForTokenClassification.ipynb).
+For an extended example see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20XlmRoBertaForTokenClassification.ipynb).
 
 Example for loading a saved transformers model:
 ```python

--- a/docs/en/transformer_entries/AlbertEmbeddings.md
+++ b/docs/en/transformer_entries/AlbertEmbeddings.md
@@ -32,7 +32,7 @@ albert = AlbertEmbeddings.load("/albert_base_uncased_en_2.5.0_2.4_1588073363475"
 ```
 The default model is `"albert_base_uncased"`, if no name is provided.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner/ner_albert.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_albert.ipynb)
 and the [AlbertEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/AlbertEmbeddingsTestSpec.scala).
 
 **Sources:**

--- a/docs/en/transformer_entries/BertEmbeddings.md
+++ b/docs/en/transformer_entries/BertEmbeddings.md
@@ -16,7 +16,7 @@ The default model is `"small_bert_L2_768"`, if no name is provided.
 
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Embeddings).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner/ner_bert.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_bert.ipynb)
 and the [BertEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddingsTestSpec.scala).
 
 **Sources** :

--- a/docs/en/transformer_entries/BertSentenceEmbeddings.md
+++ b/docs/en/transformer_entries/BertSentenceEmbeddings.md
@@ -16,7 +16,7 @@ The default model is `"sent_small_bert_L2_768"`, if no name is provided.
 
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Embeddings).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BERT%20Sentence.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BERT%20Sentence.ipynb)
 and the [BertSentenceEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddingsTestSpec.scala).
 
 **Sources** :

--- a/docs/en/transformer_entries/CamemBertEmbeddings.md
+++ b/docs/en/transformer_entries/CamemBertEmbeddings.md
@@ -20,7 +20,7 @@ For available pretrained models please see the
 [Models Hub](https://nlp.johnsnowlabs.com/models?task=Embeddings).
 
 For extended examples of usage, see the
-[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner/ner_bert.ipynb)
+[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_bert.ipynb)
 and the
 [CamemBertEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/CamemBertEmbeddingsTestSpec.scala).
 To see which models are compatible and how to import them see

--- a/docs/en/transformer_entries/DistilBertEmbeddings.md
+++ b/docs/en/transformer_entries/DistilBertEmbeddings.md
@@ -15,7 +15,7 @@ val embeddings = DistilBertEmbeddings.pretrained()
 The default model is `"distilbert_base_cased"`, if no name is provided.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Embeddings).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20DistilBERT.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20DistilBERT.ipynb)
 and the [DistilBertEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/DistilBertEmbeddingsTestSpec.scala).
 Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. To see which models are compatible and how to import them see [Import Transformers into Spark NLP 🚀](https://github.com/JohnSnowLabs/spark-nlp/discussions/5669).
 

--- a/docs/en/transformer_entries/ElmoEmbeddings.md
+++ b/docs/en/transformer_entries/ElmoEmbeddings.md
@@ -30,7 +30,7 @@ The pooling layer can be set with `setPoolingLayer` to the following values:
   - `"elmo"`: the weighted sum of the 3 layers, where the weights are trainable. This tensor has shape `[batch_size, max_length, 1024]`.
 
 For extended examples of usage, see the
-[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner/ner_elmo.ipynb)
+[Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_elmo.ipynb)
 and the [ElmoEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/ElmoEmbeddingsTestSpec.scala).
 
 **Sources:**

--- a/docs/en/transformer_entries/MarianTransformer.md
+++ b/docs/en/transformer_entries/MarianTransformer.md
@@ -22,7 +22,7 @@ val marian = MarianTransformer.pretrained()
 The default model is `"opus_mt_en_fr"`, default language is `"xx"` (meaning multi-lingual), if no values are provided.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Translation).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/multilingual/Translation_Marian.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/multilingual/Translation_Marian.ipynb)
 and the [MarianTransformerTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformerTestSpec.scala).
 
 **Sources** :

--- a/docs/en/transformer_entries/RoBertaEmbeddings.md
+++ b/docs/en/transformer_entries/RoBertaEmbeddings.md
@@ -18,7 +18,7 @@ val embeddings = RoBertaEmbeddings.pretrained()
 The default model is `"roberta_base"`, if no name is provided.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Embeddings).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20RoBERTa.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20RoBERTa.ipynb)
 and the [RoBertaEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/RoBertaEmbeddingsTestSpec.scala).
 Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. To see which models are compatible and how to import them see [Import Transformers into Spark NLP 🚀](https://github.com/JohnSnowLabs/spark-nlp/discussions/5669).
 

--- a/docs/en/transformer_entries/T5Transformer.md
+++ b/docs/en/transformer_entries/T5Transformer.md
@@ -22,7 +22,7 @@ val t5 = T5Transformer.pretrained()
 The default model is `"t5_small"`, if no name is provided.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?q=t5).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/question-answering/Question_Answering_and_Summarization_with_T5.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/question-answering/Question_Answering_and_Summarization_with_T5.ipynb)
 and the [T5TestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/T5TestSpec.scala).
 
 **Sources:**

--- a/docs/en/transformer_entries/UniversalSentenceEncoder.md
+++ b/docs/en/transformer_entries/UniversalSentenceEncoder.md
@@ -14,7 +14,7 @@ val useEmbeddings = UniversalSentenceEncoder.pretrained()
 The default model is `"tfhub_use"`, if no name is provided.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Embeddings).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb)
 and the [UniversalSentenceEncoderTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoderTestSpec.scala).
 
 **Sources:**

--- a/docs/en/transformer_entries/XlmRoBertaEmbeddings.md
+++ b/docs/en/transformer_entries/XlmRoBertaEmbeddings.md
@@ -18,7 +18,7 @@ val embeddings = XlmRoBertaEmbeddings.pretrained()
 The default model is `"xlm_roberta_base"`, default language is `"xx"` (meaning multi-lingual), if no values are provided.
 For available pretrained models please see the [Models Hub](https://nlp.johnsnowlabs.com/models?task=Embeddings).
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20XLM-RoBERTa.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20XLM-RoBERTa.ipynb)
 and the [XlmRoBertaEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddingsTestSpec.scala).
 Models from the HuggingFace 🤗 Transformers library are also compatible with Spark NLP 🚀. To see which models are compatible and how to import them see [Import Transformers into Spark NLP 🚀](https://github.com/JohnSnowLabs/spark-nlp/discussions/5669).
 

--- a/docs/en/transformer_entries/XlnetEmbeddings.md
+++ b/docs/en/transformer_entries/XlnetEmbeddings.md
@@ -34,7 +34,7 @@ xlnet = XlnetEmbeddings.load("/xlnet_large_cased_en_2.5.0_2.4_1588074397954") \
 ```
 The default model is `"xlnet_base_cased"`, if no name is provided.
 
-For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner/ner_xlnet.ipynb)
+For extended examples of usage, see the [Examples](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_xlnet.ipynb)
 and the [XlnetEmbeddingsTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/XlnetEmbeddingsTestSpec.scala).
 
 **Sources :**

--- a/python/sparknlp/annotator/chunker.py
+++ b/python/sparknlp/annotator/chunker.py
@@ -41,7 +41,7 @@ class Chunker(AnnotatorModel):
     treated as groups, so here specifically ``"<NNP>+"`` means 1 or more nouns
     in succession.
 
-    For more extended examples see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/chunking/Chunk_Extraction_with_Chunker.ipynb>`__.
+    For more extended examples see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/chunking/Chunk_Extraction_with_Chunker.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -135,4 +135,3 @@ class Chunker(AnnotatorModel):
         ...     .setRegexParsers(["<NNP>+", "<NNS>+"])
         """
         return self._set(regexParsers=value)
-

--- a/python/sparknlp/annotator/classifier_dl/classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/classifier_dl.py
@@ -55,7 +55,7 @@ class ClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEnco
     ...     .setTestDataset("test_data")
 
     For extended examples of usage, see the Examples
-    `Examples  <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb>`__.
+    `Examples  <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb>`__.
 
     ======================= ======================
     Input Annotation types  Output Annotation type
@@ -206,7 +206,7 @@ class ClassifierDLModel(AnnotatorModel, HasStorageRef, HasEngine):
     `Models Hub <https://nlp.johnsnowlabs.com/models?task=Text+Classification>`__.
 
     For extended examples of usage, see the
-    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb>`__.
+    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb>`__.
 
     ======================= ======================
     Input Annotation types  Output Annotation type

--- a/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/multi_classifier_dl.py
@@ -68,7 +68,7 @@ class MultiClassifierDLApproach(AnnotatorApproach, EvaluationDLParams, Classifie
     ...     .setLabelColumn("label") \\
     ...     .setTestDataset("test_data")
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb>`__.
 
     ======================= ======================
     Input Annotation types  Output Annotation type
@@ -267,7 +267,7 @@ class MultiClassifierDLModel(AnnotatorModel, HasStorageRef, HasEngine):
     `Jigsaw Toxic Comment Classification Challenge <https://www.kaggle.com/c/jigsaw-toxic-comment-classification-challenge/overview>`__.
     For available pretrained models please see the `Models Hub <https://nlp.johnsnowlabs.com/models?task=Text+Classification>`__.
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/MultiClassifierDL_train_multi_label_E2E_challenge_classifier.ipynb>`__.
 
     ======================= ======================
     Input Annotation types  Output Annotation type

--- a/python/sparknlp/annotator/classifier_dl/sentiment_dl.py
+++ b/python/sparknlp/annotator/classifier_dl/sentiment_dl.py
@@ -53,7 +53,7 @@ class SentimentDLApproach(AnnotatorApproach, EvaluationDLParams, ClassifierEncod
     ...     .setLabelColumn("label") \\
     ...     .setTestDataset("test_data")
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb>`__.
 
     ======================= ======================
     Input Annotation types  Output Annotation type
@@ -236,7 +236,7 @@ class SentimentDLModel(AnnotatorModel, HasStorageRef, HasEngine):
     <https://nlp.johnsnowlabs.com/models?task=Sentiment+Analysis>`__.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/SentimentDL_train_multiclass_sentiment_classifier.ipynb>`__.
 
     ======================= ======================
     Input Annotation types  Output Annotation type

--- a/python/sparknlp/annotator/coref/spanbert_coref.py
+++ b/python/sparknlp/annotator/coref/spanbert_coref.py
@@ -41,7 +41,7 @@ class SpanBertCorefModel(AnnotatorModel,
     <https://nlp.johnsnowlabs.com/models?q=coref>`__.
 
     For extended examples of usage, see the
-    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/coreference-resolution/Coreference_Resolution_SpanBertCorefModel.ipynb>`__.
+    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/coreference-resolution/Coreference_Resolution_SpanBertCorefModel.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/annotator/dependency/dependency_parser.py
+++ b/python/sparknlp/annotator/dependency/dependency_parser.py
@@ -189,7 +189,7 @@ class DependencyParserModel(AnnotatorModel):
     For available pretrained models please see the
     `Models Hub <https://nlp.johnsnowlabs.com/models>`__.
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/graph-extraction/graph_extraction_intro.ipynb>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/graph-extraction/graph_extraction_intro.ipynb>`__.
 
     ================================ ======================
     Input Annotation types           Output Annotation type
@@ -292,4 +292,3 @@ class DependencyParserModel(AnnotatorModel):
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(DependencyParserModel, name, lang, remote_loc)
-

--- a/python/sparknlp/annotator/dependency/typed_dependency_parser.py
+++ b/python/sparknlp/annotator/dependency/typed_dependency_parser.py
@@ -196,7 +196,7 @@ class TypedDependencyParserModel(AnnotatorModel):
     <https://nlp.johnsnowlabs.com/models>`__.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/graph-extraction/graph_extraction_intro.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/graph-extraction/graph_extraction_intro.ipynb>`__.
 
     ========================== ======================
     Input Annotation types     Output Annotation type
@@ -316,4 +316,3 @@ class TypedDependencyParserModel(AnnotatorModel):
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(TypedDependencyParserModel, name, lang, remote_loc)
-

--- a/python/sparknlp/annotator/document_normalizer.py
+++ b/python/sparknlp/annotator/document_normalizer.py
@@ -23,7 +23,7 @@ class DocumentNormalizer(AnnotatorModel):
     patterns. Can apply not wanted character removal with a specific policy.
     Can apply lower case normalization.
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/document-normalizer/document_normalizer_notebook.ipynb
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/document-normalizer/document_normalizer_notebook.ipynb
 >`__.
 
     ====================== ======================
@@ -197,4 +197,3 @@ class DocumentNormalizer(AnnotatorModel):
             File encoding to apply on normalized documents, by default "UTF-8"
         """
         return self._set(encoding=value)
-

--- a/python/sparknlp/annotator/embeddings/albert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/albert_embeddings.py
@@ -54,7 +54,7 @@ class AlbertEmbeddings(AnnotatorModel,
     The default model is ``"albert_base_uncased"``, if no name is provided.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner/ner_albert.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_albert.ipynb>`__.
     To see which models are compatible and how to import them see
     `Import Transformers into Spark NLP 🚀
     <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.

--- a/python/sparknlp/annotator/embeddings/bert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bert_embeddings.py
@@ -41,7 +41,7 @@ class BertEmbeddings(AnnotatorModel,
     `Models Hub <https://nlp.johnsnowlabs.com/models?task=Embeddings>`__.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner/ner_bert.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_bert.ipynb>`__.
     To see which models are compatible and how to import them see
     `Import Transformers into Spark NLP 🚀
     <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.
@@ -218,4 +218,3 @@ class BertEmbeddings(AnnotatorModel,
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(BertEmbeddings, name, lang, remote_loc)
-

--- a/python/sparknlp/annotator/embeddings/bert_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bert_sentence_embeddings.py
@@ -41,7 +41,7 @@ class BertSentenceEmbeddings(AnnotatorModel,
     `Models Hub <https://nlp.johnsnowlabs.com/models?task=Embeddings>`__.
 
     For extended examples of usage, see the
-    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BERT%20Sentence.ipynb>`__.
+    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20BERT%20Sentence.ipynb>`__.
 
     ====================== =======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/annotator/embeddings/camembert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/camembert_embeddings.py
@@ -42,7 +42,7 @@ class CamemBertEmbeddings(AnnotatorModel,
         `Models Hub <https://nlp.johnsnowlabs.com/models?task=Embeddings>`__.
 
         For extended examples of usage, see the
-        `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner/ner_bert.ipynb>`__
+        `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_bert.ipynb>`__
         and the
         `CamemBertEmbeddingsTestSpec <https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/embeddings/CamemBertEmbeddingsTestSpec.scala>`__.
 

--- a/python/sparknlp/annotator/embeddings/chunk_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/chunk_embeddings.py
@@ -21,7 +21,7 @@ class ChunkEmbeddings(AnnotatorModel):
     chunk embeddings from either Chunker, NGramGenerator, or NerConverter
     outputs.
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/embeddings/ChunkEmbeddings.ipynb>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/embeddings/ChunkEmbeddings.ipynb>`__.
 
     ========================== ======================
     Input Annotation types     Output Annotation type
@@ -147,4 +147,3 @@ class ChunkEmbeddings(AnnotatorModel):
             aggregation/pooling.
         """
         return self._set(skipOOV=value)
-

--- a/python/sparknlp/annotator/embeddings/distil_bert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/distil_bert_embeddings.py
@@ -40,7 +40,7 @@ class DistilBertEmbeddings(AnnotatorModel,
     `Models Hub <https://nlp.johnsnowlabs.com/models?task=Embeddings>`__.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20DistilBERT.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20DistilBERT.ipynb>`__.
     To see which models are compatible and how to import them see
     `Import Transformers into Spark NLP 🚀
     <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.

--- a/python/sparknlp/annotator/embeddings/elmo_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/elmo_embeddings.py
@@ -53,7 +53,7 @@ class ElmoEmbeddings(AnnotatorModel,
       trainable. This tensor has shape ``[batch_size, max_length, 1024]``.
 
     For extended examples of usage, see the
-    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner/ner_elmo.ipynb>`__.
+    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_elmo.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/annotator/embeddings/roberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/roberta_embeddings.py
@@ -45,7 +45,7 @@ class RoBertaEmbeddings(AnnotatorModel,
     <https://nlp.johnsnowlabs.com/models?task=Embeddings>`__.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20RoBERTa.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20RoBERTa.ipynb>`__.
     To see which models are compatible and how to import them see
     `Import Transformers into Spark NLP 🚀
     <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.

--- a/python/sparknlp/annotator/embeddings/sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/sentence_embeddings.py
@@ -26,7 +26,7 @@ class SentenceEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasStorageRef)
     ``"AVERAGE"`` or ``"SUM"``.
 
     For more extended examples see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/text-similarity/Spark_NLP_Spark_ML_Text_Similarity.ipynb>`__..
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-similarity/Spark_NLP_Spark_ML_Text_Similarity.ipynb>`__..
 
     ============================= =======================
     Input Annotation types        Output Annotation type
@@ -132,4 +132,3 @@ class SentenceEmbeddings(AnnotatorModel, HasEmbeddingsProperties, HasStorageRef)
             return self._set(poolingStrategy=strategy)
         else:
             return self._set(poolingStrategy="AVERAGE")
-

--- a/python/sparknlp/annotator/embeddings/universal_sentence_encoder.py
+++ b/python/sparknlp/annotator/embeddings/universal_sentence_encoder.py
@@ -38,7 +38,7 @@ class UniversalSentenceEncoder(AnnotatorModel,
     <https://nlp.johnsnowlabs.com/models?task=Embeddings>`__.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/classification/ClassifierDL_Train_multi_class_news_category_classifier.ipynb>`__.
 
     ====================== =======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/annotator/embeddings/word_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/word_embeddings.py
@@ -179,7 +179,7 @@ class WordEmbeddingsModel(AnnotatorModel, HasEmbeddingsProperties, HasStorageMod
     pretrained models please see the `Models Hub
     <https://nlp.johnsnowlabs.com/models?task=Embeddings>`__.
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/quick_start_offline.ipynb>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/quick_start_offline.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -383,4 +383,3 @@ class WordEmbeddingsModel(AnnotatorModel, HasEmbeddingsProperties, HasStorageMod
             Identifiers for the model parameters
         """
         HasStorageModel.loadStorages(path, spark, storage_ref, WordEmbeddingsModel.databases)
-

--- a/python/sparknlp/annotator/embeddings/xlm_roberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlm_roberta_embeddings.py
@@ -43,7 +43,7 @@ class XlmRoBertaEmbeddings(AnnotatorModel,
     <https://nlp.johnsnowlabs.com/models?task=Embeddings>`__.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20XLM-RoBERTa.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/transformers/HuggingFace%20in%20Spark%20NLP%20-%20XLM-RoBERTa.ipynb>`__.
     To see which models are compatible and how to import them see
     `Import Transformers into Spark NLP 🚀
     <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.

--- a/python/sparknlp/annotator/embeddings/xlnet_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlnet_embeddings.py
@@ -54,7 +54,7 @@ class XlnetEmbeddings(AnnotatorModel,
     The default model is ``"xlnet_base_cased"``, if no name is provided.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner/ner_xlnet.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_xlnet.ipynb>`__.
     To see which models are compatible and how to import them see
     `Import Transformers into Spark NLP 🚀
     <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.

--- a/python/sparknlp/annotator/keyword_extraction/yake_keyword_extraction.py
+++ b/python/sparknlp/annotator/keyword_extraction/yake_keyword_extraction.py
@@ -45,7 +45,7 @@ class YakeKeywordExtraction(AnnotatorModel):
     upper bound for the score can be set with :meth:`.setThreshold`.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/keyword-extraction/Keyword_Extraction_YAKE.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/keyword-extraction/Keyword_Extraction_YAKE.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -268,4 +268,3 @@ class YakeKeywordExtraction(AnnotatorModel):
         from pyspark.ml.wrapper import _jvm
         stopWordsObj = _jvm().org.apache.spark.ml.feature.StopWordsRemover
         return list(stopWordsObj.loadDefaultStopWords(language))
-

--- a/python/sparknlp/annotator/ld_dl/language_detector_dl.py
+++ b/python/sparknlp/annotator/ld_dl/language_detector_dl.py
@@ -39,7 +39,7 @@ class LanguageDetectorDL(AnnotatorModel, HasStorageRef, HasEngine):
 
     For available pretrained models please see the `Models Hub <https://nlp.johnsnowlabs.com/models?task=Language+Detection>`__.
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/language-detection/Language_Detection_and_Indentification.ipynb>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/language-detection/Language_Detection_and_Indentification.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/annotator/lemmatizer.py
+++ b/python/sparknlp/annotator/lemmatizer.py
@@ -25,7 +25,7 @@ class Lemmatizer(AnnotatorApproach):
     For instantiated/pretrained models, see :class:`.LemmatizerModel`.
 
     For available pretrained models please see the `Models Hub <https://nlp.johnsnowlabs.com/models?task=Lemmatization>`__.
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/italian/Train-Lemmatizer-Italian.ipynb>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/italian/Train-Lemmatizer-Italian.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -248,4 +248,3 @@ class LemmatizerModel(AnnotatorModel):
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(LemmatizerModel, name, lang, remote_loc)
-

--- a/python/sparknlp/annotator/matcher/date_matcher.py
+++ b/python/sparknlp/annotator/matcher/date_matcher.py
@@ -187,7 +187,7 @@ class DateMatcher(AnnotatorModel, DateMatcherUtils):
     `Pipelines <https://nlp.johnsnowlabs.com/docs/en/pipelines>`__.
 
     For extended examples of usage, see the
-    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/MultiDateMatcherMultiLanguage_en.ipynb>`__.
+    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/MultiDateMatcherMultiLanguage_en.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -268,4 +268,3 @@ class DateMatcher(AnnotatorModel, DateMatcherUtils):
             anchorDateMonth=-1,
             anchorDateDay=-1
         )
-

--- a/python/sparknlp/annotator/matcher/multi_date_matcher.py
+++ b/python/sparknlp/annotator/matcher/multi_date_matcher.py
@@ -33,7 +33,7 @@ class MultiDateMatcher(AnnotatorModel, DateMatcherUtils):
     For example ``"The 31st of April in the year 2008"`` will be converted into
     ``2008/04/31``.
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/MultiDateMatcherMultiLanguage_en.ipynb>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/MultiDateMatcherMultiLanguage_en.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -107,4 +107,3 @@ class MultiDateMatcher(AnnotatorModel, DateMatcherUtils):
             readMonthFirst=True,
             defaultDayWhenMissing=1
         )
-

--- a/python/sparknlp/annotator/matcher/regex_matcher.py
+++ b/python/sparknlp/annotator/matcher/regex_matcher.py
@@ -35,7 +35,7 @@ class RegexMatcher(AnnotatorApproach):
     <https://nlp.johnsnowlabs.com/docs/en/pipelines>`__.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/regex-matcher/Matching_Text_with_RegexMatcher.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/regex-matcher/Matching_Text_with_RegexMatcher.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/annotator/matcher/text_matcher.py
+++ b/python/sparknlp/annotator/matcher/text_matcher.py
@@ -25,7 +25,7 @@ class TextMatcher(AnnotatorApproach):
     :meth:`.setEntities`.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/text-matcher-pipeline/extractor.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-matcher-pipeline/extractor.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -288,4 +288,3 @@ class TextMatcherModel(AnnotatorModel):
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(TextMatcherModel, name, lang, remote_loc)
-

--- a/python/sparknlp/annotator/n_gram_generator.py
+++ b/python/sparknlp/annotator/n_gram_generator.py
@@ -27,7 +27,7 @@ class NGramGenerator(AnnotatorModel):
     length is less than n (number of elements per n-gram), no n-grams are
     returned.
 
-    For more extended examples see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/chunking/NgramGenerator.ipynb>`__.
+    For more extended examples see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/chunking/NgramGenerator.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -139,4 +139,3 @@ class NGramGenerator(AnnotatorModel):
         if len(value) > 1:
             raise Exception("Delimiter should have length == 1")
         return self._set(delimiter=value)
-

--- a/python/sparknlp/annotator/ner/ner_crf.py
+++ b/python/sparknlp/annotator/ner/ner_crf.py
@@ -39,7 +39,7 @@ class NerCrfApproach(AnnotatorApproach, NerApproach):
     Optionally the user can provide an entity dictionary file with
     :meth:`.setExternalFeatures` for better accuracy.
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/crf-ner/ner_dl_crf.ipynb>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/crf-ner/ner_dl_crf.ipynb>`__.
 
     ========================================= ======================
     Input Annotation types                    Output Annotation type
@@ -281,7 +281,7 @@ class NerCrfModel(AnnotatorModel):
     <https://nlp.johnsnowlabs.com/models?task=Named+Entity+Recognition>`__.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/crf-ner/ner_dl_crf.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/crf-ner/ner_dl_crf.ipynb>`__.
 
     ========================================= ======================
     Input Annotation types                    Output Annotation type
@@ -395,4 +395,3 @@ class NerCrfModel(AnnotatorModel):
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(NerCrfModel, name, lang, remote_loc)
-

--- a/python/sparknlp/annotator/ner/ner_dl.py
+++ b/python/sparknlp/annotator/ner/ner_dl.py
@@ -72,7 +72,7 @@ class NerDLApproach(AnnotatorApproach, NerApproach, EvaluationDLParams):
     ...     .setOutputCol("ner") \\
     ...     .setTestDataset("test_data")
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dl-ner>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner>`__.
 
     ==================================== ======================
     Input Annotation types               Output Annotation type
@@ -429,7 +429,7 @@ class NerDLModel(AnnotatorModel, HasStorageRef, HasBatchedAnnotate, HasEngine):
     ``"ner_dl"`` requires the WordEmbeddings ``"glove_100d"``.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/model-downloader/Create%20custom%20pipeline%20-%20NerDL.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/model-downloader/Create%20custom%20pipeline%20-%20NerDL.ipynb>`__.
 
     ==================================== ======================
     Input Annotation types               Output Annotation type

--- a/python/sparknlp/annotator/normalizer.py
+++ b/python/sparknlp/annotator/normalizer.py
@@ -21,7 +21,7 @@ class Normalizer(AnnotatorApproach):
     words based on a provided dictionary
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/document-normalizer/document_normalizer_notebook.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/document-normalizer/document_normalizer_notebook.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/annotator/pos/perceptron.py
+++ b/python/sparknlp/annotator/pos/perceptron.py
@@ -45,7 +45,7 @@ class PerceptronApproach(AnnotatorApproach):
 
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/french/Train-Perceptron-French.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/french/Train-Perceptron-French.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -179,7 +179,7 @@ class PerceptronModel(AnnotatorModel):
     `Pipelines <https://nlp.johnsnowlabs.com/docs/en/pipelines>`__.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/french/Train-Perceptron-French.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/french/Train-Perceptron-French.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -261,4 +261,3 @@ class PerceptronModel(AnnotatorModel):
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(PerceptronModel, name, lang, remote_loc)
-

--- a/python/sparknlp/annotator/sentence/sentence_detector.py
+++ b/python/sparknlp/annotator/sentence/sentence_detector.py
@@ -94,7 +94,7 @@ class SentenceDetector(AnnotatorModel, SentenceDetectorParams):
     if ``explodeSentences`` is set to ``true``.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/sentence-detection/SentenceDetector_advanced_examples.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/sentence-detection/SentenceDetector_advanced_examples.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/annotator/sentence/sentence_detector_dl.py
+++ b/python/sparknlp/annotator/sentence/sentence_detector_dl.py
@@ -223,7 +223,7 @@ class SentenceDetectorDLModel(AnnotatorModel, HasEngine):
     rows, if ``explodeSentences`` is set to ``true``.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/multilingual/SentenceDetectorDL.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/multilingual/SentenceDetectorDL.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/annotator/sentiment/sentiment_detector.py
+++ b/python/sparknlp/annotator/sentiment/sentiment_detector.py
@@ -29,7 +29,7 @@ class SentimentDetector(AnnotatorApproach):
     the score is ``>= 0``, else ``"negative"``.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dictionary-sentiment/sentiment.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dictionary-sentiment/sentiment.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -177,7 +177,7 @@ class SentimentDetectorModel(AnnotatorModel):
     the score is ``>= 0``, else ``"negative"``.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/dictionary-sentiment/sentiment.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dictionary-sentiment/sentiment.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -206,4 +206,3 @@ class SentimentDetectorModel(AnnotatorModel):
             classname=classname,
             java_model=java_model
         )
-

--- a/python/sparknlp/annotator/sentiment/vivekn_sentiment.py
+++ b/python/sparknlp/annotator/sentiment/vivekn_sentiment.py
@@ -29,7 +29,7 @@ class ViveknSentimentApproach(AnnotatorApproach):
     label column (either ``"positive"`` or ``"negative"``).
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/vivekn-sentiment/VivekNarayanSentimentApproach.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/vivekn-sentiment/VivekNarayanSentimentApproach.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -172,7 +172,7 @@ class ViveknSentimentModel(AnnotatorModel):
     requirements are also required.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/english/vivekn-sentiment/VivekNarayanSentimentApproach.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/vivekn-sentiment/VivekNarayanSentimentApproach.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -240,4 +240,3 @@ class ViveknSentimentModel(AnnotatorModel):
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(ViveknSentimentModel, name, lang, remote_loc)
-

--- a/python/sparknlp/annotator/seq2seq/marian_transformer.py
+++ b/python/sparknlp/annotator/seq2seq/marian_transformer.py
@@ -42,7 +42,7 @@ class MarianTransformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):
 
     For available pretrained models please see the `Models Hub <https://nlp.johnsnowlabs.com/models?task=Translation>`__.
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/multilingual/Translation_Marian.ipynb>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/multilingual/Translation_Marian.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/annotator/seq2seq/t5_transformer.py
+++ b/python/sparknlp/annotator/seq2seq/t5_transformer.py
@@ -42,7 +42,7 @@ class T5Transformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):
     <https://nlp.johnsnowlabs.com/models?q=t5>`__.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/question-answering/Question_Answering_and_Summarization_with_T5.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/question-answering/Question_Answering_and_Summarization_with_T5.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/annotator/spell_check/context_spell_checker.py
+++ b/python/sparknlp/annotator/spell_check/context_spell_checker.py
@@ -37,7 +37,7 @@ class ContextSpellCheckerApproach(AnnotatorApproach):
 
     For extended examples of usage, see the article
     `Training a Contextual Spell Checker for Italian Language <https://towardsdatascience.com/training-a-contextual-spell-checker-for-italian-language-66dda528e4bf>`__,
-    the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb>`__.
+    the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -484,7 +484,7 @@ class ContextSpellCheckerModel(AnnotatorModel, HasEngine):
     The default model is ``"spellcheck_dl"``, if no name is provided.
     For available pretrained models please see the `Models Hub <https://nlp.johnsnowlabs.com/models?task=Spell+Check>`__.
 
-    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb>`__.
+    For extended examples of usage, see the `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/annotator/stemmer.py
+++ b/python/sparknlp/annotator/stemmer.py
@@ -20,7 +20,7 @@ class Stemmer(AnnotatorModel):
     meaningful part of the word.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/stemmer/Word_Stemming_with_Stemmer.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/stemmer/Word_Stemming_with_Stemmer.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -77,4 +77,3 @@ class Stemmer(AnnotatorModel):
         self._setDefault(
             language="english"
         )
-

--- a/python/sparknlp/annotator/stop_words_cleaner.py
+++ b/python/sparknlp/annotator/stop_words_cleaner.py
@@ -37,7 +37,7 @@ class StopWordsCleaner(AnnotatorModel):
     <https://nlp.johnsnowlabs.com/models?task=Stop+Words+Removal>`__.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/stop-words/StopWordsCleaner.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/stop-words/StopWordsCleaner.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -188,4 +188,3 @@ class StopWordsCleaner(AnnotatorModel):
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(StopWordsCleaner, name, lang, remote_loc)
-

--- a/python/sparknlp/annotator/token/recursive_tokenizer.py
+++ b/python/sparknlp/annotator/token/recursive_tokenizer.py
@@ -29,7 +29,7 @@ class RecursiveTokenizer(AnnotatorApproach):
     - ``whitelist``: Whitelist of strings not to split
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/italian/Training_Context_Spell_Checker_Italian.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -203,4 +203,3 @@ class RecursiveTokenizerModel(AnnotatorModel):
             classname=classname,
             java_model=java_model
         )
-

--- a/python/sparknlp/annotator/token/tokenizer.py
+++ b/python/sparknlp/annotator/token/tokenizer.py
@@ -28,7 +28,7 @@ class Tokenizer(AnnotatorApproach):
     customizing it if defaults do not fit user needs.
 
     For extended examples of usage see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/document-normalizer/document_normalizer_notebook.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/document-normalizer/document_normalizer_notebook.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -559,4 +559,3 @@ class TokenizerModel(AnnotatorModel):
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(TokenizerModel, name, lang, remote_loc)
-

--- a/python/sparknlp/annotator/ws/word_segmenter.py
+++ b/python/sparknlp/annotator/ws/word_segmenter.py
@@ -54,7 +54,7 @@ class WordSegmenterApproach(AnnotatorApproach):
     data frames.
 
     For extended examples of usage, see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/chinese/word_segmentation>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/chinese/word_segmentation>`__.
 
     References
     ----------

--- a/python/sparknlp/base/document_assembler.py
+++ b/python/sparknlp/base/document_assembler.py
@@ -30,7 +30,7 @@ class DocumentAssembler(AnnotatorTransformer):
     refer the parameters section.
 
     For more extended examples on document pre-processing see the
-    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/document-assembler/Loading_Documents_With_DocumentAssembler.ipynb>`__.
+    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/document-assembler/Loading_Documents_With_DocumentAssembler.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/base/embeddings_finisher.py
+++ b/python/sparknlp/base/embeddings_finisher.py
@@ -34,7 +34,7 @@ class EmbeddingsFinisher(AnnotatorTransformer):
     require a ``featureCol``.
 
     For more extended examples see the
-    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/text-similarity/Spark_NLP_Spark_ML_Text_Similarity.ipynb
+    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-similarity/Spark_NLP_Spark_ML_Text_Similarity.ipynb
 >`__.
 
     ====================== ======================

--- a/python/sparknlp/base/finisher.py
+++ b/python/sparknlp/base/finisher.py
@@ -25,7 +25,7 @@ class Finisher(AnnotatorTransformer):
     outputs annotation(s) values into ``String``.
 
     For more extended examples on document pre-processing see the
-    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/model-downloader/Create%20custom%20pipeline%20-%20NerDL.ipynb
+    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/model-downloader/Create%20custom%20pipeline%20-%20NerDL.ipynb
 >`__.
 
     ====================== ======================

--- a/python/sparknlp/base/multi_document_assembler.py
+++ b/python/sparknlp/base/multi_document_assembler.py
@@ -28,7 +28,7 @@ class MultiDocumentAssembler(AnnotatorTransformer):
     refer the parameters section.
 
     For more extended examples on document pre-processing see the
-    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/document-assembler/Loading_Multiple_Documents.ipynb>`__.
+    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/document-assembler/Loading_Multiple_Documents.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type

--- a/python/sparknlp/base/token_assembler.py
+++ b/python/sparknlp/base/token_assembler.py
@@ -29,7 +29,7 @@ class TokenAssembler(AnnotatorTransformer, AnnotatorProperties):
     annotators. Requires ``DOCUMENT`` and ``TOKEN`` type annotations as input.
 
     For more extended examples on document pre-processing see the
-    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/annotation/text/english/token-assembler/Assembling_Tokens_to_Documents.ipynb>`__.
+    `Examples <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/token-assembler/Assembling_Tokens_to_Documents.ipynb>`__.
 
     ====================== ======================
     Input Annotation types Output Annotation type
@@ -122,4 +122,3 @@ class TokenAssembler(AnnotatorTransformer, AnnotatorProperties):
             Name of the Id Column
         """
         return self._set(preservePosition=value)
-

--- a/python/sparknlp/logging/comet.py
+++ b/python/sparknlp/logging/comet.py
@@ -41,7 +41,7 @@ class CometLogger:
     CometLogger reads the log file generated during the training process.
 
     For more examples see the `Examples
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/example/python/logging/Comet_SparkNLP_Integration.ipynb>`__.
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/logging/Comet_SparkNLP_Integration.ipynb>`__.
 
     Parameters
     ----------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I identified many broken links in the documentation after the change from `/.../example/...` to `/.../examples/...`. I changed everywhere on Python and Markdown files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation and docstrings

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
