### PR TITLE
SPARKNLP-784 Fix loading WordEmbeddingsModel Bug

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
@@ -229,7 +229,7 @@ class WordEmbeddingsModel(override val uid: String)
     WordpieceEmbeddingsSentence.pack(withEmbeddings)
   }
 
-  def retrieveEmbeddings(token: String): (Option[Array[Float]], Array[Float]) = {
+  private def retrieveEmbeddings(token: String): (Option[Array[Float]], Array[Float]) = {
     if ($(enableInMemoryStorage)) {
       val zeroArray = Array.fill[Float]($(dimension))(0f)
       var embeddings: Option[Array[Float]] = None

--- a/src/main/scala/com/johnsnowlabs/storage/StorageLocator.scala
+++ b/src/main/scala/com/johnsnowlabs/storage/StorageLocator.scala
@@ -26,7 +26,7 @@ case class StorageLocator(database: String, storageRef: String, sparkSession: Sp
 
   private val clusterTmpLocation: String = {
     val tmpLocation = getTmpLocation
-    if (tmpLocation.startsWith("s3:/")) {
+    if (tmpLocation.matches("s3[a]?:/.*")) {
       tmpLocation
     } else {
       val tmpLocationPath = new Path(tmpLocation)
@@ -41,15 +41,14 @@ case class StorageLocator(database: String, storageRef: String, sparkSession: Sp
   }
 
   val clusterFilePath: Path = {
-    if (!getTmpLocation.startsWith("s3:/")) {
+    if (!getTmpLocation.matches("s3[a]?:/.*")) {
       Path.mergePaths(
         new Path(fileSystem.getUri.toString + clusterTmpLocation),
         new Path("/" + clusterFileName))
     } else new Path(clusterTmpLocation + "/" + clusterFileName)
   }
 
-  val destinationScheme: String =
-    if (getTmpLocation.startsWith("s3:/")) "s3" else fileSystem.getScheme
+  val destinationScheme: String = fileSystem.getScheme
 
   private def getTmpLocation: String = {
     ConfigLoader.getConfigStringValue(ConfigHelper.storageTmpDir)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change fixes a bug when loading WordEmbeddingsModel in case `cache_folder` is defined for S3

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix this kind of error:
```
[info] Uploading model glove_100d_en_2.4.0_2.4_1579690104032 to external Cloud Storage URI: s3a://aws-glue-assets/cache_pretrained
[info] Download done! Loading the resource.
[error] Exception in thread "main" java.lang.ExceptionInInitializerError
[error]         at com.johnsnowlabs.grpc.LanguageServer.run(LanguageServer.scala:44)
[error]         at com.johnsnowlabs.grpc.LanguageServer$.start(LanguageServer.scala:28)
[error]         at com.johnsnowlabs.grpc.Main$.init(Main.scala:20)
[error]         at com.johnsnowlabs.grpc.Main$.main(Main.scala:12)
[error]         at com.johnsnowlabs.grpc.Main.main(Main.scala)
[error] Caused by: java.lang.IllegalArgumentException: Wrong FS: s3a://aws-glue-assets/cache_pretrained/glove_100d_en_2.4.0_2.4_1579690104032/storage/EMBEDDINGS_glove_100d, expected: file:///
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

- Google Colab [Notebook](https://colab.research.google.com/drive/1K3yADUa6v_-rQL9wr4inRD9vyVY2IvjB?usp=sharing)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

copilot:all