### PR TITLE
[SPARKNLP-1059] Adding aggressiveMatching parameter to DocumentSimilarityRanker

### DIFF
--- a/examples/python/annotation/text/english/text-similarity/doc-sim-ranker/test_doc_sim_ranker.ipynb
+++ b/examples/python/annotation/text/english/text-similarity/doc-sim-ranker/test_doc_sim_ranker.ipynb
@@ -1,7 +1,16 @@
 {
  "cells": [
   {
-   "attachments": {},
+   "cell_type": "markdown",
+   "id": "fd8eb60e",
+   "metadata": {},
+   "source": [
+    "![JohnSnowLabs](https://sparknlp.org/assets/images/logo.png)\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-similarity/doc-sim-rankerDocumentCharacterTextSplitter.ipynb)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "c3dc7ce5",
    "metadata": {},
@@ -30,19 +39,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create the PySpark session\n",
-    "from pyspark.sql import SparkSession\n",
-    "\n",
-    "spark = (SparkSession.builder\n",
-    "    .appName(\"Spark NLP\")\n",
-    "    .master(\"local[*]\")\n",
-    "    .config(\"spark.driver.memory\",\"16G\")\n",
-    "    .config(\"spark.driver.maxResultSize\", \"0\") \n",
-    "    .config(\"spark.kryoserializer.buffer.max\", \"2000M\")\n",
-    "    .config(\"spark.driver.bindAddress\", \"127.0.0.1\")\n",
-    "    .config(\"spark.jars.packages\", \"com.johnsnowlabs.nlp:spark-nlp_2.12:5.0.0\")\n",
-    "    .getOrCreate()\n",
-    ")"
+    "import sparknlp\n",
+    "# let's start Spark with Spark NLP\n",
+    "spark = sparknlp.start()"
    ]
   },
   {
@@ -106,7 +105,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "945e787d",
    "metadata": {},
@@ -123,7 +121,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d4d2bd1d",
    "metadata": {},
@@ -136,11 +133,15 @@
     "- setBucketLength(2.0) : LSH parameter used to control the average size of hash buckets and improve recall\n",
     "- setNumHashTables(3) : LSH parameter used to control number of hash tables used in LSH OR-amplification and improve recall\n",
     "- setVisibleDistances(True) : this setter will make distances visible in the result, useful for debugging level information\n",
-    "- setIdentityRanking(False) : this setter will make identity distance (0.0) visible, useful for debugging level information"
+    "- setIdentityRanking(False) : this setter will make identity distance (0.0) visible, useful for debugging level information\n",
+    "- setsetAggregationMethod(\"AVERAGE\"): method used to aggregate multiple sentence embeddings into a single vector\n",
+    "representation\n",
+    " - AVERAGE: This is the default it's a common approach that balances information from multiple sentences.\n",
+    " - FIRST: This can be useful if the first sentence is representative or if computational efficiency is a priority.\n",
+    " - MAX: Compute the element-wise maximum across all sentence embeddings, which can capture the most informative features from each dimension."
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0b36d5cd",
    "metadata": {},
@@ -153,7 +154,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "bf5f3564",
    "metadata": {},
@@ -283,7 +283,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "54eca293",
    "metadata": {},
@@ -326,7 +325,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2d5145eb",
    "metadata": {},
@@ -442,7 +440,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/python/sparknlp/annotator/similarity/document_similarity_ranker.py
+++ b/python/sparknlp/annotator/similarity/document_similarity_ranker.py
@@ -158,6 +158,12 @@ class DocumentSimilarityRankerApproach(AnnotatorApproach, HasEnableCachingProper
                              "(Default: `empty`)",
                              typeConverter=TypeConverters.toString)
 
+    aggregationMethod = Param(Params._dummy(),
+                              "aggregationMethod",
+                              "Specifies the method used to aggregate multiple sentence embeddings into a single vector representation.",
+                              typeConverter=TypeConverters.toString)
+
+
     def setSimilarityMethod(self, value):
         """Sets the similarity method used to calculate the neighbours.
             (Default: `"brp"`, Bucketed Random Projection for Euclidean Distance)
@@ -232,6 +238,22 @@ class DocumentSimilarityRankerApproach(AnnotatorApproach, HasEnableCachingProper
              the query to use to select nearest neighbors in the retrieval process.
         """
         return self._set(asRetrieverQuery=value)
+
+    def setAggregationMethod(self, value):
+        """Set the method used to aggregate multiple sentence embeddings into a single vector
+           representation.
+
+        Parameters
+        ----------
+        value : str
+           Options include
+            'AVERAGE' (compute the mean of all embeddings),
+            'FIRST' (use the first embedding only),
+            'MAX' (compute the element-wise maximum across embeddings)
+
+           Default ('AVERAGE')
+        """
+        return self._set(aggregationMethod=value)
 
     @keyword_only
     def __init__(self):

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/DocumentSimilarityRankerApproach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/DocumentSimilarityRankerApproach.scala
@@ -1,17 +1,16 @@
 package com.johnsnowlabs.nlp.annotators.similarity
 
 import com.johnsnowlabs.nlp.AnnotatorType.{DOC_SIMILARITY_RANKINGS, SENTENCE_EMBEDDINGS}
+import com.johnsnowlabs.nlp.annotators.similarity.DocumentSimilarityUtil._
 import com.johnsnowlabs.nlp.{AnnotatorApproach, HasEnableCachingProperties}
+import com.johnsnowlabs.util.spark.SparkUtil.retrieveColumnName
 import org.apache.spark.ml.PipelineModel
 import org.apache.spark.ml.feature.{BucketedRandomProjectionLSH, MinHashLSH}
-import org.apache.spark.ml.functions.array_to_vector
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.ml.param.{BooleanParam, Param}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
-import org.apache.spark.sql.functions.{col, flatten, udf}
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{DataFrame, Dataset}
-
-import scala.util.hashing.MurmurHash3
 
 sealed trait NeighborAnnotation {
   def neighbors: Array[_]
@@ -152,8 +151,6 @@ class DocumentSimilarityRankerApproach(override val uid: String)
 
   val DISTANCE = "distCol"
 
-  val INPUT_EMBEDDINGS = "sentence_embeddings.embeddings"
-
   val TEXT = "text"
 
   /** The similarity method used to calculate the neighbours. (Default: `"brp"`, Bucketed Random
@@ -233,6 +230,38 @@ class DocumentSimilarityRankerApproach(override val uid: String)
 
   def getAsRetrieverQuery: String = $(asRetrieverQuery)
 
+  /** Specifies the method used to aggregate multiple sentence embeddings into a single vector
+    * representation. Options include 'AVERAGE' (compute the mean of all embeddings),
+    * 'FIRST' (use the first embedding only), 'MAX' (compute the element-wise maximum across embeddings)
+    *
+    * Default AVERAGE
+    *
+    * @group param
+    */
+  val aggregationMethod = new Param[String](
+    this,
+    "aggregationMethod",
+    "Specifies the method used to aggregate multiple sentence embeddings into a single vector representation.")
+
+  /** Set the method used to aggregate multiple sentence embeddings into a single vector
+    * representation. Options include 'AVERAGE' (compute the mean of all embeddings), 'FIRST' (use
+    * the first embedding only), 'MAX' (compute the element-wise maximum across embeddings)
+    *
+    * Default AVERAGE
+    *
+    * @group param
+    */
+  def setAggregationMethod(strategy: String): this.type = {
+    strategy.toLowerCase() match {
+      case "average" => set(aggregationMethod, "AVERAGE")
+      case "first" => set(aggregationMethod, "FIRST")
+      case "max" => set(aggregationMethod, "MAX")
+      case _ => throw new MatchError("aggregationMethod must be AVERAGE, FIRST or MAX")
+    }
+  }
+
+  def getAggregationMethod: String = $(aggregationMethod)
+
   setDefault(
     similarityMethod -> "brp",
     numberOfNeighbours -> 10,
@@ -240,7 +269,8 @@ class DocumentSimilarityRankerApproach(override val uid: String)
     numHashTables -> 3,
     visibleDistances -> false,
     identityRanking -> false,
-    asRetrieverQuery -> "")
+    asRetrieverQuery -> "",
+    aggregationMethod -> "AVERAGE")
 
   def getNeighborsResultSet(
       query: (Int, Vector),
@@ -300,11 +330,22 @@ class DocumentSimilarityRankerApproach(override val uid: String)
       embeddingsDataset: Dataset[_],
       recursivePipeline: Option[PipelineModel]): DocumentSimilarityRankerModel = {
 
-    val similarityDataset: DataFrame = embeddingsDataset
-      .withColumn(s"$LSH_INPUT_COL_NAME", array_to_vector(flatten(col(INPUT_EMBEDDINGS))))
+    val inputEmbeddingsColumn =
+      s"${retrieveColumnName(embeddingsDataset, SENTENCE_EMBEDDINGS)}.embeddings"
 
-    val mh3Func = (s: String) => MurmurHash3.stringHash(s, MurmurHash3.stringSeed)
-    val mh3UDF = udf { mh3Func }
+    val similarityDataset: DataFrame = getAggregationMethod match {
+      case "AVERAGE" =>
+        embeddingsDataset
+          .withColumn(s"$LSH_INPUT_COL_NAME", averageAggregation(col(inputEmbeddingsColumn)))
+      case "FIRST" =>
+        embeddingsDataset
+          .withColumn(
+            s"$LSH_INPUT_COL_NAME",
+            firstEmbeddingAggregation(col(inputEmbeddingsColumn)))
+      case "MAX" =>
+        embeddingsDataset
+          .withColumn(s"$LSH_INPUT_COL_NAME", maxAggregation(col(inputEmbeddingsColumn)))
+    }
 
     val similarityDatasetWithHashIndex =
       similarityDataset.withColumn(INDEX_COL_NAME, mh3UDF(col(TEXT)))

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/DocumentSimilarityUtil.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/DocumentSimilarityUtil.scala
@@ -1,0 +1,29 @@
+package com.johnsnowlabs.nlp.annotators.similarity
+
+import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.sql.expressions.UserDefinedFunction
+
+import scala.util.hashing.MurmurHash3
+
+object DocumentSimilarityUtil {
+
+  import org.apache.spark.sql.functions._
+
+  val mh3Func: String => Int = (s: String) => MurmurHash3.stringHash(s, MurmurHash3.stringSeed)
+  val mh3UDF: UserDefinedFunction = udf { mh3Func }
+
+  val averageAggregation: UserDefinedFunction = udf((embeddings: Seq[Seq[Double]]) => {
+    val summed = embeddings.transpose.map(_.sum)
+    val averaged = summed.map(_ / embeddings.length)
+    Vectors.dense(averaged.toArray)
+  })
+
+  val firstEmbeddingAggregation: UserDefinedFunction = udf((embeddings: Seq[Seq[Double]]) => {
+    Vectors.dense(embeddings.head.toArray)
+  })
+
+  val maxAggregation: UserDefinedFunction = udf((embeddings: Seq[Seq[Double]]) => {
+    Vectors.dense(embeddings.transpose.map(_.max).toArray)
+  })
+
+}

--- a/src/main/scala/com/johnsnowlabs/util/spark/SparkUtil.scala
+++ b/src/main/scala/com/johnsnowlabs/util/spark/SparkUtil.scala
@@ -1,13 +1,16 @@
 package com.johnsnowlabs.util.spark
 
-import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.Dataset
 
 object SparkUtil {
 
-  // Helper UDF function to flatten arrays for Spark < 2.4.0
-  def flattenArrays: UserDefinedFunction = udf { (arrayColumn: Seq[Seq[String]]) =>
-    arrayColumn.flatten.distinct
+  def retrieveColumnName(dataset: Dataset[_], annotatorType: String): String = {
+    val structFields = dataset.schema.fields
+      .filter(field => field.metadata.contains("annotatorType"))
+      .filter(field => field.metadata.getString("annotatorType") == annotatorType)
+    val columnNames = structFields.map(structField => structField.name)
+
+    columnNames.head
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/SparkSessionTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/SparkSessionTest.scala
@@ -35,8 +35,6 @@ trait SparkSessionTest extends BeforeAndAfterAll { this: Suite =>
   val emptyDataSet: Dataset[_] = PipelineModels.dummyDataset
   val pipeline = new Pipeline()
 
-  println(s"Spark version: ${spark.version}")
-
   override def beforeAll(): Unit = {
     super.beforeAll()
 

--- a/src/test/scala/com/johnsnowlabs/nlp/similarity/DocumentSimilarityRankerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/similarity/DocumentSimilarityRankerTestSpec.scala
@@ -6,7 +6,11 @@ import com.johnsnowlabs.nlp.annotators.Tokenizer
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.annotators.similarity.DocumentSimilarityRankerApproach
 import com.johnsnowlabs.nlp.base.DocumentAssembler
-import com.johnsnowlabs.nlp.embeddings.{AlbertEmbeddings, SentenceEmbeddings}
+import com.johnsnowlabs.nlp.embeddings.{
+  AlbertEmbeddings,
+  BertSentenceEmbeddings,
+  SentenceEmbeddings
+}
 import com.johnsnowlabs.nlp.finisher.DocumentSimilarityRankerFinisher
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.tags.SlowTest
@@ -302,4 +306,124 @@ class DocumentSimilarityRankerTestSpec extends AnyFlatSpec {
     assert(transformed.columns.contains("nearest_neighbor_id"))
     assert(transformed.columns.contains("nearest_neighbor_distance"))
   }
+
+  it should "work when setting aggregation method" taggedAs SlowTest in {
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentenceDetector = new SentenceDetector()
+      .setInputCols("document")
+      .setOutputCol("sentence")
+
+    val embeddings = BertSentenceEmbeddings
+      .pretrained("sent_biobert_clinical_base_cased", "en")
+      .setInputCols("sentence")
+      .setOutputCol("sentence_embeddings")
+
+    val document_similarity_ranker = new DocumentSimilarityRankerApproach()
+      .setInputCols("sentence_embeddings")
+      .setOutputCol("doc_similarity_rankings")
+      .setSimilarityMethod("brp")
+      .setNumberOfNeighbours(1)
+      .setBucketLength(2.0)
+      .setNumHashTables(3)
+      .setVisibleDistances(true)
+      .setIdentityRanking(false)
+      .setAggregationMethod("MAX")
+
+    val document_similarity_ranker_finisher = new DocumentSimilarityRankerFinisher()
+      .setInputCols("doc_similarity_rankings")
+      .setOutputCols(
+        "finished_doc_similarity_rankings_id",
+        "finished_doc_similarity_rankings_neighbors")
+      .setExtractNearestNeighbor(true)
+
+    val pipeline = new Pipeline()
+      .setStages(
+        Array(
+          documentAssembler,
+          sentenceDetector,
+          embeddings,
+          document_similarity_ranker,
+          document_similarity_ranker_finisher))
+
+    val transformed = pipeline.fit(smallCorpus).transform(smallCorpus)
+
+    transformed
+      .select(
+        "doc_similarity_rankings",
+        "finished_doc_similarity_rankings_id",
+        "finished_doc_similarity_rankings_neighbors")
+      .show(10, false)
+  }
+
+  "Pipeline" should "should not fail if I use the outputCol and inputCols feature" taggedAs SlowTest in {
+    val nbOfNeighbors = 3
+
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentence = new SentenceDetector()
+      .setInputCols("document")
+      .setOutputCol("sentence")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val embeddings = AlbertEmbeddings
+      .pretrained()
+      .setInputCols("sentence", "token")
+      .setOutputCol("embeddings")
+
+    val embeddingsSentence = new SentenceEmbeddings()
+      .setInputCols(Array("document", "embeddings"))
+      .setOutputCol("my_sentence_emb")
+      .setPoolingStrategy("AVERAGE")
+
+    val sentenceFinisher = new EmbeddingsFinisher()
+      .setInputCols("my_sentence_emb")
+      .setOutputCols("finished_sentence_embeddings")
+      .setCleanAnnotations(false)
+
+    val query = "Fifth document, Florence in Italy, is among the most beautiful cities in Europe."
+
+    val docSimilarityRanker = new DocumentSimilarityRankerApproach()
+      .setInputCols("my_sentence_emb")
+      .setOutputCol(DOC_SIMILARITY_RANKINGS)
+      .setSimilarityMethod("brp")
+      .setNumberOfNeighbours(nbOfNeighbors)
+      .setVisibleDistances(true)
+      .setIdentityRanking(true)
+      .asRetriever(query)
+
+    val documentSimilarityFinisher = new DocumentSimilarityRankerFinisher()
+      .setInputCols("doc_similarity_rankings")
+      .setOutputCols(
+        "finished_doc_similarity_rankings_id",
+        "finished_doc_similarity_rankings_neighbors")
+
+    val pipeline = new Pipeline()
+      .setStages(
+        Array(
+          documentAssembler,
+          sentence,
+          tokenizer,
+          embeddings,
+          embeddingsSentence,
+          sentenceFinisher,
+          docSimilarityRanker,
+          documentSimilarityFinisher))
+
+    val transformed = pipeline.fit(smallCorpus).transform(smallCorpus)
+
+    transformed.show(false)
+
+    assert(transformed.count() === 3)
+    assert(transformed.columns.contains("nearest_neighbor_id"))
+    assert(transformed.columns.contains("nearest_neighbor_distance"))
+  }
+
 }

--- a/src/test/scala/com/johnsnowlabs/util/SparkUtilTest.scala
+++ b/src/test/scala/com/johnsnowlabs/util/SparkUtilTest.scala
@@ -1,0 +1,36 @@
+package com.johnsnowlabs.util
+
+import com.johnsnowlabs.nlp.AnnotatorType.{DOCUMENT, TOKEN}
+import com.johnsnowlabs.nlp.annotator.SentenceDetector
+import com.johnsnowlabs.nlp.annotators.{SparkSessionTest, Tokenizer}
+import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.util.spark.SparkUtil
+import org.apache.spark.ml.Pipeline
+import org.scalatest.flatspec.AnyFlatSpec
+
+class SparkUtilTest extends AnyFlatSpec with SparkSessionTest {
+
+  "SparkUtil" should "retrieve column name for Token annotator type " taggedAs FastTest in {
+    val expectedColumn = "token"
+    val testDataset = tokenizerPipeline.fit(emptyDataSet).transform(emptyDataSet)
+
+    val actualColumn = SparkUtil.retrieveColumnName(testDataset, TOKEN)
+
+    assert(expectedColumn == actualColumn)
+  }
+
+  it should "retrieve custom column name for Token annotator type " taggedAs FastTest in {
+    val customColumnName = "my_custom_token_col"
+    val tokenizer = new Tokenizer()
+      .setInputCols("document")
+      .setOutputCol(customColumnName)
+
+    val pipeline = new Pipeline().setStages(Array(documentAssembler, tokenizer))
+    val testDataset = pipeline.fit(emptyDataSet).transform(emptyDataSet)
+
+    val actualColumn = SparkUtil.retrieveColumnName(testDataset, TOKEN)
+
+    assert(customColumnName == actualColumn)
+  }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request introduces the `aggregationMethod` parameter to the `DocumentSimilarityRanker` annotator. The new parameter allows users to specify the method used to aggregate multiple sentence embeddings into a single vector representation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows users to tailor the aggregation method to their specific use case, whether they need a general overview (AVERAGE), focus on the initial context (FIRST), or emphasize the strongest signals (MAX).

This change solves the following issues:

- Issue #14368
- Issue #14195 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- Local Tests
- Google Colab notebook

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
