### PR TITLE
Sparknlp843 Hide parameters and setters getters in scaladoc

### DIFF
--- a/python/sparknlp/annotator/embeddings/bert_sentence_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bert_sentence_embeddings.py
@@ -17,12 +17,12 @@ from sparknlp.common import *
 
 
 class BertSentenceEmbeddings(AnnotatorModel,
-                                  HasEmbeddingsProperties,
-                                  HasCaseSensitiveProperties,
-                                  HasStorageRef,
-                                  HasBatchedAnnotate,
-                                  HasEngine,
-                                  HasMaxSentenceLengthLimit):
+                             HasEmbeddingsProperties,
+                             HasCaseSensitiveProperties,
+                             HasStorageRef,
+                             HasBatchedAnnotate,
+                             HasEngine,
+                             HasMaxSentenceLengthLimit):
     """Sentence-level embeddings using BERT. BERT (Bidirectional Encoder
     Representations from Transformers) provides dense vector representations for
     natural language by using a deep, pre-trained neural network with the

--- a/src/main/scala/com/johnsnowlabs/nlp/HasEnableCachingProperties.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasEnableCachingProperties.scala
@@ -21,7 +21,7 @@ import org.apache.spark.ml.param.BooleanParam
 trait HasEnableCachingProperties extends ParamsAndFeaturesWritable {
 
   /** Whether to enable caching DataFrames or RDDs during the training
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val enableCaching = new BooleanParam(
@@ -31,10 +31,12 @@ trait HasEnableCachingProperties extends ParamsAndFeaturesWritable {
 
   setDefault(enableCaching, false)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getEnableCaching: Boolean = $(enableCaching)
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setEnableCaching(value: Boolean): this.type = set(this.enableCaching, value)
 
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Chunker.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Chunker.scala
@@ -160,18 +160,16 @@ class Chunker(override val uid: String)
   }
 
   /** A list of regex patterns to match chunks, for example: Array(“‹DT›?‹JJ›*‹NN›”)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getRegexParsers: Array[String] = $(regexParsers)
 
   def this() = this(Identifiable.randomUID("CHUNKER"))
 
-  /** @group param */
   private lazy val replacements = Map("<" -> "(?:<", ">" -> ">)", "|" -> ">|<")
   private lazy val emptyString = ""
 
-  /** @group param */
   private lazy val POSTagPatterns: Array[Regex] = {
     getRegexParsers.map(regexParser => replaceRegexParser(regexParser))
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
@@ -113,26 +113,28 @@ trait DateMatcherUtils extends Params {
   protected val defaultYearWhenMissing: Int = Calendar.getInstance.get(Calendar.YEAR)
 
   /** Date Matcher regex patterns.
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val inputFormats: StringArrayParam =
     new StringArrayParam(this, "inputFormats", "Date Matcher inputFormats.")
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getInputFormats: Array[String] = $(inputFormats)
 
   /** @group setParam */
   def setInputFormats(value: Array[String]): this.type = set(inputFormats, value)
 
   /** Output format of parsed date (Default: `"yyyy/MM/dd"`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val outputFormat: Param[String] =
     new Param(this, "outputFormat", "Output format of parsed date")
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getOutputFormat: String = $(outputFormat)
 
   /** @group setParam */
@@ -140,7 +142,6 @@ trait DateMatcherUtils extends Params {
 
   /** Add an anchor year for the relative dates such as a day after tomorrow (Default: `-1`). If
     * it is not set, the by default it will use the current year. Example: 2021
-    *
     * @group param
     */
   val anchorDateYear: Param[Int] = new IntParam(
@@ -154,13 +155,13 @@ trait DateMatcherUtils extends Params {
     set(anchorDateYear, value)
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getAnchorDateYear: Int = $(anchorDateYear)
 
   /** Add an anchor month for the relative dates such as a day after tomorrow (Default: `-1`). By
     * default it will use the current month. Month values start from `1`, so `1` stands for
     * January.
-    *
     * @group param
     */
   val anchorDateMonth: Param[Int] = new IntParam(
@@ -177,12 +178,12 @@ trait DateMatcherUtils extends Params {
     set(anchorDateMonth, normalizedMonth)
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getAnchorDateMonth: Int = $(anchorDateMonth) + 1
 
   /** Add an anchor day for the relative dates such as a day after tomorrow (Default: `-1`). By
     * default it will use the current day. The first day of the month has value 1.
-    *
     * @group param
     */
   val anchorDateDay: Param[Int] = new IntParam(
@@ -198,11 +199,11 @@ trait DateMatcherUtils extends Params {
     set(anchorDateDay, value)
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getAnchorDateDay: Int = $(anchorDateDay)
 
   /** Whether to interpret dates as MM/DD/YYYY instead of DD/MM/YYYY (Default: `true`)
-    *
     * @group param
     */
   val readMonthFirst: BooleanParam = new BooleanParam(
@@ -213,11 +214,12 @@ trait DateMatcherUtils extends Params {
   /** @group setParam */
   def setReadMonthFirst(value: Boolean): this.type = set(readMonthFirst, value)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getReadMonthFirst: Boolean = $(readMonthFirst)
 
   /** Which day to set when it is missing from parsed input (Default: `1`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val defaultDayWhenMissing: IntParam = new IntParam(
@@ -228,18 +230,19 @@ trait DateMatcherUtils extends Params {
   /** @group setParam */
   def setDefaultDayWhenMissing(value: Int): this.type = set(defaultDayWhenMissing, value)
 
-  /** @group getParam */
+  /**  WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getDefaultDayWhenMissing: Int = $(defaultDayWhenMissing)
 
   /** Source language for explicit translation
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val sourceLanguage: Param[String] =
     new Param(this, "sourceLanguage", "source language for explicit translation")
 
   /** To get to use or not the multi-language translation.
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getSourceLanguage: String = $(sourceLanguage)
@@ -252,7 +255,7 @@ trait DateMatcherUtils extends Params {
 
   /** Matched strategy to search relaxed dates by ordered rules by more exhaustive to less
     * Strategy
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val relaxedFactoryStrategy: Param[String] =
@@ -270,7 +273,7 @@ trait DateMatcherUtils extends Params {
 
   /** To get matched strategy to search relaxed dates by ordered rules by more exhaustive to less
     * Strategy
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   def getRelaxedFactoryStrategy: String = $(relaxedFactoryStrategy)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DocumentNormalizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DocumentNormalizer.scala
@@ -126,7 +126,7 @@ class DocumentNormalizer(override val uid: String)
   def this() = this(Identifiable.randomUID("DOCUMENT_NORMALIZER"))
 
   /** Action to perform applying regex patterns on text
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val action: Param[String] =
@@ -134,7 +134,7 @@ class DocumentNormalizer(override val uid: String)
 
   /** Normalization regex patterns which match will be removed from document (Default:
     * `Array("<[^>]*>")`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val patterns: StringArrayParam = new StringArrayParam(
@@ -143,14 +143,14 @@ class DocumentNormalizer(override val uid: String)
     "Normalization regex patterns which match will be removed from document. Defaults is \"<[^>]*>\"")
 
   /** Replacement string to apply when regexes match (Default: `" "`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val replacement: Param[String] =
     new Param(this, "replacement", "Replacement string to apply when regexes match")
 
   /** Whether to convert strings to lowercase (Default: `false`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val lowercase = new BooleanParam(
@@ -160,13 +160,14 @@ class DocumentNormalizer(override val uid: String)
 
   /** RemovalPolicy to remove patterns from text with a given policy (Default: `"pretty_all"`).
     * Possible values are `"all", "pretty_all", "first", "pretty_first"`
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val policy: Param[String] =
     new Param(this, "policy", "RemovalPolicy to remove pattern from text")
 
   /** File encoding to apply on normalized documents (Default: `"disable"`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val encoding: Param[String] = new Param(
@@ -185,37 +186,37 @@ class DocumentNormalizer(override val uid: String)
     encoding -> "disable")
 
   /** Action to perform on text. (Default `"clean"`).
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getAction: String = $(action)
 
   /** Regular expressions list for normalization.
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getPatterns: Array[String] = $(patterns)
 
   /** Replacement string to apply when regexes match (Default: `" "`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getReplacement: String = $(replacement)
 
   /** Lowercase tokens (Default: `false`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getLowercase: Boolean = $(lowercase)
 
   /** Policy to remove patterns from text (Default: `"pretty_all"`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getPolicy: String = $(policy)
 
   /** Encoding to apply to normalized documents (Default: `"disable"`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getEncoding: String = $(encoding)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Lemmatizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Lemmatizer.scala
@@ -168,7 +168,8 @@ class Lemmatizer(override val uid: String) extends AnnotatorApproach[LemmatizerM
   /** @group setParam */
   def setFormCol(value: String): this.type = set(formCol, value)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getFormCol: String = $(formCol)
 
   /** Column that correspends to CoNLLU(lemmaCol=) output
@@ -181,10 +182,12 @@ class Lemmatizer(override val uid: String) extends AnnotatorApproach[LemmatizerM
   /** @group setParam */
   def setLemmaCol(value: String): this.type = set(lemmaCol, value)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getLemmaCol: String = $(lemmaCol)
 
   /** External dictionary to be used by the lemmatizer
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getDictionary: ExternalResource = $(dictionary)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/NGramGenerator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/NGramGenerator.scala
@@ -167,20 +167,20 @@ class NGramGenerator(override val uid: String)
   }
 
   /** Number elements per n-gram (>=1) (Default: `2`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getN: Int = $(n)
 
   /** Whether to calculate just the actual n-grams or all n-grams from 1 through n (Default:
     * `false`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getEnableCumulative: Boolean = $(enableCumulative)
 
   /** Glue character used to join the tokens (Default: `" "`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getDelimiter: String = $(delimiter)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Normalizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Normalizer.scala
@@ -117,6 +117,7 @@ class Normalizer(override val uid: String) extends AnnotatorApproach[NormalizerM
 
   /** Normalization regex patterns which match will be removed from token (Default:
     * `Array("[^\\pL+]")`)
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getCleanupPatterns: Array[String] = $(cleanupPatterns)
@@ -137,7 +138,8 @@ class Normalizer(override val uid: String) extends AnnotatorApproach[NormalizerM
     "Whether to convert strings to lowercase (Default: `false`)")
 
   /** Whether to convert strings to lowercase (Default: `false`)
-    * @group getParam
+    * WARNING: this is for internal use and not intended for users
+   * @group getParam
     */
   def getLowercase: Boolean = $(lowercase)
 
@@ -156,6 +158,7 @@ class Normalizer(override val uid: String) extends AnnotatorApproach[NormalizerM
     "Delimited file with list of custom words to be manually corrected")
 
   /** Delimited file with list of custom words to be manually corrected
+    * WARNING: this is for internal use and not intended for users
     * @group setParam
     */
   def setSlangDictionary(value: ExternalResource): this.type = {
@@ -210,6 +213,7 @@ class Normalizer(override val uid: String) extends AnnotatorApproach[NormalizerM
   }
 
   /** Set the minimum allowed length for each token (Default: `0`)
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getMinLength: Int = $(minLength)
@@ -234,6 +238,7 @@ class Normalizer(override val uid: String) extends AnnotatorApproach[NormalizerM
   }
 
   /** Set the maximum allowed length for each token
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getMaxLength: Int = $(maxLength)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/NormalizerModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/NormalizerModel.scala
@@ -84,10 +84,12 @@ class NormalizerModel(override val uid: String)
     "cleanupPatterns",
     "normalization regex patterns which match will be removed from token")
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setCleanupPatterns(value: Array[String]): this.type = set(cleanupPatterns, value)
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def getCleanupPatterns: Array[String] = $(cleanupPatterns)
 
   /** whether to convert strings to lowercase
@@ -96,14 +98,16 @@ class NormalizerModel(override val uid: String)
     */
   val lowercase = new BooleanParam(this, "lowercase", "whether to convert strings to lowercase")
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setLowercase(value: Boolean): this.type = set(lowercase, value)
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def getLowercase: Boolean = $(lowercase)
 
   /** slangDict
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   protected val slangDict: MapFeature[String, String] = new MapFeature(this, "slangDict")
@@ -117,40 +121,46 @@ class NormalizerModel(override val uid: String)
     "slangMatchCase",
     "whether or not to be case sensitive to match slangs. Defaults to false.")
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setSlangMatchCase(value: Boolean): this.type = set(slangMatchCase, value)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getSlangMatchCase: Boolean = $(slangMatchCase)
 
   def this() = this(Identifiable.randomUID("NORMALIZER"))
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setSlangDict(value: Map[String, String]): this.type = set(slangDict, value)
 
   /** Set the minimum allowed length for each token
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val minLength = new IntParam(this, "minLength", "Set the minimum allowed length for each token")
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setMinLength(value: Int): this.type = {
     require(value >= 0, "minLength must be greater equal than 0")
     require(value.isValidInt, "minLength must be Int")
     set(minLength, value)
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getMinLength: Int = $(minLength)
 
   /** Set the maximum allowed length for each token
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val maxLength = new IntParam(this, "maxLength", "Set the maximum allowed length for each token")
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setMaxLength(value: Int): this.type = {
     require(
       value >= $ {
@@ -161,7 +171,8 @@ class NormalizerModel(override val uid: String)
     set(maxLength, value)
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getMaxLength: Int = $(maxLength)
 
   def applyRegexPatterns(word: String): String = {
@@ -177,7 +188,7 @@ class NormalizerModel(override val uid: String)
   }
 
   /** Txt file with delimited words to be transformed into something else
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   protected def getSlangDict: Map[String, String] = $$(slangDict)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexMatcher.scala
@@ -223,7 +223,7 @@ class RegexMatcher(override val uid: String) extends AnnotatorApproach[RegexMatc
   }
 
   /** Strategy for which to match the expressions (Default: `"MATCH_ALL"`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getStrategy: String = $(strategy)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexMatcherModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexMatcherModel.scala
@@ -63,14 +63,14 @@ class RegexMatcherModel(override val uid: String)
   override val inputAnnotatorTypes: Array[AnnotatorType] = Array(DOCUMENT)
 
   /** rules
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val externalRules: ArrayFeature[(String, String)] =
     new ArrayFeature[(String, String)](this, "rules")
 
   /** MATCH_ALL|MATCH_FIRST|MATCH_COMPLETE
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val strategy: Param[String] =
@@ -79,26 +79,26 @@ class RegexMatcherModel(override val uid: String)
   def this() = this(Identifiable.randomUID("REGEX_MATCHER"))
 
   /** Can be any of MATCH_FIRST|MATCH_ALL|MATCH_COMPLETE
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group setParam
     */
   def setStrategy(value: String): this.type = set(strategy, value)
 
   /** Can be any of MATCH_FIRST|MATCH_ALL|MATCH_COMPLETE
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParams
     */
   def getStrategy: String = $(strategy).toString
 
   /** Path to file containing a set of regex,key pair. readAs can be LINE_BY_LINE or
     * SPARK_DATASET. options contain option passed to spark reader if readAs is SPARK_DATASET.
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group setParam
     */
   def setExternalRules(value: Array[(String, String)]): this.type = set(externalRules, value)
 
   /** Rules represented as Array of Tuples
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParams
     */
   def getExternalRules: Array[(String, String)] = $$(externalRules)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexTokenizer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/RegexTokenizer.scala
@@ -110,7 +110,8 @@ class RegexTokenizer(override val uid: String)
   /** @group setParam */
   def setPattern(value: String): this.type = set(pattern, value)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getPattern: String = $(pattern)
 
   /** Indicates whether to convert all characters to lowercase before tokenizing (Default:
@@ -126,7 +127,8 @@ class RegexTokenizer(override val uid: String)
   /** @group setParam */
   def setToLowercase(value: Boolean): this.type = set(toLowercase, value)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getToLowercase: Boolean = $(toLowercase)
 
   /** Minimum token length, greater than or equal to 0 (Default: `1`). Default is 1, to avoid
@@ -140,7 +142,8 @@ class RegexTokenizer(override val uid: String)
   /** @group setParam */
   def setMinLength(value: Int): this.type = set(minLength, value)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getMinLength: Int = $(minLength)
 
   /** Maximum token length, greater than or equal to 1.
@@ -153,7 +156,8 @@ class RegexTokenizer(override val uid: String)
   /** @group setParam */
   def setMaxLength(value: Int): this.type = set(maxLength, value)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getMaxLength: Int = $(maxLength)
 
   /** Indicates whether to apply the regex tokenization using a positional mask to guarantee the
@@ -170,7 +174,8 @@ class RegexTokenizer(override val uid: String)
   /** @group setParam */
   def setPositionalMask(value: Boolean): this.type = set(positionalMask, value)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getPositionalMask: Boolean = $(positionalMask)
 
   /** Indicates whether to use a trimWhitespace flag to remove whitespaces from identified tokens.
@@ -187,7 +192,8 @@ class RegexTokenizer(override val uid: String)
   /** @group setParam */
   def setTrimWhitespace(value: Boolean): this.type = set(trimWhitespace, value)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getTrimWhitespace: Boolean = $(trimWhitespace)
 
   /** Indicates whether to use a preserve initial indexes before eventual whitespaces removal in
@@ -204,7 +210,8 @@ class RegexTokenizer(override val uid: String)
   /** @group setParam */
   def setPreservePosition(value: Boolean): this.type = set(preservePosition, value)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getPreservePosition: Boolean = $(preservePosition)
 
   setDefault(

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/Stemmer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/Stemmer.scala
@@ -108,13 +108,13 @@ class Stemmer(override val uid: String)
   override val inputAnnotatorTypes: Array[AnnotatorType] = Array(TOKEN)
 
   /** Language of the text (Default: `"english"`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group setParam
     */
   def setLanguage(value: String): Stemmer = set(language, value)
 
   /** Language of the text (Default: `"english"`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getLanguage: String = $(language)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/StopWordsCleaner.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/StopWordsCleaner.scala
@@ -145,7 +145,7 @@ class StopWordsCleaner(override val uid: String)
   def setStopWords(value: Array[String]): this.type = set(stopWords, value)
 
   /** The words to be filtered out
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getStopWords: Array[String] = $(stopWords)
@@ -166,7 +166,7 @@ class StopWordsCleaner(override val uid: String)
   def setCaseSensitive(value: Boolean): this.type = set(caseSensitive, value)
 
   /** Whether to do a case-sensitive comparison over the stop words (Default: `false`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getCaseSensitive: Boolean = $(caseSensitive)
@@ -192,13 +192,14 @@ class StopWordsCleaner(override val uid: String)
   /** Locale of the input for case insensitive matching (Default: system default locale, or
     * `Locale.US` if the default locale is not in available locales). Ignored when caseSensitive
     * is true
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getLocale: String = $(locale)
 
   /** Returns system default locale, or `Locale.US` if the default locale is not in available
     * locales in JVM.
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   private val getDefaultOrUS: Locale = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcher.scala
@@ -210,7 +210,7 @@ class TextMatcher(override val uid: String)
   def setTokenizer(tokenizer: TokenizerModel): this.type = set(this.tokenizer, tokenizer)
 
   /** The [[Tokenizer]] to perform tokenization with
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getTokenizer: TokenizerModel = $$(tokenizer)
@@ -222,7 +222,7 @@ class TextMatcher(override val uid: String)
   def setCaseSensitive(v: Boolean): this.type = set(caseSensitive, v)
 
   /** Whether to match regardless of case (Default: `true`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getCaseSensitive: Boolean = $(caseSensitive)
@@ -234,7 +234,7 @@ class TextMatcher(override val uid: String)
   def setMergeOverlapping(v: Boolean): this.type = set(mergeOverlapping, v)
 
   /** Whether to merge overlapping matched chunks (Default: `false`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getMergeOverlapping: Boolean = $(mergeOverlapping)
@@ -246,7 +246,7 @@ class TextMatcher(override val uid: String)
   def setEntityValue(v: String): this.type = set(entityValue, v)
 
   /** Getter for Value for the entity metadata field
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getEntityValue: String = $(entityValue)
@@ -258,7 +258,7 @@ class TextMatcher(override val uid: String)
   def setBuildFromTokens(v: Boolean): this.type = set(buildFromTokens, v)
 
   /** Getter for buildFromTokens param
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getBuildFromTokens: Boolean = $(buildFromTokens)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcherModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/TextMatcherModel.scala
@@ -95,7 +95,7 @@ class TextMatcherModel(override val uid: String)
     "Whether the TextMatcher should take the CHUNK from TOKEN or not")
 
   /** SearchTrie of Tokens
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group setParam
     */
   def setSearchTrie(value: SearchTrie): this.type = set(searchTrie, value)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/AlbertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/AlbertEmbeddings.scala
@@ -217,7 +217,8 @@ class AlbertEmbeddings(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]): AlbertEmbeddings.this.type =
     set(this.configProtoBytes, bytes)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
   /** Max sentence length to process (Default: `128`)
@@ -246,24 +247,27 @@ class AlbertEmbeddings(override val uid: String)
   }
 
   /** It contains TF model signatures for the laded saved model
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val signatures =
     new MapFeature[String, String](model = this, name = "signatures").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setSignatures(value: Map[String, String]): this.type = {
     set(signatures, value)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getSignatures: Option[Map[String, String]] = get(this.signatures)
 
   private var _model: Option[Broadcast[Albert]] = None
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setModelIfNotSet(
       spark: SparkSession,
       tensorflowWrapper: TensorflowWrapper,

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertEmbeddings.scala
@@ -164,28 +164,31 @@ class BertEmbeddings(override val uid: String)
 
   def this() = this(Identifiable.randomUID("BERT_EMBEDDINGS"))
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def sentenceStartTokenId: Int = {
     $$(vocabulary)("[CLS]")
   }
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def sentenceEndTokenId: Int = {
     $$(vocabulary)("[SEP]")
   }
 
   /** Vocabulary used to encode the words to ids with WordPieceEncoder
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val vocabulary: MapFeature[String, Int] = new MapFeature(this, "vocabulary").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setVocabulary(value: Map[String, Int]): this.type = set(vocabulary, value)
 
   /** ConfigProto from tensorflow, serialized into byte array. Get with
     * `config_proto.SerializeToString()`
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val configProtoBytes = new IntArrayParam(
@@ -193,11 +196,13 @@ class BertEmbeddings(override val uid: String)
     "configProtoBytes",
     "ConfigProto from tensorflow, serialized into byte array. Get with config_proto.SerializeToString()")
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setConfigProtoBytes(bytes: Array[Int]): BertEmbeddings.this.type =
     set(this.configProtoBytes, bytes)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
   /** Max sentence length to process (Default: `128`)
@@ -221,24 +226,27 @@ class BertEmbeddings(override val uid: String)
   def getMaxSentenceLength: Int = $(maxSentenceLength)
 
   /** It contains TF model signatures for the laded saved model
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val signatures =
     new MapFeature[String, String](model = this, name = "signatures").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setSignatures(value: Map[String, String]): this.type = {
     set(signatures, value)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   *  @group getParam */
   def getSignatures: Option[Map[String, String]] = get(this.signatures)
 
   private var _model: Option[Broadcast[Bert]] = None
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setModelIfNotSet(
       spark: SparkSession,
       tensorflowWrapper: TensorflowWrapper): BertEmbeddings = {
@@ -256,7 +264,8 @@ class BertEmbeddings(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getModelIfNotSet: Bert = _model.get.value
 
   /** Set Embeddings dimensions for the BERT model Only possible to set this when the first time

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddings.scala
@@ -207,12 +207,14 @@ class BertSentenceEmbeddings(override val uid: String)
     */
   def getIsLong: Boolean = $(isLong)
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def sentenceStartTokenId: Int = {
     $$(vocabulary)("[CLS]")
   }
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def sentenceEndTokenId: Int = {
     $$(vocabulary)("[SEP]")
   }
@@ -235,7 +237,7 @@ class BertSentenceEmbeddings(override val uid: String)
   }
 
   /** Vocabulary used to encode the words to ids with WordPieceEncoder
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group setParam
     */
   def setVocabulary(value: Map[String, Int]): this.type = set(vocabulary, value)
@@ -262,7 +264,7 @@ class BertSentenceEmbeddings(override val uid: String)
 
   /** ConfigProto from tensorflow, serialized into byte array. Get with
     * config_proto.SerializeToString()
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/CamemBertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/CamemBertEmbeddings.scala
@@ -160,7 +160,8 @@ class CamemBertEmbeddings(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]): CamemBertEmbeddings.this.type =
     set(this.configProtoBytes, bytes)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
   /** Max sentence length to process (Default: `128`)
@@ -184,19 +185,21 @@ class CamemBertEmbeddings(override val uid: String)
   def getMaxSentenceLength: Int = $(maxSentenceLength)
 
   /** It contains TF model signatures for the laded saved model
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val signatures =
     new MapFeature[String, String](model = this, name = "signatures").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setSignatures(value: Map[String, String]): this.type = {
     set(signatures, value)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getSignatures: Option[Map[String, String]] = get(this.signatures)
 
   private var _model: Option[Broadcast[CamemBert]] = None
@@ -218,7 +221,8 @@ class CamemBertEmbeddings(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getModelIfNotSet: CamemBert = _model.get.value
 
   /** Set Embeddings dimensions for the CamemBERT model Only possible to set this when the first

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
@@ -182,7 +182,7 @@ class ChunkEmbeddings(override val uid: String)
   def setSkipOOV(value: Boolean): this.type = set(skipOOV, value)
 
   /** Choose how you would like to aggregate Word Embeddings to Chunk Embeddings: AVERAGE or SUM
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getPoolingStrategy: String = $(poolingStrategy)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/DeBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/DeBertaEmbeddings.scala
@@ -198,7 +198,8 @@ class DeBertaEmbeddings(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]): DeBertaEmbeddings.this.type =
     set(this.configProtoBytes, bytes)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
   /** Max sentence length to process (Default: `128`)
@@ -227,24 +228,27 @@ class DeBertaEmbeddings(override val uid: String)
   }
 
   /** It contains TF model signatures for the laded saved model
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val signatures =
     new MapFeature[String, String](model = this, name = "signatures").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setSignatures(value: Map[String, String]): this.type = {
     set(signatures, value)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getSignatures: Option[Map[String, String]] = get(this.signatures)
 
   private var _model: Option[Broadcast[DeBerta]] = None
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setModelIfNotSet(
       spark: SparkSession,
       tensorflowWrapper: TensorflowWrapper,

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/DistilBertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/DistilBertEmbeddings.scala
@@ -180,12 +180,13 @@ class DistilBertEmbeddings(override val uid: String)
   }
 
   /** Vocabulary used to encode the words to ids with WordPieceEncoder
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val vocabulary: MapFeature[String, Int] = new MapFeature(this, "vocabulary").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setVocabulary(value: Map[String, Int]): this.type = set(vocabulary, value)
 
   /** ConfigProto from tensorflow, serialized into byte array. Get with
@@ -202,7 +203,8 @@ class DistilBertEmbeddings(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]): DistilBertEmbeddings.this.type =
     set(this.configProtoBytes, bytes)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
   /** Max sentence length to process (Default: `128`)
@@ -226,24 +228,27 @@ class DistilBertEmbeddings(override val uid: String)
   def getMaxSentenceLength: Int = $(maxSentenceLength)
 
   /** It contains TF model signatures for the laded saved model
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val signatures =
     new MapFeature[String, String](model = this, name = "signatures").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setSignatures(value: Map[String, String]): this.type = {
     set(signatures, value)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getSignatures: Option[Map[String, String]] = get(this.signatures)
 
   private var _model: Option[Broadcast[DistilBert]] = None
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setModelIfNotSet(
       spark: SparkSession,
       tensorflowWrapper: TensorflowWrapper): DistilBertEmbeddings = {
@@ -261,7 +266,8 @@ class DistilBertEmbeddings(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getModelIfNotSet: DistilBert = _model.get.value
 
   /** Set Embeddings dimensions for the DistilBERT model. Only possible to set this when the first

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/Doc2VecModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/Doc2VecModel.scala
@@ -163,7 +163,8 @@ class Doc2VecModel(override val uid: String)
     */
   val wordVectors: MapFeature[String, Array[Float]] = new MapFeature(this, "wordVectors")
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setWordVectors(value: Map[String, Array[Float]]): this.type = set(wordVectors, value)
 
   setDefault(inputCols -> Array(TOKEN), outputCol -> "doc2vec", vectorSize -> 100)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ElmoEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ElmoEmbeddings.scala
@@ -264,7 +264,7 @@ class ElmoEmbeddings(override val uid: String)
   }
 
   /** Function used to set the embedding output layer of the ELMO model
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getPoolingLayer: String = $(poolingLayer)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaEmbeddings.scala
@@ -185,21 +185,23 @@ class RoBertaEmbeddings(override val uid: String)
   }
 
   /** Vocabulary used to encode the words to ids with bpeTokenizer.encode
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val vocabulary: MapFeature[String, Int] = new MapFeature(this, "vocabulary").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setVocabulary(value: Map[String, Int]): this.type = set(vocabulary, value)
 
   /** Holding merges.txt coming from RoBERTa model
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val merges: MapFeature[(String, String), Int] = new MapFeature(this, "merges").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setMerges(value: Map[(String, String), Int]): this.type = set(merges, value)
 
   /** ConfigProto from tensorflow, serialized into byte array. Get with
@@ -216,7 +218,8 @@ class RoBertaEmbeddings(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]): RoBertaEmbeddings.this.type =
     set(this.configProtoBytes, bytes)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
   /** Max sentence length to process (Default: `128`)
@@ -240,19 +243,21 @@ class RoBertaEmbeddings(override val uid: String)
   def getMaxSentenceLength: Int = $(maxSentenceLength)
 
   /** It contains TF model signatures for the laded saved model
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val signatures =
     new MapFeature[String, String](model = this, name = "signatures").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setSignatures(value: Map[String, String]): this.type = {
     set(signatures, value)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getSignatures: Option[Map[String, String]] = get(this.signatures)
 
   private var _model: Option[Broadcast[RoBerta]] = None

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaSentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaSentenceEmbeddings.scala
@@ -182,21 +182,23 @@ class RoBertaSentenceEmbeddings(override val uid: String)
   }
 
   /** Vocabulary used to encode the words to ids with bpeTokenizer.encode
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val vocabulary: MapFeature[String, Int] = new MapFeature(this, "vocabulary").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setVocabulary(value: Map[String, Int]): this.type = set(vocabulary, value)
 
   /** Holding merges.txt coming from RoBERTa model
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val merges: MapFeature[(String, String), Int] = new MapFeature(this, "merges").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setMerges(value: Map[(String, String), Int]): this.type = set(merges, value)
 
   /** ConfigProto from tensorflow, serialized into byte array. Get with
@@ -213,7 +215,8 @@ class RoBertaSentenceEmbeddings(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]): RoBertaSentenceEmbeddings.this.type =
     set(this.configProtoBytes, bytes)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
   /** Max sentence length to process (Default: `128`)
@@ -237,24 +240,27 @@ class RoBertaSentenceEmbeddings(override val uid: String)
   def getMaxSentenceLength: Int = $(maxSentenceLength)
 
   /** It contains TF model signatures for the laded saved model
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val signatures =
     new MapFeature[String, String](model = this, name = "signatures").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setSignatures(value: Map[String, String]): this.type = {
     set(signatures, value)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getSignatures: Option[Map[String, String]] = get(this.signatures)
 
   private var _model: Option[Broadcast[RoBerta]] = None
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setModelIfNotSet(
       spark: SparkSession,
       tensorflowWrapper: TensorflowWrapper): RoBertaSentenceEmbeddings = {
@@ -273,7 +279,8 @@ class RoBertaSentenceEmbeddings(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getModelIfNotSet: RoBerta = _model.get.value
 
   /** Set Embeddings dimensions for the RoBERTa model. Only possible to set this when the first

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/UniversalSentenceEncoder.scala
@@ -201,7 +201,7 @@ class UniversalSentenceEncoder(override val uid: String)
   }
 
   /** Whether to load SentencePiece ops file which is required only by multi-lingual models.
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getLoadSP: Boolean = $(loadSP)
@@ -216,7 +216,7 @@ class UniversalSentenceEncoder(override val uid: String)
 
   /** ConfigProto from tensorflow, serialized into byte array. Get with
     * config_proto.SerializeToString()
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group getParam
     */
   def getConfigProtoBytes: Option[Array[Byte]] =
@@ -224,10 +224,12 @@ class UniversalSentenceEncoder(override val uid: String)
 
   private var _model: Option[Broadcast[USE]] = None
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getModelIfNotSet: USE = _model.get.value
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setModelIfNotSet(spark: SparkSession, tensorflow: TensorflowWrapper): this.type = {
     if (_model.isEmpty) {
 

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/Word2VecApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/Word2VecApproach.scala
@@ -133,7 +133,8 @@ class Word2VecApproach(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getVectorSize: Int = $(vectorSize)
 
   /** The window size (context words from [-window, window]) (Default: `5`)
@@ -152,7 +153,8 @@ class Word2VecApproach(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getWindowSize: Int = $(windowSize)
 
   /** Number of partitions for sentences of words (Default: `1`).
@@ -169,7 +171,8 @@ class Word2VecApproach(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getNumPartitions: Int = $(numPartitions)
 
   /** The minimum number of times a token must appear to be included in the word2vec model's
@@ -190,7 +193,8 @@ class Word2VecApproach(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getMinCount: Int = $(minCount)
 
   /** Sets the maximum length (in words) of each sentence in the input data (Default: `1000`). Any
@@ -213,7 +217,8 @@ class Word2VecApproach(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getMaxSentenceLength: Int = $(maxSentenceLength)
 
   /** Param for Step size to be used for each iteration of optimization (&gt; 0) (Default:
@@ -233,7 +238,8 @@ class Word2VecApproach(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getStepSize: Double = $(stepSize)
 
   /** Param for maximum number of iterations (&gt;= 0) (Default: `1`)
@@ -249,7 +255,8 @@ class Word2VecApproach(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getMaxIter: Int = $(maxIter)
 
   /** Random seed for shuffling the dataset (Default: `44`)
@@ -265,7 +272,8 @@ class Word2VecApproach(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getSeed: Int = $(seed)
 
   setDefault(

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/Word2VecModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/Word2VecModel.scala
@@ -159,12 +159,13 @@ class Word2VecModel(override val uid: String)
   }
 
   /** Dictionary of words with their vectors
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val wordVectors: MapFeature[String, Array[Float]] = new MapFeature(this, "wordVectors")
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setWordVectors(value: Map[String, Array[Float]]): this.type = set(wordVectors, value)
 
   setDefault(inputCols -> Array(TOKEN), outputCol -> "word2vec", vectorSize -> 100)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
@@ -191,7 +191,8 @@ class XlmRoBertaEmbeddings(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]): XlmRoBertaEmbeddings.this.type =
     set(this.configProtoBytes, bytes)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
   /** Max sentence length to process (Default: `128`)
@@ -215,24 +216,27 @@ class XlmRoBertaEmbeddings(override val uid: String)
   def getMaxSentenceLength: Int = $(maxSentenceLength)
 
   /** It contains TF model signatures for the laded saved model
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val signatures =
     new MapFeature[String, String](model = this, name = "signatures").setProtected()
 
-  /** @group setParam */
+  /**
+   * @group setParam */
   def setSignatures(value: Map[String, String]): this.type = {
     set(signatures, value)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getSignatures: Option[Map[String, String]] = get(this.signatures)
 
   private var _model: Option[Broadcast[XlmRoberta]] = None
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setModelIfNotSet(
       spark: SparkSession,
       tensorflowWrapper: TensorflowWrapper,
@@ -251,7 +255,8 @@ class XlmRoBertaEmbeddings(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getModelIfNotSet: XlmRoberta = _model.get.value
 
   /** Set Embeddings dimensions for the XLM-RoBERTa model. Only possible to set this when the

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaSentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaSentenceEmbeddings.scala
@@ -188,7 +188,8 @@ class XlmRoBertaSentenceEmbeddings(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]): XlmRoBertaSentenceEmbeddings.this.type =
     set(this.configProtoBytes, bytes)
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
   /** Max sentence length to process (Default: `128`)
@@ -212,24 +213,27 @@ class XlmRoBertaSentenceEmbeddings(override val uid: String)
   def getMaxSentenceLength: Int = $(maxSentenceLength)
 
   /** It contains TF model signatures for the laded saved model
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val signatures =
     new MapFeature[String, String](model = this, name = "signatures").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setSignatures(value: Map[String, String]): this.type = {
     set(signatures, value)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getSignatures: Option[Map[String, String]] = get(this.signatures)
 
   private var _model: Option[Broadcast[XlmRoberta]] = None
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setModelIfNotSet(
       spark: SparkSession,
       tensorflowWrapper: TensorflowWrapper,
@@ -248,7 +252,8 @@ class XlmRoBertaSentenceEmbeddings(override val uid: String)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getModelIfNotSet: XlmRoberta = _model.get.value
 
   /** Set Embeddings dimensions for the XLM-RoBERTa model. Only possible to set this when the

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlnetEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlnetEmbeddings.scala
@@ -213,7 +213,8 @@ class XlnetEmbeddings(override val uid: String)
   def setConfigProtoBytes(bytes: Array[Int]): XlnetEmbeddings.this.type =
     set(this.configProtoBytes, bytes)
 
-  /** @group setGaram */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setGaram */
   def getConfigProtoBytes: Option[Array[Byte]] = get(this.configProtoBytes).map(_.map(_.toByte))
 
   /** Max sentence length to process (Default: `128`)
@@ -252,19 +253,22 @@ class XlnetEmbeddings(override val uid: String)
   val signatures =
     new MapFeature[String, String](model = this, name = "signatures").setProtected()
 
-  /** @group setParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group setParam */
   def setSignatures(value: Map[String, String]): this.type = {
     set(signatures, value)
     this
   }
 
-  /** @group getParam */
+  /** WARNING: this is for internal use and not intended for users
+   * @group getParam */
   def getSignatures: Option[Map[String, String]] = get(this.signatures)
 
   /** The Tensorflow XLNet Model */
   private var _model: Option[Broadcast[Xlnet]] = None
 
-  /** Sets XLNet tensorflow Model */
+  /** WARNING: this is for internal use and not intended for users
+   * Sets XLNet tensorflow Model */
   def setModelIfNotSet(
       spark: SparkSession,
       tensorflow: TensorflowWrapper,
@@ -283,7 +287,8 @@ class XlnetEmbeddings(override val uid: String)
     this
   }
 
-  /** Gets XLNet tensorflow Model */
+  /** WARNING: this is for internal use and not intended for users
+   * Gets XLNet tensorflow Model */
   def getModelIfNotSet: Xlnet = _model.get.value
 
   setDefault(batchSize -> 8, dimension -> 768, maxSentenceLength -> 128, caseSensitive -> true)

--- a/src/main/scala/com/johnsnowlabs/storage/HasStorageRef.scala
+++ b/src/main/scala/com/johnsnowlabs/storage/HasStorageRef.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.Dataset
 trait HasStorageRef extends ParamsAndFeaturesWritable {
 
   /** Unique identifier for storage (Default: `this.uid`)
-    *
+    * WARNING: this is for internal use and not intended for users
     * @group param
     */
   val storageRef = new Param[String](this, "storageRef", "storage unique identifier")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change adds a warning message in Scaladocs for the parameters, getters, and setters that are not meant for users. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid confusion between Scala and Python documentation

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
