### PR TITLE
Fix Tapas bug due to exceeding the maximum rank value

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/tapas/TapasEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/tapas/TapasEncoder.scala
@@ -187,6 +187,7 @@ class TapasEncoder(
   protected val MAX_YEAR = 2120
 
   protected val MIN_NUMBER_OF_ROWS_WITH_VALUES_PROPORTION = 0.5f
+  protected val MAX_COLUMN_RANK = 255
 
   protected val ORDINAL_SUFFIXES: Array[String] = Array("st", "nd", "rd", "th")
   protected val NUMBER_WORDS: Array[String] = Array(
@@ -525,9 +526,9 @@ class TapasEncoder(
         columnIds = setMaxSentenceLimit(emptyTokenTypes ++ columnIds ++ padding),
         rowIds = setMaxSentenceLimit(emptyTokenTypes ++ rowIds ++ padding),
         prevLabels = setMaxSentenceLimit(emptyTokenTypes ++ prevLabels ++ padding),
-        columnRanks = setMaxSentenceLimit(emptyTokenTypes ++ columnRanks ++ padding),
+        columnRanks = setMaxSentenceLimit(emptyTokenTypes ++ columnRanks.map(x => scala.math.min(x, MAX_COLUMN_RANK)) ++ padding),
         invertedColumnRanks =
-          setMaxSentenceLimit(emptyTokenTypes ++ invertedColumnRanks ++ padding),
+          setMaxSentenceLimit(emptyTokenTypes ++ invertedColumnRanks.map(x => scala.math.min(x, MAX_COLUMN_RANK)) ++ padding),
         numericRelations = setMaxSentenceLimit(emptyTokenTypes ++ numericRelations ++ padding))
     }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/tapas/TapasEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/tapas/TapasEncoder.scala
@@ -526,9 +526,10 @@ class TapasEncoder(
         columnIds = setMaxSentenceLimit(emptyTokenTypes ++ columnIds ++ padding),
         rowIds = setMaxSentenceLimit(emptyTokenTypes ++ rowIds ++ padding),
         prevLabels = setMaxSentenceLimit(emptyTokenTypes ++ prevLabels ++ padding),
-        columnRanks = setMaxSentenceLimit(emptyTokenTypes ++ columnRanks.map(x => scala.math.min(x, MAX_COLUMN_RANK)) ++ padding),
-        invertedColumnRanks =
-          setMaxSentenceLimit(emptyTokenTypes ++ invertedColumnRanks.map(x => scala.math.min(x, MAX_COLUMN_RANK)) ++ padding),
+        columnRanks = setMaxSentenceLimit(
+          emptyTokenTypes ++ columnRanks.map(x => scala.math.min(x, MAX_COLUMN_RANK)) ++ padding),
+        invertedColumnRanks = setMaxSentenceLimit(emptyTokenTypes ++ invertedColumnRanks.map(x =>
+          scala.math.min(x, MAX_COLUMN_RANK)) ++ padding),
         numericRelations = setMaxSentenceLimit(emptyTokenTypes ++ numericRelations ++ padding))
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A bug fix for the Tapas model. 

## Description
<!--- Describe your changes in detail -->
The problem is that the maximum value rank in Tapas is limited to 255 and if the text is long enough you may end up with higher ranks. The solution is to replace ranks higher than 255 with 255.

## Motivation and Context

The issue was reported by a user in the slack channel. If you feed a long text (i.e table) you may end up with ranks higher than 255 and this is the max value allowed by the model (perhaps they used a byte variable to represent it or a static array). Such ranks case a Tensorflow exception.

## How Has This Been Tested?
I first reproduced the problem by running Tapas on long enough texts and made sure that the fixes solves the problem

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
