### PR TITLE
SPARKNLP-782 Removes deprecated parameter enablePatternRegex

### DIFF
--- a/python/sparknlp/annotator/er/entity_ruler.py
+++ b/python/sparknlp/annotator/er/entity_ruler.py
@@ -27,9 +27,6 @@ class EntityRulerApproach(AnnotatorApproach, HasStorage):
     to be set as the "format" field in the ``option`` parameter map and
     depending on the file type, additional parameters might need to be set.
 
-    To enable regex extraction, ``setEnablePatternRegex(True)`` needs to be
-    called.
-
     If the file is in a JSON format, then the rule definitions need to be given
     in a list with the fields "id", "label" and "patterns"::
 
@@ -71,8 +68,6 @@ class EntityRulerApproach(AnnotatorApproach, HasStorage):
     ----------
     patternsResource
         Resource in JSON or CSV format to map entities to patterns
-    enablePatternRegex
-        Enables regex pattern match
     useStorage
         Whether to use RocksDB storage to serialize patterns
 
@@ -106,8 +101,7 @@ class EntityRulerApproach(AnnotatorApproach, HasStorage):
     ...       "patterns.csv",
     ...       ReadAs.TEXT,
     ...       {"format": "csv", "delimiter": "\\\\|"}
-    ...     ) \\
-    ...     .setEnablePatternRegex(True)
+    ...     )
     >>> pipeline = Pipeline().setStages([
     ...     documentAssembler,
     ...     tokenizer,
@@ -134,11 +128,6 @@ class EntityRulerApproach(AnnotatorApproach, HasStorage):
                              "patternsResource",
                              "Resource in JSON or CSV format to map entities to patterns",
                              typeConverter=TypeConverters.identity)
-
-    enablePatternRegex = Param(Params._dummy(),
-                               "enablePatternRegex",
-                               "Enables regex pattern match",
-                               typeConverter=TypeConverters.toBoolean)
 
     useStorage = Param(Params._dummy(),
                        "useStorage",
@@ -173,16 +162,6 @@ class EntityRulerApproach(AnnotatorApproach, HasStorage):
             Options for parsing the resource, by default {"format": "JSON"}
         """
         return self._set(patternsResource=ExternalResource(path, read_as, options))
-
-    def setEnablePatternRegex(self, value):
-        """Sets whether to enable regex pattern matching.
-
-        Parameters
-        ----------
-        value : bool
-            Whether to enable regex pattern matching.
-        """
-        return self._set(enablePatternRegex=value)
 
     def setUseStorage(self, value):
         """Sets whether to use RocksDB storage to serialize patterns.

--- a/src/main/scala/com/johnsnowlabs/storage/Database.scala
+++ b/src/main/scala/com/johnsnowlabs/storage/Database.scala
@@ -36,10 +36,6 @@ object Database {
   val TMNODES: Name = new Name {
     override val name: String = "TMNODES"
   }
-  @deprecated
-  val ENTITY_PATTERNS: Name = new Name {
-    override val name: String = "ENTITY_PATTERNS"
-  }
   val ENTITY_REGEX_PATTERNS: Name = new Name {
     override val name: String = "ENTITY_REGEX_PATTERNS"
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change removes `enablePatternRegex` parameter from EntityRuler since it's deprecated starting at spark-nlp 4.2.0. It only lets a private parameter in `EntityRulerModel` for backward compatibility

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It has been enough time since the deprecation of `enablePatternRegex`. It will be remove for the next major release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Local tests loading a model trained with older versions.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
