### PR TITLE
Fix loadSavedModel for DBFS

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -106,7 +106,7 @@ object ResourceHelper {
   case class SourceStream(resource: String) {
 
     var fileSystem: Option[FileSystem] = None
-    private val (pathExists, path) = OutputHelper.doesPathExists(resource)
+    private val (pathExists: Boolean, path: Option[Path]) = OutputHelper.doesPathExists(resource)
     if (!pathExists) {
       throw new FileNotFoundException(s"file or folder: $resource not found")
     } else {
@@ -156,7 +156,7 @@ object ResourceHelper {
             Paths.get(destination.toString, path.get.getName).toUri
           else destination.toUri
         case "dbfs" =>
-          val dbfsPath = path.toString.replace("dbfs:/", "/dbfs/")
+          val dbfsPath = path.get.toString.replace("dbfs:/", "/dbfs/")
           val sourceFile = new File(dbfsPath)
           val targetFile = new File(destination.toString)
           if (sourceFile.isFile) FileUtils.copyFileToDirectory(sourceFile, targetFile)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes a bug, where loadSavedModel throws an error, when trying to access files via DBFS.

It seems like in a previous commit for a new feature, `ResourceHelper`'s `path` variable changed types from `Path` to `Option[Path]` . Calling the `toString` method on this type will instead convert the `Option` instead of the actual path. This was fixed with `path.get`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Databricks and it is working again as expected.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
