### PR TITLE
SPARKNLP-783: Python 3.6 deprecated in Spark 3.2

### DIFF
--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -35,7 +35,11 @@ spark-shell --jars spark-nlp-assembly-4.3.2.jar
 
 ## Python
 
-Spark NLP supports Python 3.6.x and above depending on your major PySpark version.
+Spark NLP supports Python 3.7.x and above depending on your major PySpark version.
+
+**NOTE**: Since Spark version 3.2, Python 3.6 is deprecated. If you are using this
+python version, consider sticking to lower versions of Spark.
+
 #### Quick Install
 
 Let's create a new Conda environment to manage all the dependencies there. You can use Python Virtual Environment if you prefer or not have any environment.

--- a/python/docs/getting_started/index.rst
+++ b/python/docs/getting_started/index.rst
@@ -54,10 +54,12 @@ Requirements
 Spark NLP is built on top of Apache Spark `3.x`. For using Spark NLP you need:
 
 * Java 8
-* Apache Spark ``3.1.x`` (or ``3.0.x``, or ``2.4.x``, or ``2.3.x``)
+* Apache Spark (from ``2.3.x`` to ``3.3.x``)
 * Python ``3.8.x`` if you are using PySpark ``3.x``
 
-  * Python ``3.6.x`` and ``3.7.x`` if you are using PySpark ``2.3.x`` or ``2.4.x``
+    * **NOTE**: Since Spark version 3.2, Python 3.6 is deprecated. If you are using this
+      python version, consider sticking to lower versions of Spark.
+    * For Python ``3.6.x`` and ``3.7.x`` we recommend PySpark ``2.3.x`` or ``2.4.x``
 
 It is recommended to have basic knowledge of the framework and a working environment before using Spark NLP.
 Please refer to `Spark documentation <https://spark.apache.org/docs/latest/api/python/index.html>`_ to get started with Spark.

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -117,6 +117,11 @@ def start(gpu=False,
     output_level : int, optional
         Output level for logs, by default 1
 
+    Notes
+    -----
+    Since Spark version 3.2, Python 3.6 is deprecated. If you are using this
+    python version, consider sticking to lower versions of Spark.
+
     Returns
     -------
     :class:`SparkSession`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a note in the documentation, that Python 3.6 is deprecated in Spark 3.2