### PR TITLE
SPARKNLP-785 Fix WordEmbeddingsModel Bug with LightPipeline

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsModel.scala
@@ -188,7 +188,15 @@ class WordEmbeddingsModel(override val uid: String)
 
   private var memoryStorage: Option[Broadcast[Map[BytesKey, Array[Byte]]]] = None
 
-  def getInMemoryStorage: Map[BytesKey, Array[Byte]] = memoryStorage.get.value
+  private def getInMemoryStorage: Map[BytesKey, Array[Byte]] = {
+    memoryStorage.map(_.value).getOrElse {
+      if ($(enableInMemoryStorage)) {
+        getReader(Database.EMBEDDINGS).exportStorageToMap()
+      } else {
+        Map.empty
+      }
+    }
+  }
 
   override def beforeAnnotate(dataset: Dataset[_]): Dataset[_] = {
     if (this.memoryStorage.isEmpty && $(enableInMemoryStorage)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When using `WorbEmbeddingsModel` with `setEnableInMemoryStorage` as true in a `LightPipeline` it raised `Non.get` error

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make available `WorbEmbeddingsModel` in `LightPipeline`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

- Google Colab [Notebook](https://colab.research.google.com/drive/1vlqPg5rQU7SchthYBwq8VmzM7nEuG-B7?usp=sharing)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](http://nlp.johnsnowlabs.com/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
