### PR TITLE
SPARKNLP-823 Adding streaming functionality for seq2seq components

### DIFF
--- a/python/sparknlp/base/light_pipeline.py
+++ b/python/sparknlp/base/light_pipeline.py
@@ -157,7 +157,7 @@ class LightPipeline:
 
         return result
 
-    def fullAnnotate(self, target, optional_target="", streamer=False):
+    def fullAnnotate(self, target, optional_target=""):
         """Annotates the data provided into `Annotation` type results.
 
         The data should be either a list or a str.
@@ -198,8 +198,6 @@ class LightPipeline:
         if optional_target == "":
             if self.__isTextInput(target):
                 result = self.__fullAnnotateText(target)
-                if streamer:
-                    self.__streamResult(stages, result[0])
             elif self.__isAudioInput(target):
                 result = self.__fullAnnotateAudio(target)
             else:
@@ -426,7 +424,7 @@ class LightPipeline:
         seq2seq_output_cols = self.__getSeq2SeqOutputCols(stages)
         for seq2seq_output_col in seq2seq_output_cols:
             if seq2seq_output_col in result:
-                print(f"{seq2seq_output_col}: {result[seq2seq_output_col]}")
+                print(f"{result[seq2seq_output_col][0]}")
 
     def __getSeq2SeqOutputCols(self, stages):
         seq2seq_stages = [stage for stage in stages if isSeq2Seq(stage)]

--- a/python/sparknlp/common/utils.py
+++ b/python/sparknlp/common/utils.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Contains utilities for annotators."""
+import sys
 
 from sparknlp.common.read_as import ReadAs
 import sparknlp.internal as _internal
@@ -37,3 +38,7 @@ def ExternalResource(path, read_as=ReadAs.TEXT, options={}):
 def RegexRule(rule, identifier):
     return _internal._RegexRule(rule, identifier).apply()
 
+
+def isSeq2Seq(instance):
+    module = sys.modules[instance.__class__.__module__]
+    return module.__name__.startswith("sparknlp.annotator.seq2seq")

--- a/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/LightPipeline.scala
@@ -43,21 +43,11 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddings: Boolean =
       .toArray
   }
 
-  def fullAnnotate(
-      target: String,
-      optionalTarget: String = "",
-      streamer: Boolean = false): Map[String, Seq[IAnnotation]] = {
+  def fullAnnotate(target: String, optionalTarget: String = ""): Map[String, Seq[IAnnotation]] = {
     if (target.contains("/") && ResourceHelper.validFile(target)) {
       fullAnnotateImage(target)
     } else {
-      val output = fullAnnotateInternal(target, optionalTarget)
-      if (streamer) {
-        output.foreach { case (outputCol, annotation) =>
-          if (getSeq2SeqOutputCols.contains(outputCol))
-            println(s"$outputCol: ${annotation.mkString(" ")}")
-        }
-      }
-      output
+      fullAnnotateInternal(target, optionalTarget)
     }
   }
 
@@ -408,7 +398,7 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddings: Boolean =
       target: String,
       optionalTarget: String = "",
       streamer: Boolean = false): Map[String, Seq[String]] = {
-    fullAnnotate(target, optionalTarget, streamer = false).map { case (outputCol, annotation) =>
+    fullAnnotate(target, optionalTarget).map { case (outputCol, annotation) =>
       outputCol -> annotation.map { iAnnotation =>
         val annotation = iAnnotation.asInstanceOf[Annotation]
         val output = annotation.annotatorType match {
@@ -418,7 +408,7 @@ class LightPipeline(val pipelineModel: PipelineModel, parseEmbeddings: Boolean =
           case _ => annotation.result
         }
         if (streamer && getSeq2SeqOutputCols.contains(outputCol)) {
-          println(s"$outputCol: $output")
+          println(s"$output")
         }
         output
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -705,4 +705,9 @@ package object annotator {
   object RoBertaForZeroShotClassification
       extends ReadablePretrainedRoBertaForZeroShotModel
       with ReadRoBertaForZeroShotDLModel
+
+  def isSeq2SeqTransformer(instance: Any): Boolean = {
+    instance.getClass.getPackage.getName == "com.johnsnowlabs.nlp.annotators.seq2seq"
+  }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change adds a streamer argument to LightPipeline that will allow streaming data from both Scala and Python when using seq2seq features.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Add a familiar functionality for users in Seq2Seq components
- Local Tests
- Google Colab [notebook](https://colab.research.google.com/drive/12MYTlTQZRdNY4eN0SgB9yR74tYdNF5YL?usp=sharing)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
