### PR TITLE
SPARKNLP-919: Add note for Spark Version support

### DIFF
--- a/docs/en/transformer_entries/WhisperForCTC.md
+++ b/docs/en/transformer_entries/WhisperForCTC.md
@@ -12,7 +12,8 @@ languages, as well as translate from those languages into English.
 
 The audio needs to be provided pre-processed an array of floats.
 
-Note that at the moment, this annotator only supports greedy search.
+Note that at the moment, this annotator only supports greedy search and only Spark Versions
+3.4 and up are supported.
 
 For multilingual models, the language and the task (transcribe or translate) can be set with
 `setLanguage` and `setTask`.

--- a/examples/python/annotation/audio/whisper/Automatic_Speech_Recognition_Whisper_(WhisperForCTC).ipynb
+++ b/examples/python/annotation/audio/whisper/Automatic_Speech_Recognition_Whisper_(WhisperForCTC).ipynb
@@ -14,7 +14,7 @@
     "# Automatic Speech Recognition in Spark NLP\n",
     "## Whisper (WhisperForCTC)\n",
     "\n",
-    "WhisperForCTC is a Whisper Model with a language modeling head on top for Connectionist Temporal Classification (CTC). Whisper was proposed in [Robust Speech Recognition via Large-Scale Weak Supervision](https://arxiv.org/abs/2212.04356).\n",
+    "WhisperForCTC is a Whisper Model with a language modeling head on top for Connectionist Temporal Classification (CTC). Whisper was proposed in [Robust Speech Recognition via Large-Scale Weak Supervision](https://arxiv.org/abs/2212.04356). This annotator requires Spark versions 3.4.0 and up.\n",
     "\n",
     "The annotator takes audio files and transcribes it as text. The audio needs to be provided pre-processed an array of floats.\n",
     "\n",
@@ -62,7 +62,7 @@
     "!wget https://setup.johnsnowlabs.com/colab.sh -O - | bash\n",
     "\n",
     "# to process audio files\n",
-    "!pip install -q pyspark librosa"
+    "!pip install -q pyspark==3.4.1 librosa"
    ]
   },
   {

--- a/examples/python/transformers/HuggingFace in Spark NLP - WhisperForCTC.ipynb
+++ b/examples/python/transformers/HuggingFace in Spark NLP - WhisperForCTC.ipynb
@@ -18,7 +18,7 @@
     "Let's keep in mind a few things before we start 😊\n",
     "\n",
     "- This feature is only in `Spark NLP 5.1.0` and after. So please make sure you have upgraded to the latest Spark NLP release\n",
-    "- The Whisper model was introduced in `Spark NLP 5.1.0`\n",
+    "- The Whisper model was introduced in `Spark NLP 5.1.0 and requires Spark versions 3.4.0 and up.`\n",
     "- Official models are supported, but not all custom models may work."
    ]
   },
@@ -570,7 +570,8 @@
    "metadata": {},
    "source": [
     "- Let's install and setup Spark NLP in Google Colab\n",
-    "- This part is pretty easy via our simple script"
+    "- This part is pretty easy via our simple script\n",
+    "- Additionally, we will need to upgrade Spark to version 3.4.1"
    ]
   },
   {
@@ -579,7 +580,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! wget -q http://setup.johnsnowlabs.com/colab.sh -O - | bash"
+    "! wget -q http://setup.johnsnowlabs.com/colab.sh -O - | bash\n",
+    "! pip install -U pyspark==3.4.1"
    ]
   },
   {

--- a/examples/python/transformers/onnx/HuggingFace_ONNX_in_Spark_NLP_Whisper.ipynb
+++ b/examples/python/transformers/onnx/HuggingFace_ONNX_in_Spark_NLP_Whisper.ipynb
@@ -15,7 +15,7 @@
         "Let's keep in mind a few things before we start 😊\n",
         "\n",
         "- ONNX support was introduced in `Spark NLP 5.0.0`, enabling high performance inference for models. Please make sure you have upgraded to the latest Spark NLP release.\n",
-        "- The Whisper model was introduced in `Spark NLP 5.1.0`\n",
+        "- The Whisper model was introduced in `Spark NLP 5.1.0 and requires Spark version 3.4.1 and up.`\n",
         "- Official models are supported, but not all custom models may work."
       ]
     },
@@ -397,7 +397,8 @@
         "## Import and Save Whisper in Spark NLP\n",
         "\n",
         "- Let's install and setup Spark NLP in Google Colab\n",
-        "- This part is pretty easy via our simple script"
+        "- This part is pretty easy via our simple script\n",
+        "- Additionally, we need to upgrade Spark to version 3.4.1."
       ]
     },
     {
@@ -408,7 +409,8 @@
       },
       "outputs": [],
       "source": [
-        "! wget -q http://setup.johnsnowlabs.com/colab.sh -O - | bash"
+        "! wget -q http://setup.johnsnowlabs.com/colab.sh -O - | bash\n",
+        "! pip install -U pyspark==3.4.1"
       ]
     },
     {

--- a/python/sparknlp/annotator/audio/whisper_for_ctc.py
+++ b/python/sparknlp/annotator/audio/whisper_for_ctc.py
@@ -30,7 +30,8 @@ class WhisperForCTC(AnnotatorModel,
 
     The audio needs to be provided pre-processed an array of floats.
 
-    Note that at the moment, this annotator only supports greedy search.
+    Note that at the moment, this annotator only supports greedy search and only Spark Versions
+    3.4 and up are supported.
 
     For multilingual models, the language and the task (transcribe or translate) can be set with
     ``setLanguage`` and ``setTask``.

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/audio/WhisperForCTC.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/audio/WhisperForCTC.scala
@@ -34,8 +34,9 @@ import com.johnsnowlabs.ml.util.{ONNX, TensorFlow}
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotators.audio.feature_extractor.{Preprocessor, WhisperPreprocessor}
 import com.johnsnowlabs.nlp.serialization.{MapFeature, StructFeature}
+import com.johnsnowlabs.util.Version
 import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.ml.param.{BooleanParam, IntArrayParam, IntParam, Param}
+import org.apache.spark.ml.param.{BooleanParam, IntArrayParam, Param}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.SparkSession
 import org.json4s._
@@ -53,7 +54,8 @@ import org.json4s.jackson.JsonMethods._
   * For multilingual models, the language and the task (transcribe or translate) can be set with
   * `setLanguage` and `setTask`.
   *
-  * Note that at the moment, this annotator only supports greedy search.
+ * Note that at the moment, this annotator only supports greedy search and only Spark Versions
+ * 3.4 and up are supported.
   *
   * Pretrained models can be loaded with `pretrained` of the companion object:
   * {{{
@@ -424,7 +426,12 @@ trait ReadWhisperForCTCDLModel extends ReadTensorflowModel with ReadOnnxModel {
   override val onnxFile: String = "whisper_ctc_onnx"
   val suffix: String = "_whisper_ctc"
 
+  private def checkVersion(spark: SparkSession): Unit = {
+    val version = Version.parse(spark.version).toFloat
+    require(version >= 3.4, "WhisperForCTC requires Spark versions 3.4 and up.")
+  }
   def readModel(instance: WhisperForCTC, path: String, spark: SparkSession): Unit = {
+    checkVersion(spark)
 
     instance.getEngine match {
       case TensorFlow.name =>
@@ -457,6 +464,8 @@ trait ReadWhisperForCTCDLModel extends ReadTensorflowModel with ReadOnnxModel {
   addReader(readModel)
 
   def loadSavedModel(modelPath: String, spark: SparkSession): WhisperForCTC = {
+    checkVersion(spark)
+
     implicit val formats: DefaultFormats.type = DefaultFormats // for json4s
 
     val (localModelPath, detectedEngine) =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a note and a check for WhisperForCTC. Only Spark Versions 3.4 and up are supported for this annotator.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More transparent errors, so that users will know which version to use.