### PR TITLE
SPARKNLP-748: Custom Entity Name for Date2Chunk

### DIFF
--- a/python/sparknlp/annotator/date2_chunk.py
+++ b/python/sparknlp/annotator/date2_chunk.py
@@ -29,16 +29,17 @@ class Date2Chunk(AnnotatorModel):
 
     Parameters
     ----------
-    None
+    entityName
+        Entity name for the metadata, by default ``"DATE"``.
 
     Examples
     --------
     >>> from pyspark.ml import Pipeline
 
-import sparknlp
-from sparknlp.base import *
-from sparknlp.annotator import *
-documentAssembler = DocumentAssembler() \\
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> documentAssembler = DocumentAssembler() \\
     ...     .setInputCol("text") \\
     ...     .setOutputCol("document")
     >>> date = DateMatcher() \\
@@ -70,3 +71,18 @@ documentAssembler = DocumentAssembler() \\
     @keyword_only
     def __init__(self):
         super(Date2Chunk, self).__init__(classname="com.johnsnowlabs.nlp.annotators.Date2Chunk")
+        self._setDefault(entityName="DATE")
+
+    entityName = Param(Params._dummy(), "entityName", "Entity name for the metadata",
+                       TypeConverters.toString)
+
+    def setEntityName(self, name):
+        """Sets Learning Rate, by default 0.001.
+
+        Parameters
+        ----------
+        v : float
+            Learning Rate
+        """
+        self._set(entityName=name)
+        return self

--- a/python/test/annotator/date2_chunk_test.py
+++ b/python/test/annotator/date2_chunk_test.py
@@ -51,7 +51,8 @@ class Date2ChunkTestSpec(unittest.TestCase):
 
         date_to_chunk = Date2Chunk() \
             .setInputCols(['date']) \
-            .setOutputCol("date_chunk")
+            .setOutputCol("date_chunk") \
+            .setEntityName("DATUM")
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Date2Chunk.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Date2Chunk.scala
@@ -18,12 +18,13 @@ package com.johnsnowlabs.nlp.annotators
 
 import com.johnsnowlabs.nlp.AnnotatorType._
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasSimpleAnnotate}
+import org.apache.spark.ml.param.Param
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 
 /** Converts `DATE` type Annotations to `CHUNK` type.
   *
   * This can be useful if the following annotators after DateMatcher and MultiDateMatcher require
-  * `CHUNK` types.
+  * `CHUNK` types. The entity name in the metadata can be changed with `setEntityName`.
   *
   * ==Example==
   * {{{
@@ -104,6 +105,20 @@ class Date2Chunk(override val uid: String)
 
   def this() = this(Identifiable.randomUID("Date2Chunk"))
 
+  /** Entity name for metadata (Default: `DATE`)
+    *
+    * @group param
+    */
+  val entityName =
+    new Param[String](this, "entityName", "Entity name for the metadata")
+
+  /** Sets entity name for metadata (Default: `DATE`)
+    *
+    * @group setParam
+    */
+  def setEntityName(name: String): this.type = set(this.entityName, name)
+
+  setDefault(entityName -> "DATE")
   override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
     annotations.map { date =>
       Annotation(
@@ -111,7 +126,7 @@ class Date2Chunk(override val uid: String)
         date.begin,
         date.end,
         date.result,
-        date.metadata ++ Map("entity" -> "DATE", "chunk" -> "0"))
+        date.metadata ++ Map("entity" -> $(entityName), "chunk" -> "0"))
     }
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR adds a new feature to the `Date2Chunk` annotator that allows the user to change the name of the converted date entity.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing and new tests are passing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)