### PR TITLE
Fix pretrained models not being found on dbfs systems

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFModel.scala
@@ -235,25 +235,8 @@ trait ReadAutoGGUFModel {
   this: ParamsAndFeaturesReadable[AutoGGUFModel] =>
 
   def readModel(instance: AutoGGUFModel, path: String, spark: SparkSession): Unit = {
-    def findGGUFModelInFolder(): String = {
-      val folder =
-        new java.io.File(
-          path.replace("file:", "")
-        ) // File should be local at this point. TODO: Except if its HDFS?
-      if (folder.exists && folder.isDirectory) {
-        folder.listFiles
-          .filter(_.isFile)
-          .filter(_.getName.endsWith(".gguf"))
-          .map(_.getAbsolutePath)
-          .headOption // Should only be one file
-          .getOrElse(throw new IllegalArgumentException(s"Could not find GGUF model in $path"))
-      } else {
-        throw new IllegalArgumentException(s"Path $path is not a directory")
-      }
-    }
-
-    val model = AutoGGUFModel.loadSavedModel(findGGUFModelInFolder(), spark)
-    instance.setModelIfNotSet(spark, model.getModelIfNotSet)
+    val model: GGUFWrapper = GGUFWrapper.readModel(path, spark)
+    instance.setModelIfNotSet(spark, model)
   }
 
   addReader(readModel)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes a a bug with loading pretrained models, when running AutoGGUF model pipelines from Databricks. 

This is due to an issue, with how paths are handled when loading the gguf file. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests are passing on databricks.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
