### PR TITLE
SPARKNLP-763 Implementing ZeroShot Text Classification for BERT and DistilBERT based on NLI

### DIFF
--- a/python/sparknlp/annotator/classifier_dl/__init__.py
+++ b/python/sparknlp/annotator/classifier_dl/__init__.py
@@ -43,3 +43,4 @@ from sparknlp.annotator.classifier_dl.camembert_for_token_classification import 
 from sparknlp.annotator.classifier_dl.tapas_for_question_answering import *
 from sparknlp.annotator.classifier_dl.camembert_for_sequence_classification import *
 from sparknlp.annotator.classifier_dl.camembert_for_question_answering import *
+from sparknlp.annotator.classifier_dl.bert_for_zero_shot_classification import *

--- a/python/sparknlp/annotator/classifier_dl/bert_for_zero_shot_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_zero_shot_classification.py
@@ -1,0 +1,216 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Contains classes for BertForSequenceClassification."""
+
+from sparknlp.common import *
+
+
+class BertForZeroShotClassification(AnnotatorModel,
+                                    HasCaseSensitiveProperties,
+                                    HasBatchedAnnotate,
+                                    HasClassifierActivationProperties,
+                                    HasCandidateLabelsProperties,
+                                    HasEngine):
+    """BertForZeroShotClassification can load Bert Models with sequence classification/regression head on top
+    (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
+
+    Pretrained models can be loaded with :meth:`.pretrained` of the companion
+    object:
+
+    >>> sequenceClassifier = BertForZeroShotClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label")
+
+    The default model is ``"bert_base_sequence_classifier_imdb"``, if no name is
+    provided.
+
+    For available pretrained models please see the `Models Hub
+    <https://nlp.johnsnowlabs.com/models?task=Text+Classification>`__.
+
+    To see which models are compatible and how to import them see
+    `Import Transformers into Spark NLP 🚀
+    <https://github.com/JohnSnowLabs/spark-nlp/discussions/5669>`_.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT, TOKEN``    ``CATEGORY``
+    ====================== ======================
+
+    Parameters
+    ----------
+    batchSize
+        Batch size. Large values allows faster processing but requires more
+        memory, by default 8
+    caseSensitive
+        Whether to ignore case in tokens for embeddings matching, by default
+        True
+    configProtoBytes
+        ConfigProto from tensorflow, serialized into byte array.
+    maxSentenceLength
+        Max sentence length to process, by default 128
+    coalesceSentences
+        Instead of 1 class per sentence (if inputCols is `sentence`) output 1
+        class per document by averaging probabilities in all sentences, by
+        default False
+    activation
+        Whether to calculate logits via Softmax or Sigmoid, by default
+        `"softmax"`.
+
+    Examples
+    --------
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("token")
+    >>> sequenceClassifier = BertForZeroShotClassification.pretrained() \\
+    ...     .setInputCols(["token", "document"]) \\
+    ...     .setOutputCol("label") \\
+    ...     .setCaseSensitive(True)
+    >>> pipeline = Pipeline().setStages([
+    ...     documentAssembler,
+    ...     tokenizer,
+    ...     sequenceClassifier
+    ... ])
+    >>> data = spark.createDataFrame([["I loved this movie when I was a child.", "It was pretty boring."]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.select("label.result").show(truncate=False)
+    +------+
+    |result|
+    +------+
+    |[pos] |
+    |[neg] |
+    +------+
+    """
+    name = "BertForZeroShotClassification"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.TOKEN]
+
+    outputAnnotatorType = AnnotatorType.CATEGORY
+
+    maxSentenceLength = Param(Params._dummy(),
+                              "maxSentenceLength",
+                              "Max sentence length to process",
+                              typeConverter=TypeConverters.toInt)
+
+    configProtoBytes = Param(Params._dummy(),
+                             "configProtoBytes",
+                             "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
+                             TypeConverters.toListInt)
+
+    coalesceSentences = Param(Params._dummy(), "coalesceSentences",
+                              "Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.",
+                              TypeConverters.toBoolean)
+
+    def getClasses(self):
+        """
+        Returns labels used to train this model
+        """
+        return self._call_java("getClasses")
+
+    def setConfigProtoBytes(self, b):
+        """Sets configProto from tensorflow, serialized into byte array.
+
+        Parameters
+        ----------
+        b : List[int]
+            ConfigProto from tensorflow, serialized into byte array
+        """
+        return self._set(configProtoBytes=b)
+
+    def setMaxSentenceLength(self, value):
+        """Sets max sentence length to process, by default 128.
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
+        return self._set(maxSentenceLength=value)
+
+    def setCoalesceSentences(self, value):
+        """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.
+        Due to max sequence length limit in almost all transformer models such as BERT (512 tokens), this parameter helps feeding all the sentences
+        into the model and averaging all the probabilities for the entire document instead of probabilities per sentence. (Default: true)
+
+        Parameters
+        ----------
+        value : bool
+            If the output of all sentences will be averaged to one output
+        """
+        return self._set(coalesceSentences=value)
+
+    @keyword_only
+    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.BertForZeroShotClassification",
+                 java_model=None):
+        super(BertForZeroShotClassification, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        self._setDefault(
+            batchSize=8,
+            maxSentenceLength=128,
+            caseSensitive=True,
+            coalesceSentences=False,
+            activation="softmax"
+        )
+
+    @staticmethod
+    def loadSavedModel(folder, spark_session):
+        """Loads a locally saved model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the saved model
+            spark_session : pyspark.sql.SparkSession
+            The current SparkSession
+
+        Returns
+        -------
+        BertForZeroShotClassification
+            The restored model
+        """
+        from sparknlp.internal import _BertZeroShotClassifierLoader
+        jModel = _BertZeroShotClassifierLoader(folder, spark_session._jsparkSession)._java_obj
+        return BertForZeroShotClassification(java_model=jModel)
+
+    @staticmethod
+    def pretrained(name="bert_base_sequence_classifier_imdb", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default
+            "bert_base_sequence_classifier_imdb"
+            lang : str, optional
+            Language of the pretrained model, by default "en"
+            remote_loc : str, optional
+            Optional remote address of the resource, by default None. Will use
+            Spark NLPs repositories otherwise.
+
+        Returns
+        -------
+        BertForZeroShotClassification
+            The restored model
+        """
+        from sparknlp.pretrained import ResourceDownloader
+        return ResourceDownloader.downloadModel(BertForZeroShotClassification, name, lang, remote_loc)

--- a/python/sparknlp/annotator/classifier_dl/bert_for_zero_shot_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_zero_shot_classification.py
@@ -22,8 +22,13 @@ class BertForZeroShotClassification(AnnotatorModel,
                                     HasClassifierActivationProperties,
                                     HasCandidateLabelsProperties,
                                     HasEngine):
-    """BertForZeroShotClassification can load Bert Models with sequence classification/regression head on top
-    (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
+    """BertForZeroShotClassification using a `ModelForSequenceClassification` trained on NLI (natural language
+    inference) tasks. Equivalent of `BertForSequenceClassification` models, but these models don't require a hardcoded
+    number of potential classes, they can be chosen at runtime. It usually means it's slower but it is much more
+    flexible.
+
+    Any combination of sequences and labels can be passed and each combination will be posed as a premise/hypothesis
+    pair and passed to the pretrained model.
 
     Pretrained models can be loaded with :meth:`.pretrained` of the companion
     object:

--- a/python/sparknlp/annotator/classifier_dl/bert_for_zero_shot_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_zero_shot_classification.py
@@ -32,7 +32,7 @@ class BertForZeroShotClassification(AnnotatorModel,
     ...     .setInputCols(["token", "document"]) \\
     ...     .setOutputCol("label")
 
-    The default model is ``"bert_base_sequence_classifier_imdb"``, if no name is
+    The default model is ``"bert_base_cased_zero_shot_classifier_xnli"``, if no name is
     provided.
 
     For available pretrained models please see the `Models Hub
@@ -193,14 +193,14 @@ class BertForZeroShotClassification(AnnotatorModel,
         return BertForZeroShotClassification(java_model=jModel)
 
     @staticmethod
-    def pretrained(name="bert_base_sequence_classifier_imdb", lang="en", remote_loc=None):
+    def pretrained(name="bert_base_cased_zero_shot_classifier_xnli", lang="en", remote_loc=None):
         """Downloads and loads a pretrained model.
 
         Parameters
         ----------
         name : str, optional
             Name of the pretrained model, by default
-            "bert_base_sequence_classifier_imdb"
+            "bert_base_cased_zero_shot_classifier_xnli"
             lang : str, optional
             Language of the pretrained model, by default "en"
             remote_loc : str, optional

--- a/python/sparknlp/common/properties.py
+++ b/python/sparknlp/common/properties.py
@@ -391,3 +391,47 @@ class HasEngine:
            Deep Learning engine used for this model"
         """
         return self.getOrDefault(self.engine)
+
+
+class HasCandidateLabelsProperties:
+    candidateLabels = Param(Params._dummy(), "candidateLabels",
+                            "Deep Learning engine used for this model",
+                            typeConverter=TypeConverters.toListString)
+
+    contradictionIdParam = Param(Params._dummy(), "contradictionIdParam",
+                                 "contradictionIdParam",
+                                 typeConverter=TypeConverters.toInt)
+
+    entailmentIdParam = Param(Params._dummy(), "entailmentIdParam",
+                              "contradictionIdParam",
+                              typeConverter=TypeConverters.toInt)
+
+    def setCandidateLabels(self, v):
+        """Sets candidateLabels.
+
+        Parameters
+        ----------
+        v : list[string]
+            candidateLabels
+        """
+        return self._set(candidateLabels=v)
+
+    def setContradictionIdParam(self, v):
+        """Sets contradictionIdParam.
+
+        Parameters
+        ----------
+        v : int
+            contradictionIdParam
+        """
+        return self._set(contradictionIdParam=v)
+
+    def setEntailmentIdParam(self, v):
+        """Sets entailmentIdParam.
+
+        Parameters
+        ----------
+        v : int
+            entailmentIdParam
+        """
+        return self._set(entailmentIdParam=v)

--- a/python/sparknlp/internal/__init__.py
+++ b/python/sparknlp/internal/__init__.py
@@ -497,3 +497,9 @@ class _RobertaQAToZeroShotNerLoader(ExtendedJavaWrapper):
     def __init__(self, path):
         super(_RobertaQAToZeroShotNerLoader, self).__init__(
             "com.johnsnowlabs.nlp.annotators.ner.dl.ZeroShotNerModel.load", path)
+
+
+class _BertZeroShotClassifierLoader(ExtendedJavaWrapper):
+    def __init__(self, path, jspark):
+        super(_BertZeroShotClassifierLoader, self).__init__(
+            "com.johnsnowlabs.nlp.annotators.classifier.dl.BertForZeroShotClassification.loadSavedModel", path, jspark)

--- a/python/test/annotator/classifier_dl/bert_for_zero_shot_classification_test.py
+++ b/python/test/annotator/classifier_dl/bert_for_zero_shot_classification_test.py
@@ -1,0 +1,52 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class BertForZeroShotClassificationTestSpec(unittest.TestCase):
+    def setUp(self):
+        self.spark = SparkContextForTest.spark
+        self.text = "I have a problem with my iphone that needs to be resolved asap!!"
+        self.inputDataset = self.spark.createDataFrame([[self.text]]) \
+            .toDF("text")
+
+    def runTest(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        zero_shot_classifier = BertForZeroShotClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("class") \
+            .setCandidateLabels(["urgent", "mobile", "travel", "movie", "music", "sport", "weather", "technology"])
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            zero_shot_classifier
+        ])
+
+        model = pipeline.fit(self.inputDataset)
+        model.transform(self.inputDataset).show()
+        light_pipeline = LightPipeline(model)
+        annotations_result = light_pipeline.fullAnnotate(self.text)

--- a/src/main/scala/com/johnsnowlabs/ml/ai/AlbertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/AlbertClassification.scala
@@ -71,6 +71,11 @@ private[johnsnowlabs] class AlbertClassification(
     sentenceTokenPieces
   }
 
+  def tokenizeSeqString(
+      candidateLabels: Seq[String],
+      maxSeqLength: Int,
+      caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = ???
+
   def tokenizeDocument(
       docs: Seq[Annotation],
       maxSeqLength: Int,
@@ -222,6 +227,12 @@ private[johnsnowlabs] class AlbertClassification(
 
     batchScores
   }
+
+  def tagZeroShotSequence(
+      batch: Seq[Array[Int]],
+      entailmentId: Int,
+      contradictionId: Int,
+      activation: String): Array[Array[Float]] = ???
 
   def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) = {
     val tensors = new TensorResources()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/BertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/BertClassification.scala
@@ -79,8 +79,8 @@ private[johnsnowlabs] class BertClassification(
     }
   }
 
-   def tokenizeSeqString(
-       candidateLabels: Seq[String],
+  def tokenizeSeqString(
+      candidateLabels: Seq[String],
       maxSeqLength: Int,
       caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = {
 
@@ -330,18 +330,6 @@ private[johnsnowlabs] class BertClassification(
     tensors.clearSession(outs)
     tensors.clearTensors()
 
-//    val dim = rawScores.length / batchLength
-//    val batchScores: Array[Array[Float]] =
-//      rawScores
-//        .grouped(dim)
-//        .map(scores =>
-//          activation match {
-//            case ActivationFunction.softmax => calculateSoftmax(scores)
-//            case ActivationFunction.sigmoid => calculateSigmoid(scores)
-//            case _ => calculateSoftmax(scores)
-//          })
-//        .toArray
-//    Array(batchScores)
     val dim = rawScores.length / batchLength
     rawScores
       .grouped(dim)

--- a/src/main/scala/com/johnsnowlabs/ml/ai/CamemBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/CamemBertClassification.scala
@@ -81,6 +81,11 @@ private[johnsnowlabs] class CamemBertClassification(
     sentenceTokenPieces
   }
 
+  def tokenizeSeqString(
+      candidateLabels: Seq[String],
+      maxSeqLength: Int,
+      caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = ???
+
   def tokenizeDocument(
       docs: Seq[Annotation],
       maxSeqLength: Int,
@@ -222,6 +227,12 @@ private[johnsnowlabs] class CamemBertClassification(
 
     batchScores
   }
+
+  def tagZeroShotSequence(
+      batch: Seq[Array[Int]],
+      entailmentId: Int,
+      contradictionId: Int,
+      activation: String): Array[Array[Float]] = ???
 
   def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) = {
     val tensors = new TensorResources()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/DeBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/DeBertaClassification.scala
@@ -71,6 +71,11 @@ private[johnsnowlabs] class DeBertaClassification(
     sentenceTokenPieces
   }
 
+  def tokenizeSeqString(
+      candidateLabels: Seq[String],
+      maxSeqLength: Int,
+      caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = ???
+
   def tokenizeDocument(
       docs: Seq[Annotation],
       maxSeqLength: Int,
@@ -222,6 +227,12 @@ private[johnsnowlabs] class DeBertaClassification(
 
     batchScores
   }
+
+  def tagZeroShotSequence(
+      batch: Seq[Array[Int]],
+      entailmentId: Int,
+      contradictionId: Int,
+      activation: String): Array[Array[Float]] = ???
 
   def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) = {
     val tensors = new TensorResources()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/DistilBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/DistilBertClassification.scala
@@ -80,6 +80,11 @@ private[johnsnowlabs] class DistilBertClassification(
     }
   }
 
+  def tokenizeSeqString(
+      candidateLabels: Seq[String],
+      maxSeqLength: Int,
+      caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = ???
+
   def tokenizeDocument(
       docs: Seq[Annotation],
       maxSeqLength: Int,
@@ -234,6 +239,12 @@ private[johnsnowlabs] class DistilBertClassification(
 
     batchScores
   }
+
+  def tagZeroShotSequence(
+      batch: Seq[Array[Int]],
+      entailmentId: Int,
+      contradictionId: Int,
+      activation: String): Array[Array[Float]] = ???
 
   def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) = {
     val tensors = new TensorResources()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
@@ -80,6 +80,11 @@ private[johnsnowlabs] class RoBertaClassification(
     }
   }
 
+  def tokenizeSeqString(
+      candidateLabels: Seq[String],
+      maxSeqLength: Int,
+      caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = ???
+
   def tokenizeDocument(
       docs: Seq[Annotation],
       maxSeqLength: Int,
@@ -228,6 +233,12 @@ private[johnsnowlabs] class RoBertaClassification(
 
     batchScores
   }
+
+  def tagZeroShotSequence(
+      batch: Seq[Array[Int]],
+      entailmentId: Int,
+      contradictionId: Int,
+      activation: String): Array[Array[Float]] = ???
 
   def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) = {
     val tensors = new TensorResources()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
@@ -124,6 +124,96 @@ private[johnsnowlabs] trait XXXForClassification {
 
   }
 
+  def predictSequenceWithZeroShot(
+      tokenizedSentences: Seq[TokenizedSentence],
+      sentences: Seq[Sentence],
+      candidateLabels: Array[String],
+      entailmentId: Int,
+      contradictionId: Int,
+      batchSize: Int,
+      maxSentenceLength: Int,
+      caseSensitive: Boolean,
+      coalesceSentences: Boolean = false,
+      tags: Map[String, Int],
+      activation: String = ActivationFunction.softmax): Seq[Annotation] = {
+
+    val wordPieceTokenizedSentences =
+      tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
+
+    val candidateLabelsKeyValue = candidateLabels.zipWithIndex.toMap
+    val contradiction_id: Int = if (entailmentId == 0) contradictionId else 0
+
+    val labelsTokenized =
+      tokenizeSeqString(candidateLabels, maxSentenceLength, caseSensitive)
+
+    /*Run calculation by batches*/
+    wordPieceTokenizedSentences
+      .zip(sentences)
+      .zipWithIndex
+      .grouped(batchSize)
+      .flatMap { batch =>
+        val tokensBatch = batch.map(x => (x._1._1, x._2))
+
+        /* Start internal batching for zero shot */
+        val encodedTokensLabels = tokensBatch.map { sent =>
+          labelsTokenized.flatMap(labels =>
+            encodeSequence(Seq(sent._1), Seq(labels), maxSentenceLength))
+        }
+
+        val logits = encodedTokensLabels.map { encodedSeq =>
+          tagZeroShotSequence(encodedSeq, entailmentId, contradictionId, activation)
+        }
+
+        val multiClassScores =
+          logits.map(scores => calculateSoftmax(scores.map(x => x(entailmentId)))).toArray
+        val multiLabelScores =
+          logits
+            .map(scores =>
+              scores
+                .map(x => calculateSoftmax(Array(x(contradiction_id), x(entailmentId))))
+                .map(_.last))
+            .toArray
+
+        activation match {
+          case ActivationFunction.softmax =>
+            if (coalesceSentences) {
+              val scores = multiClassScores.transpose.map(_.sum / multiClassScores.length)
+              val label = scoresToLabelForSequenceClassifier(candidateLabelsKeyValue, scores)
+              val meta = constructMetaForSequenceClassifier(candidateLabelsKeyValue, scores)
+              Array(constructAnnotationForSequenceClassifier(sentences.head, label, meta))
+            } else {
+              sentences.zip(multiClassScores).map { case (sentence, scores) =>
+                val label = scoresToLabelForSequenceClassifier(candidateLabelsKeyValue, scores)
+                val meta = constructMetaForSequenceClassifier(candidateLabelsKeyValue, scores)
+                constructAnnotationForSequenceClassifier(sentence, label, meta)
+              }
+            }
+
+          case ActivationFunction.sigmoid =>
+            if (coalesceSentences) {
+              val scores = multiLabelScores.transpose.map(_.sum / multiLabelScores.length)
+              val labels = scores.zipWithIndex
+                .filter(x => x._1 > 0.5)
+                .flatMap(x => candidateLabelsKeyValue.filter(_._2 == x._2))
+              val meta = constructMetaForSequenceClassifier(candidateLabelsKeyValue, scores)
+              labels.map(label =>
+                constructAnnotationForSequenceClassifier(sentences.head, label._1, meta))
+            } else {
+              sentences.zip(multiLabelScores).flatMap { case (sentence, scores) =>
+                val labels = scores.zipWithIndex
+                  .filter(x => x._1 > 0.5)
+                  .flatMap(x => candidateLabelsKeyValue.filter(_._2 == x._2))
+                val meta = constructMetaForSequenceClassifier(candidateLabelsKeyValue, scores)
+                labels.map(label =>
+                  constructAnnotationForSequenceClassifier(sentence, label._1, meta))
+              }
+            }
+        }
+      }
+      .toSeq
+
+  }
+
   def scoresToLabelForSequenceClassifier(tags: Map[String, Int], scores: Array[Float]): String = {
     tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
   }
@@ -212,6 +302,11 @@ private[johnsnowlabs] trait XXXForClassification {
       maxSeqLength: Int,
       caseSensitive: Boolean): Seq[WordpieceTokenizedSentence]
 
+  def tokenizeSeqString(
+      candidateLabels: Seq[String],
+      maxSeqLength: Int,
+      caseSensitive: Boolean): Seq[WordpieceTokenizedSentence]
+
   def tokenizeDocument(
       docs: Seq[Annotation],
       maxSeqLength: Int,
@@ -264,6 +359,12 @@ private[johnsnowlabs] trait XXXForClassification {
 
   def tagSequence(batch: Seq[Array[Int]], activation: String): Array[Array[Float]]
 
+  def tagZeroShotSequence(
+      batch: Seq[Array[Int]],
+      entailmentId: Int,
+      contradictionId: Int,
+      activation: String): Array[Array[Float]]
+
   def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]])
 
   /** Calculate softmax from returned logits
@@ -276,7 +377,7 @@ private[johnsnowlabs] trait XXXForClassification {
     exp.map(x => x / exp.sum).map(_.toFloat)
   }
 
-  /** Calcuate sigmoid from returned logits
+  /** Calculate sigmoid from returned logits
     * @param scores
     *   logits output from output layer
     * @return

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoBertaClassification.scala
@@ -71,6 +71,11 @@ private[johnsnowlabs] class XlmRoBertaClassification(
     sentenceTokenPieces
   }
 
+  def tokenizeSeqString(
+      candidateLabels: Seq[String],
+      maxSeqLength: Int,
+      caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = ???
+
   def tokenizeDocument(
       docs: Seq[Annotation],
       maxSeqLength: Int,
@@ -211,6 +216,12 @@ private[johnsnowlabs] class XlmRoBertaClassification(
 
     batchScores
   }
+
+  def tagZeroShotSequence(
+      batch: Seq[Array[Int]],
+      entailmentId: Int,
+      contradictionId: Int,
+      activation: String): Array[Array[Float]] = ???
 
   def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) = {
     val tensors = new TensorResources()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XlnetClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XlnetClassification.scala
@@ -72,6 +72,11 @@ private[johnsnowlabs] class XlnetClassification(
     sentenceTokenPieces
   }
 
+  def tokenizeSeqString(
+      candidateLabels: Seq[String],
+      maxSeqLength: Int,
+      caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = ???
+
   def tokenizeDocument(
       docs: Seq[Annotation],
       maxSeqLength: Int,
@@ -220,6 +225,12 @@ private[johnsnowlabs] class XlnetClassification(
 
     batchScores
   }
+
+  def tagZeroShotSequence(
+      batch: Seq[Array[Int]],
+      entailmentId: Int,
+      contradictionId: Int,
+      activation: String): Array[Array[Float]] = ???
 
   def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) = {
     (Array.empty[Array[Float]], Array.empty[Array[Float]])

--- a/src/main/scala/com/johnsnowlabs/nlp/HasCandidateLabelsProperties.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasCandidateLabelsProperties.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp
+
+import org.apache.spark.ml.param.{StringArrayParam, IntParam}
+
+trait HasCandidateLabelsProperties extends ParamsAndFeaturesWritable {
+
+  /** Candidate labels for classification, you can set candidateLabels dynamically during the
+    * runtime
+    *
+    * @group param
+    */
+  val candidateLabels: StringArrayParam = new StringArrayParam(
+    this,
+    "candidateLabels",
+    "Candidate labels for classification, you can set candidateLabels dynamically during the runtime")
+
+  /** @group getParam */
+  def getCandidateLabels: Array[String] = $(candidateLabels)
+
+  /** @group setParam */
+  def setCandidateLabels(value: Array[String]): this.type = set(candidateLabels, value)
+
+  /** @group param */
+  val entailmentIdParam = new IntParam(this, "entailmentIdParam", "")
+
+  /** @group param */
+  val contradictionIdParam = new IntParam(this, "contradictionIdParam", "")
+
+  setDefault(
+    candidateLabels -> Array("urgent", "not_urgent"),
+    contradictionIdParam -> 0,
+    entailmentIdParam -> 2)
+}

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -677,4 +677,11 @@ package object annotator {
 
   object Chunk2Doc extends DefaultParamsReadable[Chunk2Doc]
 
+  type BertForZeroShotClassification =
+    com.johnsnowlabs.nlp.annotators.classifier.dl.BertForZeroShotClassification
+
+  object BertForZeroShotClassification
+      extends ReadablePretrainedBertForZeroShotModel
+      with ReadBertForZeroShotDLModel
+
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
@@ -95,7 +95,7 @@ import java.io.File
   * }}}
   *
   * @see
-  *   [[BertForSequenceClassification]] for sequnece-level classification
+  *   [[BertForSequenceClassification]] for sequence-level classification
   * @see
   *   [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of
   *   transformer based classifiers

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassification.scala
@@ -39,7 +39,7 @@ import java.io.File
 /** BertForZeroShotClassification using a `ModelForSequenceClassification` trained on NLI (natural
   * language inference) tasks. Equivalent of `BertForSequenceClassification` models, but these
   * models don't require a hardcoded number of potential classes, they can be chosen at runtime.
-  * It usually means it's slower but it is much** more flexible.
+  * It usually means it's slower but it is much more flexible.
   *
   * Any combination of sequences and labels can be passed and each combination will be posed as a
   * premise/hypothesis pair and passed to the pretrained model.

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassification.scala
@@ -1,0 +1,454 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.ml.ai.BertClassification
+import com.johnsnowlabs.ml.tensorflow._
+import com.johnsnowlabs.ml.util.LoadExternalModel.{
+  loadSentencePieceAsset,
+  loadTextAsset,
+  modelSanityCheck,
+  notSupportedEngineError
+}
+import com.johnsnowlabs.ml.util.ModelEngine
+import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.serialization.MapFeature
+import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.param.{BooleanParam, IntArrayParam, IntParam}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.SparkSession
+
+import java.io.File
+
+/** BertForZeroShotClassification using a `ModelForSequenceClassification` trained on NLI (natural
+  * language inference) tasks. Equivalent of `BertForSequenceClassification` models, but these
+  * models don't require a hardcoded number of potential classes, they can be chosen at runtime.
+  * It usually means it's slower but it is much** more flexible.
+  *
+  * Any combination of sequences and labels can be passed and each combination will be posed as a
+  * premise/hypothesis pair and passed to the pretrained model.
+  *
+  * Pretrained models can be loaded with `pretrained` of the companion object:
+  * {{{
+  * val sequenceClassifier = BertForZeroShotClassification.pretrained()
+  *   .setInputCols("token", "document")
+  *   .setOutputCol("label")
+  * }}}
+  * The default model is `"bert_base_sequence_classifier_imdb"`, if no name is provided.
+  *
+  * For available pretrained models please see the
+  * [[https://nlp.johnsnowlabs.com/models?task=Text+Classification Models Hub]].
+  *
+  * To see which models are compatible and how to import them see
+  * [[https://github.com/JohnSnowLabs/spark-nlp/discussions/5669]] and to see more extended
+  * examples, see
+  * [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassification.scala BertForZeroShotClassification]].
+  *
+  * ==Example==
+  * {{{
+  * import spark.implicits._
+  * import com.johnsnowlabs.nlp.base._
+  * import com.johnsnowlabs.nlp.annotator._
+  * import org.apache.spark.ml.Pipeline
+  *
+  * val documentAssembler = new DocumentAssembler()
+  *   .setInputCol("text")
+  *   .setOutputCol("document")
+  *
+  * val tokenizer = new Tokenizer()
+  *   .setInputCols("document")
+  *   .setOutputCol("token")
+  *
+  * val sequenceClassifier = BertForZeroShotClassification.pretrained()
+  *   .setInputCols("token", "document")
+  *   .setOutputCol("label")
+  *   .setCaseSensitive(true)
+  *
+  * val pipeline = new Pipeline().setStages(Array(
+  *   documentAssembler,
+  *   tokenizer,
+  *   sequenceClassifier
+  * ))
+  *
+  * val data = Seq("I loved this movie when I was a child.", "It was pretty boring.").toDF("text")
+  * val result = pipeline.fit(data).transform(data)
+  *
+  * result.select("label.result").show(false)
+  * +------+
+  * |result|
+  * +------+
+  * |[pos] |
+  * |[neg] |
+  * +------+
+  * }}}
+  *
+  * @see
+  *   [[BertForZeroShotClassification]] for sequence-level classification
+  * @see
+  *   [[https://nlp.johnsnowlabs.com/docs/en/annotators Annotators Main Page]] for a list of
+  *   transformer based classifiers
+  * @param uid
+  *   required uid for storing annotator to disk
+  * @groupname anno Annotator types
+  * @groupdesc anno
+  *   Required input and expected output annotator types
+  * @groupname Ungrouped Members
+  * @groupname param Parameters
+  * @groupname setParam Parameter setters
+  * @groupname getParam Parameter getters
+  * @groupname Ungrouped Members
+  * @groupprio param  1
+  * @groupprio anno  2
+  * @groupprio Ungrouped 3
+  * @groupprio setParam  4
+  * @groupprio getParam  5
+  * @groupdesc param
+  *   A list of (hyper-)parameter keys this annotator can take. Users can set and get the
+  *   parameter values through setters and getters, respectively.
+  */
+class BertForZeroShotClassification(override val uid: String)
+    extends AnnotatorModel[BertForZeroShotClassification]
+    with HasBatchedAnnotate[BertForZeroShotClassification]
+    with WriteTensorflowModel
+    with HasCaseSensitiveProperties
+    with HasClassifierActivationProperties
+    with HasEngine
+    with HasCandidateLabelsProperties {
+
+  /** Annotator reference id. Used to identify elements in metadata or to refer to this annotator
+    * type
+    */
+  def this() = this(Identifiable.randomUID("BERT_FOR_ZERO_SHOT_CLASSIFICATION"))
+
+  /** Input Annotator Types: DOCUMENT, TOKEN
+    *
+    * @group anno
+    */
+  override val inputAnnotatorTypes: Array[String] =
+    Array(AnnotatorType.DOCUMENT, AnnotatorType.TOKEN)
+
+  /** Output Annotator Types: CATEGORY
+    *
+    * @group anno
+    */
+  override val outputAnnotatorType: AnnotatorType = AnnotatorType.CATEGORY
+
+  /** @group setParam */
+  def sentenceStartTokenId: Int = {
+    $$(vocabulary)("[CLS]")
+  }
+
+  /** @group setParam */
+  def sentenceEndTokenId: Int = {
+    $$(vocabulary)("[SEP]")
+  }
+
+  /** Vocabulary used to encode the words to ids with WordPieceEncoder
+    *
+    * @group param
+    */
+  val vocabulary: MapFeature[String, Int] = new MapFeature(this, "vocabulary")
+
+  /** @group setParam */
+  def setVocabulary(value: Map[String, Int]): this.type = {
+    if (get(vocabulary).isEmpty)
+      set(vocabulary, value)
+    this
+  }
+
+  /** Labels used to decode predicted IDs back to string tags
+    *
+    * @group param
+    */
+  val labels: MapFeature[String, Int] = new MapFeature(this, "labels")
+
+  /** @group setParam */
+  def setLabels(value: Map[String, Int]): this.type = {
+    if (get(labels).isEmpty)
+      set(labels, value)
+    this
+  }
+
+  /** Returns labels used to train this model */
+  def getClasses: Array[String] = {
+    $$(labels).keys.toArray
+  }
+
+  /** Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document
+    * by averaging probabilities in all sentences (Default: `false`).
+    *
+    * Due to max sequence length limit in almost all transformer models such as BERT (512 tokens),
+    * this parameter helps feeding all the sentences into the model and averaging all the
+    * probabilities for the entire document instead of probabilities per sentence.
+    *
+    * @group param
+    */
+  val coalesceSentences = new BooleanParam(
+    this,
+    "coalesceSentences",
+    "If sets to true the output of all sentences will be averaged to one output instead of one output per sentence. Default to true.")
+
+  /** @group setParam */
+  def setCoalesceSentences(value: Boolean): this.type = set(coalesceSentences, value)
+
+  /** @group getParam */
+  def getCoalesceSentences: Boolean = $(coalesceSentences)
+
+  /** ConfigProto from tensorflow, serialized into byte array. Get with
+    * `config_proto.SerializeToString()`
+    *
+    * @group param
+    */
+  val configProtoBytes = new IntArrayParam(
+    this,
+    "configProtoBytes",
+    "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
+
+  /** @group setParam */
+  def setConfigProtoBytes(bytes: Array[Int]): BertForZeroShotClassification.this.type =
+    set(this.configProtoBytes, bytes)
+
+  /** @group getParam */
+  def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
+
+  /** Max sentence length to process (Default: `128`)
+    *
+    * @group param
+    */
+  val maxSentenceLength =
+    new IntParam(this, "maxSentenceLength", "Max sentence length to process")
+
+  /** @group setParam */
+  def setMaxSentenceLength(value: Int): this.type = {
+    require(
+      value <= 512,
+      "BERT models do not support sequences longer than 512 because of trainable positional embeddings.")
+    require(value >= 1, "The maxSentenceLength must be at least 1")
+    set(maxSentenceLength, value)
+    this
+  }
+
+  /** @group getParam */
+  def getMaxSentenceLength: Int = $(maxSentenceLength)
+
+  /** It contains TF model signatures for the laded saved model
+    *
+    * @group param
+    */
+  val signatures = new MapFeature[String, String](model = this, name = "signatures")
+
+  /** @group setParam */
+  def setSignatures(value: Map[String, String]): this.type = {
+    if (get(signatures).isEmpty)
+      set(signatures, value)
+    this
+  }
+
+  /** @group getParam */
+  def getSignatures: Option[Map[String, String]] = get(this.signatures)
+
+  private var _model: Option[Broadcast[BertClassification]] = None
+
+  /** @group setParam */
+  def setModelIfNotSet(
+      spark: SparkSession,
+      tensorflowWrapper: TensorflowWrapper): BertForZeroShotClassification = {
+    if (_model.isEmpty) {
+      _model = Some(
+        spark.sparkContext.broadcast(
+          new BertClassification(
+            tensorflowWrapper,
+            sentenceStartTokenId,
+            sentenceEndTokenId,
+            configProtoBytes = getConfigProtoBytes,
+            tags = $$(labels),
+            signatures = getSignatures,
+            $$(vocabulary))))
+    }
+
+    this
+  }
+
+  /** @group getParam */
+  def getModelIfNotSet: BertClassification = _model.get.value
+
+  /** Whether to lowercase tokens or not (Default: `true`).
+    *
+    * @group setParam
+    */
+  override def setCaseSensitive(value: Boolean): this.type = {
+    if (get(caseSensitive).isEmpty)
+      set(this.caseSensitive, value)
+    this
+  }
+
+  setDefault(
+    batchSize -> 8,
+    maxSentenceLength -> 128,
+    caseSensitive -> true,
+    coalesceSentences -> false)
+
+  /** takes a document and annotations and produces new annotations of this annotator's annotation
+    * type
+    *
+    * @param batchedAnnotations
+    *   Annotations that correspond to inputAnnotationCols generated by previous annotators if any
+    * @return
+    *   any number of annotations processed for every input annotation. Not necessary one to one
+    *   relationship
+    */
+  override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
+    batchedAnnotations.map(annotations => {
+      val sentences = SentenceSplit.unpack(annotations).toArray
+      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+
+      if (tokenizedSentences.nonEmpty) {
+        getModelIfNotSet.predictSequenceWithZeroShot(
+          tokenizedSentences,
+          sentences,
+          $(candidateLabels),
+          $(entailmentIdParam),
+          $(contradictionIdParam),
+          $(batchSize),
+          $(maxSentenceLength),
+          $(caseSensitive),
+          $(coalesceSentences),
+          $$(labels),
+          $(activation))
+
+      } else {
+        Seq.empty[Annotation]
+      }
+    })
+  }
+
+  override def onWrite(path: String, spark: SparkSession): Unit = {
+    super.onWrite(path, spark)
+    writeTensorflowModelV2(
+      path,
+      spark,
+      getModelIfNotSet.tensorflowWrapper,
+      "_bert_classification",
+      BertForZeroShotClassification.tfFile,
+      configProtoBytes = getConfigProtoBytes)
+  }
+
+}
+
+trait ReadablePretrainedBertForZeroShotModel
+    extends ParamsAndFeaturesReadable[BertForZeroShotClassification]
+    with HasPretrained[BertForZeroShotClassification] {
+  override val defaultModelName: Some[String] = Some("bert_base_sequence_classifier_imdb")
+
+  /** Java compliant-overrides */
+  override def pretrained(): BertForZeroShotClassification = super.pretrained()
+
+  override def pretrained(name: String): BertForZeroShotClassification = super.pretrained(name)
+
+  override def pretrained(name: String, lang: String): BertForZeroShotClassification =
+    super.pretrained(name, lang)
+
+  override def pretrained(
+      name: String,
+      lang: String,
+      remoteLoc: String): BertForZeroShotClassification = super.pretrained(name, lang, remoteLoc)
+}
+
+trait ReadBertForZeroShotDLModel extends ReadTensorflowModel {
+  this: ParamsAndFeaturesReadable[BertForZeroShotClassification] =>
+
+  override val tfFile: String = "bert_classification_tensorflow"
+
+  def readModel(
+      instance: BertForZeroShotClassification,
+      path: String,
+      spark: SparkSession): Unit = {
+
+    val tf = readTensorflowModel(path, spark, "_bert_classification_tf", initAllTables = false)
+    instance.setModelIfNotSet(spark, tf)
+  }
+
+  addReader(readModel)
+
+  def loadSavedModel(modelPath: String, spark: SparkSession): BertForZeroShotClassification = {
+
+    val (localModelPath, detectedEngine) = modelSanityCheck(modelPath)
+
+    val vocabs = loadTextAsset(localModelPath, "vocab.txt").zipWithIndex.toMap
+    val labels = loadTextAsset(localModelPath, "labels.txt").zipWithIndex.toMap
+
+    val entailmentIds = labels.filter(x => x._1.toLowerCase().startsWith("entail")).values.toArray
+    val contradictionIds =
+      labels.filter(x => x._1.toLowerCase().startsWith("contradict")).values.toArray
+
+    require(
+      entailmentIds.length == 1 && contradictionIds.length == 1,
+      s"""This annotator supports classifiers trained on NLI datasets. You must have only at least 2 or maximum 3 labels in your dataset:
+         
+          example with 3 labels: 'contradict', 'neutral', 'entailment'
+          example with 2 labels: 'contradict', 'entailment'
+
+          You can modify assets/labels.txt file to match the above format.
+
+          Current labels: ${labels.keys.mkString(", ")}
+          """)
+
+    val annotatorModel = new BertForZeroShotClassification()
+      .setVocabulary(vocabs)
+      .setLabels(labels)
+      .setCandidateLabels(labels.keys.toArray)
+
+    /* set the entailment id */
+    annotatorModel.set(annotatorModel.entailmentIdParam, entailmentIds.head)
+    /* set the contradiction id */
+    annotatorModel.set(annotatorModel.contradictionIdParam, contradictionIds.head)
+    /* set the engine */
+    annotatorModel.set(annotatorModel.engine, detectedEngine)
+
+    detectedEngine match {
+      case ModelEngine.tensorflow =>
+        val (wrapper, signatures) =
+          TensorflowWrapper.read(localModelPath, zipped = false, useBundle = true)
+
+        val _signatures = signatures match {
+          case Some(s) => s
+          case None => throw new Exception("Cannot load signature definitions from model!")
+        }
+
+        /** the order of setSignatures is important if we use getSignatures inside
+          * setModelIfNotSet
+          */
+        annotatorModel
+          .setSignatures(_signatures)
+          .setModelIfNotSet(spark, wrapper)
+
+      case _ =>
+        throw new Exception(notSupportedEngineError)
+    }
+
+    annotatorModel
+  }
+}
+
+/** This is the companion object of [[BertForZeroShotClassification]]. Please refer to that class
+  * for the documentation.
+  */
+object BertForZeroShotClassification
+    extends ReadablePretrainedBertForZeroShotModel
+    with ReadBertForZeroShotDLModel

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassification.scala
@@ -50,7 +50,7 @@ import java.io.File
   *   .setInputCols("token", "document")
   *   .setOutputCol("label")
   * }}}
-  * The default model is `"bert_base_sequence_classifier_imdb"`, if no name is provided.
+  * The default model is `"bert_base_cased_zero_shot_classifier_xnli"`, if no name is provided.
   *
   * For available pretrained models please see the
   * [[https://nlp.johnsnowlabs.com/models?task=Text+Classification Models Hub]].
@@ -354,7 +354,7 @@ class BertForZeroShotClassification(override val uid: String)
 trait ReadablePretrainedBertForZeroShotModel
     extends ParamsAndFeaturesReadable[BertForZeroShotClassification]
     with HasPretrained[BertForZeroShotClassification] {
-  override val defaultModelName: Some[String] = Some("bert_base_sequence_classifier_imdb")
+  override val defaultModelName: Some[String] = Some("bert_base_cased_zero_shot_classifier_xnli")
 
   /** Java compliant-overrides */
   override def pretrained(): BertForZeroShotClassification = super.pretrained()

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -713,7 +713,8 @@ object PythonResourceDownloader {
     "TapasForQuestionAnswering" -> TapasForQuestionAnswering,
     "CamemBertForSequenceClassification" -> CamemBertForSequenceClassification,
     "CamemBertForQuestionAnswering" -> CamemBertForQuestionAnswering,
-    "ZeroShotNerModel" -> ZeroShotNerModel)
+    "ZeroShotNerModel" -> ZeroShotNerModel,
+    "BertForZeroShotClassification" -> BertForZeroShotClassification)
 
   // List pairs of types such as the one with key type can load a pretrained model from the value type
   val typeMapper: Map[String, String] = Map("ZeroShotNerModel" -> "RoBertaForQuestionAnswering")

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassificationTestSpec.scala
@@ -57,29 +57,18 @@ class BertForZeroShotClassificationTestSpec extends AnyFlatSpec {
       .pretrained()
       .setInputCols(Array("token", "document"))
       .setOutputCol("multi_class")
-      .setCaseSensitive(false)
-      .setCoalesceSentences(false)
-      .setCandidateLabels(candidateLabels)
-
-    val tokenClassifierSigmoid = BertForZeroShotClassification
-      .pretrained()
-      .setInputCols(Array("token", "document"))
-      .setOutputCol("multi_label")
-      .setCaseSensitive(false)
-      .setCoalesceSentences(false)
-      .setActivation("sigmoid")
+      .setCaseSensitive(true)
+      .setCoalesceSentences(true)
       .setCandidateLabels(candidateLabels)
 
     val pipeline = new Pipeline().setStages(
-      Array(document, tokenizer, tokenClassifier, tokenClassifierSigmoid))
+      Array(document, tokenizer, tokenClassifier))
 
     val pipelineModel = pipeline.fit(ddd)
     val pipelineDF = pipelineModel.transform(ddd)
 
     pipelineDF.select("multi_class").show(20, false)
     pipelineDF.select("document.result", "multi_class.result").show(20, false)
-    pipelineDF.select("multi_label").show(20, false)
-    pipelineDF.select("document.result", "multi_label.result").show(20, false)
     pipelineDF
       .withColumn("doc_size", size(col("document")))
       .withColumn("label_size", size(col("multi_class")))
@@ -118,8 +107,8 @@ class BertForZeroShotClassificationTestSpec extends AnyFlatSpec {
       .pretrained()
       .setInputCols(Array("token", "document"))
       .setOutputCol("label")
-      .setCaseSensitive(false)
-      .setCoalesceSentences(false)
+      .setCaseSensitive(true)
+      .setCoalesceSentences(true)
       .setCandidateLabels(candidateLabels)
       .setBatchSize(2)
 
@@ -162,8 +151,8 @@ class BertForZeroShotClassificationTestSpec extends AnyFlatSpec {
       .pretrained()
       .setInputCols(Array("token", "sentence"))
       .setOutputCol("class")
-      .setCaseSensitive(false)
-      .setCoalesceSentences(false)
+      .setCaseSensitive(true)
+      .setCoalesceSentences(true)
       .setCandidateLabels(candidateLabels)
       .setBatchSize(2)
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassificationTestSpec.scala
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.classifier.dl
+
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.training.CoNLL
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.SlowTest
+import com.johnsnowlabs.util.Benchmark
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.functions.{col, explode, size}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class BertForZeroShotClassificationTestSpec extends AnyFlatSpec {
+
+  import ResourceHelper.spark.implicits._
+
+  val candidateLabels =
+    Array("urgent", "mobile", "travel", "movie", "music", "sport", "weather", "technology")
+
+  "BertForSBertForZeroShotClassification" should "correctly load custom model with extracted signatures" taggedAs SlowTest in {
+
+    val ddd = Seq(
+      "I have a problem with my iphone that needs to be resolved asap!!",
+      "Last week I upgraded my iOS version and ever since then my phone has been overheating whenever I use your app.",
+      "I have a phone and I love it!",
+      "I really want to visit Germany and I am planning to go there next year.",
+      "Let's watch some movies tonight! I am in the mood for a horror movie.",
+      "Have you watched the match yesterday? It was a great game!",
+      "We need to harry up and get to the airport. We are going to miss our flight!")
+      .toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val tokenClassifier = BertForZeroShotClassification
+      .pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("multi_class")
+      .setCaseSensitive(false)
+      .setCoalesceSentences(false)
+      .setCandidateLabels(candidateLabels)
+
+    val tokenClassifierSigmoid = BertForZeroShotClassification
+      .pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("multi_label")
+      .setCaseSensitive(false)
+      .setCoalesceSentences(false)
+      .setActivation("sigmoid")
+      .setCandidateLabels(candidateLabels)
+
+    val pipeline = new Pipeline().setStages(
+      Array(document, tokenizer, tokenClassifier, tokenClassifierSigmoid))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("multi_class").show(20, false)
+    pipelineDF.select("document.result", "multi_class.result").show(20, false)
+    pipelineDF.select("multi_label").show(20, false)
+    pipelineDF.select("document.result", "multi_label.result").show(20, false)
+    pipelineDF
+      .withColumn("doc_size", size(col("document")))
+      .withColumn("label_size", size(col("multi_class")))
+      .where(col("doc_size") =!= col("label_size"))
+      .select("doc_size", "label_size", "document.result", "multi_class.result")
+      .show(20, false)
+
+    val totalDocs = pipelineDF.select(explode($"document.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"multi_class.result")).count.toInt
+
+    println(s"total tokens: $totalDocs")
+    println(s"total embeddings: $totalLabels")
+
+    assert(totalDocs == totalLabels)
+  }
+
+  "BertForZeroShotClassification" should "be saved and loaded correctly" taggedAs SlowTest in {
+
+    import ResourceHelper.spark.implicits._
+
+    val ddd = Seq(
+      "John Lenon was born in London and lived in Paris. My name is Sarah and I live in London",
+      "Rare Hendrix song draft sells for almost $17,000.",
+      "EU rejects German call to boycott British lamb .",
+      "TORONTO 1996-08-21").toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val tokenClassifier = BertForZeroShotClassification
+      .pretrained()
+      .setInputCols(Array("token", "document"))
+      .setOutputCol("label")
+      .setCaseSensitive(false)
+      .setCoalesceSentences(false)
+      .setCandidateLabels(candidateLabels)
+      .setBatchSize(2)
+
+    val pipeline = new Pipeline().setStages(Array(document, tokenizer, tokenClassifier))
+
+    val pipelineModel = pipeline.fit(ddd)
+    val pipelineDF = pipelineModel.transform(ddd)
+
+    pipelineDF.select("label.result").show(false)
+
+    Benchmark.time("Time to save BertForZeroShotClassification pipeline model") {
+      pipelineModel.write.overwrite().save("./tmp_bertfornli_pipeline")
+    }
+
+    Benchmark.time("Time to save BertForZeroShotClassification model") {
+      pipelineModel.stages.last
+        .asInstanceOf[BertForZeroShotClassification]
+        .write
+        .overwrite()
+        .save("./tmp_bertforsnli_model")
+    }
+
+    val loadedPipelineModel = PipelineModel.load("./tmp_bertfornli_pipeline")
+    loadedPipelineModel.transform(ddd).select("label.result").show(false)
+
+    val loadedSequenceModel = BertForZeroShotClassification.load("./tmp_bertforsnli_model")
+    println(loadedSequenceModel.getClasses.mkString("Array(", ", ", ")"))
+
+  }
+
+  "BertForZeroShotClassification" should "benchmark test" taggedAs SlowTest in {
+
+    val conll = CoNLL(explodeSentences = false)
+    val training_data =
+      conll
+        .readDataset(ResourceHelper.spark, "src/test/resources/conll2003/eng.train")
+        .repartition(12)
+
+    val tokenClassifier = BertForZeroShotClassification
+      .pretrained()
+      .setInputCols(Array("token", "sentence"))
+      .setOutputCol("class")
+      .setCaseSensitive(false)
+      .setCoalesceSentences(false)
+      .setCandidateLabels(candidateLabels)
+      .setBatchSize(2)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(tokenClassifier))
+
+    val pipelineDF = pipeline.fit(training_data).transform(training_data).cache()
+    Benchmark.time("Time to save pipeline results") {
+      pipelineDF.write.mode("overwrite").parquet("./tmp_nli_classifier")
+    }
+
+    pipelineDF.select("class").show(2, false)
+    pipelineDF.select("sentence.result", "class.result").show(2, false)
+
+    // only works if it's softmax - one lable per row
+    pipelineDF
+      .withColumn("doc_size", size(col("sentence")))
+      .withColumn("label_size", size(col("class")))
+      .where(col("doc_size") =!= col("label_size"))
+      .select("doc_size", "label_size", "sentence.result", "class.result")
+      .show(20, false)
+
+    val totalDocs = pipelineDF.select(explode($"sentence.result")).count.toInt
+    val totalLabels = pipelineDF.select(explode($"class.result")).count.toInt
+
+    println(s"total docs: $totalDocs")
+    println(s"total classes: $totalLabels")
+
+    assert(totalDocs == totalLabels)
+  }
+}


### PR DESCRIPTION
This PR introduces ZeroShot text classification. 

> BertForZeroShotClassification using a `ModelForSequenceClassification` trained on NLI (natural language inference) tasks. Equivalent of `BertForSequenceClassification` models, but these models don't require a hardcoded number of potential classes, they can be chosen at runtime. It usually means it's slower but it is much** more flexible. Any combination of sequences and labels can be passed and each combination will be posed as a premise/hypothesis pair and passed to the pretrained model.