### PR TITLE
Add support for ONNX to ALBERT, CamemBERT,  XLM-RoBERTa, XLNet, and Longformer

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoberta.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoberta.scala
@@ -16,11 +16,13 @@
 
 package com.johnsnowlabs.ml.ai
 
+import ai.onnxruntime.OnnxTensor
 import com.johnsnowlabs.ml.ai.util.PrepareEmbeddings
+import com.johnsnowlabs.ml.onnx.OnnxWrapper
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{SentencePieceWrapper, SentencepieceEncoder}
 import com.johnsnowlabs.ml.tensorflow.sign.{ModelSignatureConstants, ModelSignatureManager}
 import com.johnsnowlabs.ml.tensorflow.{TensorResources, TensorflowWrapper}
-import com.johnsnowlabs.ml.util.ModelArch
+import com.johnsnowlabs.ml.util.{ModelArch, ONNX, TensorFlow}
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 
@@ -71,7 +73,8 @@ import scala.collection.JavaConverters._
   *   Model's inputs and output(s) signatures
   */
 private[johnsnowlabs] class XlmRoberta(
-    val tensorflowWrapper: TensorflowWrapper,
+    val tensorflowWrapper: Option[TensorflowWrapper],
+    val onnxWrapper: Option[OnnxWrapper],
     val spp: SentencePieceWrapper,
     caseSensitive: Boolean = true,
     configProtoBytes: Option[Array[Byte]] = None,
@@ -81,6 +84,10 @@ private[johnsnowlabs] class XlmRoberta(
 
   val _tfRoBertaSignatures: Map[String, String] =
     signatures.getOrElse(ModelSignatureManager.apply())
+  val detectedEngine: String =
+    if (tensorflowWrapper.isDefined) TensorFlow.name
+    else if (onnxWrapper.isDefined) ONNX.name
+    else TensorFlow.name
 
   private val SentenceStartTokenId = 0
   private val SentenceEndTokenId = 2
@@ -104,42 +111,81 @@ private[johnsnowlabs] class XlmRoberta(
     val maxSentenceLength = batch.map(pieceIds => pieceIds.length).max
     val batchLength = batch.length
 
-    val tensors = new TensorResources()
+    val embeddings = detectedEngine match {
 
-    val (tokenTensors, maskTensors) =
-      PrepareEmbeddings.prepareBatchTensors(
-        tensors = tensors,
-        batch = batch,
-        maxSentenceLength = maxSentenceLength,
-        batchLength = batchLength,
-        sentencePadTokenId = SentencePadTokenId)
+      case ONNX.name =>
+        // [nb of encoded sentences , maxSentenceLength]
+        val (runner, env) = onnxWrapper.get.getSession()
 
-    val runner = tensorflowWrapper
-      .getTFSessionWithSignature(
-        configProtoBytes = configProtoBytes,
-        savedSignatures = signatures,
-        initAllTables = false)
-      .runner
+        val tokenTensors =
+          OnnxTensor.createTensor(env, batch.map(x => x.map(x => x.toLong)).toArray)
+        val maskTensors =
+          OnnxTensor.createTensor(
+            env,
+            batch.map(sentence => sentence.map(x => if (x == 0L) 0L else 1L)).toArray)
 
-    runner
-      .feed(
-        _tfRoBertaSignatures
-          .getOrElse(ModelSignatureConstants.InputIds.key, "missing_input_id_key"),
-        tokenTensors)
-      .feed(
-        _tfRoBertaSignatures
-          .getOrElse(ModelSignatureConstants.AttentionMask.key, "missing_input_mask_key"),
-        maskTensors)
-      .fetch(_tfRoBertaSignatures
-        .getOrElse(ModelSignatureConstants.LastHiddenState.key, "missing_sequence_output_key"))
+        val inputs =
+          Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
-    val outs = runner.run().asScala
-    val embeddings = TensorResources.extractFloats(outs.head)
+        // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
+        try {
+          val results = runner.run(inputs)
+          try {
+            val embeddings = results
+              .get("last_hidden_state")
+              .get()
+              .asInstanceOf[OnnxTensor]
+              .getFloatBuffer
+              .array()
+            tokenTensors.close()
+            maskTensors.close()
+            embeddings
 
-    tokenTensors.close()
-    maskTensors.close()
-    tensors.clearSession(outs)
-    tensors.clearTensors()
+          } finally if (results != null) results.close()
+        }
+      case _ =>
+        val tensors = new TensorResources()
+
+        val (tokenTensors, maskTensors) =
+          PrepareEmbeddings.prepareBatchTensors(
+            tensors = tensors,
+            batch = batch,
+            maxSentenceLength = maxSentenceLength,
+            batchLength = batchLength,
+            sentencePadTokenId = SentencePadTokenId)
+
+        val runner = tensorflowWrapper.get
+          .getTFSessionWithSignature(
+            configProtoBytes = configProtoBytes,
+            savedSignatures = signatures,
+            initAllTables = false)
+          .runner
+
+        runner
+          .feed(
+            _tfRoBertaSignatures
+              .getOrElse(ModelSignatureConstants.InputIds.key, "missing_input_id_key"),
+            tokenTensors)
+          .feed(
+            _tfRoBertaSignatures
+              .getOrElse(ModelSignatureConstants.AttentionMask.key, "missing_input_mask_key"),
+            maskTensors)
+          .fetch(
+            _tfRoBertaSignatures
+              .getOrElse(
+                ModelSignatureConstants.LastHiddenState.key,
+                "missing_sequence_output_key"))
+
+        val outs = runner.run().asScala
+        val embeddings = TensorResources.extractFloats(outs.head)
+
+        tokenTensors.close()
+        maskTensors.close()
+        tensors.clearSession(outs)
+        tensors.clearTensors()
+
+        embeddings
+    }
 
     PrepareEmbeddings.prepareBatchWordEmbeddings(
       batch,
@@ -163,7 +209,7 @@ private[johnsnowlabs] class XlmRoberta(
         batchLength = batchLength,
         sentencePadTokenId = SentencePadTokenId)
 
-    val runner = tensorflowWrapper
+    val runner = tensorflowWrapper.get
       .getTFSessionWithSignature(
         configProtoBytes = configProtoBytes,
         savedSignatures = signatures,

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/AlbertEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/AlbertEmbeddings.scala
@@ -17,6 +17,7 @@
 package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.ml.ai.Albert
+import com.johnsnowlabs.ml.onnx.{OnnxWrapper, ReadOnnxModel, WriteOnnxModel}
 import com.johnsnowlabs.ml.tensorflow._
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{
   ReadSentencePieceModel,
@@ -28,7 +29,7 @@ import com.johnsnowlabs.ml.util.LoadExternalModel.{
   modelSanityCheck,
   notSupportedEngineError
 }
-import com.johnsnowlabs.ml.util.TensorFlow
+import com.johnsnowlabs.ml.util.{ONNX, TensorFlow}
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.serialization.MapFeature
@@ -180,6 +181,7 @@ class AlbertEmbeddings(override val uid: String)
     with HasBatchedAnnotate[AlbertEmbeddings]
     with WriteTensorflowModel
     with WriteSentencePieceModel
+    with WriteOnnxModel
     with HasEmbeddingsProperties
     with HasStorageRef
     with HasCaseSensitiveProperties
@@ -266,7 +268,8 @@ class AlbertEmbeddings(override val uid: String)
   /** @group setParam */
   def setModelIfNotSet(
       spark: SparkSession,
-      tensorflowWrapper: TensorflowWrapper,
+      tensorflowWrapper: Option[TensorflowWrapper],
+      onnxWrapper: Option[OnnxWrapper],
       spp: SentencePieceWrapper): AlbertEmbeddings = {
     if (_model.isEmpty) {
 
@@ -274,6 +277,7 @@ class AlbertEmbeddings(override val uid: String)
         spark.sparkContext.broadcast(
           new Albert(
             tensorflowWrapper,
+            onnxWrapper,
             spp,
             batchSize = $(batchSize),
             configProtoBytes = getConfigProtoBytes,
@@ -329,18 +333,34 @@ class AlbertEmbeddings(override val uid: String)
 
   override def onWrite(path: String, spark: SparkSession): Unit = {
     super.onWrite(path, spark)
-    writeTensorflowModelV2(
-      path,
-      spark,
-      getModelIfNotSet.tensorflowWrapper,
-      "_albert",
-      AlbertEmbeddings.tfFile,
-      configProtoBytes = getConfigProtoBytes)
+    val suffix = "_albert"
+
+    getEngine match {
+      case TensorFlow.name =>
+        writeTensorflowModelV2(
+          path,
+          spark,
+          getModelIfNotSet.tensorflowWrapper.get,
+          suffix,
+          AlbertEmbeddings.tfFile,
+          configProtoBytes = getConfigProtoBytes)
+      case ONNX.name =>
+        writeOnnxModel(
+          path,
+          spark,
+          getModelIfNotSet.onnxWrapper.get,
+          suffix,
+          AlbertEmbeddings.onnxFile)
+
+      case _ =>
+        throw new Exception(notSupportedEngineError)
+    }
+
     writeSentencePieceModel(
       path,
       spark,
       getModelIfNotSet.spp,
-      "_albert",
+      suffix,
       AlbertEmbeddings.sppFile)
 
   }
@@ -370,16 +390,33 @@ trait ReadablePretrainedAlbertModel
     super.pretrained(name, lang, remoteLoc)
 }
 
-trait ReadAlbertDLModel extends ReadTensorflowModel with ReadSentencePieceModel {
+trait ReadAlbertDLModel
+    extends ReadTensorflowModel
+    with ReadSentencePieceModel
+    with ReadOnnxModel {
   this: ParamsAndFeaturesReadable[AlbertEmbeddings] =>
 
   override val tfFile: String = "albert_tensorflow"
+  override val onnxFile: String = "albert_onnx"
   override val sppFile: String = "albert_spp"
 
   def readModel(instance: AlbertEmbeddings, path: String, spark: SparkSession): Unit = {
-    val tf = readTensorflowModel(path, spark, "_albert_tf", initAllTables = false)
-    val spp = readSentencePieceModel(path, spark, "_albert_spp", sppFile)
-    instance.setModelIfNotSet(spark, tf, spp)
+
+    instance.getEngine match {
+      case TensorFlow.name =>
+        val tfWrapper = readTensorflowModel(path, spark, "_albert_tf", initAllTables = false)
+        val spp = readSentencePieceModel(path, spark, "_albert_spp", sppFile)
+        instance.setModelIfNotSet(spark, Some(tfWrapper), None, spp)
+
+      case ONNX.name => {
+        val onnxWrapper =
+          readOnnxModel(path, spark, "_albert_onnx", zipped = true, useBundle = false, None)
+        val spp = readSentencePieceModel(path, spark, "_albert_spp", sppFile)
+        instance.setModelIfNotSet(spark, None, Some(onnxWrapper), spp)
+      }
+      case _ =>
+        throw new Exception(notSupportedEngineError)
+    }
   }
 
   addReader(readModel)
@@ -397,7 +434,7 @@ trait ReadAlbertDLModel extends ReadTensorflowModel with ReadSentencePieceModel 
 
     detectedEngine match {
       case TensorFlow.name =>
-        val (wrapper, signatures) =
+        val (tfWrapper, signatures) =
           TensorflowWrapper.read(localModelPath, zipped = false, useBundle = true)
 
         val _signatures = signatures match {
@@ -410,7 +447,12 @@ trait ReadAlbertDLModel extends ReadTensorflowModel with ReadSentencePieceModel 
           */
         annotatorModel
           .setSignatures(_signatures)
-          .setModelIfNotSet(spark, wrapper, spModel)
+          .setModelIfNotSet(spark, Some(tfWrapper), None, spModel)
+
+      case ONNX.name =>
+        val onnxWrapper = OnnxWrapper.read(localModelPath, zipped = false, useBundle = true)
+        annotatorModel
+          .setModelIfNotSet(spark, None, Some(onnxWrapper), spModel)
 
       case _ =>
         throw new Exception(notSupportedEngineError)

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaEmbeddings.scala
@@ -17,6 +17,7 @@
 package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.ml.ai.XlmRoberta
+import com.johnsnowlabs.ml.onnx.{OnnxWrapper, ReadOnnxModel, WriteOnnxModel}
 import com.johnsnowlabs.ml.tensorflow._
 import com.johnsnowlabs.ml.tensorflow.sentencepiece.{
   ReadSentencePieceModel,
@@ -28,7 +29,7 @@ import com.johnsnowlabs.ml.util.LoadExternalModel.{
   modelSanityCheck,
   notSupportedEngineError
 }
-import com.johnsnowlabs.ml.util.{ModelArch, TensorFlow}
+import com.johnsnowlabs.ml.util.{ModelArch, ONNX, TensorFlow}
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.serialization.MapFeature
@@ -167,6 +168,7 @@ class XlmRoBertaEmbeddings(override val uid: String)
     with HasBatchedAnnotate[XlmRoBertaEmbeddings]
     with WriteTensorflowModel
     with WriteSentencePieceModel
+    with WriteOnnxModel
     with HasEmbeddingsProperties
     with HasStorageRef
     with HasCaseSensitiveProperties
@@ -235,13 +237,15 @@ class XlmRoBertaEmbeddings(override val uid: String)
   /** @group setParam */
   def setModelIfNotSet(
       spark: SparkSession,
-      tensorflowWrapper: TensorflowWrapper,
+      tensorflowWrapper: Option[TensorflowWrapper],
+      onnxWrapper: Option[OnnxWrapper],
       spp: SentencePieceWrapper): XlmRoBertaEmbeddings = {
     if (_model.isEmpty) {
       _model = Some(
         spark.sparkContext.broadcast(
           new XlmRoberta(
             tensorflowWrapper,
+            onnxWrapper,
             spp,
             $(caseSensitive),
             configProtoBytes = getConfigProtoBytes,
@@ -332,18 +336,34 @@ class XlmRoBertaEmbeddings(override val uid: String)
 
   override def onWrite(path: String, spark: SparkSession): Unit = {
     super.onWrite(path, spark)
-    writeTensorflowModelV2(
-      path,
-      spark,
-      getModelIfNotSet.tensorflowWrapper,
-      "_xlmroberta",
-      XlmRoBertaEmbeddings.tfFile,
-      configProtoBytes = getConfigProtoBytes)
+    val suffix = "_xlmroberta"
+
+    getEngine match {
+      case TensorFlow.name =>
+        writeTensorflowModelV2(
+          path,
+          spark,
+          getModelIfNotSet.tensorflowWrapper.get,
+          suffix,
+          XlmRoBertaEmbeddings.tfFile,
+          configProtoBytes = getConfigProtoBytes)
+      case ONNX.name =>
+        writeOnnxModel(
+          path,
+          spark,
+          getModelIfNotSet.onnxWrapper.get,
+          suffix,
+          XlmRoBertaEmbeddings.onnxFile)
+
+      case _ =>
+        throw new Exception(notSupportedEngineError)
+    }
+
     writeSentencePieceModel(
       path,
       spark,
       getModelIfNotSet.spp,
-      "_xlmroberta",
+      suffix,
       XlmRoBertaEmbeddings.sppFile)
   }
 
@@ -367,17 +387,33 @@ trait ReadablePretrainedXlmRobertaModel
     super.pretrained(name, lang, remoteLoc)
 }
 
-trait ReadXlmRobertaDLModel extends ReadTensorflowModel with ReadSentencePieceModel {
+trait ReadXlmRobertaDLModel
+    extends ReadTensorflowModel
+    with ReadSentencePieceModel
+    with ReadOnnxModel {
   this: ParamsAndFeaturesReadable[XlmRoBertaEmbeddings] =>
 
   override val tfFile: String = "xlmroberta_tensorflow"
+  override val onnxFile: String = "xlmroberta_onnx"
   override val sppFile: String = "xlmroberta_spp"
 
   def readModel(instance: XlmRoBertaEmbeddings, path: String, spark: SparkSession): Unit = {
 
-    val tf = readTensorflowModel(path, spark, "_xlmroberta_tf", initAllTables = false)
-    val spp = readSentencePieceModel(path, spark, "_xlmroberta_spp", sppFile)
-    instance.setModelIfNotSet(spark, tf, spp)
+    instance.getEngine match {
+      case TensorFlow.name =>
+        val tfWrapper = readTensorflowModel(path, spark, "_xlmroberta_tf", initAllTables = false)
+        val spp = readSentencePieceModel(path, spark, "_xlmroberta_spp", sppFile)
+        instance.setModelIfNotSet(spark, Some(tfWrapper), None, spp)
+
+      case ONNX.name => {
+        val onnxWrapper =
+          readOnnxModel(path, spark, "_xlmroberta_onnx", zipped = true, useBundle = false, None)
+        val spp = readSentencePieceModel(path, spark, "_xlmroberta_spp", sppFile)
+        instance.setModelIfNotSet(spark, None, Some(onnxWrapper), spp)
+      }
+      case _ =>
+        throw new Exception(notSupportedEngineError)
+    }
   }
 
   addReader(readModel)
@@ -395,7 +431,7 @@ trait ReadXlmRobertaDLModel extends ReadTensorflowModel with ReadSentencePieceMo
 
     detectedEngine match {
       case TensorFlow.name =>
-        val (wrapper, signatures) =
+        val (tfWrapper, signatures) =
           TensorflowWrapper.read(localModelPath, zipped = false, useBundle = true)
 
         val _signatures = signatures match {
@@ -408,7 +444,12 @@ trait ReadXlmRobertaDLModel extends ReadTensorflowModel with ReadSentencePieceMo
           */
         annotatorModel
           .setSignatures(_signatures)
-          .setModelIfNotSet(spark, wrapper, spModel)
+          .setModelIfNotSet(spark, Some(tfWrapper), None, spModel)
+
+      case ONNX.name =>
+        val onnxWrapper = OnnxWrapper.read(localModelPath, zipped = false, useBundle = true)
+        annotatorModel
+          .setModelIfNotSet(spark, None, Some(onnxWrapper), spModel)
 
       case _ =>
         throw new Exception(notSupportedEngineError)


### PR DESCRIPTION
This PR adds support for ONNX models to the following Spark NLP Annotators:

- [ ] ALBERT
- [ ] CamemBERT
- [ ] XLM-RoBERTa
- [ ] XLNet
- [ ] Longformer
