### PR TITLE
[SPARKNLP-906] Fix reading suffix

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxSerializeModel.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxSerializeModel.scala
@@ -126,7 +126,7 @@ trait ReadOnnxModel {
 
     val wrappers = (modelNames map { modelName: String =>
       // 2. Copy to local dir
-      val localModelFile = modelName + suffix
+      val localModelFile = modelName
       fs.copyToLocalFile(new Path(path, localModelFile), new Path(tmpFolder))
 
       val localPath = new Path(tmpFolder, localModelFile).toString

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/audio/WhisperForCTCTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/audio/WhisperForCTCTest.scala
@@ -32,12 +32,12 @@ class WhisperForCTCTest extends AnyFlatSpec with WhisperForCTCBehaviors {
 
   // Needs to be added manually
   lazy val modelTf: WhisperForCTC = WhisperForCTC
-    .loadSavedModel("exported_tf/openai/whisper-tiny", ResourceHelper.spark)
+    .pretrained("asr_whisper_tiny")
     .setInputCols("audio_assembler")
     .setOutputCol("document")
 
   lazy val modelOnnx: WhisperForCTC = WhisperForCTC
-    .loadSavedModel("exported_onnx/openai/whisper-tiny", ResourceHelper.spark)
+    .pretrained()
     .setInputCols("audio_assembler")
     .setOutputCol("document")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR fixes the loading onnx whisper models. Previously, a suffix was used to name the model files. This has been removed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All Tests passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
