### PR TITLE
SPARKNLP 801 set up warmup for all embeddings

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/ai/Albert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/Albert.scala
@@ -81,6 +81,14 @@ private[johnsnowlabs] class Albert(
   private val SentencePadTokenId = spp.getSppModel.pieceToId("[pad]")
   private val SentencePieceDelimiterId = spp.getSppModel.pieceToId("▁")
 
+  private def sessionWarmup(): Unit = {
+    val dummyInput =
+      Array(101, 2292, 1005, 1055, 4010, 6279, 1996, 5219, 2005, 1996, 2034, 28937, 1012, 102)
+    tag(Seq(dummyInput))
+  }
+
+  sessionWarmup()
+
   def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
 
     val maxSentenceLength = batch.map(pieceIds => pieceIds.length).max

--- a/src/main/scala/com/johnsnowlabs/ml/ai/Bert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/Bert.scala
@@ -55,6 +55,14 @@ private[johnsnowlabs] class Bert(
 
   val _tfBertSignatures: Map[String, String] = signatures.getOrElse(ModelSignatureManager.apply())
 
+  private def sessionWarmup(): Unit = {
+    val dummyInput =
+      Array(101, 2292, 1005, 1055, 4010, 6279, 1996, 5219, 2005, 1996, 2034, 28937, 1012, 102)
+    tag(Seq(dummyInput))
+  }
+
+  sessionWarmup()
+
   def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
 
     val maxSentenceLength = batch.map(pieceIds => pieceIds.length).max

--- a/src/main/scala/com/johnsnowlabs/ml/ai/CamemBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/CamemBert.scala
@@ -56,6 +56,14 @@ private[johnsnowlabs] class CamemBert(
   private val SentencePadTokenId = spp.getSppModel.pieceToId("<pad>") + PieceIdOffset
   private val SentencePieceDelimiterId = spp.getSppModel.pieceToId("▁") + PieceIdOffset
 
+  private def sessionWarmup(): Unit = {
+    val dummyInput =
+      Array(5, 54, 110, 11, 10, 15540, 215, 1280, 808, 25352, 1782, 808, 24696, 378, 17409, 9, 6)
+    tag(Seq(dummyInput))
+  }
+
+  sessionWarmup()
+
   def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
 
     val maxSentenceLength = batch.map(pieceIds => pieceIds.length).max

--- a/src/main/scala/com/johnsnowlabs/ml/ai/DistilBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/DistilBert.scala
@@ -74,6 +74,14 @@ private[johnsnowlabs] class DistilBert(
 
   val _tfBertSignatures: Map[String, String] = signatures.getOrElse(ModelSignatureManager.apply())
 
+  private def sessionWarmup(): Unit = {
+    val dummyInput =
+      Array(101, 2292, 1005, 1055, 4010, 6279, 1996, 5219, 2005, 1996, 2034, 28937, 1012, 102)
+    tag(Seq(dummyInput))
+  }
+
+  sessionWarmup()
+
   def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
 
     val maxSentenceLength = batch.map(pieceIds => pieceIds.length).max

--- a/src/main/scala/com/johnsnowlabs/ml/ai/RoBerta.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/RoBerta.scala
@@ -49,6 +49,14 @@ private[johnsnowlabs] class RoBerta(
   val _tfRoBertaSignatures: Map[String, String] =
     signatures.getOrElse(ModelSignatureManager.apply())
 
+  private def sessionWarmup(): Unit = {
+    val dummyInput =
+      Array(0, 7939, 18, 3279, 658, 5, 19374, 13, 5, 78, 42752, 4, 2)
+    tag(Seq(dummyInput))
+  }
+
+  sessionWarmup()
+
   def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
 
     val maxSentenceLength = batch.map(pieceIds => pieceIds.length).max

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoberta.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoberta.scala
@@ -85,6 +85,14 @@ private[johnsnowlabs] class XlmRoberta(
   private val SentencePadTokenId = 1
   private val SentencePieceDelimiterId = spp.getSppModel.pieceToId("▁")
 
+  private def sessionWarmup(): Unit = {
+    val dummyInput =
+      Array(0, 10842, 25, 7, 24814, 2037, 70, 148735, 100, 70, 5117, 53498, 6620, 5, 2)
+    tag(Seq(dummyInput))
+  }
+
+  sessionWarmup()
+
   def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
 
     val maxSentenceLength = batch.map(pieceIds => pieceIds.length).max

--- a/src/main/scala/com/johnsnowlabs/ml/ai/Xlnet.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/Xlnet.scala
@@ -90,6 +90,14 @@ private[johnsnowlabs] class Xlnet(
   private val SentencePadTokenId = spp.getSppModel.pieceToId("<pad>")
   private val SentencePieceDelimiterId = spp.getSppModel.pieceToId("▁")
 
+  private def sessionWarmup(): Unit = {
+    val dummyInput =
+      Array(2834, 26, 23, 2458, 499, 18, 14976, 28, 18, 89, 25, 11574, 9, 4, 3)
+    tag(Seq(dummyInput))
+  }
+
+  sessionWarmup()
+
   def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] = {
 
     val maxSentenceLength = batch.map(pieceIds => pieceIds.length).max


### PR DESCRIPTION
This PR adds `warmup` TF session for the remaining of annotators: 
- ALBERT
- BERT
- CamemBERT
- DistilBERT
- RoBERTa
- XLM-RoBERTa
- XLNet

The warmup runs once when the model is being loaded to reduce the first inference time, it is also useful when external models are being imported. This makes sure those models work right there without the need of inferencing afterwards.