### PR TITLE
Add unzip param to downloadModelDirectly in ResourceDownloader

### DIFF
--- a/python/sparknlp/internal/__init__.py
+++ b/python/sparknlp/internal/__init__.py
@@ -328,15 +328,9 @@ class _CoverageResult(ExtendedJavaWrapper):
 
 
 class _DownloadModelDirectly(ExtendedJavaWrapper):
-    def __init__(self, name, remote_loc="public/models"):
+    def __init__(self, name, remote_loc="public/models", unzip=True):
         super(_DownloadModelDirectly, self).__init__(
-            "com.johnsnowlabs.nlp.pretrained.PythonResourceDownloader.downloadModelDirectly", name, remote_loc)
-
-
-class _DownloadModelDirectlyAsZip(ExtendedJavaWrapper):
-    def __init__(self, s3URI):
-        super(_DownloadModelDirectlyAsZip, self).__init__(
-            "com.johnsnowlabs.nlp.pretrained.PythonResourceDownloader.downloadModelDirectlyAsZip", s3URI)
+            "com.johnsnowlabs.nlp.pretrained.PythonResourceDownloader.downloadModelDirectly", name, remote_loc, unzip)
 
 
 class _DownloadModel(ExtendedJavaWrapper):

--- a/python/sparknlp/internal/__init__.py
+++ b/python/sparknlp/internal/__init__.py
@@ -333,6 +333,12 @@ class _DownloadModelDirectly(ExtendedJavaWrapper):
             "com.johnsnowlabs.nlp.pretrained.PythonResourceDownloader.downloadModelDirectly", name, remote_loc)
 
 
+class _DownloadModelDirectlyAsZip(ExtendedJavaWrapper):
+    def __init__(self, s3URI):
+        super(_DownloadModelDirectlyAsZip, self).__init__(
+            "com.johnsnowlabs.nlp.pretrained.PythonResourceDownloader.downloadModelDirectlyAsZip", s3URI)
+
+
 class _DownloadModel(ExtendedJavaWrapper):
     def __init__(self, reader, name, language, remote_loc, validator):
         super(_DownloadModel, self).__init__("com.johnsnowlabs.nlp.pretrained." + validator + ".downloadModel", reader,

--- a/python/sparknlp/pretrained/resource_downloader.py
+++ b/python/sparknlp/pretrained/resource_downloader.py
@@ -104,29 +104,21 @@ class ResourceDownloader(object):
             return reader(classname=None, java_model=j_obj)
 
     @staticmethod
-    def downloadModelDirectly(name, remote_loc="public/models"):
+    def downloadModelDirectly(name, remote_loc="public/models", unzip=True):
         """Downloads a model directly to the cache folder.
-
-        Parameters
-        ----------
-        name : str
-            Name of the model
-        remote_loc : str, optional
-            Directory of the remote Spark NLP Folder, by default "public/models"
-        """
-        _internal._DownloadModelDirectly(name, remote_loc).apply()
-
-    @staticmethod
-    def downloadModelDirectlyAsZip(s3URI):
-        """Downloads a model directly as zip to the cache folder.
         You can use to copy-paste the s3 URI from the model hub  and download the model.
         For available s3 URI and models, please see the `Models Hub <https://sparknlp.org/models>`__.
         Parameters
         ----------
-        s3URI : str
-            s3URI link of the model
+        name : str
+            Name of the model or s3 URI
+        remote_loc : str, optional
+            Directory of the remote Spark NLP Folder, by default "public/models"
+        unzip : Bool, optional
+            Used to unzip model, by default 'True'
         """
-        _internal._DownloadModelDirectlyAsZip(s3URI).apply()
+        _internal._DownloadModelDirectly(name, remote_loc, unzip).apply()
+
 
     @staticmethod
     def downloadPipeline(name, language, remote_loc=None):

--- a/python/sparknlp/pretrained/resource_downloader.py
+++ b/python/sparknlp/pretrained/resource_downloader.py
@@ -117,6 +117,18 @@ class ResourceDownloader(object):
         _internal._DownloadModelDirectly(name, remote_loc).apply()
 
     @staticmethod
+    def downloadModelDirectlyAsZip(s3URI):
+        """Downloads a model directly as zip to the cache folder.
+        You can use to copy-paste the s3 URI from the model hub  and download the model.
+        For available s3 URI and models, please see the `Models Hub <https://sparknlp.org/models>`__.
+        Parameters
+        ----------
+        s3URI : str
+            s3URI link of the model
+        """
+        _internal._DownloadModelDirectlyAsZip(s3URI).apply()
+
+    @staticmethod
     def downloadPipeline(name, language, remote_loc=None):
         """Downloads and loads a pipeline with the default downloader.
 

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloader.scala
@@ -491,23 +491,19 @@ object ResourceDownloader {
     path.get
   }
 
-  /** Downloads a resource from the default S3 bucket in the cache pretrained folder.
+  /** Downloads a model from the default S3 bucket to the cache pretrained folder.
     * @param model
-    *   the name of the key in the S3 bucket
+    *   the name of the key in the S3 bucket or s3 URI
     * @param folder
-    *   the language of the model
-    * @return
-    *   the path to the downloaded file
+    *   the folder of the model
+    * @param unzip
+    *   used to unzip the model, by default true
     */
-  def downloadModelDirectly(model: String, folder: String = publicLoc): Unit = {
-    getResourceDownloader(folder).downloadAndUnzipFile(model)
-  }
-
-  def downloadModelDirectlyAsZip(s3URI: String): Unit = {
-    val s3FilePath = ResourceHelper.parseS3URI(s3URI)._2
-    val folder = s3FilePath.substring(0, s3FilePath.length - s3FilePath.split("/").last.length)
-    ResourceDownloader.getResourceDownloader(folder)
-      .downloadAndUnzipFile(s3FilePath, unzip = false)
+  def downloadModelDirectly(
+      model: String,
+      folder: String = publicLoc,
+      unzip: Boolean = true): Unit = {
+    getResourceDownloader(folder).downloadAndUnzipFile(model, unzip)
   }
 
   def downloadModel[TModel <: PipelineStage](
@@ -763,13 +759,12 @@ object PythonResourceDownloader {
     ResourceDownloader.clearCache(name, Option(language), correctedFolder)
   }
 
-  def downloadModelDirectly(model: String, remoteLoc: String = null): Unit = {
+  def downloadModelDirectly(
+      model: String,
+      remoteLoc: String = null,
+      unzip: Boolean = true): Unit = {
     val correctedFolder = Option(remoteLoc).getOrElse(ResourceDownloader.publicLoc)
-    ResourceDownloader.downloadModelDirectly(model, correctedFolder)
-  }
-
-  def downloadModelDirectlyAsZip(s3URI: String): Unit = {
-    ResourceDownloader.downloadModelDirectlyAsZip(s3URI)
+    ResourceDownloader.downloadModelDirectly(model, correctedFolder, unzip)
   }
 
   def showUnCategorizedResources(): String = {

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/S3ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/S3ResourceDownloader.scala
@@ -308,8 +308,16 @@ class S3ResourceDownloader(
   }
 
   def downloadAndUnzipFile(s3FilePath: String, unzip: Boolean): Option[String] = {
+    // handle s3FilePath options:
+    // 1--> s3://auxdata.johnsnowlabs.com/public/models/albert_base_sequence_classifier_ag_news_en_3.4.0_3.0_1639648298937.zip
+    // 2--> public/models/albert_base_sequence_classifier_ag_news_en_3.4.0_3.0_1639648298937.zip
 
-    val s3File = s3FilePath.split("/").last
+    val newS3FilePath = if (s3FilePath.startsWith("s3")) {
+      ResourceHelper.parseS3URI(s3FilePath)._2
+    } else s3FilePath
+
+    val s3File = newS3FilePath.split("/").last
+
     val destinationFile = new Path(cachePath.toString + "/" + s3File)
     val splitPath = destinationFile.toString.substring(0, destinationFile.toString.length - 4)
 
@@ -318,7 +326,7 @@ class S3ResourceDownloader(
       val tmpFileName = Files.createTempFile(s3File, "").toString
       val tmpFile = new File(tmpFileName)
 
-      val newStrfilePath: String = s3FilePath
+      val newStrfilePath: String = newS3FilePath
       val mybucket: String = bucket
       // 2. Download content to tmp file
       awsGateway.getS3Object(mybucket, newStrfilePath, tmpFile)

--- a/src/test/scala/com/johnsnowlabs/nlp/pretrained/MockResourceDownloader.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/pretrained/MockResourceDownloader.scala
@@ -35,5 +35,5 @@ class MockResourceDownloader(resourcePath: String) extends ResourceDownloader {
 
   def downloadMetadataIfNeed(folder: String): List[ResourceMetadata] = resources
 
-  override def downloadAndUnzipFile(s3FilePath: String): Option[String] = Some("model")
+  override def downloadAndUnzipFile(s3FilePath: String, unzip: Boolean = true): Option[String] = Some("model")
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/pretrained/MockResourceDownloader.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/pretrained/MockResourceDownloader.scala
@@ -34,6 +34,6 @@ class MockResourceDownloader(resourcePath: String) extends ResourceDownloader {
   val resources: List[ResourceMetadata] = ResourceMetadata.readResources(resourcePath)
 
   def downloadMetadataIfNeed(folder: String): List[ResourceMetadata] = resources
-
-  override def downloadAndUnzipFile(s3FilePath: String, unzip: Boolean = true): Option[String] = Some("model")
+  override def downloadAndUnzipFile(s3FilePath: String, unzip: Boolean = true): Option[String] =
+    Some("model")
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloaderMetaSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloaderMetaSpec.scala
@@ -191,6 +191,16 @@ class ResourceDownloaderMetaSpec extends AnyFlatSpec with BeforeAndAfter {
       "public/models/bert_base_cased_es_3.2.2_3.0_1630999631885.zip")
   }
 
+  it should "download a model and keep it as zip" taggedAs SlowTest in {
+    ResourceDownloader.privateDownloader = realPrivateDownloader
+    ResourceDownloader.publicDownloader = realPublicDownloader
+    ResourceDownloader.communityDownloader = realCommunityDownloader
+    ResourceDownloader.downloadModelDirectly(
+      "s3://auxdata.johnsnowlabs.com/public/models/albert_base_sequence_classifier_ag_news_en_3.4.0_3.0_1639648298937.zip",
+      folder = "public/models",
+      unzip = false)
+  }
+
   it should "be able to list from online metadata" in {
     ResourceDownloader.privateDownloader = realPrivateDownloader
     ResourceDownloader.publicDownloader = realPublicDownloader


### PR DESCRIPTION
This PR adds a unzip argument to downloadModelDirectly in ResourceDownloader

## Description
issue: https://github.com/JohnSnowLabs/spark-nlp-internal/issues/1837

1) Added unzip argument to downloadModelDirectly() in ResourceDownloader.
BEFORE:   downloadModelDirectly(name, remote_loc="public/models")
AFTER:     downloadModelDirectly(name, remote_loc="public/models", unzip=True)

2) Updated also name argument
BEFORE:  clinical/models/deidentify_enriched_clinical_en_2.7.2_2.4_1611917177874.zip
AFTER:   1--> clinical/models/deidentify_enriched_clinical_en_2.7.2_2.4_1611917177874.zip  
              2--> s3://auxdata.johnsnowlabs.com/clinical/models/deidentify_enriched_clinical_en_2.7.2_2.4_1611917177874.zip

3) deleted duplicate codes
Note: supported Backward compatibility

## How Has This Been Tested?
Tested via Scala and Python tests locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [] All new and existing tests passed.

