### PR TITLE
SPARKNLP-1026: Fix documentation for sparknlp.start()

### DIFF
--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -72,18 +72,27 @@ jupyter notebook
 
 </div><div class="h3-box" markdown="1">
 
-#### Start Spark NLP Session from python
+#### Start Spark NLP Session from Python
 
-If you need to manually start SparkSession because you have other configurations and `sparknlp.start()` is not including them, you can manually start the SparkSession:
+ Spark session for Spark NLP can be created (or retrieved) by using `sparknlp.start()`:
+
+```python
+import sparknlp
+spark = sparknlp.start()
+```
+
+If you need to manually start SparkSession because you have other configurations and `sparknlp.start()` is not including them,
+you can manually start the SparkSession with:
 
 ```python
 spark = SparkSession.builder \
-    .appName("Spark NLP")\
-    .master("local[*]")\
-    .config("spark.driver.memory","16G")\
+    .appName("Spark NLP") \
+    .master("local[*]") \
+    .config("spark.driver.memory", "16G") \
+    .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer") \
+    .config("spark.kryoserializer.buffer.max", "2000M") \
     .config("spark.driver.maxResultSize", "0") \
-    .config("spark.kryoserializer.buffer.max", "2000M")\
-    .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:5.3.1")\
+    .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:5.3.1") \
     .getOrCreate()
 ```
 

--- a/python/docs/getting_started/index.rst
+++ b/python/docs/getting_started/index.rst
@@ -130,11 +130,12 @@ you can manually start the SparkSession with:
 .. code-block:: python
     :substitutions:
 
-    spark = SparkSession.builder \
-        .appName("Spark NLP")\
-        .master("local[4]")\
-        .config("spark.driver.memory","16G")\
+    SparkSession.builder \
+        .appName("Spark NLP") \
+        .master("local[*]") \
+        .config("spark.driver.memory", "16G") \
+        .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer") \
+        .config("spark.kryoserializer.buffer.max", "2000M") \
         .config("spark.driver.maxResultSize", "0") \
-        .config("spark.kryoserializer.buffer.max", "2000M")\
-        .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:|release|")\
+        .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:|release|") \
         .getOrCreate()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes inconsistent documentation regarding `sparknlp.start()` and how to manually start a Spark NLP Session

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #14198.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No code changes, only documentation.