### PR TITLE
[SPARKNLP-1052] Adding random suffix to avoid duplication in spark files

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
@@ -20,6 +20,7 @@ import ai.onnxruntime.OrtSession.SessionOptions
 import ai.onnxruntime.OrtSession.SessionOptions.{ExecutionMode, OptLevel}
 import ai.onnxruntime.providers.OrtCUDAProviderOptions
 import ai.onnxruntime.{OrtEnvironment, OrtSession}
+import com.johnsnowlabs.ml.util.LoadExternalModel
 import com.johnsnowlabs.util.{ConfigHelper, FileHelper, ZipArchiveUtil}
 import org.apache.spark.SparkFiles
 import org.apache.spark.sql.SparkSession
@@ -114,9 +115,10 @@ object OnnxWrapper {
       .toString
 
     // 2. Unpack archive
+    val randomSuffix = generateRandomSuffix(onnxFileSuffix)
     val folder =
       if (zipped)
-        ZipArchiveUtil.unzip(new File(modelPath), Some(tmpFolder), onnxFileSuffix)
+        ZipArchiveUtil.unzip(new File(modelPath), Some(tmpFolder), randomSuffix)
       else
         modelPath
 
@@ -149,6 +151,11 @@ object OnnxWrapper {
     val onnxWrapper = new OnnxWrapper(onnxFileName, dataFileDirectory)
 
     onnxWrapper
+  }
+
+  private def generateRandomSuffix(fileSuffix: Option[String]): Option[String] = {
+    val randomSuffix = Some(LoadExternalModel.generateRandomString(10))
+    Some(s"${randomSuffix.get}${fileSuffix.getOrElse("")}")
   }
 
   private def mapToSessionOptionsObject(sessionOptions: Map[String, String]): SessionOptions = {

--- a/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoWrapper.scala
@@ -17,8 +17,8 @@
 package com.johnsnowlabs.ml.openvino
 
 import com.johnsnowlabs.ml.util.LoadExternalModel.notSupportedEngineError
-import com.johnsnowlabs.ml.util.{ONNX, Openvino, TensorFlow}
-import com.johnsnowlabs.util.{ConfigHelper, ConfigLoader, FileHelper, ZipArchiveUtil}
+import com.johnsnowlabs.ml.util.{LoadExternalModel, ONNX, Openvino, TensorFlow}
+import com.johnsnowlabs.util.{FileHelper, ZipArchiveUtil}
 import org.apache.commons.io.{FileUtils, FilenameUtils}
 import org.apache.spark.SparkFiles
 import org.apache.spark.sql.SparkSession
@@ -113,9 +113,10 @@ object OpenvinoWrapper {
       .toAbsolutePath
       .toString
 
+    val randomSuffix = generateRandomSuffix(ovFileSuffix)
     val folder =
       if (zipped)
-        ZipArchiveUtil.unzip(new File(modelPath), Some(tmpFolder), ovFileSuffix)
+        ZipArchiveUtil.unzip(new File(modelPath), Some(tmpFolder), randomSuffix)
       else
         modelPath
 
@@ -149,6 +150,11 @@ object OpenvinoWrapper {
     openvinoWrapper.compiledModel = compiledModel
 
     openvinoWrapper
+  }
+
+  private def generateRandomSuffix(fileSuffix: Option[String]): Option[String] = {
+    val randomSuffix = Some(LoadExternalModel.generateRandomString(10))
+    Some(s"${randomSuffix.get}${fileSuffix.getOrElse("")}")
   }
 
   /** Convert the model at srcPath to OpenVINO IR Format and export to exportPath.

--- a/src/main/scala/com/johnsnowlabs/ml/util/LoadExternalModel.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/util/LoadExternalModel.scala
@@ -22,6 +22,7 @@ import com.johnsnowlabs.nlp.util.io.{ExternalResource, ReadAs, ResourceHelper}
 import java.io.File
 import java.nio.file.Paths
 import scala.io.Source
+import scala.util.Random
 
 object LoadExternalModel {
 
@@ -226,6 +227,18 @@ object LoadExternalModel {
     val f = new File(filePath, fileName)
     require(f.exists(), s"File $fileName not found in folder $filePath")
     f
+  }
+
+  /** Generates a random alphanumeric string of a given length.
+    *
+    * @param n
+    *   the length of the generated string
+    * @return
+    *   a random alphanumeric string of length n
+    */
+  def generateRandomString(n: Int): String = {
+    val alphanumeric = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    (1 to n).map(_ => alphanumeric(Random.nextInt(alphanumeric.length))).mkString
   }
 
 }

--- a/src/main/scala/com/johnsnowlabs/util/ZipArchiveUtil.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ZipArchiveUtil.scala
@@ -135,7 +135,7 @@ object ZipArchiveUtil {
 
     val zip = new ZipFile(file)
     zip.entries.asScala foreach { entry =>
-      val entryName = if (suffix.isDefined) suffix.get + "_" + entry.getName else entry.getName
+      val entryName = buildEntryName(entry, suffix)
       val entryPath = {
         if (entryName.startsWith(basename))
           entryName.substring(0, basename.length)
@@ -163,6 +163,11 @@ object ZipArchiveUtil {
     }
 
     destDir.getPath
+  }
+
+  private def buildEntryName(entry: ZipEntry, suffix: Option[String]): String = {
+    val entryName = if (suffix.isDefined) suffix.get + "_" + entry.getName else entry.getName
+    entryName.split("_").distinct.mkString("_")
   }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR addresses the issue of file duplication by adding a random suffix when using `sparkContext.addFile` for ONNX and OpenVINO models. This enhancement ensures that each file added to Spark has a unique name, preventing conflicts and improving the robustness of file handling in distributed environments.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Check [this jira](https://johnsnowlabs.atlassian.net/browse/SPARKNLP-1052) issue

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- Databricks notebooks
- Google Colab notebooks

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
