### PR TITLE
Resolve saving bug with multilabel parameter

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/HasClassifierActivationProperties.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasClassifierActivationProperties.scala
@@ -16,7 +16,7 @@
 
 package com.johnsnowlabs.nlp
 
-import org.apache.spark.ml.param.{FloatParam, Param}
+import org.apache.spark.ml.param.{BooleanParam, FloatParam, Param}
 
 trait HasClassifierActivationProperties extends ParamsAndFeaturesWritable {
 
@@ -47,7 +47,7 @@ trait HasClassifierActivationProperties extends ParamsAndFeaturesWritable {
     *
     * @group param
     */
-  val multilabel: Param[Boolean] = new Param(
+  val multilabel: BooleanParam = new BooleanParam(
     this,
     "multilabel",
     "Whether or not the result should be multi-class (the sum of all probabilities is 1.0) or multi-label (each label has a probability between 0.0 to 1.0). Default is False i.e. multi-class")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes a bug, preventing annotators to be saved if they had the `multilabel` parameter.

The Parameter in question is declared as a `Param[Boolean]` . If declared like that, it does not have a json(Decode|Encode) implemented. This will throw an error when attempting to save the annotator.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`"$Annotator" should "be saved and loaded correctly"` type tests are passing again.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
