### PR TITLE
Closed the S3 connection

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/pretrained/S3ResourceDownloader.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/pretrained/S3ResourceDownloader.scala
@@ -53,9 +53,11 @@ class S3ResourceDownloader(
     val needToRefresh =
       lastMetadataState.isEmpty || lastMetadataState.get.lastModified.before(lastModifiedTimeInS3)
     if (!needToRefresh) {
+      metadataObject.close()
       lastMetadataState.get.metadata
     } else {
       val metadata = ResourceMetadata.readResources(metadataObject.getObjectContent)
+      metadataObject.close()
       repoFolder2Metadata(folder) = RepositoryMetadata(
         folder,
         lastModifiedTimeInS3,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The main goal of this PR is to close the connection of s3.  

## Description
<!--- Describe your changes in detail -->
Releases any underlying system resources by invoking the close() method in ResourceDownloader. 
 There is a bug in spark-nlp==5.3.3, related to https://github.com/JohnSnowLabs/spark-nlp/pull/14224
When a lot of models are downloaded; 
since the connection is consumed,  
"Timeout waiting for connection from pool" error is thrown. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
 There is a bug in spark-nlp==5.3.3. This PR will solve the bug.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Locally with Python and Scala. 
Additionally, I ran some test code in the Jenkins server when using the jar I created from this branch

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
