### PR TITLE
[WIP] SPARKNLP-831: Python Dynamic Setters and Getters

### DIFF
--- a/python/sparknlp/annotator/token/tokenizer.py
+++ b/python/sparknlp/annotator/token/tokenizer.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 """Contains classes for the Tokenizer."""
 
-
 from sparknlp.common import *
 
 
@@ -130,27 +129,27 @@ class Tokenizer(AnnotatorApproach):
 
     contextChars = Param(Params._dummy(),
                          "contextChars",
-                         "character list used to separate from token boundaries",
+                         "The character list used to separate from token boundaries",
                          typeConverter=TypeConverters.toListString)
 
     splitPattern = Param(Params._dummy(),
                          "splitPattern",
-                         "character list used to separate from the inside of tokens",
+                         "The character list used to separate from the inside of tokens",
                          typeConverter=TypeConverters.toString)
 
     splitChars = Param(Params._dummy(),
                        "splitChars",
-                       "character list used to separate from the inside of tokens",
+                       "The character list used to separate from the inside of tokens",
                        typeConverter=TypeConverters.toListString)
 
     minLength = Param(Params._dummy(),
                       "minLength",
-                      "Set the minimum allowed length for each token",
+                      "The minimum allowed length for each token",
                       typeConverter=TypeConverters.toInt)
 
     maxLength = Param(Params._dummy(),
                       "maxLength",
-                      "Set the maximum allowed length for each token",
+                      "The maximum allowed length for each token",
                       typeConverter=TypeConverters.toInt)
 
     @keyword_only
@@ -164,102 +163,6 @@ class Tokenizer(AnnotatorApproach):
             maxLength=99999
         )
 
-    def getInfixPatterns(self):
-        """Gets regex patterns that match tokens within a single target. Groups
-        identify different sub-tokens.
-
-        Returns
-        -------
-        List[str]
-            The infix patterns
-        """
-        return self.getOrDefault("infixPatterns")
-
-    def getSuffixPattern(self):
-        """Gets regex with groups and ends with ``\\z`` to match target suffix.
-
-        Returns
-        -------
-        str
-            The suffix pattern
-        """
-        return self.getOrDefault("suffixPattern")
-
-    def getPrefixPattern(self):
-        """Gets regex with groups and begins with ``\\A`` to match target
-        prefix.
-
-        Returns
-        -------
-        str
-            The prefix pattern
-        """
-        return self.getOrDefault("prefixPattern")
-
-    def getContextChars(self):
-        """Gets character list used to separate from token boundaries.
-
-        Returns
-        -------
-        List[str]
-            Character list used to separate from token boundaries
-        """
-        return self.getOrDefault("contextChars")
-
-    def getSplitChars(self):
-        """Gets character list used to separate from the inside of tokens.
-
-        Returns
-        -------
-        List[str]
-            Character list used to separate from the inside of tokens
-        """
-        return self.getOrDefault("splitChars")
-
-    def setTargetPattern(self, value):
-        """Sets pattern to grab from text as token candidates, by default
-        ``\\S+``.
-
-        Parameters
-        ----------
-        value : str
-            Pattern to grab from text as token candidates
-        """
-        return self._set(targetPattern=value)
-
-    def setPrefixPattern(self, value):
-        """Sets regex with groups and begins with ``\\A`` to match target prefix, by
-        default ``\\A([^\\s\\w\\$\\.]*)``.
-
-        Parameters
-        ----------
-        value : str
-            Regex with groups and begins with ``\\A`` to match target prefix
-        """
-        return self._set(prefixPattern=value)
-
-    def setSuffixPattern(self, value):
-        """Sets regex with groups and ends with ``\\z`` to match target suffix,
-        by default ``([^\\s\\w]?)([^\\s\\w]*)\\z``.
-
-        Parameters
-        ----------
-        value : str
-            Regex with groups and ends with ``\\z`` to match target suffix
-        """
-        return self._set(suffixPattern=value)
-
-    def setInfixPatterns(self, value):
-        """Sets regex patterns that match tokens within a single target. Groups
-        identify different sub-tokens.
-
-        Parameters
-        ----------
-        value : List[str]
-            Regex patterns that match tokens within a single target
-        """
-        return self._set(infixPatterns=value)
-
     def addInfixPattern(self, value):
         """Adds an additional regex pattern that match tokens within a single
         target. Groups identify different sub-tokens.
@@ -269,32 +172,10 @@ class Tokenizer(AnnotatorApproach):
         value : str
             Regex pattern that match tokens within a single target
         """
-        try:
-            infix_patterns = self.getInfixPatterns()
-        except KeyError:
-            infix_patterns = []
+        _infix_patterns = self.getInfixPatterns()
+        infix_patterns = _infix_patterns if _infix_patterns is not None else []
         infix_patterns.insert(0, value)
-        return self._set(infixPatterns=infix_patterns)
-
-    def setExceptions(self, value):
-        """Sets words that won't be affected by tokenization rules.
-
-        Parameters
-        ----------
-        value : List[str]
-            Words that won't be affected by tokenization rules
-        """
-        return self._set(exceptions=value)
-
-    def getExceptions(self):
-        """Gets words that won't be affected by tokenization rules.
-
-        Returns
-        -------
-        List[str]
-            Words that won't be affected by tokenization rules
-        """
-        return self.getOrDefault("exceptions")
+        return self.setInfixPatterns(infix_patterns)
 
     def setExceptionsPath(self, path, read_as=ReadAs.TEXT, options={"format": "text"}):
         """Path to txt file with list of token exceptions
@@ -311,53 +192,6 @@ class Tokenizer(AnnotatorApproach):
         opts = options.copy()
         return self._set(exceptionsPath=ExternalResource(path, read_as, opts))
 
-    def addException(self, value):
-        """Adds an additional word that won't be affected by tokenization rules.
-
-        Parameters
-        ----------
-        value : str
-            Additional word that won't be affected by tokenization rules
-        """
-        try:
-            exception_tokens = self.getExceptions()
-        except KeyError:
-            exception_tokens = []
-        exception_tokens.append(value)
-        return self._set(exceptions=exception_tokens)
-
-    def setCaseSensitiveExceptions(self, value):
-        """Sets whether to care for case sensitiveness in exceptions, by default
-        True.
-
-        Parameters
-        ----------
-        value : bool
-            Whether to care for case sensitiveness in exceptions
-        """
-        return self._set(caseSensitiveExceptions=value)
-
-    def getCaseSensitiveExceptions(self):
-        """Gets whether to care for case sensitiveness in exceptions.
-
-        Returns
-        -------
-        bool
-            Whether to care for case sensitiveness in exceptions
-        """
-        return self.getOrDefault("caseSensitiveExceptions")
-
-    def setContextChars(self, value):
-        """Sets character list used to separate from token boundaries, by
-        default ['.', ',', ';', ':', '!', '?', '*', '-', '(', ')', '"', "'"].
-
-        Parameters
-        ----------
-        value : List[str]
-            Character list used to separate from token boundaries
-        """
-        return self._set(contextChars=value)
-
     def addContextChars(self, value):
         """Adds an additional character to the list used to separate from token
         boundaries.
@@ -367,33 +201,10 @@ class Tokenizer(AnnotatorApproach):
         value : str
             Additional context character
         """
-        try:
-            context_chars = self.getContextChars()
-        except KeyError:
-            context_chars = []
+        _context_chars = self.getContextChars()
+        context_chars = _context_chars if _context_chars is not None else []
         context_chars.append(value)
-        return self._set(contextChars=context_chars)
-
-    def setSplitPattern(self, value):
-        """Sets pattern to separate from the inside of tokens. Takes priority
-        over splitChars.
-
-        Parameters
-        ----------
-        value : str
-            Pattern used to separate from the inside of tokens
-        """
-        return self._set(splitPattern=value)
-
-    def setSplitChars(self, value):
-        """Sets character list used to separate from the inside of tokens.
-
-        Parameters
-        ----------
-        value : List[str]
-            Character list used to separate from the inside of tokens
-        """
-        return self._set(splitChars=value)
+        return self.setContextChars(context_chars)
 
     def addSplitChars(self, value):
         """Adds an additional character to separate from the inside of tokens.
@@ -403,32 +214,10 @@ class Tokenizer(AnnotatorApproach):
         value : str
             Additional character to separate from the inside of tokens
         """
-        try:
-            split_chars = self.getSplitChars()
-        except KeyError:
-            split_chars = []
+        _split_chars = self.getSplitChars()
+        split_chars = _split_chars if _split_chars is not None else []
         split_chars.append(value)
-        return self._set(splitChars=split_chars)
-
-    def setMinLength(self, value):
-        """Sets the minimum allowed length for each token, by default 0.
-
-        Parameters
-        ----------
-        value : int
-            Minimum allowed length for each token
-        """
-        return self._set(minLength=value)
-
-    def setMaxLength(self, value):
-        """Sets the maximum allowed length for each token, by default 99999.
-
-        Parameters
-        ----------
-        value : int
-            Maximum allowed length for each token
-        """
-        return self._set(maxLength=value)
+        return self.setSplitChars(splitChars=split_chars)
 
     def _create_model(self, java_model):
         return TokenizerModel(java_model=java_model)
@@ -501,27 +290,6 @@ class TokenizerModel(AnnotatorModel):
             targetPattern="\\S+",
             caseSensitiveExceptions=True
         )
-
-    def setSplitPattern(self, value):
-        """Sets pattern to separate from the inside of tokens. Takes priority
-        over splitChars.
-
-        Parameters
-        ----------
-        value : str
-            Pattern used to separate from the inside of tokens
-        """
-        return self._set(splitPattern=value)
-
-    def setSplitChars(self, value):
-        """Sets character list used to separate from the inside of tokens.
-
-        Parameters
-        ----------
-        value : List[str]
-            Character list used to separate from the inside of tokens
-        """
-        return self._set(splitChars=value)
 
     def addSplitChars(self, value):
         """Adds an additional character to separate from the inside of tokens.

--- a/python/sparknlp/internal/converters.py
+++ b/python/sparknlp/internal/converters.py
@@ -1,4 +1,5 @@
 from pyspark import SparkContext
+from pyspark.ml.linalg import DenseVector, Matrix
 from pyspark.ml.param import TypeConverters
 from pyspark.ml.wrapper import JavaWrapper
 
@@ -20,31 +21,6 @@ def base_type_to_java_class(spark_context, value_type):
                 f" to equivalent Java Class not implemented."
             )
         )
-
-
-def type_converter_to_type_string(type_converter):
-    if type_converter == TypeConverters.toListInt:
-        return "List[int]"
-    elif type_converter == TypeConverters.toList:
-        return "List"
-    elif type_converter == TypeConverters.toListFloat:
-        return "List[float]"
-    elif type_converter == TypeConverters.toListString:
-        return "List[str]"
-    elif type_converter == TypeConverters.toVector:
-        return "Vector"
-    elif type_converter == TypeConverters.toMatrix:
-        return "Matrix"
-    elif type_converter == TypeConverters.toFloat:
-        return "float"
-    elif type_converter == TypeConverters.toInt:
-        return "int"
-    elif type_converter == TypeConverters.toString:
-        return "str"
-    elif type_converter == TypeConverters.toBoolean:
-        return "bool"
-    else:
-        return None
 
 
 def list_elem_type(type_converter):
@@ -77,8 +53,8 @@ def list_to_java_array(value, type_converter):
     if len(value) > 0:
         elem_type = type(value[0])
         if (
-                type_converter_elem_type is not None
-                and elem_type != type_converter_elem_type
+            type_converter_elem_type is not None
+            and elem_type != type_converter_elem_type
         ):
             print(
                 "Warning: Conversion received a list with type that does not correspond the parameters type converter."

--- a/python/sparknlp/internal/converters.py
+++ b/python/sparknlp/internal/converters.py
@@ -1,0 +1,102 @@
+from pyspark import SparkContext
+from pyspark.ml.param import TypeConverters
+from pyspark.ml.wrapper import JavaWrapper
+
+
+def base_type_to_java_class(spark_context, value_type):
+    jvm = spark_context._gateway.jvm
+    if value_type == bool:
+        return jvm.java.lang.Boolean
+    elif value_type == str:
+        return jvm.java.lang.String
+    elif value_type == int:
+        return jvm.java.lang.Integer
+    elif value_type == float:
+        return jvm.java.lang.Double
+    else:
+        raise ValueError(
+            (
+                f"Tried to convert type for java array creation, but conversion from type {value_type}"
+                f" to equivalent Java Class not implemented."
+            )
+        )
+
+
+def type_converter_to_type_string(type_converter):
+    if type_converter == TypeConverters.toListInt:
+        return "List[int]"
+    elif type_converter == TypeConverters.toList:
+        return "List"
+    elif type_converter == TypeConverters.toListFloat:
+        return "List[float]"
+    elif type_converter == TypeConverters.toListString:
+        return "List[str]"
+    elif type_converter == TypeConverters.toVector:
+        return "Vector"
+    elif type_converter == TypeConverters.toMatrix:
+        return "Matrix"
+    elif type_converter == TypeConverters.toFloat:
+        return "float"
+    elif type_converter == TypeConverters.toInt:
+        return "int"
+    elif type_converter == TypeConverters.toString:
+        return "str"
+    elif type_converter == TypeConverters.toBoolean:
+        return "bool"
+    else:
+        return None
+
+
+def list_elem_type(type_converter):
+    """Tries to retrieve to type of list elements from the provided type converter.
+
+    The type is required to create Java side arrays for the setters.
+
+    Parameters
+    ----------
+    type_converter
+        One of the functions of TypeConverters
+
+    Returns
+    -------
+        The type of the elements of a list
+    """
+
+    if type_converter == TypeConverters.toListInt:
+        return int
+    elif type_converter == TypeConverters.toListFloat:
+        return float
+    elif type_converter == TypeConverters.toListString:
+        return str
+    else:
+        return None
+
+
+def list_to_java_array(value, type_converter):
+    type_converter_elem_type = list_elem_type(type_converter)
+    if len(value) > 0:
+        elem_type = type(value[0])
+        if (
+                type_converter_elem_type is not None
+                and elem_type != type_converter_elem_type
+        ):
+            print(
+                "Warning: Conversion received a list with type that does not correspond the parameters type converter."
+                " You might encounter errors when the java side function is called with this type."
+            )
+    else:
+        elem_type = type_converter_elem_type
+    if elem_type is None:
+        raise ValueError(
+            (
+                "Passed an empty list to a setter, but could not infer the type of the elements."
+                " The parameter might not have a TypeConverter defined."
+                " Therefore, it's not possible to create java arrays to be passed to the JVM side setters."
+                " If you think this setter should accept empty lists, please open an issue on GitHub."
+            )
+        )
+    type_java_class = base_type_to_java_class(
+        SparkContext._active_spark_context, elem_type
+    )
+    value_array = JavaWrapper._new_java_array(value, type_java_class)
+    return value_array

--- a/python/sparknlp/internal/doc_string_generator.py
+++ b/python/sparknlp/internal/doc_string_generator.py
@@ -1,0 +1,55 @@
+from pyspark.ml.param import TypeConverters
+
+
+def type_converter_to_type_string(type_converter):
+    if type_converter == TypeConverters.toListInt:
+        return "List[int]"
+    elif type_converter == TypeConverters.toList:
+        return "List"
+    elif type_converter == TypeConverters.toListFloat:
+        return "List[float]"
+    elif type_converter == TypeConverters.toListString:
+        return "List[str]"
+    elif type_converter == TypeConverters.toVector:
+        return "Vector"
+    elif type_converter == TypeConverters.toMatrix:
+        return "Matrix"
+    elif type_converter == TypeConverters.toFloat:
+        return "float"
+    elif type_converter == TypeConverters.toInt:
+        return "int"
+    elif type_converter == TypeConverters.toString:
+        return "str"
+    elif type_converter == TypeConverters.toBoolean:
+        return "bool"
+    else:
+        return None
+
+
+class DocStringGenerator:
+    @staticmethod
+    def generate_numpydoc_getter(description):
+        description = description[0].lower() + description[1:]
+        doc_string = f"Gets {description}."
+        return doc_string
+
+    @staticmethod
+    def generate_numpydoc_setter(param, default_value=None):
+        description = param.doc
+        description = description[0].lower() + description[1:]
+        description = (
+            description
+            if not default_value
+            else description + f", by default {default_value}"
+        )
+        param_type = type_converter_to_type_string(param.typeConverter)
+        param_type = f" : {param_type}" if param_type else ""
+        doc_string = (
+            f"Sets {description}.\n"
+            f"\n"
+            f"Parameters\n"
+            f"----------\n"
+            f"value{param_type}\n"
+            f"    {description}"
+        )  # TODO: Default value
+        return doc_string

--- a/python/sparknlp/internal/params_getters_setters.py
+++ b/python/sparknlp/internal/params_getters_setters.py
@@ -16,56 +16,151 @@
 import re
 
 from pyspark.ml.param import Params
+from sparknlp.internal.converters import (
+    type_converter_to_type_string,
+    list_to_java_array,
+)
+
+
+class DocStringGenerator:
+    @staticmethod
+    def generate_numpydoc_getter(description):
+        description = description[0].lower() + description[1:]
+        doc_string = f"Gets {description}."
+        return doc_string
+
+    @staticmethod
+    def generate_numpydoc_setter(param, default_value=None):
+        description = param.doc
+        description = description[0].lower() + description[1:]
+        description = (
+            description
+            if not default_value
+            else description + f", by default {default_value}"
+        )
+        param_type = type_converter_to_type_string(param.typeConverter)
+        param_type = f" : {param_type}" if param_type else ""
+        doc_string = (
+            f"Sets {description}.\n"
+            f"\n"
+            f"Parameters\n"
+            f"----------\n"
+            f"value{param_type}\n"
+            f"    {description}"
+        )  # TODO: Default value
+        return doc_string
 
 
 class ParamsGettersSetters(Params):
-    getter_attrs = []
+    """Class that generates setter and getter functions for parameters defined in an annotator class.
+
+    The setter function will attempt to convert the provided value and call the Scala side setter function.
+    """
 
     def __init__(self):
         super(ParamsGettersSetters, self).__init__()
         for param in self.params:
             param_name = param.name
-            fg_attr = "get" + re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), param_name)
-            fs_attr = "set" + re.sub(r"(?:^|_)(.)", lambda m: m.group(1).upper(), param_name)
-            # Generates getter and setter only if not exists
-            try:
-                getattr(self, fg_attr)
-            except AttributeError:
-                setattr(self, fg_attr, self.getParamValue(param_name))
-            try:
-                getattr(self, fs_attr)
-            except AttributeError:
-                setattr(self, fs_attr, self.setParamValue(param_name))
+            getter_function_name = "get" + re.sub(
+                r"(?:^|_)(.)", lambda m: m.group(1).upper(), param_name
+            )
+            setter_function_name = "set" + re.sub(
+                r"(?:^|_)(.)", lambda m: m.group(1).upper(), param_name
+            )
 
-    def getParamValue(self, paramName):
-        """Gets the value of a parameter.
+            # Generates getter and setter only if not exists
+            if not hasattr(self, getter_function_name):
+                getter_function = self._get_getter_function(param_name)
+                getter_function.__doc__ = DocStringGenerator.generate_numpydoc_getter(
+                    param.doc
+                )
+
+                setattr(self, getter_function_name, getter_function)
+
+            if not hasattr(self, setter_function_name):
+                setter_function = self._get_setter_java(
+                    setter_function_name, param.typeConverter
+                )
+                setter_function.__doc__ = DocStringGenerator.generate_numpydoc_setter(
+                    param
+                )
+
+                setattr(self, setter_function_name, setter_function)
+
+    def _get_getter_function(self, paramName):
+        """Returns the getter function of a parameter.
 
         Parameters
         ----------
         paramName : str
             Name of the parameter
+
+        Returns
+        -------
+        Getter Function of the parameter name
         """
 
-        def r():
+        def getter():
             try:
                 return self.getOrDefault(paramName)
             except KeyError:
                 return None
 
-        return r
+        return getter
 
-    def setParamValue(self, paramName):
-        """Sets the value of a parameter.
+    def _get_setter_function(self, paramName):
+        """Returns the setter function of a parameter.
 
         Parameters
         ----------
         paramName : str
             Name of the parameter
+
+        Returns
+        -------
+        Setter Function of the parameter name
         """
 
-        def r(v):
+        def setter(v):
             self.set(self.getParam(paramName), v)
             return self
 
-        return r
+        return setter
 
+    def _get_setter_java(self, setter_name, type_converter):
+        """Returns a setter function, which calls the equivalent on the java side.
+
+        Parameters
+        ----------
+        setter_name : str
+            Name of the setter of parameter
+        type_converter
+            TypeConvert used for the parameter
+
+        Returns
+        -------
+        Setter Function for the java side setter
+        """
+
+        def setter(value):
+            """
+            Calls the setter on the java side, using the provided value.
+
+            If the value is a list, the type will be converted to be compatible with Scala Arrays.
+
+            Parameters
+            ----------
+            value
+                The provided value to set
+
+            Returns
+            -------
+            self
+            """
+            if type(value) == list:
+                value = list_to_java_array(value, type_converter)
+
+            self._call_java(setter_name, value)
+            return self
+
+        return setter

--- a/python/test/internal/params_getters_setters_test.py
+++ b/python/test/internal/params_getters_setters_test.py
@@ -1,12 +1,8 @@
 import unittest
-from contextlib import redirect_stdout
-import io
 
 import pytest
-from py4j.protocol import Py4JError
 from pyspark.ml.param import Param, Params, TypeConverters
 
-from sparknlp.annotator import Tokenizer
 from sparknlp.internal import ParamsGettersSetters
 from test.util import SparkSessionForTest
 
@@ -20,6 +16,13 @@ class ParamGettersSettersTestSpec(unittest.TestCase):
             "testStrParam",
             "Str Parameter for Test",
             typeConverter=TypeConverters.toString,
+        )
+
+        testFloatParam = Param(
+            Params._dummy(),
+            "testFloatParam",
+            "Float Parameter for Test",
+            typeConverter=TypeConverters.toFloat,
         )
 
         testListIntParam = Param(
@@ -99,10 +102,11 @@ class ParamGettersSettersTestSpec(unittest.TestCase):
         with pytest.raises(ValueError):
             self.annotator.setTestListNoTypeParam([])
 
-    def test_set_wrong_types_warning(self):
-        tokenizer = Tokenizer()
-        with redirect_stdout(io.StringIO()) as f:
-            with pytest.raises(Py4JError):
-                tokenizer.setInfixPatterns([0.5, 0.3])
-            captured_output = f.getvalue()
-        assert "Warning: " in captured_output
+    def test_type_conversion(self):
+        with pytest.raises(TypeError):
+            self.annotator.setTestStrParam(1)
+
+        self.annotator.setTestFloatParam(5)
+        get_val = self.annotator.getTestFloatParam()
+        assert type(get_val) is float
+        assert get_val == 5.0

--- a/python/test/internal/params_getters_setters_test.py
+++ b/python/test/internal/params_getters_setters_test.py
@@ -1,0 +1,108 @@
+import unittest
+from contextlib import redirect_stdout
+import io
+
+import pytest
+from py4j.protocol import Py4JError
+from pyspark.ml.param import Param, Params, TypeConverters
+
+from sparknlp.annotator import Tokenizer
+from sparknlp.internal import ParamsGettersSetters
+from test.util import SparkSessionForTest
+
+
+class ParamGettersSettersTestSpec(unittest.TestCase):
+    spark = SparkSessionForTest.spark
+
+    class MockAnnotator(ParamsGettersSetters):
+        testStrParam = Param(
+            Params._dummy(),
+            "testStrParam",
+            "Str Parameter for Test",
+            typeConverter=TypeConverters.toString,
+        )
+
+        testListIntParam = Param(
+            Params._dummy(),
+            "testListIntParam",
+            "List Int Parameter for Test",
+            typeConverter=TypeConverters.toListInt,
+        )
+
+        testListBoolParam = Param(
+            Params._dummy(),
+            "testListBoolParam",
+            "ListBool Parameter for Test",
+            typeConverter=TypeConverters.toList,
+        )
+
+        testListFloatParam = Param(
+            Params._dummy(),
+            "testListFloatParam",
+            "ListFloat Parameter for Test",
+            typeConverter=TypeConverters.toListFloat,
+        )
+
+        testListNoTypeParam = Param(
+            Params._dummy(), "testListNoTypeParam", "List Parameter without type"
+        )
+
+        param_vals = {}
+
+        def _call_java(self, function_name, value):
+            self.param_vals[function_name] = value
+
+        def getOrDefault(self, paramName):
+            param_name = f"set{paramName[0].upper()}{paramName[1:]}"
+            return self.param_vals[param_name]
+
+    annotator = MockAnnotator()
+
+    def test_set_param_value(self):
+        self.annotator.setTestStrParam("test")
+
+    def test_get_param_value(self):
+        self.annotator.setTestStrParam("test")
+        assert self.annotator.getTestStrParam() == "test"
+
+    def test_set_param_value_list(self):
+        int_list = [1, 2, 3]
+        self.annotator.setTestListIntParam(int_list)
+        get_int_list = self.annotator.getTestListIntParam()
+        assert type(get_int_list) != list
+        for i1, i2 in zip(int_list, get_int_list):
+            assert i1 == i2
+
+        float_list = [0.1, 0.2, 0.3]
+        self.annotator.setTestListFloatParam(float_list)
+        get_float_list = self.annotator.getTestListFloatParam()
+        assert type(get_float_list) != list
+        for i1, i2 in zip(float_list, get_float_list):
+            assert i1 == i2
+
+    def test_set_param_custom_list(self):
+        bool_list = [True, False, True]
+        self.annotator.setTestListBoolParam(bool_list)
+        get_bool_list = self.annotator.getTestListBoolParam()
+        assert type(get_bool_list) != list
+        for i1, i2 in zip(bool_list, get_bool_list):
+            assert i1 == i2
+
+    def test_set_param_custom_list_not_implemented(self):
+        value = [self.annotator]
+        with pytest.raises(ValueError):
+            self.annotator.setTestListNoTypeParam(value)
+
+    def test_set_empty_param_list(self):
+        self.annotator.setTestListIntParam([])
+
+        with pytest.raises(ValueError):
+            self.annotator.setTestListNoTypeParam([])
+
+    def test_set_wrong_types_warning(self):
+        tokenizer = Tokenizer()
+        with redirect_stdout(io.StringIO()) as f:
+            with pytest.raises(Py4JError):
+                tokenizer.setInfixPatterns([0.5, 0.3])
+            captured_output = f.getvalue()
+        assert "Warning: " in captured_output

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala
@@ -27,6 +27,7 @@ import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.sql.Dataset
 
 import java.util.regex.Pattern
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 /** Tokenizes raw text in document type columns into TokenizedSentence .
@@ -314,6 +315,14 @@ class Tokenizer(override val uid: String) extends AnnotatorApproach[TokenizerMod
     * @group setParam
     */
   def setInfixPatterns(value: Array[String]): this.type = set(infixPatterns, value)
+
+//  implicit def arrayListToArray(arrayList: java.util.ArrayList[String]): Array[String] =
+//    arrayList.asScala.toArray
+//
+//  def setInfixPatterns(value: java.util.ArrayList[String]): this.type = {
+//    val valueScala: Array[String] = value
+//    setInfixPatterns(valueScala)
+//  }
 
   /** Add an extension pattern regex with groups to the top of thsetExceptionse rules (will target
     * first, from more specific to the more general).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This WIP PR changes, how parameters of annotators will be set on the Python side. The getter and setter functions are dynamically generated. The generated setter functions call the equivalent on on the Scala side, to automatically enable validations implemented there. These functions can still be implemented manually. They will only be generated if they don't exist.

An example of how the new annotators would look like, can be seen in the [`Tokenizer`](https://github.com/JohnSnowLabs/spark-nlp/blob/3b91e580b3560a42e0872ee8d4edde37207c5d6e/python/sparknlp/annotator/token/tokenizer.py) class. We only need to declare the parameters, and the corresponding getters and setters (with doc string) will be accessible. Only functions with special behavior will still need to be implemented.

TODO:

- [ ] Only Tokenizer implemented so far
- [x] Type checks for provided arguments

### How it works

This is done with the `ParamsGettersSetters` mix-in (which already existed). While it already generated getters and setters which didn't exist in the class, it tried to set parameters directly via Spark. This was modified to call the equivalent one on the Scala side instead:

https://github.com/JohnSnowLabs/spark-nlp/blob/3b91e580b3560a42e0872ee8d4edde37207c5d6e/python/sparknlp/internal/params_getters_setters.py#L145-L164

Py4J automatically converts primitive types, when trying to call a java function. However, when trying to pass a list as a parameter, Py4J would convert to an `ArrayList`. This would clash with the signature on the Scala side, as the functions require an `Array`. A new [`converter.py`](https://github.com/JohnSnowLabs/spark-nlp/blob/3b91e580b3560a42e0872ee8d4edde37207c5d6e/python/sparknlp/internal/converters.py) module implements the necessary conversion for it to work as expected.

Note/TODO: We might want to change the existing class [ExtendedJavaWrapper](https://github.com/JohnSnowLabs/spark-nlp/blob/ccce219e7bb1fd7185bdf77fca319ceb819f8936/python/sparknlp/internal/extended_java_wrapper.py#L22) to incorporate this behavior. I'm not sure if these functionalities are used anywhere at the moment.

### Tradeoffs
As the functions are dynamically generated

- documentation for the getters and setters will not be available anymore. We will have to add documentation for users to "just" assume they exist
- Code hints will not be available in IDEs (But are available in interactive environments such as jupyter or colab, see screenshots)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some setter functions on the Scala side have validity checks for the input. These would have to be equivalently implemented on the Python side, leading to unnecessary work (and error proneness). This change will eliminate this need and speed up annotator implementation on the Python side as well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- New tests added for the generator class. 
- New tests to verify Scala side checks are happening for the Tokenizer. 
- All tests are Passing

## Screenshots (if appropriate):
Doc Strings in interactive Environment:
![image](https://github.com/JohnSnowLabs/spark-nlp/assets/33089471/eee9775d-f521-4d52-9498-91807b355f20)

Verification from Scala side:
https://github.com/JohnSnowLabs/spark-nlp/blob/ccce219e7bb1fd7185bdf77fca319ceb819f8936/src/main/scala/com/johnsnowlabs/nlp/annotators/Tokenizer.scala#L288-L292
![image](https://github.com/JohnSnowLabs/spark-nlp/assets/33089471/8eda248f-d57d-4518-a1fd-adf7b5ea906c)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
