### PR TITLE
[SPARKNLP-1058] Adding aggressiveMatching parameter

### DIFF
--- a/python/sparknlp/annotator/matcher/date_matcher.py
+++ b/python/sparknlp/annotator/matcher/date_matcher.py
@@ -72,6 +72,11 @@ class DateMatcherUtils(Params):
                                    "Matched Strategy to searches relaxed dates",
                                    typeConverter=TypeConverters.toString)
 
+    aggressiveMatching = Param(Params._dummy(),
+                               "aggressiveMatching",
+                               "Whether to aggressively attempt to find date matches, even in ambiguous or less common formats",
+                               typeConverter=TypeConverters.toBoolean)
+
     def setInputFormats(self, value):
         """Sets input formats patterns to match in the documents.
 
@@ -176,6 +181,16 @@ class DateMatcherUtils(Params):
             Matched strategy to search relaxed dates by ordered rules by more exhaustive to less Strategy
         """
         return self._set(relaxedFactoryStrategy=matchStrategy)
+
+    def setAggressiveMatching(self, value):
+        """ Sets whether to aggressively attempt to find date matches, even in ambiguous or less common formats
+
+        Parameters
+        ----------
+        aggressiveMatching : Boolean
+            Whether to aggressively attempt to find date matches, even in ambiguous or less common formats
+        """
+        return self._set(aggressiveMatching=value)
 
 
 class DateMatcher(AnnotatorModel, DateMatcherUtils):

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcher.scala
@@ -164,12 +164,15 @@ class DateMatcher(override val uid: String)
     def inputFormatsAreDefined = !getInputFormats.sameElements(EMPTY_INIT_ARRAY)
 
     val possibleDate: Option[MatchedDateTime] =
-      if (inputFormatsAreDefined)
-        runInputFormatsSearch(_text)
-      else
-        runDateExtractorChain(_text)
+      if (inputFormatsAreDefined) runInputFormatsSearch(_text) else runDateExtractorChain(_text)
 
-    possibleDate.orElse(setTimeIfAny(possibleDate, _text))
+    if (getAggressiveMatching) {
+      possibleDate
+        .orElse(runDateExtractorChain(_text))
+        .orElse(setTimeIfAny(possibleDate, _text))
+    } else {
+      possibleDate.orElse(setTimeIfAny(possibleDate, _text))
+    }
   }
 
   private def runDateExtractorChain(_text: String) = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/DateMatcherUtils.scala
@@ -275,6 +275,28 @@ trait DateMatcherUtils extends Params {
     */
   def getRelaxedFactoryStrategy: String = $(relaxedFactoryStrategy)
 
+  /** Whether to aggressively attempt to find date matches, even in ambiguous or less common
+    * formats (Default: `false`)
+    *
+    * @group param
+    */
+  val aggressiveMatching: BooleanParam = new BooleanParam(
+    this,
+    "aggressiveMatching",
+    "Whether to aggressively attempt to find date matches, even in ambiguous or less common formats")
+
+  /** To set aggressive matching Strategy
+    *
+    * @group param
+    */
+  def setAggressiveMatching(value: Boolean): this.type = set(aggressiveMatching, value)
+
+  /** To get aggressive matching Strategy
+    *
+    * @group param
+    */
+  def getAggressiveMatching: Boolean = $(aggressiveMatching)
+
   setDefault(
     inputFormats -> Array(""),
     outputFormat -> "yyyy/MM/dd",
@@ -284,7 +306,8 @@ trait DateMatcherUtils extends Params {
     readMonthFirst -> true,
     defaultDayWhenMissing -> 1,
     sourceLanguage -> "en",
-    relaxedFactoryStrategy -> MatchStrategy.MATCH_FIRST.toString)
+    relaxedFactoryStrategy -> MatchStrategy.MATCH_FIRST.toString,
+    aggressiveMatching -> false)
 
   protected val formalFactoryInputFormats = new RuleFactory(MatchStrategy.MATCH_ALL)
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/MultiDateMatcher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/MultiDateMatcher.scala
@@ -194,7 +194,9 @@ class MultiDateMatcher(override val uid: String)
       else
         runDateExtractorChain(_text)
 
-    possibleDates
+    if (getAggressiveMatching && possibleDates.isEmpty) {
+      runDateExtractorChain(_text)
+    } else possibleDates
   }
 
   private def extractRelativeDateFuture(text: String): Seq[MatchedDateTime] = {

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/MultiDateMatcherMultiLanguageTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/MultiDateMatcherMultiLanguageTestSpec.scala
@@ -479,4 +479,33 @@ class MultiDateMatcherMultiLanguageTestSpec extends AnyFlatSpec with DateMatcher
     assert(results.contains(getOneDayAgoDate()) && results.contains(getInTwoWeeksDate()))
   }
 
+  "a DataMatcher" should "make a more forceful or proactive approach in finding dates when aggressive match is set" in {
+
+    val data = DataBuilder.basicDataBuild(
+      "See you on next monday.",
+      "I was born at 01/03/98",
+      "She was born on 02/03/1966.",
+      "The project started yesterday and will finish next year.",
+      "She will graduate by July 2023.",
+      "She will visit doctor tomorrow and next month again.")
+
+    val multiDate = new MultiDateMatcher()
+      .setInputCols(Array("document"))
+      .setReadMonthFirst(false)
+      .setOutputCol("multi_date")
+      .setInputFormats(Array("dd/MM/yyyy"))
+      .setOutputFormat("dd/MM/yyyy")
+      .setAggressiveMatching(true)
+
+    val pipeline = new Pipeline().setStages(Array(multiDate))
+
+    val annotated = pipeline.fit(data).transform(data)
+    val collectResult = annotated.select("multi_date").collect()
+
+    collectResult.foreach { result =>
+      val annotations = Annotation.getAnnotations(result, "multi_date")
+      assert(annotations.nonEmpty)
+    }
+  }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adding `aggressiveMatching` parameter to find dates even in ambiguous or less common formats. This will instruct the annotator to execute `runDateExtractorChain` method for empty outputs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See issue #14100

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

- Local Test
- Google Colab [notebook](https://colab.research.google.com/drive/1993b8yfvLlpg7hZysAFDp1kI8mVa-BYV?usp=sharing)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
