### PR TITLE
Cache mechanism implementation for metadata.json

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/RepositoryMetadata.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/RepositoryMetadata.scala
@@ -16,19 +16,16 @@
 
 package com.johnsnowlabs.nlp.pretrained
 
-import java.sql.Timestamp
 
 /** Describes state of repository Repository could be any s3 folder that has metadata.json
   * describing list of resources inside
   */
-case class RepositoryMetadata(
-    // Path to repository metadata file
-    metadataFile: String,
-    // Path to repository folder
+protected case class RepositoryMetadata(
+    // Path to repository folder like 'public/models'
     repoFolder: String,
-    // Aws file metadata.json version
-    version: String,
+    // Last modified time of metadata.json in s3
+    lastModified: java.util.Date,
     // Last time metadata was downloaded
-    lastMetadataDownloaded: Timestamp,
+    lastMetadataDownloaded: java.util.Date,
     // List of all available resources in repository
     metadata: List[ResourceMetadata])

--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/S3ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/S3ResourceDownloader.scala
@@ -24,8 +24,6 @@ import org.apache.hadoop.fs.Path
 
 import java.io.File
 import java.nio.file.Files
-import java.sql.Timestamp
-import java.util.Calendar
 import java.util.zip.ZipInputStream
 import scala.collection.mutable
 
@@ -48,16 +46,21 @@ class S3ResourceDownloader(
   lazy val awsGateway = new AWSGateway(region = region, credentialsType = credentialsType)
 
   def downloadMetadataIfNeed(folder: String): List[ResourceMetadata] = {
-    val lastState = repoFolder2Metadata.get(folder)
-
-    val fiveMinsBefore = getTimestamp(-5)
-    val needToRefresh = lastState.isEmpty || lastState.get.lastMetadataDownloaded
-      .before(fiveMinsBefore)
-
+    val lastMetadataState = repoFolder2Metadata.get(folder)
+    val metadataFilePath = awsGateway.getS3File(s3Path, folder, "metadata.json")
+    val metadataObject = awsGateway.client.getObject(bucket, metadataFilePath)
+    val lastModifiedTimeInS3 = metadataObject.getObjectMetadata.getLastModified
+    val needToRefresh = lastMetadataState.isEmpty || lastMetadataState.get.lastModified.before(lastModifiedTimeInS3)
     if (!needToRefresh) {
-      lastState.get.metadata
+      lastMetadataState.get.metadata
     } else {
-      awsGateway.getMetadata(s3Path, folder, bucket)
+      val metadata = ResourceMetadata.readResources(metadataObject.getObjectContent)
+      repoFolder2Metadata(folder) = RepositoryMetadata(
+        folder,
+        lastModifiedTimeInS3,
+        java.util.Date.from(java.time.Instant.now()),
+        metadata)
+      metadata
     }
   }
 
@@ -244,14 +247,6 @@ class S3ResourceDownloader(
           fileSystem.delete(unzippedFile, true)
       }
     }
-  }
-
-  private def getTimestamp(addMinutes: Int = 0): Timestamp = {
-    val cal = Calendar.getInstance()
-    cal.add(Calendar.MINUTE, addMinutes)
-    val timestamp = new Timestamp(cal.getTime.getTime)
-    cal.clear()
-    timestamp
   }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
issue --> https://github.com/JohnSnowLabs/spark-nlp/issues/14221
Cache mechanism implementation for metadata.json. 
Nowadays, metadata.json is more than 10MB and it will increase in the future.
## Description
<!--- Describe your changes in detail -->
The main logic is here: 
1 - gets3Object that includes getLastModified() (just contains a summary, do not download the whole metadata.json file.)
2- check the condition (cache contains up-to-date metadata)
3- If the cache contains up-to-date metadata, get it; 
Otherwise, download it, set it to the cache, and return it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
