### PR TITLE
SPARKNLP-938 E5 and MPNet embeddings crash on a sentence basis - missing pool average

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/ai/MPNet.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/MPNet.scala
@@ -64,13 +64,23 @@ private[johnsnowlabs] class MPNet(
     *   sentence embeddings
     */
   private def getSentenceEmbedding(batch: Seq[Array[Int]]): Array[Array[Float]] = {
+    val maxSentenceLength = batch.map(pieceIds => pieceIds.length).max
+    val paddedBatch = batch.map(arr => padArrayWithZeros(arr, maxSentenceLength))
     val embeddings = detectedEngine match {
       case ONNX.name =>
-        getSentenceEmbeddingFromOnnx(batch)
+        getSentenceEmbeddingFromOnnx(paddedBatch)
       case _ =>
-        getSentenceEmbeddingFromTF(batch)
+        getSentenceEmbeddingFromTF(paddedBatch)
     }
     embeddings
+  }
+
+  private def padArrayWithZeros(arr: Array[Int], maxLength: Int): Array[Int] = {
+    if (arr.length >= maxLength) {
+      arr
+    } else {
+      arr ++ Array.fill(maxLength - arr.length)(0)
+    }
   }
 
   /** Get sentence embeddings for a batch of sentences

--- a/src/main/scala/com/johnsnowlabs/ml/util/LinAlg.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/util/LinAlg.scala
@@ -72,7 +72,8 @@ object LinAlg {
     val sentenceEmbeddingsMatrix = embeddings.grouped(dim).toArray
     val attentionMaskMatrix = expandedAttentionMask.grouped(dim).toArray
 
-    val elementWiseProduct = computeElementWiseProduct(sentenceEmbeddingsMatrix, attentionMaskMatrix)
+    val elementWiseProduct =
+      computeElementWiseProduct(sentenceEmbeddingsMatrix, attentionMaskMatrix)
     val weightedSum: Array[Float] = elementWiseProduct.transpose.map(_.sum)
 
     val sumAlongDimension2: Array[Float] = attentionMaskMatrix.transpose.map(_.sum)
@@ -81,16 +82,17 @@ object LinAlg {
     computeElementWiseDivision(weightedSum, totalWeight)
   }
 
-  def computeElementWiseProduct(arrayA:  Array[Array[Float]], arrayB:  Array[Array[Float]]): Array[Array[Float]] = {
-    arrayA.zip(arrayB).map {
-      case (row1, row2) => row1.zip(row2).map { case (a, b) => a * b }
+  def computeElementWiseProduct(
+      arrayA: Array[Array[Float]],
+      arrayB: Array[Array[Float]]): Array[Array[Float]] = {
+    arrayA.zip(arrayB).map { case (row1, row2) =>
+      row1.zip(row2).map { case (a, b) => a * b }
     }
   }
 
-  def computeElementWiseDivision(arrayA:  Array[Float], arrayB:  Array[Float]): Array[Float] = {
-    arrayA.zip(arrayB).map {
-      case (a, b) =>
-        if (b != 0.0f) a / b else 0.0f // Avoid division by zero
+  def computeElementWiseDivision(arrayA: Array[Float], arrayB: Array[Float]): Array[Float] = {
+    arrayA.zip(arrayB).map { case (a, b) =>
+      if (b != 0.0f) a / b else 0.0f // Avoid division by zero
     }
   }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/E5EmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/E5EmbeddingsTestSpec.scala
@@ -16,9 +16,10 @@
 
 package com.johnsnowlabs.nlp.embeddings
 
+import com.johnsnowlabs.nlp.annotators.sentence_detector_dl.SentenceDetectorDLModel
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.tags.{SlowTest}
+import com.johnsnowlabs.tags.SlowTest
 import org.apache.spark.ml.Pipeline
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -53,5 +54,30 @@ class E5EmbeddingsTestSpec extends AnyFlatSpec {
     val pipelineDF = pipeline.fit(ddd).transform(ddd)
     pipelineDF.select("e5.embeddings").show(truncate = false)
 
+  }
+
+  it should "work with sentences" taggedAs SlowTest in {
+    import ResourceHelper.spark.implicits._
+    val testData = "I really enjoy my job. This is amazing"
+    val testDf = Seq(testData).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentenceDetectorDL = SentenceDetectorDLModel
+      .pretrained("sentence_detector_dl", "en")
+      .setInputCols(Array("document"))
+      .setOutputCol("sentences")
+
+    val embeddings = E5Embeddings
+      .pretrained()
+      .setInputCols(Array("sentences"))
+      .setOutputCol("e5")
+
+    val pipeline = new Pipeline().setStages(Array(document, sentenceDetectorDL, embeddings))
+
+    val pipelineDF = pipeline.fit(testDf).transform(testDf)
+    pipelineDF.select("e5.embeddings").show()
   }
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/E5EmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/E5EmbeddingsTestSpec.scala
@@ -21,6 +21,7 @@ import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.tags.SlowTest
 import org.apache.spark.ml.Pipeline
+import org.apache.spark.sql.functions.{col, size}
 import org.scalatest.flatspec.AnyFlatSpec
 
 class E5EmbeddingsTestSpec extends AnyFlatSpec {
@@ -56,6 +57,37 @@ class E5EmbeddingsTestSpec extends AnyFlatSpec {
 
   }
 
+  it should "have embeddings of the same size" taggedAs SlowTest in {
+    import ResourceHelper.spark.implicits._
+    val testDf = Seq(
+      "I like apples",
+      "I like bananas \\n and other things \\n like icream \\n and cats",
+      "I like rockets")
+      .toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val embeddings = E5Embeddings
+      .pretrained()
+      .setInputCols(Array("document"))
+      .setOutputCol("e5")
+
+    val pipeline = new Pipeline().setStages(Array(document, embeddings))
+
+    val pipelineDF = pipeline.fit(testDf).transform(testDf)
+
+    val embeddingsDF = pipelineDF.withColumn("embeddings", col("e5.embeddings").getItem(0))
+
+    val sizesArray: Array[Int] = embeddingsDF
+      .select(size(col("embeddings")).as("size"))
+      .collect()
+      .map(row => row.getAs[Int]("size"))
+
+    assert(sizesArray.forall(_ == sizesArray.head))
+  }
+
   it should "work with sentences" taggedAs SlowTest in {
     import ResourceHelper.spark.implicits._
     val testData = "I really enjoy my job. This is amazing"
@@ -80,4 +112,5 @@ class E5EmbeddingsTestSpec extends AnyFlatSpec {
     val pipelineDF = pipeline.fit(testDf).transform(testDf)
     pipelineDF.select("e5.embeddings").show()
   }
+
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/E5EmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/E5EmbeddingsTestSpec.scala
@@ -110,7 +110,7 @@ class E5EmbeddingsTestSpec extends AnyFlatSpec {
     val pipeline = new Pipeline().setStages(Array(document, sentenceDetectorDL, embeddings))
 
     val pipelineDF = pipeline.fit(testDf).transform(testDf)
-    pipelineDF.select("e5.embeddings").show()
+    pipelineDF.select("e5.embeddings").show(false)
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/MPNetEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/MPNetEmbeddingsTestSpec.scala
@@ -16,9 +16,10 @@
 
 package com.johnsnowlabs.nlp.embeddings
 
+import com.johnsnowlabs.nlp.annotator.SentenceDetectorDLModel
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.tags.{FastTest, SlowTest}
+import com.johnsnowlabs.tags.SlowTest
 import org.apache.spark.ml.Pipeline
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -45,6 +46,71 @@ class MPNetEmbeddingsTestSpec extends AnyFlatSpec {
     val pipelineDF = pipeline.fit(ddd).transform(ddd)
     pipelineDF.select("mpnet.embeddings").show(truncate = false)
 
+  }
+
+  it should "loadSaved ONNX model" in {
+    val mpnetEmbeddings = MPNetEmbeddings
+      .loadSavedModel(
+        "/home/danilo/IdeaProjects/MySpikes/python_spikes/src/nlp/hugging_face/onnx_models/mpnet/embeddings/sentence-transformers/all-mpnet-base-v2",
+        ResourceHelper.spark)
+      .setInputCols("document")
+      .setOutputCol("mpnet")
+
+    mpnetEmbeddings.write.overwrite().save("tmp_mpnet_embeddings_onxx_spark_nlp")
+  }
+
+  it should "work for ONNX multi sentences" in {
+    import ResourceHelper.spark.implicits._
+    val testData = "I really enjoy my job. This is amazing"
+    val testDf = Seq(testData).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentenceDetectorDL = SentenceDetectorDLModel
+      .pretrained("sentence_detector_dl", "en")
+      .setInputCols(Array("document"))
+      .setOutputCol("sentences")
+
+    val embeddings = MPNetEmbeddings
+      .load("tmp_mpnet_embeddings_onxx_spark_nlp")
+      .setInputCols("sentences")
+      .setOutputCol("mpnet")
+
+    val pipeline = new Pipeline().setStages(Array(document, sentenceDetectorDL, embeddings))
+
+    val pipelineModel = pipeline.fit(testDf)
+    val pipelineDF = pipelineModel.transform(testDf)
+
+    pipelineDF.select("mpnet.embeddings").show()
+  }
+
+  it should "work with sentences" taggedAs SlowTest in {
+    import ResourceHelper.spark.implicits._
+    val testData = "I really enjoy my job. This is amazing"
+    val testDf = Seq(testData).toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentenceDetectorDL = SentenceDetectorDLModel
+      .pretrained("sentence_detector_dl", "en")
+      .setInputCols(Array("document"))
+      .setOutputCol("sentences")
+
+    val embeddings = MPNetEmbeddings
+      .pretrained()
+      .setInputCols("sentences")
+      .setOutputCol("mpnet")
+
+    val pipeline = new Pipeline().setStages(Array(document, sentenceDetectorDL, embeddings))
+
+    val pipelineModel = pipeline.fit(testDf)
+    val pipelineDF = pipelineModel.transform(testDf)
+
+    pipelineDF.select("mpnet.embeddings").show()
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/MPNetEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/MPNetEmbeddingsTestSpec.scala
@@ -48,44 +48,6 @@ class MPNetEmbeddingsTestSpec extends AnyFlatSpec {
 
   }
 
-  it should "loadSaved ONNX model" in {
-    val mpnetEmbeddings = MPNetEmbeddings
-      .loadSavedModel(
-        "/home/danilo/IdeaProjects/MySpikes/python_spikes/src/nlp/hugging_face/onnx_models/mpnet/embeddings/sentence-transformers/all-mpnet-base-v2",
-        ResourceHelper.spark)
-      .setInputCols("document")
-      .setOutputCol("mpnet")
-
-    mpnetEmbeddings.write.overwrite().save("tmp_mpnet_embeddings_onxx_spark_nlp")
-  }
-
-  it should "work for ONNX multi sentences" in {
-    import ResourceHelper.spark.implicits._
-    val testData = "I really enjoy my job. This is amazing"
-    val testDf = Seq(testData).toDF("text")
-
-    val document = new DocumentAssembler()
-      .setInputCol("text")
-      .setOutputCol("document")
-
-    val sentenceDetectorDL = SentenceDetectorDLModel
-      .pretrained("sentence_detector_dl", "en")
-      .setInputCols(Array("document"))
-      .setOutputCol("sentences")
-
-    val embeddings = MPNetEmbeddings
-      .load("tmp_mpnet_embeddings_onxx_spark_nlp")
-      .setInputCols("sentences")
-      .setOutputCol("mpnet")
-
-    val pipeline = new Pipeline().setStages(Array(document, sentenceDetectorDL, embeddings))
-
-    val pipelineModel = pipeline.fit(testDf)
-    val pipelineDF = pipelineModel.transform(testDf)
-
-    pipelineDF.select("mpnet.embeddings").show()
-  }
-
   it should "work with sentences" taggedAs SlowTest in {
     import ResourceHelper.spark.implicits._
     val testData = "I really enjoy my job. This is amazing"

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/MPNetEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/MPNetEmbeddingsTestSpec.scala
@@ -22,6 +22,7 @@ import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.tags.SlowTest
 import org.apache.spark.ml.Pipeline
 import org.scalatest.flatspec.AnyFlatSpec
+import org.apache.spark.sql.functions.{col, size}
 
 class MPNetEmbeddingsTestSpec extends AnyFlatSpec {
 
@@ -46,6 +47,76 @@ class MPNetEmbeddingsTestSpec extends AnyFlatSpec {
     val pipelineDF = pipeline.fit(ddd).transform(ddd)
     pipelineDF.select("mpnet.embeddings").show(truncate = false)
 
+  }
+
+  it should "have embeddings of the same size" taggedAs SlowTest in {
+    import ResourceHelper.spark.implicits._
+    val testDf = Seq(
+      "I like apples",
+      "I like bananas \\n and other things \\n like icream \\n and cats",
+      "I like rockets")
+      .toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val embeddings = MPNetEmbeddings
+      .pretrained()
+      .setInputCols("document")
+      .setOutputCol("mpnet")
+
+    val pipeline = new Pipeline().setStages(Array(document, embeddings))
+
+    val pipelineModel = pipeline.fit(testDf)
+    val pipelineDF = pipelineModel.transform(testDf)
+
+    val embeddingsDF = pipelineDF.withColumn("embeddings", col("mpnet.embeddings").getItem(0))
+    val sizesArray: Array[Int] = embeddingsDF
+      .select(size(col("embeddings")).as("size"))
+      .collect()
+      .map(row => row.getAs[Int]("size"))
+
+    assert(sizesArray.forall(_ == sizesArray.head))
+  }
+
+  it should "loadSaved ONNX model" in {
+    val mpnetEmbeddings = MPNetEmbeddings
+      .loadSavedModel(
+        "/home/danilo/IdeaProjects/MySpikes/python_spikes/src/nlp/hugging_face/onnx_models/mpnet/embeddings/sentence-transformers/all-mpnet-base-v2",
+        ResourceHelper.spark)
+      .setInputCols("document")
+      .setOutputCol("mpnet")
+
+    mpnetEmbeddings.write.overwrite().save("tmp_mpnet_embeddings_onxx_spark_nlp")
+  }
+
+  it should "work for ONNX multi sentences" in {
+    import ResourceHelper.spark.implicits._
+    val testData = "I really enjoy my job. This is amazing"
+    val testDf = Seq(testData)
+      .toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentenceDetectorDL = SentenceDetectorDLModel
+      .pretrained("sentence_detector_dl", "en")
+      .setInputCols(Array("document"))
+      .setOutputCol("sentences")
+
+    val embeddings = MPNetEmbeddings
+      .load("tmp_mpnet_embeddings_onxx_spark_nlp")
+      .setInputCols("sentences")
+      .setOutputCol("mpnet")
+
+    val pipeline = new Pipeline().setStages(Array(document, sentenceDetectorDL, embeddings))
+
+    val pipelineModel = pipeline.fit(testDf)
+    val pipelineDF = pipelineModel.transform(testDf)
+
+    pipelineDF.select("mpnet.embeddings").show()
   }
 
   it should "work with sentences" taggedAs SlowTest in {

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/MPNetEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/MPNetEmbeddingsTestSpec.scala
@@ -104,7 +104,7 @@ class MPNetEmbeddingsTestSpec extends AnyFlatSpec {
     val pipelineModel = pipeline.fit(testDf)
     val pipelineDF = pipelineModel.transform(testDf)
 
-    pipelineDF.select("mpnet.embeddings").show()
+    pipelineDF.select("mpnet.embeddings").show(false)
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/MPNetEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/MPNetEmbeddingsTestSpec.scala
@@ -80,45 +80,6 @@ class MPNetEmbeddingsTestSpec extends AnyFlatSpec {
     assert(sizesArray.forall(_ == sizesArray.head))
   }
 
-  it should "loadSaved ONNX model" in {
-    val mpnetEmbeddings = MPNetEmbeddings
-      .loadSavedModel(
-        "/home/danilo/IdeaProjects/MySpikes/python_spikes/src/nlp/hugging_face/onnx_models/mpnet/embeddings/sentence-transformers/all-mpnet-base-v2",
-        ResourceHelper.spark)
-      .setInputCols("document")
-      .setOutputCol("mpnet")
-
-    mpnetEmbeddings.write.overwrite().save("tmp_mpnet_embeddings_onxx_spark_nlp")
-  }
-
-  it should "work for ONNX multi sentences" in {
-    import ResourceHelper.spark.implicits._
-    val testData = "I really enjoy my job. This is amazing"
-    val testDf = Seq(testData)
-      .toDF("text")
-
-    val document = new DocumentAssembler()
-      .setInputCol("text")
-      .setOutputCol("document")
-
-    val sentenceDetectorDL = SentenceDetectorDLModel
-      .pretrained("sentence_detector_dl", "en")
-      .setInputCols(Array("document"))
-      .setOutputCol("sentences")
-
-    val embeddings = MPNetEmbeddings
-      .load("tmp_mpnet_embeddings_onxx_spark_nlp")
-      .setInputCols("sentences")
-      .setOutputCol("mpnet")
-
-    val pipeline = new Pipeline().setStages(Array(document, sentenceDetectorDL, embeddings))
-
-    val pipelineModel = pipeline.fit(testDf)
-    val pipelineDF = pipelineModel.transform(testDf)
-
-    pipelineDF.select("mpnet.embeddings").show()
-  }
-
   it should "work with sentences" taggedAs SlowTest in {
     import ResourceHelper.spark.implicits._
     val testData = "I really enjoy my job. This is amazing"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change modifies E5 and MPNet embeddings by adding a method for padding with zeros all required arrays inside a batch to ensure all of them have the same length.
In addition, this change resolves a bug with ONNX models where the size of the embedding is different for some sentences.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves issue #14049
Solves issue #14066

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

- Local Tests
- Google Colab [notebooks](https://colab.research.google.com/drive/1cVpUKzDswMQ_V6MiWlKrj6ZtDa2Ge7o5?usp=sharing)
- ONNX MPNet and E5 embeddings sizes [notebook](https://colab.research.google.com/drive/16eokLJ_SCA2OLy7vWuA76tu4aMIYn8MS#scrollTo=lnZ5ed06Dy7c)
- TF MPNet Embeddings size [notebook](https://colab.research.google.com/drive/1YsBtxGxDnv3iyTq7nwMP1CTJb4AaI7FG#scrollTo=IGvfkp4avWu7)
- E5 Embeddings values [notebook](https://colab.research.google.com/drive/1cVpUKzDswMQ_V6MiWlKrj6ZtDa2Ge7o5?usp=sharing)
- MPNet Embeddings values [notebook](https://colab.research.google.com/drive/1bdh1gNup4YI7X-famPPRmUfiaUJoeEus?usp=sharing)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
