### PR TITLE
Fixing onnx saving path bug

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
@@ -79,8 +79,8 @@ object OnnxWrapper {
 
   // TODO: make sure this.synchronized is needed or it's not a bottleneck
   private def withSafeOnnxModelLoader(
-                                       onnxModel: Array[Byte],
-                                       sessionOptions: Option[SessionOptions] = None): (OrtSession, OrtEnvironment) =
+     onnxModel: Array[Byte],
+     sessionOptions: Option[SessionOptions] = None): (OrtSession, OrtEnvironment) =
     this.synchronized {
       val env = OrtEnvironment.getEnvironment()
 
@@ -118,11 +118,11 @@ object OnnxWrapper {
     }
 
   def read(
-            modelPath: String,
-            zipped: Boolean = true,
-            useBundle: Boolean = false,
-            modelName: String = "model",
-            sessionOptions: Option[SessionOptions] = None): OnnxWrapper = {
+      modelPath: String,
+      zipped: Boolean = true,
+      useBundle: Boolean = false,
+      modelName: String = "model",
+      sessionOptions: Option[SessionOptions] = None): OnnxWrapper = {
 
     // 1. Create tmp folder
     val tmpFolder = Files
@@ -163,8 +163,8 @@ object OnnxWrapper {
   }
 
   case class EncoderDecoderWrappers(
-                                     encoder: OnnxWrapper,
-                                     decoder: OnnxWrapper,
-                                     decoderWithPast: OnnxWrapper)
+       encoder: OnnxWrapper,
+       decoder: OnnxWrapper,
+       decoderWithPast: OnnxWrapper)
 
 }

--- a/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
@@ -79,8 +79,8 @@ object OnnxWrapper {
 
   // TODO: make sure this.synchronized is needed or it's not a bottleneck
   private def withSafeOnnxModelLoader(
-                                       onnxModel: Array[Byte],
-                                       sessionOptions: Option[SessionOptions] = None): (OrtSession, OrtEnvironment) =
+    onnxModel: Array[Byte],
+    sessionOptions: Option[SessionOptions] = None): (OrtSession, OrtEnvironment) =
     this.synchronized {
       val env = OrtEnvironment.getEnvironment()
 

--- a/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
@@ -166,5 +166,4 @@ object OnnxWrapper {
        encoder: OnnxWrapper,
        decoder: OnnxWrapper,
        decoderWithPast: OnnxWrapper)
-
 }

--- a/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
@@ -79,8 +79,8 @@ object OnnxWrapper {
 
   // TODO: make sure this.synchronized is needed or it's not a bottleneck
   private def withSafeOnnxModelLoader(
-    onnxModel: Array[Byte],
-    sessionOptions: Option[SessionOptions] = None): (OrtSession, OrtEnvironment) =
+                                       onnxModel: Array[Byte],
+                                       sessionOptions: Option[SessionOptions] = None): (OrtSession, OrtEnvironment) =
     this.synchronized {
       val env = OrtEnvironment.getEnvironment()
 

--- a/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
@@ -58,9 +58,12 @@ class OnnxWrapper(var onnxModel: Array[Byte]) extends Serializable {
       .toString
 
     // 2. Save onnx model
-    val onnxFile = Paths.get(tmpFolder, file).toString
-    FileUtils.writeByteArrayToFile(new File(onnxFile), onnxModel)
+    val onnxFile = Paths
+      .get(tmpFolder,
+       file.replace(":", ""))
+      .toString
 
+    FileUtils.writeByteArrayToFile(new File(onnxFile), onnxModel)
     // 4. Zip folder
     if (zip) ZipArchiveUtil.zip(tmpFolder, file)
 
@@ -76,8 +79,8 @@ object OnnxWrapper {
 
   // TODO: make sure this.synchronized is needed or it's not a bottleneck
   private def withSafeOnnxModelLoader(
-      onnxModel: Array[Byte],
-      sessionOptions: Option[SessionOptions] = None): (OrtSession, OrtEnvironment) =
+                                       onnxModel: Array[Byte],
+                                       sessionOptions: Option[SessionOptions] = None): (OrtSession, OrtEnvironment) =
     this.synchronized {
       val env = OrtEnvironment.getEnvironment()
 
@@ -115,11 +118,11 @@ object OnnxWrapper {
     }
 
   def read(
-      modelPath: String,
-      zipped: Boolean = true,
-      useBundle: Boolean = false,
-      modelName: String = "model",
-      sessionOptions: Option[SessionOptions] = None): OnnxWrapper = {
+            modelPath: String,
+            zipped: Boolean = true,
+            useBundle: Boolean = false,
+            modelName: String = "model",
+            sessionOptions: Option[SessionOptions] = None): OnnxWrapper = {
 
     // 1. Create tmp folder
     val tmpFolder = Files
@@ -160,8 +163,8 @@ object OnnxWrapper {
   }
 
   case class EncoderDecoderWrappers(
-      encoder: OnnxWrapper,
-      decoder: OnnxWrapper,
-      decoderWithPast: OnnxWrapper)
+                                     encoder: OnnxWrapper,
+                                     decoder: OnnxWrapper,
+                                     decoderWithPast: OnnxWrapper)
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/E5EmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/E5EmbeddingsTestSpec.scala
@@ -18,7 +18,7 @@ package com.johnsnowlabs.nlp.embeddings
 
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.tags.{SlowTest, FastTest}
+import com.johnsnowlabs.tags.{SlowTest}
 import org.apache.spark.ml.Pipeline
 import org.scalatest.flatspec.AnyFlatSpec
 


### PR DESCRIPTION
FIxes saving of Onnx models on windows 

## Description
Currently, Onnx models can't be saved on windows because of the temporary path being used. This PR fixes the temporary path by replacing the character which can raise an exception while saving 



## How Has This Been Tested?
Tested locally by saving models and reloading them on windows 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
