### PR TITLE
Sparknlp 747 Date2Chunk and Chunk2Doc are not in the correct Python module

### DIFF
--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -19,13 +19,13 @@ from pyspark.sql import SparkSession
 from sparknlp import annotator
 # Must be declared here one by one or else PretrainedPipeline will fail with AttributeError
 from sparknlp.base import DocumentAssembler, MultiDocumentAssembler, Finisher, EmbeddingsFinisher, TokenAssembler, \
-    Chunk2Doc, Doc2Chunk, AudioAssembler, GraphFinisher, ImageAssembler, TableAssembler
+    Doc2Chunk, AudioAssembler, GraphFinisher, ImageAssembler, TableAssembler
 from pyspark.conf import SparkConf
 from pyspark.context import SparkContext
 from pyspark.java_gateway import launch_gateway
 
 sys.modules['com.johnsnowlabs.nlp.annotators'] = annotator
-sys.modules['com.johnsnowlabs.nlp.annotators.tokenizer'] = annotator
+sys.modules['com.johnsnsowlabs.nlp.annotators.tokenizer'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.tokenizer.wordpiece'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.ner'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.ner.regex'] = annotator

--- a/python/sparknlp/annotator/__init__.py
+++ b/python/sparknlp/annotator/__init__.py
@@ -43,6 +43,8 @@ from sparknlp.annotator.coref import *
 from sparknlp.annotator.tf_ner_dl_graph_builder import *
 from sparknlp.annotator.cv import *
 from sparknlp.annotator.audio import *
+from sparknlp.annotator.chunk2_doc import *
+from sparknlp.annotator.date2_chunk import *
 
 if sys.version_info[0] == 2:
     raise ImportError(

--- a/python/sparknlp/annotator/chunk2_doc.py
+++ b/python/sparknlp/annotator/chunk2_doc.py
@@ -77,7 +77,7 @@ class Chunk2Doc(AnnotatorTransformer, AnnotatorProperties):
 
     @keyword_only
     def __init__(self):
-        super(Chunk2Doc, self).__init__(classname="com.johnsnowlabs.nlp.Chunk2Doc")
+        super(Chunk2Doc, self).__init__(classname="com.johnsnowlabs.nlp.annotators.Chunk2Doc")
 
     @keyword_only
     def setParams(self):

--- a/python/sparknlp/annotator/date2_chunk.py
+++ b/python/sparknlp/annotator/date2_chunk.py
@@ -67,5 +67,6 @@ documentAssembler = DocumentAssembler() \\
 
     outputAnnotatorType = AnnotatorType.CHUNK
 
+    @keyword_only
     def __init__(self):
         super(Date2Chunk, self).__init__(classname="com.johnsnowlabs.nlp.annotators.Date2Chunk")

--- a/python/sparknlp/base/__init__.py
+++ b/python/sparknlp/base/__init__.py
@@ -12,8 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Module of base Spark NLP annotators."""
-
-from sparknlp.base.chunk2_doc import *
 from sparknlp.base.doc2_chunk import *
 from sparknlp.base.document_assembler import *
 from sparknlp.base.multi_document_assembler import *
@@ -29,5 +27,3 @@ from sparknlp.base.image_assembler import *
 from sparknlp.base.audio_assembler import *
 from sparknlp.base.table_assembler import *
 from sparknlp.base.token2_chunk import *
-from sparknlp.base.date2_chunk import *
-

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -41,13 +41,7 @@ import com.johnsnowlabs.nlp.annotators.ld.dl.{
   ReadablePretrainedLanguageDetectorDLModel
 }
 import com.johnsnowlabs.nlp.annotators.ner.crf.ReadablePretrainedNerCrf
-import com.johnsnowlabs.nlp.annotators.ner.dl.{
-  ReadZeroShotNerDLModel,
-  ReadablePretrainedNerDL,
-  ReadablePretrainedZeroShotNer,
-  ReadsNERGraph,
-  WithGraphResolver
-}
+import com.johnsnowlabs.nlp.annotators.ner.dl._
 import com.johnsnowlabs.nlp.annotators.parser.dep.ReadablePretrainedDependency
 import com.johnsnowlabs.nlp.annotators.parser.typdep.ReadablePretrainedTypedDependency
 import com.johnsnowlabs.nlp.annotators.pos.perceptron.ReadablePretrainedPerceptron
@@ -678,4 +672,9 @@ package object annotator {
   type Date2Chunk = com.johnsnowlabs.nlp.annotators.Date2Chunk
 
   object Date2Chunk extends DefaultParamsReadable[Date2Chunk]
+
+  type Chunk2Doc = com.johnsnowlabs.nlp.annotators.Chunk2Doc
+
+  object Chunk2Doc extends DefaultParamsReadable[Chunk2Doc]
+
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Chunk2Doc.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Chunk2Doc.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.johnsnowlabs.nlp
+package com.johnsnowlabs.nlp.annotators
 
 import com.johnsnowlabs.nlp.AnnotatorType.{CHUNK, DOCUMENT}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, Doc2Chunk, HasSimpleAnnotate}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 
 /** Converts a `CHUNK` type column back into `DOCUMENT`. Useful when trying to re-tokenize or do
@@ -27,7 +28,7 @@ import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
   * {{{
   * import spark.implicits._
   * import com.johnsnowlabs.nlp.pretrained.PretrainedPipeline
-  * import com.johnsnowlabs.nlp.Chunk2Doc
+  * import com.johnsnowlabs.nlp.annotators.Chunk2Doc
   *
   * val data = Seq((1, "New York and New Jersey aren't that far apart actually.")).toDF("id", "text")
   *

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Date2Chunk.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Date2Chunk.scala
@@ -20,8 +20,6 @@ import com.johnsnowlabs.nlp.AnnotatorType._
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasSimpleAnnotate}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 
-import scala.collection.immutable.Map
-
 /** Converts `DATE` type Annotations to `CHUNK` type.
   *
   * This can be useful if the following annotators after DateMatcher and MultiDateMatcher require

--- a/src/main/scala/com/johnsnowlabs/nlp/base.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/base.scala
@@ -16,6 +16,7 @@
 
 package com.johnsnowlabs.nlp
 
+import com.johnsnowlabs.nlp
 import org.apache.spark.ml.util.DefaultParamsReadable
 
 package object base {
@@ -35,10 +36,6 @@ package object base {
   type Doc2Chunk = com.johnsnowlabs.nlp.Doc2Chunk
 
   object Doc2Chunk extends DefaultParamsReadable[Doc2Chunk]
-
-  type Chunk2Doc = com.johnsnowlabs.nlp.Chunk2Doc
-
-  object Chunk2Doc extends DefaultParamsReadable[Chunk2Doc]
 
   type Finisher = com.johnsnowlabs.nlp.Finisher
 
@@ -63,4 +60,5 @@ package object base {
   type TableAssembler = com.johnsnowlabs.nlp.TableAssembler
 
   object TableAssembler extends DefaultParamsReadable[TableAssembler]
+
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/Date2ChunkTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/Date2ChunkTestSpec.scala
@@ -17,7 +17,7 @@
 package com.johnsnowlabs.nlp
 
 import com.johnsnowlabs.nlp.annotator._
-import com.johnsnowlabs.nlp.annotators.MultiDateMatcher
+import com.johnsnowlabs.nlp.annotators.{Date2Chunk, MultiDateMatcher}
 import com.johnsnowlabs.tags.FastTest
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.{Dataset, Row}
@@ -66,6 +66,7 @@ class Date2ChunkTestSpec extends AnyFlatSpec {
     val pipeline = new Pipeline().setStages(Array(date, multiDate, date2Chunk, multiDate2Chunk))
 
     val pipelineModel = pipeline.fit(data)
+    pipelineModel.write.overwrite().save("./tmp_date2chunk_pipeline")
     val lightPipeline = new LightPipeline(pipelineModel)
 
     lightPipeline.annotate("Hello from Spark NLP in 2023 !")

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddingsTestSpec.scala
@@ -16,10 +16,8 @@
 
 package com.johnsnowlabs.nlp.embeddings
 
-import com.johnsnowlabs.nlp.annotator.{SentenceDetectorDLModel, Tokenizer}
-import com.johnsnowlabs.nlp.annotators.RegexMatcher
-import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
-import com.johnsnowlabs.nlp.base.{Chunk2Doc, DocumentAssembler}
+import com.johnsnowlabs.nlp.annotator._
+import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.training.CoNLL
 import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
 import com.johnsnowlabs.tags.{FastTest, SlowTest}


### PR DESCRIPTION
When a pipeline is saved with either Date2Chunk or Chunk2Doc annotators, when it is being loaded in Python it cannot find these annotators. The pacakges were not sync between Python and Scala. 

These two annotators are now under `annotators` package in Python and Scala