### PR TITLE
Addition chunk metadata to ChunkEmbeddings output

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddings.scala
@@ -260,7 +260,7 @@ class ChunkEmbeddings(override val uid: String)
               begin = chunk.begin,
               end = chunk.end,
               result = chunk.result,
-              metadata = Map(
+              metadata = chunk.metadata ++ Map(
                 "sentence" -> sentenceIdx.toString,
                 "chunk" -> chunkIdx.toString,
                 "token" -> chunk.result,

--- a/src/test/scala/com/johnsnowlabs/nlp/AnnotationUtils.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/AnnotationUtils.scala
@@ -1,0 +1,46 @@
+package com.johnsnowlabs.nlp
+
+import com.johnsnowlabs.nlp.AnnotatorType.DOCUMENT
+import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Row}
+
+object AnnotationUtils {
+
+  private lazy val spark = SparkAccessor.spark
+
+  implicit class AnnotationRow(annotation: Annotation) {
+
+    def toRow(): Row = {
+      Row(
+        annotation.annotatorType,
+        annotation.begin,
+        annotation.end,
+        annotation.result,
+        annotation.metadata,
+        annotation.embeddings)
+    }
+  }
+
+  implicit class DocumentRow(s: String) {
+    def toRow(metadata: Map[String, String] = Map("sentence" -> "0")): Row = {
+      Row(Seq(Annotation(DOCUMENT, 0, s.length, s, metadata).toRow()))
+    }
+  }
+
+  /** Create a DataFrame with the given column name, annotator type and annotations row Output
+    * column will be compatible with the Spark NLP annotators
+    */
+  def createAnnotatorDataframe(
+      columnName: String,
+      annotatorType: String,
+      annotationsRow: Row): DataFrame = {
+    val metadataBuilder: MetadataBuilder = new MetadataBuilder()
+    metadataBuilder.putString("annotatorType", annotatorType)
+    val documentField =
+      StructField(columnName, Annotation.arrayType, nullable = false, metadataBuilder.build)
+    val struct = StructType(Array(documentField))
+    val rdd = spark.sparkContext.parallelize(Seq(annotationsRow))
+    spark.createDataFrame(rdd, struct)
+  }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Addition chunk metadata to ChunkEmbeddings output
## Description
<!--- Describe your changes in detail -->
Previously, ChunkEmbeddings would lose the data in the chunk's original metadata in the output. This PR will continue to keep that metadata in the result.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When chunks are found by NERs, we get the entity information like {"entity": "NAME"}. Losing this information makes the result of ChunkEmbeddings unusable. I am thinking of writing a new annotator that takes the result of ChunkEmbeddings as input.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I wrote a solid unit test and added a helper unit test class named AnnotationUtils.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
