### PR TITLE
[SPARKNLP-937] Fixing chunk construction when an entity is found

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/er/AhoCorasickAutomaton.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/er/AhoCorasickAutomaton.scala
@@ -123,7 +123,7 @@ class AhoCorasickAutomaton(
 
       if (state == 0 && previousState > 0) {
         val node = nodes(previousState).get
-        if (node.isLeaf) {
+        if (node.isLeaf && node.entity.nonEmpty) {
           val chunkAnnotation = buildAnnotation(chunk, node.entity, node.id, sentence)
           chunkAnnotations.append(chunkAnnotation)
           chunk.clear()
@@ -135,8 +135,10 @@ class AhoCorasickAutomaton(
 
     if (chunk.nonEmpty) {
       val node = nodes(previousState).get
-      val chunkAnnotation = buildAnnotation(chunk, node.entity, node.id, sentence)
-      chunkAnnotations.append(chunkAnnotation)
+      if (node.entity.nonEmpty) {
+        val chunkAnnotation = buildAnnotation(chunk, node.entity, node.id, sentence)
+        chunkAnnotations.append(chunkAnnotation)
+      }
       chunk.clear()
     }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/er/EntityRulerTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/er/EntityRulerTest.scala
@@ -791,7 +791,7 @@ class EntityRulerTest extends AnyFlatSpec with SparkSessionTest {
     AssertAnnotations.assertFields(expectedEntitiesFromText6, actualEntities)
   }
 
-  it should "work with LightPipeline" in {
+  it should "work with LightPipeline" taggedAs FastTest in {
     val externalResource =
       ExternalResource(s"$testPath/keywords_only.json", ReadAs.TEXT, Map("format" -> "json"))
     val entityRulerPipeline = getEntityRulerKeywordsPipeline(externalResource, useStorage = false)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes an issue where EntityRuler output includes unexpected matches.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solving issue #13951

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- Local Tests
- Google Colab notebook

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
