### PR TITLE
SPARKNLP-786 Add support for non-schema NER tags

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerTagsEncoding.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/NerTagsEncoding.scala
@@ -87,9 +87,9 @@ object NerTagsEncoding {
 
     }
 
-    def getTag(tag: String): Option[String] = {
+    def getTag(tag: String, startsWithSchema: Boolean = true): Option[String] = {
       try {
-        lastTag = Some(tag.substring(2))
+        lastTag = Some(if (startsWithSchema) tag.substring(2) else tag)
       } catch {
         case e: StringIndexOutOfBoundsException =>
           require(
@@ -101,16 +101,17 @@ object NerTagsEncoding {
 
     for (i <- 0 until words) {
       val tag = sentence.tags(i)
-      if (lastTag.isDefined && (tag.startsWith(beginningTagChunk) || tag == noChunk)) {
+      val hasSchema = tag.startsWith(beginningTagChunk)
+      if (lastTag.isDefined && (hasSchema || tag == noChunk)) {
         flushEntity(lastTagStart, i - 1)
       }
 
       if (includeNoneEntities && lastTag.isEmpty) {
-        lastTag = if (tag == noChunk) Some(tag) else getTag(tag)
+        lastTag = if (tag == noChunk) Some(tag) else getTag(tag, hasSchema)
         lastTagStart = i
       } else {
         if (lastTag.isEmpty && tag != noChunk) {
-          lastTag = getTag(tag)
+          lastTag = getTag(tag, hasSchema)
           lastTagStart = i
         }
       }


### PR DESCRIPTION
This PR adds support for NER tags without any schema to be detected correctly in NerConverter annotator.

Currently, if the NER labels/tags generated by NerDLModel or any XXXForTokenClassification annotators have no schema (IO/IOB/IOB2/etc.) the NerConverter has some difficulties to extract the tag in its metadata. 

IOB/IOB2 -> I-PER / B-PER
without Schema -> PER

```sh
+----------------------------------------------------------------------------------------------+
|result                                                                                        |
+----------------------------------------------------------------------------------------------+
|[PER, PER, O, O, O, LOC, O, O, O, LOC, O, O, O, O, PER, O, O, O, O, LOC]                      |
|[ORG, PER, O, O, O, O, O, O, O]                                                               |
|[ORG, O, ORG, O, O, O, ORG, ORG, O]                                                           |
|[LOC, O]                                                                                      |
|[PER, PER, O, O, O, O, O, O, O, O, O, LOC, O, LOC, O, O, O, O, O, O, O, O, O, O, O, O, O, LOC]|
|[LOC, O, O, O, O, LOC, LOC, O]                                                                |
|[PER, PER, O, O, O, LOC]                                                                      |
|[O, O, O, O, O, MISC, O, O, MISC, O, O, O, O, O, O, O, O, O, O, O, O, O, O]                   |
+----------------------------------------------------------------------------------------------+

+-------------------------------------------+
|result                                     |
+-------------------------------------------+
|[John Lenon, London, Paris, Sarah, London] |
|[Rare Hendrix]                             |
|[EU, German, British lamb]                 |
|[TORONTO]                                  |
|[Barack Obama, Honolulu, Hawaï, États-Unis]|
|[Paris, la France]                         |
|[george washington, washington]            |
|[Camembert, Français]                      |
+-------------------------------------------+

+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|metadata                                                                                                                                                                                                                                                                                                                                        |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|[{entity -> R, sentence -> 0, chunk -> 0, confidence -> 0.9936409}, {entity -> C, sentence -> 0, chunk -> 1, confidence -> 0.9953128}, {entity -> C, sentence -> 0, chunk -> 2, confidence -> 0.99524385}, {entity -> R, sentence -> 0, chunk -> 3, confidence -> 0.790784}, {entity -> C, sentence -> 0, chunk -> 4, confidence -> 0.99527025}]|
|[{entity -> G, sentence -> 0, chunk -> 0, confidence -> 0.6287162}]                                                                                                                                                                                                                                                                             |
|[{entity -> G, sentence -> 0, chunk -> 0, confidence -> 0.9442431}, {entity -> G, sentence -> 0, chunk -> 1, confidence -> 0.71734494}, {entity -> G, sentence -> 0, chunk -> 2, confidence -> 0.8528497}]                                                                                                                                      |
|[{entity -> C, sentence -> 0, chunk -> 0, confidence -> 0.98190045}]                                                                                                                                                                                                                                                                            |
|[{entity -> R, sentence -> 0, chunk -> 0, confidence -> 0.99367046}, {entity -> C, sentence -> 0, chunk -> 1, confidence -> 0.995496}, {entity -> C, sentence -> 0, chunk -> 2, confidence -> 0.9955146}, {entity -> C, sentence -> 0, chunk -> 3, confidence -> 0.9870782}]                                                                    |
|[{entity -> C, sentence -> 0, chunk -> 0, confidence -> 0.99531066}, {entity -> C, sentence -> 0, chunk -> 1, confidence -> 0.8560585}]                                                                                                                                                                                                         |
|[{entity -> R, sentence -> 0, chunk -> 0, confidence -> 0.9946363}, {entity -> C, sentence -> 0, chunk -> 1, confidence -> 0.9790525}]                                                                                                                                                                                                          |
|[{entity -> SC, sentence -> 0, chunk -> 0, confidence -> 0.98350376}, {entity -> SC, sentence -> 0, chunk -> 1, confidence -> 0.9772832}]                                                                                                                                                                                                       |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

The issue here is the `G` or `SC` which is a partial extraction of the tags without any schema. This PR adds a support to extract non-schema NER tags in metadata.