### PR TITLE
SPARKNLP-1000: Fix No Operation named [init_all_tables] for GPT2

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/ai/GPT2.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/GPT2.scala
@@ -133,7 +133,9 @@ private[johnsnowlabs] class GPT2(
       effectiveBatch_size = batch.length
     }
 
-    val session = tensorflow.getTFSessionWithSignature(configProtoBytes = configProtoBytes)
+    val session = tensorflow.getTFSessionWithSignature(
+      configProtoBytes = configProtoBytes,
+      initAllTables = false)
 
     val maxSentenceLength = batch.map(_.length).max
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR fixes `java.lang.IllegalArgumentException: No Operation named [init_all_tables] in the Graph` when model needs to be deserialized (e.g. broadcast to worker nodes). The deserialization is skipped when the model is already loaded (so the issue will only appear on the worker nodes and not the driver)

GPT2 does not contain tables and so does not require this command. Moreover, this is a legacy feature of TF 1.x models.




## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #14110.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests for GPT2 are passing on a cluster.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
