### PR TITLE
SPARKNLP-832-MultiDateMatcher-doesn-t-return-multiple-dates

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
@@ -326,7 +326,7 @@ trait DateMatcherUtils extends Params {
     * first only. any other matches discarded Auto completes short versions of months. Any two
     * digit year is considered to be XX century
     */
-  protected val relaxedFactory: RuleFactory = new RuleFactory(MatchStrategy.MATCH_FIRST)
+  protected val relaxedFactory: RuleFactory = new RuleFactory(MatchStrategy.MATCH_ALL)
     .addRule(relaxedDayNumbered, "relaxed days")
     .addRule(relaxedMonths.r, "relaxed months exclusive")
     .addRule(relaxedYear, "relaxed year")

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/MultiDateMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/MultiDateMatcher.scala
@@ -247,7 +247,14 @@ class MultiDateMatcher(override val uid: String)
     }
 
   private def extractRelaxedDate(text: String): Seq[MatchedDateTime] = {
-    val possibleDates = relaxedFactory.findMatch(text)
+      val possibleDates = relaxedFactory.findMatch(text)
+      val possibleDatesByIndexMatch = possibleDates.groupBy(_.indexMatch)
+      possibleDatesByIndexMatch.flatMap{ case (_, possibleDates) =>
+        computePossibleDates(possibleDates)
+      }.toSeq
+  }
+
+  private def computePossibleDates(possibleDates: Seq[RuleFactory.RuleMatch]): Seq[MatchedDateTime] = {
     var dayMatch = $(defaultDayWhenMissing)
     var monthMatch = defaultMonthWhenMissing
     var yearMatch = defaultYearWhenMissing
@@ -256,7 +263,7 @@ class MultiDateMatcher(override val uid: String)
     possibleDates.foreach(possibleDate => {
 
       if (possibleDate.identifier == "relaxed days" && possibleDate.content.matched.exists(
-          _.isDigit)) {
+        _.isDigit)) {
         changes += 1
         dayMatch = possibleDate.content.matched.filter(_.isDigit).toInt
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/util/regex/RuleFactory.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/regex/RuleFactory.scala
@@ -69,7 +69,9 @@ class RuleFactory(
     matchStrategy match {
       case MATCH_ALL =>
         rules.flatMap(rule =>
-          rule.regex.findAllMatchIn(text).map(m => RuleMatch(m, rule.identifier)))
+          rule.regex.findAllMatchIn(text).zipWithIndex.map{ case (currentMatch, index) =>
+            RuleMatch(currentMatch, rule.identifier, index)
+          })
       case MATCH_FIRST =>
         rules.flatMap(rule =>
           rule.regex.findFirstMatchIn(text).map(m => RuleMatch(m, rule.identifier)))
@@ -234,7 +236,7 @@ object RuleFactory {
     * @param identifier
     *   user provided identification of a rule
     */
-  case class RuleMatch(content: Regex.Match, identifier: String)
+  case class RuleMatch(content: Regex.Match, identifier: String, indexMatch: Int = -1)
 }
 
 /** Allowed strategies for [[RuleFactory]] applications regarding replacement */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change modifies the code to support the scenario where a text has multiple dates content.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To solve a bug that only outputs one date regardless of the number of dates presented in a text

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- Local Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
