### PR TITLE
SPARKNLP-746: Handle empty validation sets

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowClassifier.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowClassifier.scala
@@ -130,7 +130,7 @@ class TensorflowClassifier(
         enableOutputLogs,
         outputLogsPath)
 
-      if (validationSplit > 0.0) {
+      if (validationSet.nonEmpty && validationSplit > 0.0) {
         println(
           s"Quality on validation dataset (${validationSplit * 100}%), validation examples = ${validationSet.length}")
         outputLog(
@@ -145,6 +145,9 @@ class TensorflowClassifier(
           extended = evaluationLogExtended,
           enableOutputLogs,
           outputLogsPath)
+      } else if (validationSet.isEmpty) {
+        println(f"WARNING: Could not create validation set. " +
+          f"Number of data points (${inputs._1.length}) not enough for validation split $validationSplit.")
       }
 
       if (testSet.nonEmpty) {
@@ -256,7 +259,7 @@ class TensorflowClassifier(
       .run()
 
     val tagsId = TensorResources.extractFloats(calculated.get(0)).grouped(numClasses).toArray
-    val predictedLabels = tagsId.map { case (score) =>
+    val predictedLabels = tagsId.map { score =>
       val labelId = score.zipWithIndex.maxBy(_._1)._2
       labelId
     }

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowMultiClassifier.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowMultiClassifier.scala
@@ -152,7 +152,7 @@ private[johnsnowlabs] class TensorflowMultiClassifier(
         enableOutputLogs,
         outputLogsPath)
 
-      if (validationSplit > 0.0) {
+      if (validationSet.nonEmpty && validationSplit > 0.0) {
         println(
           s"Quality on validation dataset (${validationSplit * 100}%), validation examples = ${validationSet.length} ")
         outputLog(
@@ -167,6 +167,9 @@ private[johnsnowlabs] class TensorflowMultiClassifier(
           extended = evaluationLogExtended,
           enableOutputLogs,
           outputLogsPath)
+      } else if (validationSet.isEmpty) {
+        println(f"WARNING: Could not create validation set. " +
+          f"Number of data points (${trainInputs._1.length}) not enough for validation split $validationSplit.")
       }
 
       if (testInputs.isDefined) {

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLTestSpec.scala
@@ -25,6 +25,8 @@ import org.apache.spark.ml.Pipeline
 import org.scalatest.flatspec.AnyFlatSpec
 
 class ClassifierDLTestSpec extends AnyFlatSpec {
+  import ResourceHelper.spark.implicits._
+
 
   "ClassifierDL" should "correctly train IMDB train dataset" taggedAs SlowTest in {
 
@@ -58,7 +60,7 @@ class ClassifierDLTestSpec extends AnyFlatSpec {
 
     val pipelineModel = pipeline.fit(smallCorpus)
 
-    pipelineModel.transform(smallCorpus).select("document").show(1, false)
+    pipelineModel.transform(smallCorpus).select("document").show(1, truncate = false)
 
   }
 
@@ -106,5 +108,42 @@ class ClassifierDLTestSpec extends AnyFlatSpec {
     val classifierDL = ClassifierDLModel.pretrained("classifierdl_use_trec50")
     classifierDL.getClasses.foreach(x => print(x + ", "))
   }
+
+  "ClassifierDL" should "not fail on empty validation sets" taggedAs SlowTest in {
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentenceEmbeddings = BertSentenceEmbeddings
+      .pretrained("sent_small_bert_L2_128")
+      .setInputCols("document")
+      .setOutputCol("sentence_embeddings")
+
+    val docClassifier = new ClassifierDLApproach()
+      .setInputCols("sentence_embeddings")
+      .setOutputCol("category")
+      .setLabelColumn("label")
+      .setBatchSize(8)
+      .setMaxEpochs(1)
+      .setLr(5e-3f)
+      .setDropout(0.5f)
+      .setValidationSplit(0.1f)
+
+
+    val pipeline = new Pipeline()
+      .setStages(Array(documentAssembler, sentenceEmbeddings, docClassifier))
+
+    val data = Seq(
+      ("This is good.", "good"),
+      ("This is bad.", "bad"),
+      ("This has no labels", "")
+    ).toDF("text", "label")
+
+
+    val pipelineModel = pipeline.fit(data)
+
+    pipelineModel.transform(data).select("document").show(1, truncate = false)
+  }
+
 
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Users can set a validation split when training a `ClassifierDLApproach` or `MultiClassifierDLApproach`. However, if this fraction and training data count is low, it can result in empty validation. Currently, this will cause an uncaught error. This PR fixes this and prints a warning.

Changes:
- handle and print warning when insufficient training data with low validation split produces empty validation set
- resolved some warnings

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects otherareas of the code, etc. -->
Added new tests to reflect the behavior.  Tests are passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)

