### PR TITLE
SPARKNLP-800 Adding threshold parameter to all ForSequenceClassification

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/ai/AlbertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/AlbertClassification.scala
@@ -41,7 +41,8 @@ private[johnsnowlabs] class AlbertClassification(
     val spp: SentencePieceWrapper,
     configProtoBytes: Option[Array[Byte]] = None,
     tags: Map[String, Int],
-    signatures: Option[Map[String, String]] = None)
+    signatures: Option[Map[String, String]] = None,
+    threshold: Float = 0.5f)
     extends Serializable
     with XXXForClassification {
 
@@ -54,6 +55,7 @@ private[johnsnowlabs] class AlbertClassification(
   protected val sentenceEndTokenId: Int = spp.getSppModel.pieceToId("[SEP]")
 
   private val sentencePieceDelimiterId: Int = spp.getSppModel.pieceToId("▁")
+  protected val sigmoidThreshold: Float = threshold
 
   def tokenizeWithAlignment(
       sentences: Seq[TokenizedSentence],

--- a/src/main/scala/com/johnsnowlabs/ml/ai/BertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/BertClassification.scala
@@ -45,13 +45,15 @@ private[johnsnowlabs] class BertClassification(
     configProtoBytes: Option[Array[Byte]] = None,
     tags: Map[String, Int],
     signatures: Option[Map[String, String]] = None,
-    vocabulary: Map[String, Int])
+    vocabulary: Map[String, Int],
+    threshold: Float = 0.5f)
     extends Serializable
     with XXXForClassification {
 
   val _tfBertSignatures: Map[String, String] = signatures.getOrElse(ModelSignatureManager.apply())
 
   protected val sentencePadTokenId = 0
+  protected val sigmoidThreshold: Float = threshold
 
   def tokenizeWithAlignment(
       sentences: Seq[TokenizedSentence],

--- a/src/main/scala/com/johnsnowlabs/ml/ai/CamemBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/CamemBertClassification.scala
@@ -21,6 +21,8 @@ import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignat
 import com.johnsnowlabs.ml.tensorflow.{TensorResources, TensorflowWrapper}
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.{ActivationFunction, Annotation}
+import org.apache.spark.ml.param.Params
+import org.apache.spark.ml.util.Identifiable
 import org.tensorflow.ndarray.buffer.{IntDataBuffer, LongDataBuffer}
 
 import scala.collection.JavaConverters._
@@ -41,7 +43,8 @@ private[johnsnowlabs] class CamemBertClassification(
     val spp: SentencePieceWrapper,
     configProtoBytes: Option[Array[Byte]] = None,
     tags: Map[String, Int],
-    signatures: Option[Map[String, String]] = None)
+    signatures: Option[Map[String, String]] = None,
+    threshold: Float = 0.5f)
     extends Serializable
     with XXXForClassification {
 
@@ -59,6 +62,7 @@ private[johnsnowlabs] class CamemBertClassification(
   // unlike other models the delimiter id is correct and does not need pieceIdOffset
   // subtracting pieceIdOffset here to make up for adding it later in SP class
   protected val sentencePieceDelimiterId: Int = spp.getSppModel.pieceToId("▁") - pieceIdOffset
+  protected val sigmoidThreshold: Float = threshold
 
   def tokenizeWithAlignment(
       sentences: Seq[TokenizedSentence],

--- a/src/main/scala/com/johnsnowlabs/ml/ai/DeBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/DeBertaClassification.scala
@@ -41,7 +41,8 @@ private[johnsnowlabs] class DeBertaClassification(
     val spp: SentencePieceWrapper,
     configProtoBytes: Option[Array[Byte]] = None,
     tags: Map[String, Int],
-    signatures: Option[Map[String, String]] = None)
+    signatures: Option[Map[String, String]] = None,
+    threshold: Float = 0.5f)
     extends Serializable
     with XXXForClassification {
 
@@ -54,6 +55,7 @@ private[johnsnowlabs] class DeBertaClassification(
   protected val sentenceEndTokenId: Int = spp.getSppModel.pieceToId("[SEP]")
 
   private val sentencePieceDelimiterId: Int = spp.getSppModel.pieceToId("▁")
+  protected val sigmoidThreshold: Float = threshold
 
   def tokenizeWithAlignment(
       sentences: Seq[TokenizedSentence],

--- a/src/main/scala/com/johnsnowlabs/ml/ai/DistilBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/DistilBertClassification.scala
@@ -45,7 +45,8 @@ private[johnsnowlabs] class DistilBertClassification(
     configProtoBytes: Option[Array[Byte]] = None,
     tags: Map[String, Int],
     signatures: Option[Map[String, String]] = None,
-    vocabulary: Map[String, Int])
+    vocabulary: Map[String, Int],
+    threshold: Float = 0.5f)
     extends Serializable
     with XXXForClassification {
 
@@ -53,6 +54,7 @@ private[johnsnowlabs] class DistilBertClassification(
     signatures.getOrElse(ModelSignatureManager.apply())
 
   protected val sentencePadTokenId = 0
+  protected val sigmoidThreshold: Float = threshold
 
   def tokenizeWithAlignment(
       sentences: Seq[TokenizedSentence],

--- a/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
@@ -47,12 +47,15 @@ private[johnsnowlabs] class RoBertaClassification(
     tags: Map[String, Int],
     signatures: Option[Map[String, String]] = None,
     merges: Map[(String, String), Int],
-    vocabulary: Map[String, Int])
+    vocabulary: Map[String, Int],
+    threshold: Float = 0.5f)
     extends Serializable
     with XXXForClassification {
 
   val _tfRoBertaSignatures: Map[String, String] =
     signatures.getOrElse(ModelSignatureManager.apply())
+
+  protected val sigmoidThreshold: Float = threshold
 
   def tokenizeWithAlignment(
       sentences: Seq[TokenizedSentence],

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
@@ -24,6 +24,7 @@ private[johnsnowlabs] trait XXXForClassification {
   protected val sentencePadTokenId: Int
   protected val sentenceStartTokenId: Int
   protected val sentenceEndTokenId: Int
+  protected val sigmoidThreshold: Float
 
   def predict(
       tokenizedSentences: Seq[TokenizedSentence],
@@ -102,7 +103,7 @@ private[johnsnowlabs] trait XXXForClassification {
             if (coalesceSentences) {
               val scores = logits.transpose.map(_.sum / logits.length)
               val labels = scores.zipWithIndex
-                .filter(x => x._1 > 0.5)
+                .filter(x => x._1 > sigmoidThreshold)
                 .flatMap(x => tags.filter(_._2 == x._2))
               val meta = constructMetaForSequenceClassifier(tags, scores)
               labels.map(label =>
@@ -110,7 +111,7 @@ private[johnsnowlabs] trait XXXForClassification {
             } else {
               sentences.zip(logits).flatMap { case (sentence, scores) =>
                 val labels = scores.zipWithIndex
-                  .filter(x => x._1 > 0.5)
+                  .filter(x => x._1 > sigmoidThreshold)
                   .flatMap(x => tags.filter(_._2 == x._2))
                 val meta = constructMetaForSequenceClassifier(tags, scores)
                 labels.map(label =>

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoBertaClassification.scala
@@ -41,7 +41,8 @@ private[johnsnowlabs] class XlmRoBertaClassification(
     val spp: SentencePieceWrapper,
     configProtoBytes: Option[Array[Byte]] = None,
     tags: Map[String, Int],
-    signatures: Option[Map[String, String]] = None)
+    signatures: Option[Map[String, String]] = None,
+    threshold: Float = 0.5f)
     extends Serializable
     with XXXForClassification {
 
@@ -53,6 +54,7 @@ private[johnsnowlabs] class XlmRoBertaClassification(
   protected val sentencePadTokenId: Int = 1
 
   private val sentencePieceDelimiterId = spp.getSppModel.pieceToId("▁")
+  protected val sigmoidThreshold: Float = threshold
 
   def tokenizeWithAlignment(
       sentences: Seq[TokenizedSentence],

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XlnetClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XlnetClassification.scala
@@ -41,7 +41,8 @@ private[johnsnowlabs] class XlnetClassification(
     val spp: SentencePieceWrapper,
     configProtoBytes: Option[Array[Byte]] = None,
     tags: Map[String, Int],
-    signatures: Option[Map[String, String]] = None)
+    signatures: Option[Map[String, String]] = None,
+    threshold: Float = 0.5f)
     extends Serializable
     with XXXForClassification {
 
@@ -54,6 +55,7 @@ private[johnsnowlabs] class XlnetClassification(
   override protected val sentencePadTokenId: Int = spp.getSppModel.pieceToId("<pad>")
 
   private val sentencePieceDelimiterId = spp.getSppModel.pieceToId("▁")
+  protected val sigmoidThreshold: Float = threshold
 
   def tokenizeWithAlignment(
       sentences: Seq[TokenizedSentence],

--- a/src/main/scala/com/johnsnowlabs/nlp/HasClassifierActivationProperties.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasClassifierActivationProperties.scala
@@ -16,7 +16,7 @@
 
 package com.johnsnowlabs.nlp
 
-import org.apache.spark.ml.param.Param
+import org.apache.spark.ml.param.{FloatParam, Param}
 
 trait HasClassifierActivationProperties extends ParamsAndFeaturesWritable {
 
@@ -29,7 +29,19 @@ trait HasClassifierActivationProperties extends ParamsAndFeaturesWritable {
     "activation",
     "Whether to calculate logits via Softmax or Sigmoid. Default is Softmax")
 
-  setDefault(activation, ActivationFunction.softmax)
+  /** Choose the threshold to determine which logits are considered to be positive or negative.
+    * (Default: `0.5f`). The value should be between 0.0 and 1.0. Changing the threshold value
+    * will affect the resulting labels and can be used to adjust the balance between precision and
+    * recall in the classification process.
+    *
+    * @group param
+    */
+  val threshold = new FloatParam(
+    this,
+    "threshold",
+    "Choose the threshold to determine which logits are considered to be positive or negative")
+
+  setDefault(activation -> ActivationFunction.softmax, threshold -> 0.5f)
 
   /** @group getParam */
   def getActivation: String = $(activation)
@@ -47,6 +59,17 @@ trait HasClassifierActivationProperties extends ParamsAndFeaturesWritable {
     }
 
   }
+
+  /** Choose the threshold to determine which logits are considered to be positive or negative.
+    * (Default: `0.5f`). The value should be between 0.0 and 1.0. Changing the threshold value
+    * will affect the resulting labels and can be used to adjust the balance between precision and
+    * recall in the classification process.
+    *
+    * @group param
+    */
+  def setThreshold(threshold: Float): this.type =
+    set(this.threshold, threshold)
+
 }
 
 object ActivationFunction {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassification.scala
@@ -249,7 +249,8 @@ class AlbertForSequenceClassification(override val uid: String)
             spp,
             configProtoBytes = getConfigProtoBytes,
             tags = $$(labels),
-            signatures = getSignatures)))
+            signatures = getSignatures,
+            threshold = $(threshold))))
     }
 
     this

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
@@ -266,7 +266,8 @@ class BertForSequenceClassification(override val uid: String)
             configProtoBytes = getConfigProtoBytes,
             tags = $$(labels),
             signatures = getSignatures,
-            $$(vocabulary))))
+            $$(vocabulary),
+            threshold = $(threshold))))
     }
 
     this

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassification.scala
@@ -279,7 +279,8 @@ class BertForZeroShotClassification(override val uid: String)
             configProtoBytes = getConfigProtoBytes,
             tags = $$(labels),
             signatures = getSignatures,
-            $$(vocabulary))))
+            $$(vocabulary),
+            threshold = $(threshold))))
     }
 
     this

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForSequenceClassification.scala
@@ -249,7 +249,8 @@ class CamemBertForSequenceClassification(override val uid: String)
             spp,
             configProtoBytes = getConfigProtoBytes,
             tags = $$(labels),
-            signatures = getSignatures)))
+            signatures = getSignatures,
+            threshold = $(threshold))))
     }
 
     this

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DeBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DeBertaForSequenceClassification.scala
@@ -248,7 +248,8 @@ class DeBertaForSequenceClassification(override val uid: String)
             spp,
             configProtoBytes = getConfigProtoBytes,
             tags = $$(labels),
-            signatures = getSignatures)))
+            signatures = getSignatures,
+            threshold = $(threshold))))
     }
 
     this

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
@@ -262,7 +262,8 @@ class DistilBertForSequenceClassification(override val uid: String)
             configProtoBytes = getConfigProtoBytes,
             tags = $$(labels),
             signatures = getSignatures,
-            $$(vocabulary))))
+            $$(vocabulary),
+            threshold = $(threshold))))
     }
 
     this

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassification.scala
@@ -275,7 +275,8 @@ class LongformerForSequenceClassification(override val uid: String)
             tags = $$(labels),
             signatures = getSignatures,
             $$(merges),
-            $$(vocabulary))))
+            $$(vocabulary),
+            threshold = $(threshold))))
     }
 
     this

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassification.scala
@@ -275,7 +275,8 @@ class RoBertaForSequenceClassification(override val uid: String)
             tags = $$(labels),
             signatures = getSignatures,
             $$(merges),
-            $$(vocabulary))))
+            $$(vocabulary),
+            threshold = $(threshold))))
     }
 
     this

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
@@ -248,7 +248,8 @@ class XlmRoBertaForSequenceClassification(override val uid: String)
             spp,
             configProtoBytes = getConfigProtoBytes,
             tags = $$(labels),
-            signatures = getSignatures)))
+            signatures = getSignatures,
+            threshold = $(threshold))))
     }
 
     this

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassification.scala
@@ -249,7 +249,8 @@ class XlnetForSequenceClassification(override val uid: String)
             spp,
             configProtoBytes = getConfigProtoBytes,
             tags = $$(labels),
-            signatures = getSignatures)))
+            signatures = getSignatures,
+            threshold = $(threshold))))
     }
 
     this


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change adds a `threshold` parameter to all annotators that use XXXForSequenceClassification and ZeroShotClassification components.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow users to setup this parameter to adjust the balance between precision and recall in the classification process.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Local unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
