### PR TITLE
Fixes to AhoCorasick implementation in order to pass Suffix Link tests

### DIFF
--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/er/AhoCorasickAutomatonTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/er/AhoCorasickAutomatonTest.scala
@@ -133,4 +133,46 @@ class AhoCorasickAutomatonTest extends AnyFlatSpec {
 
   }
 
+  it should "not miss a match when hopping from a leaf node through a suffix link" taggedAs FastTest in {
+    val englishAlphabet =
+      "abcdefghijklmnopqrstuvwxyz," + "abcdefghijklmnopqrstuvwxyz".toUpperCase()
+    val entityPatterns = Array(
+      EntityPattern(
+        "PER",
+        Seq("abc", "cdef"))
+    )
+    val text = "abcd"
+    val sentence = Sentence(text, 0, text.length, 0)
+
+    val automaton = new AhoCorasickAutomaton(englishAlphabet, entityPatterns)
+    val actualOutput = automaton.searchPatternsInText(sentence)
+
+    val expectedOutput = Seq(
+      Annotation(CHUNK, 0, 3, "abc", Map("entity" -> "PER", "sentence" -> "0"))
+    )
+    assert(actualOutput == expectedOutput)
+
+  }
+
+  it should "not return merged chunks when overlapping through suffix links" taggedAs FastTest in {
+    val englishAlphabet =
+      "abcdefghijklmnopqrstuvwxyz," + "abcdefghijklmnopqrstuvwxyz".toUpperCase()
+    val entityPatterns = Array(
+      EntityPattern(
+        "PER",
+        Seq("abcy", "bcx"))
+    )
+    val text = "abcx"
+    val sentence = Sentence(text, 0, text.length, 0)
+
+    val automaton = new AhoCorasickAutomaton(englishAlphabet, entityPatterns)
+    val actualOutput = automaton.searchPatternsInText(sentence)
+
+    val expectedOutput = Seq(
+      Annotation(CHUNK, 1, 4, "bcx", Map("entity" -> "PER", "sentence" -> "0"))
+    )
+    assert(actualOutput == expectedOutput)
+
+  }
+
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/er/AhoCorasickAutomatonTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/er/AhoCorasickAutomatonTest.scala
@@ -148,7 +148,7 @@ class AhoCorasickAutomatonTest extends AnyFlatSpec {
     val actualOutput = automaton.searchPatternsInText(sentence)
 
     val expectedOutput = Seq(
-      Annotation(CHUNK, 0, 3, "abc", Map("entity" -> "PER", "sentence" -> "0"))
+      Annotation(CHUNK, 0, 2, "abc", Map("entity" -> "PER", "sentence" -> "0"))
     )
     assert(actualOutput == expectedOutput)
 
@@ -169,7 +169,7 @@ class AhoCorasickAutomatonTest extends AnyFlatSpec {
     val actualOutput = automaton.searchPatternsInText(sentence)
 
     val expectedOutput = Seq(
-      Annotation(CHUNK, 1, 4, "bcx", Map("entity" -> "PER", "sentence" -> "0"))
+      Annotation(CHUNK, 1, 3, "bcx", Map("entity" -> "PER", "sentence" -> "0"))
     )
     assert(actualOutput == expectedOutput)
 


### PR DESCRIPTION
## Description
Added a fix to correctly include a chunk annotation when jumping from a leaf node through a Suffix Link
Added a fix to correctly determine the span of a chunk annotation when jumping from a non-leaf node through a Suffix Link

## Motivation and Context
https://github.com/JohnSnowLabs/spark-nlp/issues/14187

## How Has This Been Tested?
Added tests that should pass and did not pass before the fix
Java 11
Spark 3.4
Spark NLP 5.2.2

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
