### PR TITLE
SPARKNLP-828: Raise error when exceeding max input length

### DIFF
--- a/docs/en/transformer_entries/MarianTransformer.md
+++ b/docs/en/transformer_entries/MarianTransformer.md
@@ -13,6 +13,10 @@ development. MarianTransformer uses the models trained by MarianNMT.
 It is currently the engine behind the Microsoft Translator Neural Machine Translation services and being deployed by
 many companies, organizations and research projects.
 
+Note that this model only supports inputs up to 512 tokens. If you are working with longer 
+inputs, consider splitting them first. For example, you can use the SentenceDetectorDL annotator to
+split longer texts into sentences.
+
 Pretrained models can be loaded with `pretrained` of the companion object:
 ```
 val marian = MarianTransformer.pretrained()

--- a/python/sparknlp/annotator/classifier_dl/albert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/albert_for_question_answering.py
@@ -18,7 +18,8 @@ from sparknlp.common import *
 class AlbertForQuestionAnswering(AnnotatorModel,
                                  HasCaseSensitiveProperties,
                                  HasBatchedAnnotate,
-                                 HasEngine):
+                                 HasEngine,
+                                 HasMaxSentenceLengthLimit):
     """AlbertForQuestionAnswering can load ALBERT Models with a span classification head on top for extractive
     question-answering tasks like SQuAD (a linear layer on top of the hidden-states output to compute span start
     logits and span end logits).
@@ -91,11 +92,6 @@ class AlbertForQuestionAnswering(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CHUNK
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with "
@@ -117,15 +113,7 @@ class AlbertForQuestionAnswering(AnnotatorModel,
         """
         return self._set(configProtoBytes=b)
 
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
 
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.AlbertForQuestionAnswering",

--- a/python/sparknlp/annotator/classifier_dl/albert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/albert_for_sequence_classification.py
@@ -20,7 +20,8 @@ class AlbertForSequenceClassification(AnnotatorModel,
                                       HasCaseSensitiveProperties,
                                       HasBatchedAnnotate,
                                       HasClassifierActivationProperties,
-                                      HasEngine):
+                                      HasEngine,
+                                      HasMaxSentenceLengthLimit):
     """AlbertForSequenceClassification can load Albert Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -104,11 +105,6 @@ class AlbertForSequenceClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CATEGORY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -133,16 +129,6 @@ class AlbertForSequenceClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     def setCoalesceSentences(self, value):
         """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.

--- a/python/sparknlp/annotator/classifier_dl/albert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/albert_for_token_classification.py
@@ -19,7 +19,8 @@ from sparknlp.common import *
 class AlbertForTokenClassification(AnnotatorModel,
                                    HasCaseSensitiveProperties,
                                    HasBatchedAnnotate,
-                                   HasEngine):
+                                   HasEngine,
+                                   HasMaxSentenceLengthLimit):
     """AlbertForTokenClassification can load ALBERT Models with a token
     classification head on top (a linear layer on top of the hidden-states
     output) e.g. for Named-Entity-Recognition (NER) tasks.
@@ -100,11 +101,6 @@ class AlbertForTokenClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.NAMED_ENTITY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -125,16 +121,6 @@ class AlbertForTokenClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.AlbertForTokenClassification",

--- a/python/sparknlp/annotator/classifier_dl/bert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_sequence_classification.py
@@ -21,7 +21,8 @@ class BertForSequenceClassification(AnnotatorModel,
                                     HasCaseSensitiveProperties,
                                     HasBatchedAnnotate,
                                     HasClassifierActivationProperties,
-                                    HasEngine):
+                                    HasEngine,
+                                    HasMaxSentenceLengthLimit):
     """BertForSequenceClassification can load Bert Models with sequence classification/regression head on top
     (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -105,11 +106,6 @@ class BertForSequenceClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CATEGORY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -134,16 +130,6 @@ class BertForSequenceClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     def setCoalesceSentences(self, value):
         """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.

--- a/python/sparknlp/annotator/classifier_dl/bert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/bert_for_token_classification.py
@@ -19,7 +19,8 @@ from sparknlp.common import *
 class BertForTokenClassification(AnnotatorModel,
                                  HasCaseSensitiveProperties,
                                  HasBatchedAnnotate,
-                                 HasEngine):
+                                 HasEngine,
+                                 HasMaxSentenceLengthLimit):
     """BertForTokenClassification can load Bert Models with a token
     classification head on top (a linear layer on top of the hidden-states
     output) e.g. for Named-Entity-Recognition (NER) tasks.
@@ -98,11 +99,6 @@ class BertForTokenClassification(AnnotatorModel,
 
     outputAnnotatorType: AnnotatorType = AnnotatorType.NAMED_ENTITY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -123,16 +119,6 @@ class BertForTokenClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.BertForTokenClassification",

--- a/python/sparknlp/annotator/classifier_dl/camembert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/camembert_for_question_answering.py
@@ -18,7 +18,8 @@ from sparknlp.common import *
 class CamemBertForQuestionAnswering(AnnotatorModel,
                                     HasCaseSensitiveProperties,
                                     HasBatchedAnnotate,
-                                    HasEngine):
+                                    HasEngine,
+                                    HasMaxSentenceLengthLimit):
     """CamemBertForQuestionAnswering can load CamemBERT Models with a span classification head on top for extractive
     question-answering tasks like SQuAD (a linear layer on top of the hidden-states output to compute span start
     logits and span end logits).
@@ -91,11 +92,6 @@ class CamemBertForQuestionAnswering(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CHUNK
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -114,16 +110,6 @@ class CamemBertForQuestionAnswering(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForQuestionAnswering",

--- a/python/sparknlp/annotator/classifier_dl/camembert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/camembert_for_sequence_classification.py
@@ -20,7 +20,8 @@ class CamemBertForSequenceClassification(AnnotatorModel,
                                          HasCaseSensitiveProperties,
                                          HasBatchedAnnotate,
                                          HasClassifierActivationProperties,
-                                         HasEngine):
+                                         HasEngine,
+                                         HasMaxSentenceLengthLimit):
     """CamemBertForSequenceClassification can load CamemBERT Models with a sequence
     classification/regression head on top (a linear layer on top of the pooled output)
     e.g. for multi-class document classification tasks.
@@ -104,11 +105,6 @@ class CamemBertForSequenceClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CATEGORY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -133,16 +129,6 @@ class CamemBertForSequenceClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     def setCoalesceSentences(self, value):
         """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1

--- a/python/sparknlp/annotator/classifier_dl/camembert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/camembert_for_token_classification.py
@@ -18,7 +18,8 @@ from sparknlp.common import *
 class CamemBertForTokenClassification(AnnotatorModel,
                                       HasCaseSensitiveProperties,
                                       HasBatchedAnnotate,
-                                      HasEngine):
+                                      HasEngine,
+                                      HasMaxSentenceLengthLimit):
     """CamemBertForTokenClassification can load CamemBERT Models with a token
     classification head on top (a linear layer on top of the hidden-states
     output) e.g. for Named-Entity-Recognition (NER) tasks.
@@ -94,11 +95,6 @@ class CamemBertForTokenClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.NAMED_ENTITY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -119,16 +115,6 @@ class CamemBertForTokenClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.CamemBertForTokenClassification",

--- a/python/sparknlp/annotator/classifier_dl/deberta_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/deberta_for_question_answering.py
@@ -18,7 +18,8 @@ from sparknlp.common import *
 class DeBertaForQuestionAnswering(AnnotatorModel,
                                   HasCaseSensitiveProperties,
                                   HasBatchedAnnotate,
-                                  HasEngine):
+                                  HasEngine,
+                                  HasMaxSentenceLengthLimit):
     """DeBertaForQuestionAnswering can load DeBERTa Models with a span classification head on top for extractive
     question-answering tasks like SQuAD (a linear layer on top of the hidden-states output to compute span start
     logits and span end logits).
@@ -91,11 +92,6 @@ class DeBertaForQuestionAnswering(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CHUNK
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -114,16 +110,6 @@ class DeBertaForQuestionAnswering(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.DeBertaForQuestionAnswering",

--- a/python/sparknlp/annotator/classifier_dl/deberta_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/deberta_for_sequence_classification.py
@@ -19,7 +19,8 @@ class DeBertaForSequenceClassification(AnnotatorModel,
                                        HasCaseSensitiveProperties,
                                        HasBatchedAnnotate,
                                        HasClassifierActivationProperties,
-                                       HasEngine):
+                                       HasEngine,
+                                       HasMaxSentenceLengthLimit):
     """DeBertaForSequenceClassification can load DeBERTa v2 & v3 Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -100,11 +101,6 @@ class DeBertaForSequenceClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CATEGORY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -129,16 +125,6 @@ class DeBertaForSequenceClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     def setCoalesceSentences(self, value):
         """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging
@@ -210,4 +196,3 @@ class DeBertaForSequenceClassification(AnnotatorModel,
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(DeBertaForSequenceClassification, name, lang, remote_loc)
-

--- a/python/sparknlp/annotator/classifier_dl/deberta_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/deberta_for_token_classification.py
@@ -19,7 +19,8 @@ from sparknlp.common import *
 class DeBertaForTokenClassification(AnnotatorModel,
                                     HasCaseSensitiveProperties,
                                     HasBatchedAnnotate,
-                                    HasEngine):
+                                    HasEngine,
+                                    HasMaxSentenceLengthLimit):
     """DeBertaForTokenClassification can load DeBERTa v2&v3 Models with a token
     classification head on top (a linear layer on top of the hidden-states
     output) e.g. for Named-Entity-Recognition (NER) tasks.
@@ -98,11 +99,6 @@ class DeBertaForTokenClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.NAMED_ENTITY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -123,16 +119,6 @@ class DeBertaForTokenClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.DeBertaForTokenClassification",

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_question_answering.py
@@ -18,7 +18,8 @@ from sparknlp.common import *
 class DistilBertForQuestionAnswering(AnnotatorModel,
                                      HasCaseSensitiveProperties,
                                      HasBatchedAnnotate,
-                                     HasEngine):
+                                     HasEngine,
+                                     HasMaxSentenceLengthLimit):
     """DistilBertForQuestionAnswering can load DistilBERT Models with a span classification head on top for extractive
     question-answering tasks like SQuAD (a linear layer on top of the hidden-states output to compute span start
     logits and span end logits).
@@ -91,11 +92,6 @@ class DistilBertForQuestionAnswering(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CHUNK
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -114,16 +110,6 @@ class DistilBertForQuestionAnswering(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.DistilBertForQuestionAnswering",

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_sequence_classification.py
@@ -20,7 +20,8 @@ class DistilBertForSequenceClassification(AnnotatorModel,
                                           HasCaseSensitiveProperties,
                                           HasBatchedAnnotate,
                                           HasClassifierActivationProperties,
-                                          HasEngine):
+                                          HasEngine,
+                                          HasMaxSentenceLengthLimit):
     """DistilBertForSequenceClassification can load DistilBERT Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -104,11 +105,6 @@ class DistilBertForSequenceClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CATEGORY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -133,16 +129,6 @@ class DistilBertForSequenceClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     def setCoalesceSentences(self, value):
         """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_token_classification.py
@@ -19,7 +19,8 @@ from sparknlp.common import *
 class DistilBertForTokenClassification(AnnotatorModel,
                                        HasCaseSensitiveProperties,
                                        HasBatchedAnnotate,
-                                       HasEngine):
+                                       HasEngine,
+                                       HasMaxSentenceLengthLimit):
     """DistilBertForTokenClassification can load Bert Models with a token
     classification head on top (a linear layer on top of the hidden-states
     output) e.g. for Named-Entity-Recognition (NER) tasks.
@@ -96,11 +97,6 @@ class DistilBertForTokenClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.NAMED_ENTITY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -121,16 +117,6 @@ class DistilBertForTokenClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.DistilBertForTokenClassification",

--- a/python/sparknlp/annotator/classifier_dl/distil_bert_for_zero_shot_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/distil_bert_for_zero_shot_classification.py
@@ -21,7 +21,8 @@ class DistilBertForZeroShotClassification(AnnotatorModel,
                                           HasBatchedAnnotate,
                                           HasClassifierActivationProperties,
                                           HasCandidateLabelsProperties,
-                                          HasEngine):
+                                          HasEngine,
+                                          HasMaxSentenceLengthLimit):
     """DistilBertForZeroShotClassification using a `ModelForSequenceClassification` trained on NLI (natural language
     inference) tasks. Equivalent of `DistilBertForSequenceClassification` models, but these models don't require a hardcoded
     number of potential classes, they can be chosen at runtime. It usually means it's slower but it is much more
@@ -110,11 +111,6 @@ class DistilBertForZeroShotClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CATEGORY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -139,16 +135,6 @@ class DistilBertForZeroShotClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     def setCoalesceSentences(self, value):
         """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging

--- a/python/sparknlp/annotator/classifier_dl/longformer_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/longformer_for_question_answering.py
@@ -18,7 +18,8 @@ from sparknlp.common import *
 class LongformerForQuestionAnswering(AnnotatorModel,
                                      HasCaseSensitiveProperties,
                                      HasBatchedAnnotate,
-                                     HasEngine):
+                                     HasEngine,
+                                     HasLongMaxSentenceLengthLimit):
     """LongformerForQuestionAnswering can load Longformer Models with a span classification head on top for extractive
     question-answering tasks like SQuAD (a linear layer on top of the hidden-states output to compute span start
     logits and span end logits).
@@ -91,11 +92,6 @@ class LongformerForQuestionAnswering(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CHUNK
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -114,16 +110,6 @@ class LongformerForQuestionAnswering(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.LongformerForQuestionAnswering",

--- a/python/sparknlp/annotator/classifier_dl/longformer_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/longformer_for_sequence_classification.py
@@ -20,7 +20,8 @@ class LongformerForSequenceClassification(AnnotatorModel,
                                           HasCaseSensitiveProperties,
                                           HasBatchedAnnotate,
                                           HasClassifierActivationProperties,
-                                          HasEngine):
+                                          HasEngine,
+                                          HasLongMaxSentenceLengthLimit):
     """LongformerForSequenceClassification can load Longformer Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -104,11 +105,6 @@ class LongformerForSequenceClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CATEGORY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -133,16 +129,6 @@ class LongformerForSequenceClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     def setCoalesceSentences(self, value):
         """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.

--- a/python/sparknlp/annotator/classifier_dl/longformer_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/longformer_for_token_classification.py
@@ -19,7 +19,8 @@ from sparknlp.common import *
 class LongformerForTokenClassification(AnnotatorModel,
                                        HasCaseSensitiveProperties,
                                        HasBatchedAnnotate,
-                                       HasEngine):
+                                       HasEngine,
+                                       HasLongMaxSentenceLengthLimit):
     """LongformerForTokenClassification can load Longformer Models with a token
     classification head on top (a linear layer on top of the hidden-states
     output) e.g. for Named-Entity-Recognition (NER) tasks.
@@ -97,11 +98,6 @@ class LongformerForTokenClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.NAMED_ENTITY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -122,16 +118,6 @@ class LongformerForTokenClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.LongformerForTokenClassification",

--- a/python/sparknlp/annotator/classifier_dl/roberta_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/roberta_for_question_answering.py
@@ -18,7 +18,8 @@ from sparknlp.common import *
 class RoBertaForQuestionAnswering(AnnotatorModel,
                                   HasCaseSensitiveProperties,
                                   HasBatchedAnnotate,
-                                  HasEngine):
+                                  HasEngine,
+                                  HasMaxSentenceLengthLimit):
     """RoBertaForQuestionAnswering can load RoBERTa Models with a span classification head on top for extractive
     question-answering tasks like SQuAD (a linear layer on top of the hidden-states output to compute span start
     logits and span end logits).
@@ -91,11 +92,6 @@ class RoBertaForQuestionAnswering(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CHUNK
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -114,16 +110,6 @@ class RoBertaForQuestionAnswering(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.RoBertaForQuestionAnswering",

--- a/python/sparknlp/annotator/classifier_dl/roberta_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/roberta_for_sequence_classification.py
@@ -20,7 +20,8 @@ class RoBertaForSequenceClassification(AnnotatorModel,
                                        HasCaseSensitiveProperties,
                                        HasBatchedAnnotate,
                                        HasClassifierActivationProperties,
-                                       HasEngine):
+                                       HasEngine,
+                                       HasMaxSentenceLengthLimit):
     """RoBertaForSequenceClassification can load RoBERTa Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -104,11 +105,6 @@ class RoBertaForSequenceClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CATEGORY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -133,16 +129,6 @@ class RoBertaForSequenceClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     def setCoalesceSentences(self, value):
         """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.

--- a/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_question_answering.py
+++ b/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_question_answering.py
@@ -18,7 +18,8 @@ from sparknlp.common import *
 class XlmRoBertaForQuestionAnswering(AnnotatorModel,
                                      HasCaseSensitiveProperties,
                                      HasBatchedAnnotate,
-                                     HasEngine):
+                                     HasEngine,
+                                     HasMaxSentenceLengthLimit):
     """XlmRoBertaForQuestionAnswering can load XLM-RoBERTa Models with a span classification head on top for extractive
     question-answering tasks like SQuAD (a linear layer on top of the hidden-states output to compute span start
     logits and span end logits).
@@ -91,11 +92,6 @@ class XlmRoBertaForQuestionAnswering(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CHUNK
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -114,16 +110,6 @@ class XlmRoBertaForQuestionAnswering(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.XlmRoBertaForQuestionAnswering",

--- a/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_sequence_classification.py
@@ -20,7 +20,8 @@ class XlmRoBertaForSequenceClassification(AnnotatorModel,
                                           HasCaseSensitiveProperties,
                                           HasBatchedAnnotate,
                                           HasClassifierActivationProperties,
-                                          HasEngine):
+                                          HasEngine,
+                                          HasMaxSentenceLengthLimit):
     """XlmRoBertaForSequenceClassification can load XLM-RoBERTa Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -104,11 +105,6 @@ class XlmRoBertaForSequenceClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CATEGORY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -133,16 +129,6 @@ class XlmRoBertaForSequenceClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     def setCoalesceSentences(self, value):
         """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.

--- a/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlm_roberta_for_token_classification.py
@@ -19,7 +19,8 @@ from sparknlp.common import *
 class XlmRoBertaForTokenClassification(AnnotatorModel,
                                        HasCaseSensitiveProperties,
                                        HasBatchedAnnotate,
-                                       HasEngine):
+                                       HasEngine,
+                                       HasMaxSentenceLengthLimit):
     """XlmRoBertaForTokenClassification can load XLM-RoBERTa Models with a token
     classification head on top (a linear layer on top of the hidden-states
     output) e.g. for Named-Entity-Recognition (NER) tasks.
@@ -94,11 +95,6 @@ class XlmRoBertaForTokenClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.NAMED_ENTITY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -119,16 +115,6 @@ class XlmRoBertaForTokenClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.XlmRoBertaForTokenClassification",

--- a/python/sparknlp/annotator/classifier_dl/xlnet_for_sequence_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlnet_for_sequence_classification.py
@@ -20,7 +20,8 @@ class XlnetForSequenceClassification(AnnotatorModel,
                                      HasCaseSensitiveProperties,
                                      HasBatchedAnnotate,
                                      HasClassifierActivationProperties,
-                                     HasEngine):
+                                     HasEngine,
+                                     HasMaxSentenceLengthLimit):
     """XlnetForSequenceClassification can load XLNet Models with sequence classification/regression head on
     top (a linear layer on top of the pooled output) e.g. for multi-class document classification tasks.
 
@@ -104,11 +105,6 @@ class XlnetForSequenceClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.CATEGORY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -133,16 +129,6 @@ class XlnetForSequenceClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     def setCoalesceSentences(self, value):
         """Instead of 1 class per sentence (if inputCols is '''sentence''') output 1 class per document by averaging probabilities in all sentences.

--- a/python/sparknlp/annotator/classifier_dl/xlnet_for_token_classification.py
+++ b/python/sparknlp/annotator/classifier_dl/xlnet_for_token_classification.py
@@ -19,7 +19,8 @@ from sparknlp.common import *
 class XlnetForTokenClassification(AnnotatorModel,
                                   HasCaseSensitiveProperties,
                                   HasBatchedAnnotate,
-                                  HasEngine):
+                                  HasEngine,
+                                  HasMaxSentenceLengthLimit):
     """XlnetForTokenClassification can load XLNet Models with a token
     classification head on top (a linear layer on top of the hidden-states
     output) e.g. for Named-Entity-Recognition (NER) tasks.
@@ -97,11 +98,6 @@ class XlnetForTokenClassification(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.NAMED_ENTITY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -122,16 +118,6 @@ class XlnetForTokenClassification(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 128.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.classifier.dl.XlnetForTokenClassification",

--- a/python/sparknlp/annotator/coref/spanbert_coref.py
+++ b/python/sparknlp/annotator/coref/spanbert_coref.py
@@ -20,7 +20,8 @@ class SpanBertCorefModel(AnnotatorModel,
                          HasEmbeddingsProperties,
                          HasCaseSensitiveProperties,
                          HasStorageRef,
-                         HasEngine):
+                         HasEngine,
+                         HasMaxSentenceLengthLimit):
     """
     A coreference resolution model based on SpanBert.
 
@@ -114,11 +115,6 @@ class SpanBertCorefModel(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.DEPENDENCY
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     maxSegmentLength = Param(Params._dummy(),
                              "maxSegmentLength",
                              "Max segment length",
@@ -143,16 +139,6 @@ class SpanBertCorefModel(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     def setMaxSegmentLength(self, value):
         """Sets max segment length

--- a/python/sparknlp/annotator/embeddings/albert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/albert_embeddings.py
@@ -21,7 +21,8 @@ class AlbertEmbeddings(AnnotatorModel,
                        HasCaseSensitiveProperties,
                        HasStorageRef,
                        HasBatchedAnnotate,
-                       HasEngine):
+                       HasEngine,
+                       HasMaxSentenceLengthLimit):
     """ALBERT: A Lite Bert For Self-Supervised Learning Of Language
     Representations - Google Research, Toyota Technological Institute at Chicago
 
@@ -163,11 +164,6 @@ class AlbertEmbeddings(AnnotatorModel,
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
                              TypeConverters.toListInt)
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
 
@@ -177,16 +173,6 @@ class AlbertEmbeddings(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.AlbertEmbeddings", java_model=None):

--- a/python/sparknlp/annotator/embeddings/bert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bert_embeddings.py
@@ -20,7 +20,8 @@ class BertEmbeddings(AnnotatorModel,
                      HasEmbeddingsProperties,
                      HasCaseSensitiveProperties,
                      HasStorageRef,
-                     HasBatchedAnnotate):
+                     HasBatchedAnnotate,
+                     HasMaxSentenceLengthLimit):
     """Token-level embeddings using BERT.
 
     BERT (Bidirectional Encoder Representations from Transformers) provides
@@ -134,11 +135,6 @@ class BertEmbeddings(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.WORD_EMBEDDINGS
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -153,16 +149,6 @@ class BertEmbeddings(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.BertEmbeddings", java_model=None):

--- a/python/sparknlp/annotator/embeddings/bert_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bert_sentence_embeddings.py
@@ -17,11 +17,12 @@ from sparknlp.common import *
 
 
 class BertSentenceEmbeddings(AnnotatorModel,
-                             HasEmbeddingsProperties,
-                             HasCaseSensitiveProperties,
-                             HasStorageRef,
-                             HasBatchedAnnotate,
-                             HasEngine):
+                                  HasEmbeddingsProperties,
+                                  HasCaseSensitiveProperties,
+                                  HasStorageRef,
+                                  HasBatchedAnnotate,
+                                  HasEngine,
+                                  HasMaxSentenceLengthLimit):
     """Sentence-level embeddings using BERT. BERT (Bidirectional Encoder
     Representations from Transformers) provides dense vector representations for
     natural language by using a deep, pre-trained neural network with the
@@ -133,11 +134,6 @@ class BertSentenceEmbeddings(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.SENTENCE_EMBEDDINGS
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     isLong = Param(Params._dummy(),
                    "isLong",
                    "Use Long type instead of Int type for inputs buffer - Some Bert models require Long instead of Int.",
@@ -157,16 +153,6 @@ class BertSentenceEmbeddings(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     def setIsLong(self, value):
         """Sets whether to use Long type instead of Int type for inputs buffer.

--- a/python/sparknlp/annotator/embeddings/camembert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/camembert_embeddings.py
@@ -21,7 +21,8 @@ class CamemBertEmbeddings(AnnotatorModel,
                           HasCaseSensitiveProperties,
                           HasStorageRef,
                           HasBatchedAnnotate,
-                          HasEngine):
+                          HasEngine,
+                          HasMaxSentenceLengthLimit):
     """The CamemBERT model was proposed in CamemBERT: a Tasty French Language Model by
         Louis Martin, Benjamin Muller, Pedro Javier Ortiz Suárez, Yoann Dupont, Laurent
         Romary, Éric Villemonte de la Clergerie, Djamé Seddah, and Benoît Sagot.
@@ -143,13 +144,6 @@ class CamemBertEmbeddings(AnnotatorModel,
         TypeConverters.toListInt,
     )
 
-    maxSentenceLength = Param(
-        Params._dummy(),
-        "maxSentenceLength",
-        "Max sentence length to process",
-        typeConverter=TypeConverters.toInt,
-    )
-
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
 
@@ -159,16 +153,6 @@ class CamemBertEmbeddings(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.CamemBertEmbeddings", java_model=None):

--- a/python/sparknlp/annotator/embeddings/deberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/deberta_embeddings.py
@@ -20,7 +20,8 @@ class DeBertaEmbeddings(AnnotatorModel,
                         HasCaseSensitiveProperties,
                         HasStorageRef,
                         HasBatchedAnnotate,
-                        HasEngine):
+                        HasEngine,
+                        HasMaxSentenceLengthLimit):
     """The DeBERTa model was proposed in DeBERTa: Decoding-enhanced BERT with
     Disentangled Attention by Pengcheng He, Xiaodong Liu, Jianfeng Gao, Weizhu
     Chen It is based on Google’s BERT model released in 2018 and Facebook’s
@@ -141,11 +142,6 @@ class DeBertaEmbeddings(AnnotatorModel,
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
                              TypeConverters.toListInt)
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
 
@@ -155,16 +151,6 @@ class DeBertaEmbeddings(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.DeBertaEmbeddings", java_model=None):

--- a/python/sparknlp/annotator/embeddings/distil_bert_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/distil_bert_embeddings.py
@@ -21,7 +21,8 @@ class DistilBertEmbeddings(AnnotatorModel,
                            HasCaseSensitiveProperties,
                            HasStorageRef,
                            HasBatchedAnnotate,
-                           HasEngine):
+                           HasEngine,
+                           HasMaxSentenceLengthLimit):
     """DistilBERT is a small, fast, cheap and light Transformer model trained by
     distilling BERT base. It has 40% less parameters than ``bert-base-uncased``,
     runs 60% faster while preserving over 95% of BERT's performances as measured
@@ -149,11 +150,6 @@ class DistilBertEmbeddings(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.WORD_EMBEDDINGS
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -168,16 +164,6 @@ class DistilBertEmbeddings(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.DistilBertEmbeddings", java_model=None):

--- a/python/sparknlp/annotator/embeddings/longformer_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/longformer_embeddings.py
@@ -21,7 +21,8 @@ class LongformerEmbeddings(AnnotatorModel,
                            HasCaseSensitiveProperties,
                            HasStorageRef,
                            HasBatchedAnnotate,
-                           HasEngine):
+                           HasEngine,
+                           HasLongMaxSentenceLengthLimit):
     """Longformer is a transformer model for long documents. The Longformer
     model was presented in `Longformer: The Long-Document Transformer` by Iz
     Beltagy, Matthew E. Peters, Arman Cohan. longformer-base-4096 is a BERT-like
@@ -139,11 +140,6 @@ class LongformerEmbeddings(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.WORD_EMBEDDINGS
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -158,16 +154,6 @@ class LongformerEmbeddings(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process, by default 1024.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.LongformerEmbeddings", java_model=None):

--- a/python/sparknlp/annotator/embeddings/roberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/roberta_embeddings.py
@@ -21,7 +21,8 @@ class RoBertaEmbeddings(AnnotatorModel,
                         HasCaseSensitiveProperties,
                         HasStorageRef,
                         HasBatchedAnnotate,
-                        HasEngine):
+                        HasEngine,
+                        HasMaxSentenceLengthLimit):
     """Creates word embeddings using RoBERTa.
 
     The RoBERTa model was proposed in `RoBERTa: A Robustly Optimized BERT
@@ -151,11 +152,6 @@ class RoBertaEmbeddings(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.WORD_EMBEDDINGS
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -170,16 +166,6 @@ class RoBertaEmbeddings(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.RoBertaEmbeddings", java_model=None):

--- a/python/sparknlp/annotator/embeddings/roberta_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/roberta_sentence_embeddings.py
@@ -17,11 +17,12 @@ from sparknlp.common import *
 
 
 class RoBertaSentenceEmbeddings(AnnotatorModel,
-                                HasEmbeddingsProperties,
-                                HasCaseSensitiveProperties,
-                                HasStorageRef,
-                                HasBatchedAnnotate,
-                                HasEngine):
+                                     HasEmbeddingsProperties,
+                                     HasCaseSensitiveProperties,
+                                     HasStorageRef,
+                                     HasBatchedAnnotate,
+                                     HasEngine,
+                                     HasMaxSentenceLengthLimit):
     """Sentence-level embeddings using RoBERTa. The RoBERTa model was proposed in RoBERTa: A Robustly Optimized BERT
     Pretraining Approach  by Yinhan Liu, Myle Ott, Naman Goyal, Jingfei Du, Mandar Joshi, Danqi Chen, Omer Levy,
     Mike Lewis, Luke Zettlemoyer, Veselin Stoyanov. It is based on Google's BERT model released in 2018. It builds on
@@ -119,11 +120,6 @@ class RoBertaSentenceEmbeddings(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.SENTENCE_EMBEDDINGS
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -138,16 +134,6 @@ class RoBertaSentenceEmbeddings(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.RoBertaSentenceEmbeddings", java_model=None):

--- a/python/sparknlp/annotator/embeddings/xlm_roberta_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlm_roberta_embeddings.py
@@ -21,7 +21,8 @@ class XlmRoBertaEmbeddings(AnnotatorModel,
                            HasCaseSensitiveProperties,
                            HasStorageRef,
                            HasBatchedAnnotate,
-                           HasEngine):
+                           HasEngine,
+                           HasMaxSentenceLengthLimit):
     """The XLM-RoBERTa model was proposed in `Unsupervised Cross-lingual
     Representation Learning at Scale` by Alexis Conneau, Kartikay Khandelwal,
     Naman Goyal, Vishrav Chaudhary, Guillaume Wenzek, Francisco Guzman, Edouard
@@ -151,11 +152,6 @@ class XlmRoBertaEmbeddings(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.WORD_EMBEDDINGS
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -170,16 +166,6 @@ class XlmRoBertaEmbeddings(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.XlmRoBertaEmbeddings", java_model=None):

--- a/python/sparknlp/annotator/embeddings/xlm_roberta_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlm_roberta_sentence_embeddings.py
@@ -17,11 +17,12 @@ from sparknlp.common import *
 
 
 class XlmRoBertaSentenceEmbeddings(AnnotatorModel,
-                                   HasEmbeddingsProperties,
-                                   HasCaseSensitiveProperties,
-                                   HasStorageRef,
-                                   HasBatchedAnnotate,
-                                   HasEngine):
+                                        HasEmbeddingsProperties,
+                                        HasCaseSensitiveProperties,
+                                        HasStorageRef,
+                                        HasBatchedAnnotate,
+                                        HasEngine,
+                                        HasMaxSentenceLengthLimit):
     """Sentence-level embeddings using XLM-RoBERTa. The XLM-RoBERTa model was proposed in Unsupervised Cross-lingual
     Representation Learning at Scale  by Alexis Conneau, Kartikay Khandelwal, Naman Goyal, Vishrav Chaudhary,
     Guillaume Wenzek, Francisco GuzmÃ¡n, Edouard Grave, Myle Ott, Luke Zettlemoyer and Veselin Stoyanov. It is based
@@ -122,11 +123,6 @@ class XlmRoBertaSentenceEmbeddings(AnnotatorModel,
 
     outputAnnotatorType = AnnotatorType.SENTENCE_EMBEDDINGS
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     configProtoBytes = Param(Params._dummy(),
                              "configProtoBytes",
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
@@ -141,16 +137,6 @@ class XlmRoBertaSentenceEmbeddings(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.XlmRoBertaSentenceEmbeddings", java_model=None):

--- a/python/sparknlp/annotator/embeddings/xlnet_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/xlnet_embeddings.py
@@ -21,7 +21,8 @@ class XlnetEmbeddings(AnnotatorModel,
                       HasCaseSensitiveProperties,
                       HasStorageRef,
                       HasBatchedAnnotate,
-                      HasEngine):
+                      HasEngine,
+                      HasMaxSentenceLengthLimit):
     """XlnetEmbeddings (XLNet): Generalized Autoregressive Pretraining for
     Language Understanding
 
@@ -160,11 +161,6 @@ class XlnetEmbeddings(AnnotatorModel,
                              "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()",
                              TypeConverters.toListInt)
 
-    maxSentenceLength = Param(Params._dummy(),
-                              "maxSentenceLength",
-                              "Max sentence length to process",
-                              typeConverter=TypeConverters.toInt)
-
     def setConfigProtoBytes(self, b):
         """Sets configProto from tensorflow, serialized into byte array.
 
@@ -174,16 +170,6 @@ class XlnetEmbeddings(AnnotatorModel,
             ConfigProto from tensorflow, serialized into byte array
         """
         return self._set(configProtoBytes=b)
-
-    def setMaxSentenceLength(self, value):
-        """Sets max sentence length to process.
-
-        Parameters
-        ----------
-        value : int
-            Max sentence length to process
-        """
-        return self._set(maxSentenceLength=value)
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.embeddings.XlnetEmbeddings", java_model=None):

--- a/python/sparknlp/annotator/seq2seq/marian_transformer.py
+++ b/python/sparknlp/annotator/seq2seq/marian_transformer.py
@@ -30,6 +30,11 @@ class MarianTransformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):
     Translation services and being deployed by many companies, organizations and
     research projects.
 
+    Note that this model only supports inputs up to 512 tokens. If you are
+    working with longer inputs, consider splitting them first. For example, you
+    can use the SentenceDetectorDL annotator to split longer texts into
+    sentences.
+
     Pretrained models can be loaded with :meth:`.pretrained` of the companion
     object:
 
@@ -176,13 +181,16 @@ class MarianTransformer(AnnotatorModel, HasBatchedAnnotate, HasEngine):
 
     def setMaxInputLength(self, value):
         """Sets the maximum length for encoder inputs (source language texts),
-        by default 40.
+        by default 40. The value should be less than 512, as the Marian Transformer does not
+        support inputs longer than 512 tokens.
 
         Parameters
         ----------
         value : int
             The maximum length for encoder inputs (source language texts)
         """
+        if value > 512:
+            raise ValueError("MarianTransformer model does not support sequences longer than 512.")
         return self._set(maxInputLength=value)
 
     def setMaxOutputLength(self, value):

--- a/python/sparknlp/common/properties.py
+++ b/python/sparknlp/common/properties.py
@@ -433,3 +433,44 @@ class HasCandidateLabelsProperties:
             entailmentIdParam
         """
         return self._set(entailmentIdParam=v)
+
+
+class HasMaxSentenceLengthLimit:
+    # Default Value, can be overridden
+    max_length_limit = 512
+
+    maxSentenceLength = Param(Params._dummy(),
+                              "maxSentenceLength",
+                              "Max sentence length to process",
+                              typeConverter=TypeConverters.toInt)
+
+    def setMaxSentenceLength(self, value):
+        """Sets max sentence length to process.
+
+        Note that a maximum limit exists depending on the model. If you are working with long single
+        sequences, consider splitting up the input first with another annotator e.g. SentenceDetector.
+
+        Parameters
+        ----------
+        value : int
+            Max sentence length to process
+        """
+        if value > self.max_length_limit:
+            raise ValueError(
+                f"{self.__class__.__name__} models do not support token sequences longer than {self.max_length_limit}.\n"
+                f"Consider splitting up the input first with another annotator e.g. SentenceDetector.")
+        return self._set(maxSentenceLength=value)
+
+    def getMaxSentenceLength(self):
+        """Gets max sentence of the model.
+
+        Returns
+        -------
+        int
+            Max sentence length to process
+        """
+        return self.getOrDefault("maxSentenceLength")
+
+
+class HasLongMaxSentenceLengthLimit(HasMaxSentenceLengthLimit):
+    max_length_limit = 4096

--- a/python/test/annotator/classifier_dl/albert_for_sequence_classification_test.py
+++ b/python/test/annotator/classifier_dl/albert_for_sequence_classification_test.py
@@ -1,0 +1,55 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class AlbertForSequenceClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+        self.tested_annotator = AlbertForSequenceClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("class")
+
+    def test_run(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        albert = self.tested_annotator
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            albert
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()
+
+        print(self.classifier.getClasses())
+        print(self.classifier.getBatchSize())

--- a/python/test/annotator/classifier_dl/albert_for_token_classification_test.py
+++ b/python/test/annotator/classifier_dl/albert_for_token_classification_test.py
@@ -18,25 +18,28 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
-@pytest.mark.fast
-class AlbertForTokenClassificationTestSpec(unittest.TestCase):
+@pytest.mark.slow
+class AlbertForTokenClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
 
-    def runTest(self):
+        self.tested_annotator = AlbertForTokenClassification.pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("ner")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        token_classifier = AlbertForTokenClassification.pretrained() \
-            .setInputCols(["document", "token"]) \
-            .setOutputCol("ner")
+        token_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/classifier_dl/bert_for_question_answering_test.py
+++ b/python/test/annotator/classifier_dl/bert_for_question_answering_test.py
@@ -1,0 +1,49 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class BertForQuestionAnsweringTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.tested_annotator = BertForQuestionAnswering.pretrained() \
+            .setInputCols(["document_question", "document_context"]) \
+            .setOutputCol("answer") \
+            .setCaseSensitive(False)
+
+    def test_run(self):
+        documentAssembler = MultiDocumentAssembler() \
+            .setInputCols(["question", "context"]) \
+            .setOutputCols(["document_question", "document_context"])
+
+        questionAnswering = self.tested_annotator
+
+        pipeline = Pipeline().setStages([
+            documentAssembler,
+            questionAnswering
+        ])
+
+        data = SparkContextForTest.spark.createDataFrame(
+            [["What's my name?", "My name is Clara and I live in Berkeley."]]).toDF("question",
+                                                                                    "context")
+        result = pipeline.fit(data).transform(data)
+        result.select("answer.result").show(truncate=False)

--- a/python/test/annotator/classifier_dl/bert_for_sequence_classification_test.py
+++ b/python/test/annotator/classifier_dl/bert_for_sequence_classification_test.py
@@ -1,0 +1,59 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class BertForSequenceClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+        self.tested_annotator = BertForSequenceClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("class")
+
+    def test_run(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        doc_classifier = self.tested_annotator
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            doc_classifier
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()
+
+        print(self.classifier.getClasses())
+        print(self.classifier.getBatchSize())
+
+    def test_maxSentenceLength(self):
+        with pytest.raises(ValueError):
+            self.classifier.setMaxSentenceLength(5000)

--- a/python/test/annotator/classifier_dl/bert_for_token_classification_test.py
+++ b/python/test/annotator/classifier_dl/bert_for_token_classification_test.py
@@ -18,25 +18,28 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class BertForTokenClassificationTestSpec(unittest.TestCase):
+class BertForTokenClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
 
-    def runTest(self):
+        self.tested_annotator = BertForTokenClassification.pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("ner")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        token_classifier = BertForTokenClassification.pretrained() \
-            .setInputCols(["document", "token"]) \
-            .setOutputCol("ner")
+        token_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/classifier_dl/bert_for_zero_shot_classification_test.py
+++ b/python/test/annotator/classifier_dl/bert_for_zero_shot_classification_test.py
@@ -16,29 +16,32 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class BertForZeroShotClassificationTestSpec(unittest.TestCase):
+class BertForZeroShotClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.spark = SparkContextForTest.spark
         self.text = "I have a problem with my iphone that needs to be resolved asap!!"
         self.inputDataset = self.spark.createDataFrame([[self.text]]) \
             .toDF("text")
 
-    def runTest(self):
+        self.tested_annotator = BertForZeroShotClassification \
+            .pretrained("bert_base_cased_zero_shot_classifier_xnli") \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("class") \
+            .setCandidateLabels(["urgent", "mobile", "travel", "movie", "music", "sport", "weather", "technology"])
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        zero_shot_classifier = BertForZeroShotClassification \
-            .pretrained() \
-            .setInputCols(["document", "token"]) \
-            .setOutputCol("class") \
-            .setCandidateLabels(["urgent", "mobile", "travel", "movie", "music", "sport", "weather", "technology"])
+        zero_shot_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/classifier_dl/camembert_for_question_aswering_test.py
+++ b/python/test/annotator/classifier_dl/camembert_for_question_aswering_test.py
@@ -16,11 +16,12 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class CamemBertForQuestionAnsweringTestSpec(unittest.TestCase):
+class CamemBertForQuestionAnsweringTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.spark = SparkContextForTest.spark
         self.question = "Où est-ce que je vis?"
@@ -28,16 +29,18 @@ class CamemBertForQuestionAnsweringTestSpec(unittest.TestCase):
         self.inputDataset = self.spark.createDataFrame([[self.question, self.context]]) \
             .toDF("question", "context")
 
-    def runTest(self):
-        document_assembler = MultiDocumentAssembler() \
-            .setInputCols("question", "context") \
-            .setOutputCols("document_question", "document_context")
-
-        qa_classifier = CamemBertForQuestionAnswering.pretrained() \
+        self.tested_annotator = CamemBertForQuestionAnswering.pretrained() \
             .setInputCols("document_question", "document_context") \
             .setOutputCol("answer") \
             .setCaseSensitive(True) \
             .setMaxSentenceLength(512)
+
+    def test_run(self):
+        document_assembler = MultiDocumentAssembler() \
+            .setInputCols("question", "context") \
+            .setOutputCols("document_question", "document_context")
+
+        qa_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/classifier_dl/camembert_for_sequence_classification_test.py
+++ b/python/test/annotator/classifier_dl/camembert_for_sequence_classification_test.py
@@ -1,0 +1,55 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class CamemBertForSequenceClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+        self.tested_annotator = CamemBertForSequenceClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("ner")
+
+    def test_run(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        doc_classifier = self.tested_annotator
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            doc_classifier
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()
+
+        print(self.classifier.getClasses())
+        print(self.classifier.getBatchSize())

--- a/python/test/annotator/classifier_dl/camembert_for_token_classification_test.py
+++ b/python/test/annotator/classifier_dl/camembert_for_token_classification_test.py
@@ -27,17 +27,19 @@ class CamemBertForTokenClassificationTestSpec(unittest.TestCase):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
 
-    def runTest(self):
+        self.tested_annotator = CamemBertForTokenClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("ner")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        token_classifier = CamemBertForTokenClassification \
-            .pretrained() \
-            .setInputCols(["document", "token"]) \
-            .setOutputCol("ner")
+        token_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/classifier_dl/deberta_for_question_answering_test.py
+++ b/python/test/annotator/classifier_dl/deberta_for_question_answering_test.py
@@ -1,0 +1,49 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class DeBertaForQuestionAnsweringTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.tested_annotator = DeBertaForQuestionAnswering.pretrained() \
+            .setInputCols(["document_question", "document_context"]) \
+            .setOutputCol("answer") \
+            .setCaseSensitive(False)
+
+    def test_run(self):
+        documentAssembler = MultiDocumentAssembler() \
+            .setInputCols(["question", "context"]) \
+            .setOutputCols(["document_question", "document_context"])
+
+        questionAnswering = self.tested_annotator
+
+        pipeline = Pipeline().setStages([
+            documentAssembler,
+            questionAnswering
+        ])
+
+        data = SparkContextForTest.spark.createDataFrame(
+            [["What's my name?", "My name is Clara and I live in Berkeley."]]).toDF("question",
+                                                                                    "context")
+        result = pipeline.fit(data).transform(data)
+        result.select("answer.result").show(truncate=False)

--- a/python/test/annotator/classifier_dl/deberta_for_sequence_classification_test.py
+++ b/python/test/annotator/classifier_dl/deberta_for_sequence_classification_test.py
@@ -18,26 +18,29 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class DeBertaForSequenceClassificationTestSpec(unittest.TestCase):
+class DeBertaForSequenceClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
 
-    def runTest(self):
+        self.tested_annotator = DeBertaForSequenceClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("class")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        doc_classifier = DeBertaForSequenceClassification \
-            .pretrained() \
-            .setInputCols(["document", "token"]) \
-            .setOutputCol("class")
+        doc_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/classifier_dl/deberta_for_token_classification_test.py
+++ b/python/test/annotator/classifier_dl/deberta_for_token_classification_test.py
@@ -1,0 +1,51 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class DeBertaForTokenClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+        self.tested_annotator = DeBertaForTokenClassification.pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("ner")
+
+    def test_run(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        doc_classifier = self.tested_annotator
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            doc_classifier
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()

--- a/python/test/annotator/classifier_dl/distil_bert_for_sequence_classification_test.py
+++ b/python/test/annotator/classifier_dl/distil_bert_for_sequence_classification_test.py
@@ -18,25 +18,29 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class DistilBertForSequenceClassificationTestSpec(unittest.TestCase):
+class DistilBertForSequenceClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
 
-    def runTest(self):
+        self.tested_annotator = DistilBertForSequenceClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("class")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        doc_classifier = DistilBertForSequenceClassification.pretrained() \
-            .setInputCols(["document", "token"]) \
-            .setOutputCol("class")
+        doc_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,
@@ -46,4 +50,3 @@ class DistilBertForSequenceClassificationTestSpec(unittest.TestCase):
 
         model = pipeline.fit(self.data)
         model.transform(self.data).show()
-

--- a/python/test/annotator/classifier_dl/distil_bert_for_zero_shot_classification_test.py
+++ b/python/test/annotator/classifier_dl/distil_bert_for_zero_shot_classification_test.py
@@ -16,29 +16,32 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class DistilBertForZeroShotClassificationTestSpec(unittest.TestCase):
+class DistilBertForZeroShotClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.spark = SparkContextForTest.spark
         self.text = "I have a problem with my iphone that needs to be resolved asap!!"
         self.inputDataset = self.spark.createDataFrame([[self.text]]) \
             .toDF("text")
 
-    def runTest(self):
+        self.tested_annotator = DistilBertForZeroShotClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("class") \
+            .setCandidateLabels(["urgent", "mobile", "travel", "movie", "music", "sport", "weather", "technology"])
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        zero_shot_classifier = DistilBertForZeroShotClassification \
-            .pretrained() \
-            .setInputCols(["document", "token"]) \
-            .setOutputCol("class") \
-            .setCandidateLabels(["urgent", "mobile", "travel", "movie", "music", "sport", "weather", "technology"])
+        zero_shot_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/classifier_dl/distilbert_for_question_answering_test.py
+++ b/python/test/annotator/classifier_dl/distilbert_for_question_answering_test.py
@@ -1,0 +1,48 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class DistilBertForQuestionAnsweringTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.tested_annotator = DistilBertForQuestionAnswering.pretrained() \
+            .setInputCols(["document_question", "document_context"]) \
+            .setOutputCol("answer") \
+            .setCaseSensitive(False)
+
+    def test_run(self):
+        documentAssembler = MultiDocumentAssembler() \
+            .setInputCols(["question", "context"]) \
+            .setOutputCols(["document_question", "document_context"])
+
+        questionAnswering = self.tested_annotator
+
+        pipeline = Pipeline().setStages([
+            documentAssembler,
+        ])
+
+        data = SparkContextForTest.spark.createDataFrame(
+            [["What's my name?", "My name is Clara and I live in Berkeley."]]).toDF("question",
+                                                                                    "context")
+        result = pipeline.fit(data).transform(data)
+        result.select("answer.result").show(truncate=False)

--- a/python/test/annotator/classifier_dl/distilbert_for_token_classification_test.py
+++ b/python/test/annotator/classifier_dl/distilbert_for_token_classification_test.py
@@ -18,32 +18,37 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class DeBertaForTokenClassificationTestSpec(unittest.TestCase):
+class DistilBertForTokenClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
 
-    def runTest(self):
+        self.tested_annotator = DistilBertForTokenClassification.pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("ner")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        doc_classifier = DeBertaForTokenClassification \
-            .pretrained() \
-            .setInputCols(["document", "token"]) \
-            .setOutputCol("class")
+        token_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,
             tokenizer,
-            doc_classifier
+            token_classifier
         ])
 
         model = pipeline.fit(self.data)
         model.transform(self.data).show()
+
+        print(self.classifier.getClasses())
+        print(self.classifier.getBatchSize())

--- a/python/test/annotator/classifier_dl/longformer_for_question_answering_test.py
+++ b/python/test/annotator/classifier_dl/longformer_for_question_answering_test.py
@@ -1,0 +1,51 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class LongformerForQuestionAnsweringTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    valid_max_length = 4096
+
+    def setUp(self):
+        self.tested_annotator = LongformerForQuestionAnswering.pretrained() \
+            .setInputCols(["document_question", "document_context"]) \
+            .setOutputCol("answer") \
+            .setCaseSensitive(False)
+
+    def test_run(self):
+        documentAssembler = MultiDocumentAssembler() \
+            .setInputCols(["question", "context"]) \
+            .setOutputCols(["document_question", "document_context"])
+
+        questionAnswering = self.tested_annotator
+
+        pipeline = Pipeline().setStages([
+            documentAssembler,
+            questionAnswering
+        ])
+
+        data = SparkContextForTest.spark.createDataFrame(
+            [["What's my name?", "My name is Clara and I live in Berkeley."]]).toDF("question",
+                                                                                    "context")
+        result = pipeline.fit(data).transform(data)
+        result.select("answer.result").show(truncate=False)

--- a/python/test/annotator/classifier_dl/longformer_for_sequence_classification_test.py
+++ b/python/test/annotator/classifier_dl/longformer_for_sequence_classification_test.py
@@ -1,0 +1,57 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class LongformerForSequenceClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    valid_max_length = 4096
+
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+        self.tested_annotator = LongformerForSequenceClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("class")
+
+    def test_run(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        doc_classifier = self.tested_annotator
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            doc_classifier
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()
+
+        print(self.classifier.getClasses())
+        print(self.classifier.getBatchSize())

--- a/python/test/annotator/classifier_dl/longformer_for_token_classification_test.py
+++ b/python/test/annotator/classifier_dl/longformer_for_token_classification_test.py
@@ -18,25 +18,30 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class LongformerForTokenClassificationTestSpec(unittest.TestCase):
+class LongformerForTokenClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    valid_max_length = 4096
+
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
 
-    def runTest(self):
+        self.tested_annotator = LongformerForTokenClassification.pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("ner")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        token_classifier = LongformerForTokenClassification.pretrained() \
-            .setInputCols(["document", "token"]) \
-            .setOutputCol("ner")
+        token_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/classifier_dl/roberta_for_question_answering_test.py
+++ b/python/test/annotator/classifier_dl/roberta_for_question_answering_test.py
@@ -1,0 +1,49 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class RoBertaForQuestionAnsweringTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.tested_annotator = RoBertaForQuestionAnswering.pretrained() \
+            .setInputCols(["document_question", "document_context"]) \
+            .setOutputCol("answer") \
+            .setCaseSensitive(False)
+
+    def test_run(self):
+        documentAssembler = MultiDocumentAssembler() \
+            .setInputCols(["question", "context"]) \
+            .setOutputCols(["document_question", "document_context"])
+
+        questionAnswering = self.tested_annotator
+
+        pipeline = Pipeline().setStages([
+            documentAssembler,
+            questionAnswering
+        ])
+
+        data = SparkContextForTest.spark.createDataFrame(
+            [["What's my name?", "My name is Clara and I live in Berkeley."]]).toDF("question",
+                                                                                    "context")
+        result = pipeline.fit(data).transform(data)
+        result.select("answer.result").show(truncate=False)

--- a/python/test/annotator/classifier_dl/roberta_for_sequence_classification_test.py
+++ b/python/test/annotator/classifier_dl/roberta_for_sequence_classification_test.py
@@ -18,25 +18,29 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class RoBertaForSequenceClassificationTestSpec(unittest.TestCase):
+class RoBertaForSequenceClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
 
-    def runTest(self):
+        self.tested_annotator = RoBertaForSequenceClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("class")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        doc_classifier = RoBertaForSequenceClassification.pretrained() \
-            .setInputCols(["document", "token"]) \
-            .setOutputCol("class")
+        doc_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,
@@ -46,4 +50,3 @@ class RoBertaForSequenceClassificationTestSpec(unittest.TestCase):
 
         model = pipeline.fit(self.data)
         model.transform(self.data).show()
-

--- a/python/test/annotator/classifier_dl/xlm_roberta_for_question_answering_test.py
+++ b/python/test/annotator/classifier_dl/xlm_roberta_for_question_answering_test.py
@@ -1,0 +1,49 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class XlmRoBertaForQuestionAnsweringTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.tested_annotator = XlmRoBertaForQuestionAnswering.pretrained() \
+            .setInputCols(["document_question", "document_context"]) \
+            .setOutputCol("answer") \
+            .setCaseSensitive(False)
+
+    def test_run(self):
+        documentAssembler = MultiDocumentAssembler() \
+            .setInputCols(["question", "context"]) \
+            .setOutputCols(["document_question", "document_context"])
+
+        questionAnswering = self.tested_annotator
+
+        pipeline = Pipeline().setStages([
+            documentAssembler,
+            questionAnswering
+        ])
+
+        data = SparkContextForTest.spark.createDataFrame(
+            [["What's my name?", "My name is Clara and I live in Berkeley."]]).toDF("question",
+                                                                                    "context")
+        result = pipeline.fit(data).transform(data)
+        result.select("answer.result").show(truncate=False)

--- a/python/test/annotator/classifier_dl/xlm_roberta_for_token_classification_test.py
+++ b/python/test/annotator/classifier_dl/xlm_roberta_for_token_classification_test.py
@@ -18,25 +18,28 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class XlmRoBertaForTokenClassificationTestSpec(unittest.TestCase):
+class XlmRoBertaForTokenClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
 
-    def runTest(self):
+        self.tested_annotator = XlmRoBertaForTokenClassification.pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("ner")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        token_classifier = XlmRoBertaForTokenClassification.pretrained() \
-            .setInputCols(["document", "token"]) \
-            .setOutputCol("ner")
+        token_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/classifier_dl/xlnet_for_sequence_classification_test.py
+++ b/python/test/annotator/classifier_dl/xlnet_for_sequence_classification_test.py
@@ -1,0 +1,55 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class XlnetForSequenceClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+        self.tested_annotator = XlnetForSequenceClassification \
+            .pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("class")
+
+    def test_run(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        doc_classifier = self.tested_annotator
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            doc_classifier
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()
+
+        print(self.classifier.getClasses())
+        print(self.classifier.getBatchSize())

--- a/python/test/annotator/classifier_dl/xlnet_for_token_classification_test.py
+++ b/python/test/annotator/classifier_dl/xlnet_for_token_classification_test.py
@@ -18,25 +18,28 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class XlnetForTokenClassificationTestSpec(unittest.TestCase):
+class XlnetForTokenClassificationTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
 
-    def runTest(self):
+        self.tested_annotator = XlnetForTokenClassification.pretrained() \
+            .setInputCols(["document", "token"]) \
+            .setOutputCol("ner")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        token_classifier = XlnetForTokenClassification.pretrained() \
-            .setInputCols(["document", "token"]) \
-            .setOutputCol("ner")
+        token_classifier = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,
@@ -46,4 +49,3 @@ class XlnetForTokenClassificationTestSpec(unittest.TestCase):
 
         model = pipeline.fit(self.data)
         model.transform(self.data).show()
-

--- a/python/test/annotator/common/has_max_sentence_length_test.py
+++ b/python/test/annotator/common/has_max_sentence_length_test.py
@@ -1,0 +1,30 @@
+import unittest
+
+import pytest
+
+from sparknlp.common.properties import HasMaxSentenceLengthLimit
+
+
+class HasMaxSentenceLengthTests:
+    tested_annotator = None
+    valid_max_length = 512
+    over_max_length = 5000
+
+    def test_max_length(self):
+        if not self.tested_annotator:
+            raise Exception("Please set the annotator to \"tested_annotator\" before running this test.")
+
+        self.tested_annotator.setMaxSentenceLength(self.valid_max_length)
+
+        with pytest.raises(ValueError):
+            self.tested_annotator.setMaxSentenceLength(self.over_max_length)
+
+
+@pytest.mark.fast
+class HasMaxSentenceLengthTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        class MockAnnotator(HasMaxSentenceLengthLimit):
+            def _set(self, maxSentenceLength):
+                pass
+
+        self.tested_annotator = MockAnnotator()

--- a/python/test/annotator/coref/spanbert_coref_test.py
+++ b/python/test/annotator/coref/spanbert_coref_test.py
@@ -11,18 +11,18 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import os
 import unittest
 
 import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkSessionForTest
 
 
 @pytest.mark.slow
-class SpanBertCorefTestSpec(unittest.TestCase):
+class SpanBertCorefTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
 
     def setUp(self):
         self.data = SparkSessionForTest.spark.createDataFrame([
@@ -35,7 +35,12 @@ class SpanBertCorefTestSpec(unittest.TestCase):
             [" "]
         ]).toDF("text")
 
-    def runTest(self):
+        self.tested_annotator = SpanBertCorefModel() \
+            .pretrained() \
+            .setInputCols(["sentences", "tokens"]) \
+            .setOutputCol("corefs")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
@@ -48,10 +53,7 @@ class SpanBertCorefTestSpec(unittest.TestCase):
             .setInputCols(["sentences"]) \
             .setOutputCol("tokens")
 
-        coref = SpanBertCorefModel() \
-            .pretrained() \
-            .setInputCols(["sentences", "tokens"]) \
-            .setOutputCol("corefs")
+        coref = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/embeddings/albert_embeddings_test.py
+++ b/python/test/annotator/embeddings/albert_embeddings_test.py
@@ -18,17 +18,22 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class AlbertEmbeddingsTestSpec(unittest.TestCase):
+class AlbertEmbeddingsTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
 
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
 
-    def runTest(self):
+        self.tested_annotator = AlbertEmbeddings.pretrained() \
+            .setInputCols(["sentence", "token"]) \
+            .setOutputCol("embeddings")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
@@ -38,9 +43,7 @@ class AlbertEmbeddingsTestSpec(unittest.TestCase):
         tokenizer = Tokenizer() \
             .setInputCols(["sentence"]) \
             .setOutputCol("token")
-        albert = AlbertEmbeddings.pretrained() \
-            .setInputCols(["sentence", "token"]) \
-            .setOutputCol("embeddings")
+        albert = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/embeddings/bert_embeddings_test.py
+++ b/python/test/annotator/embeddings/bert_embeddings_test.py
@@ -18,17 +18,22 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class BertEmbeddingsTestSpec(unittest.TestCase):
+class BertEmbeddingsTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
 
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
 
-    def runTest(self):
+        self.tested_annotator = BertEmbeddings.pretrained() \
+            .setInputCols(["sentence", "token"]) \
+            .setOutputCol("embeddings")
+
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
@@ -38,9 +43,7 @@ class BertEmbeddingsTestSpec(unittest.TestCase):
         tokenizer = Tokenizer() \
             .setInputCols(["sentence"]) \
             .setOutputCol("token")
-        albert = BertEmbeddings.pretrained() \
-            .setInputCols(["sentence", "token"]) \
-            .setOutputCol("embeddings")
+        albert = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/embeddings/bert_sentence_embeddings_test.py
+++ b/python/test/annotator/embeddings/bert_sentence_embeddings_test.py
@@ -1,0 +1,48 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class BertSentenceEmbeddingsTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+
+        self.tested_annotator = BertSentenceEmbeddings.pretrained() \
+            .setInputCols(["document"]) \
+            .setOutputCol("sentence_embeddings")
+
+    def test_run(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        sentence_embeddings = self.tested_annotator
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            sentence_embeddings
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()

--- a/python/test/annotator/embeddings/camembert_embeddings_test.py
+++ b/python/test/annotator/embeddings/camembert_embeddings_test.py
@@ -18,25 +18,27 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class CamemBertEmbeddingsTestSpec(unittest.TestCase):
+class CamemBertEmbeddingsTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+        self.tested_annotator = CamemBertEmbeddings.pretrained() \
+            .setInputCols(["token", "document"]) \
+            .setOutputCol("camembert_embeddings")
 
-    def runTest(self):
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
         tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
 
-        embeddings = CamemBertEmbeddings.pretrained() \
-            .setInputCols(["token", "document"]) \
-            .setOutputCol("camembert_embeddings")
+        embeddings = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,

--- a/python/test/annotator/embeddings/deberta_embeddings_test.py
+++ b/python/test/annotator/embeddings/deberta_embeddings_test.py
@@ -1,0 +1,50 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class DeBertaEmbeddingsTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+        self.tested_annotator = DeBertaEmbeddings.pretrained() \
+            .setInputCols(["token", "document"]) \
+            .setOutputCol("camembert_embeddings")
+
+    def test_run(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        embeddings = self.tested_annotator
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            embeddings
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()

--- a/python/test/annotator/embeddings/distilbert_embeddings_test.py
+++ b/python/test/annotator/embeddings/distilbert_embeddings_test.py
@@ -1,0 +1,50 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class DistilBertEmbeddingsTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+        self.tested_annotator = DistilBertEmbeddings.pretrained() \
+            .setInputCols(["token", "document"]) \
+            .setOutputCol("camembert_embeddings")
+
+    def test_run(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        embeddings = self.tested_annotator
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            embeddings
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()

--- a/python/test/annotator/embeddings/longformer_embeddings_test.py
+++ b/python/test/annotator/embeddings/longformer_embeddings_test.py
@@ -1,0 +1,50 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class LongformerEmbeddingsTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+        self.tested_annotator = LongformerEmbeddings.pretrained() \
+            .setInputCols(["token", "document"]) \
+            .setOutputCol("Longformer_embeddings")
+
+    def test_run(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        embeddings = self.tested_annotator
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            embeddings
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()

--- a/python/test/annotator/embeddings/roberta_embeddings_test.py
+++ b/python/test/annotator/embeddings/roberta_embeddings_test.py
@@ -1,0 +1,50 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class RoBertaEmbeddingsTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+        self.tested_annotator = RoBertaEmbeddings.pretrained() \
+            .setInputCols(["token", "document"]) \
+            .setOutputCol("RoBerta_embeddings")
+
+    def test_run(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        embeddings = self.tested_annotator
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            embeddings
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()

--- a/python/test/annotator/embeddings/roberta_sentence_embeddings_test.py
+++ b/python/test/annotator/embeddings/roberta_sentence_embeddings_test.py
@@ -18,23 +18,25 @@ import pytest
 
 from sparknlp.annotator import *
 from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
 from test.util import SparkContextForTest
 
 
 @pytest.mark.slow
-class RoBertaSentenceEmbeddingsTestSpec(unittest.TestCase):
+class RoBertaSentenceEmbeddingsTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
             .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+        self.tested_annotator = RoBertaSentenceEmbeddings.pretrained() \
+            .setInputCols(["document"]) \
+            .setOutputCol("sentence_embeddings")
 
-    def runTest(self):
+    def test_run(self):
         document_assembler = DocumentAssembler() \
             .setInputCol("text") \
             .setOutputCol("document")
 
-        sentence_embeddings = RoBertaSentenceEmbeddings.pretrained() \
-            .setInputCols(["document"]) \
-            .setOutputCol("sentence_embeddings")
+        sentence_embeddings = self.tested_annotator
 
         pipeline = Pipeline(stages=[
             document_assembler,
@@ -43,4 +45,3 @@ class RoBertaSentenceEmbeddingsTestSpec(unittest.TestCase):
 
         model = pipeline.fit(self.data)
         model.transform(self.data).show()
-

--- a/python/test/annotator/embeddings/xlm_roberta_embeddings_test.py
+++ b/python/test/annotator/embeddings/xlm_roberta_embeddings_test.py
@@ -1,0 +1,50 @@
+#  Copyright 2017-2022 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.annotator.common.has_max_sentence_length_test import HasMaxSentenceLengthTests
+from test.util import SparkContextForTest
+
+
+@pytest.mark.slow
+class XlmRoBertaEmbeddingsTestSpec(unittest.TestCase, HasMaxSentenceLengthTests):
+    def setUp(self):
+        self.data = SparkContextForTest.spark.read.option("header", "true") \
+            .csv(path="file:///" + os.getcwd() + "/../src/test/resources/embeddings/sentence_embeddings.csv")
+        self.tested_annotator = XlmRoBertaEmbeddings.pretrained() \
+            .setInputCols(["token", "document"]) \
+            .setOutputCol("XlmRoBerta_embeddings")
+
+    def test_run(self):
+        document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+
+        tokenizer = Tokenizer().setInputCols("document").setOutputCol("token")
+
+        embeddings = self.tested_annotator
+
+        pipeline = Pipeline(stages=[
+            document_assembler,
+            tokenizer,
+            embeddings
+        ])
+
+        model = pipeline.fit(self.data)
+        model.transform(self.data).show()

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
@@ -48,6 +48,10 @@ import org.apache.spark.sql.SparkSession
   * It is currently the engine behind the Microsoft Translator Neural Machine Translation services
   * and being deployed by many companies, organizations and research projects.
   *
+  * Note that this model only supports inputs up to 512 tokens. If you are working with longer
+  * inputs, consider splitting them first. For example, you can use the SentenceDetectorDL
+  * annotator to split longer texts into sentences first.
+  *
   * Pretrained models can be loaded with `pretrained` of the companion object:
   * {{{
   * val marian = MarianTransformer.pretrained()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR introduces an exception in transformer based annotators. If an invalid value is used to set the max input length, an exception is thrown (limit is 512, or 4096 for the longformer). This exception exists on the scala side but was missing in python. These exceptions are now in sync.

This is done by introducing a new property `HasMaxSentenceLengthLimit`:

https://github.com/JohnSnowLabs/spark-nlp/blob/cce5dc84c94fc8397dc922c9d323455b696eb8dc/python/sparknlp/common/properties.py#L438-L476

A note regarding this has also been added to the documentation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Users have been experiencing issues when trying to translate long texts. This should make it clear, that very long inputs are not intended for these models. Users should use a Sentence Detector to split the text to smaller chunks first and this new change will avoid exception by not allowing users to set anything larger than 512 in maxInputLength parameter. (a bug only on Python side)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests have been amended to cover this behaviour. Missing tests were added for some annotators.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
