### PR TITLE
[SPARKNLP-1096] Adding support to Microsoft Fabric for WordEmbeddings

### DIFF
--- a/src/main/scala/com/johnsnowlabs/storage/RocksDBConnection.scala
+++ b/src/main/scala/com/johnsnowlabs/storage/RocksDBConnection.scala
@@ -43,9 +43,11 @@ final class RocksDBConnection private (path: String) extends AutoCloseable {
 
   def findLocalIndex: String = {
     val tmpIndexStorageLocalPath = RocksDBConnection.getTmpIndexStorageLocalPath(path)
-    if (new File(tmpIndexStorageLocalPath).exists()) {
+    val tmpIndexStorageLocalPathExists = new File(tmpIndexStorageLocalPath).exists()
+    val pathExist = new File(path.stripPrefix("file:")).exists()
+    if (tmpIndexStorageLocalPathExists) {
       tmpIndexStorageLocalPath
-    } else if (new File(path).exists()) {
+    } else if (pathExist) {
       path
     } else {
       val localFromClusterPath = SparkFiles.get(path)

--- a/src/main/scala/com/johnsnowlabs/util/Version.scala
+++ b/src/main/scala/com/johnsnowlabs/util/Version.scala
@@ -48,9 +48,10 @@ object Version {
   def parse(str: String): Version = {
     val parts = str
       .replaceAll("-rc\\d", "")
-      .split('.')
+      .split("[.-]")
       .takeWhile(p => isInteger(p))
       .map(p => p.toInt)
+      .take(3)
       .toList
 
     Version(parts)

--- a/src/test/scala/com/johnsnowlabs/nlp/util/VersionTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/util/VersionTest.scala
@@ -16,13 +16,14 @@
 
 package com.johnsnowlabs.nlp.util
 
+import com.johnsnowlabs.tags.FastTest
 import com.johnsnowlabs.util.Version
 import org.junit.Assert.{assertFalse, assertTrue}
 import org.scalatest.flatspec.AnyFlatSpec
 
 class VersionTest extends AnyFlatSpec {
 
-  "Version" should "cast to float version of 1 digit" in {
+  "Version" should "cast to float version of 1 digit" taggedAs FastTest in {
 
     val actualVersion1 = Version(1).toFloat
     val actualVersion15 = Version(15).toFloat
@@ -32,7 +33,7 @@ class VersionTest extends AnyFlatSpec {
 
   }
 
-  it should "cast to float version of 2 digits" in {
+  it should "cast to float version of 2 digits" taggedAs FastTest in {
     val actualVersion1_2 = Version(List(1, 2)).toFloat
     val actualVersion2_7 = Version(List(2, 7)).toFloat
 
@@ -40,7 +41,7 @@ class VersionTest extends AnyFlatSpec {
     assert(actualVersion2_7 == 2.7f)
   }
 
-  it should "cast to float version of 3 digits" in {
+  it should "cast to float version of 3 digits" taggedAs FastTest in {
     val actualVersion1_2_5 = Version(List(1, 2, 5)).toFloat
     val actualVersion3_2_0 = Version(List(3, 2, 0)).toFloat
     val actualVersion2_0_6 = Version(List(2, 0, 6)).toFloat
@@ -50,13 +51,13 @@ class VersionTest extends AnyFlatSpec {
     assert(actualVersion2_0_6 == 2.06f)
   }
 
-  it should "raise error when casting to float version > 3 digits" in {
+  it should "raise error when casting to float version > 3 digits" taggedAs FastTest in {
     assertThrows[UnsupportedOperationException] {
       Version(List(3, 0, 2, 5)).toFloat
     }
   }
 
-  it should "be compatible for latest versions" in {
+  it should "be compatible for latest versions" taggedAs FastTest in {
     var currentVersion = Version(List(1, 2, 3))
     var modelVersion = Version(List(1, 2))
 
@@ -80,7 +81,7 @@ class VersionTest extends AnyFlatSpec {
 
   }
 
-  it should "be not compatible for latest versions" in {
+  it should "be not compatible for latest versions" taggedAs FastTest in {
     var currentVersion = Version(List(1, 2))
     var modelVersion = Version(List(1, 2, 3))
 
@@ -101,6 +102,73 @@ class VersionTest extends AnyFlatSpec {
     isNotCompatible = Version.isCompatible(currentVersion, modelVersion)
 
     assertFalse(isNotCompatible)
+  }
+
+  it should "parse a version with fewer than 3 numbers" taggedAs FastTest in {
+    val someVersion = "3.2"
+    val expectedVersion = "3.2"
+    val expectedFloatVersion = 3.2f
+    val actualVersion = Version.parse(someVersion)
+
+    assert(expectedVersion == actualVersion.toString)
+    assert(expectedFloatVersion == actualVersion.toFloat)
+  }
+
+  it should "parse a version with 3 numbers" taggedAs FastTest in {
+    val someVersion = "3.4.2"
+    val expectedFloatVersion = 3.42f
+    val actualVersion = Version.parse(someVersion)
+
+    assert(someVersion == actualVersion.toString)
+    assert(expectedFloatVersion == actualVersion.toFloat)
+  }
+
+  it should "truncate a version to 3 digits when it has more than 3 digits" taggedAs FastTest in {
+    val someVersion = "3.5.1.5.4.20241007.4"
+    val expectedVersion = "3.5.1"
+    val expectedFloatVersion = 3.51f
+    val actualVersion = Version.parse(someVersion)
+
+    assert(expectedVersion == actualVersion.toString)
+    assert(expectedFloatVersion == actualVersion.toFloat)
+  }
+
+  it should "handle a version with missing parts" taggedAs FastTest in {
+    val someVersion = "3"
+    val expectedVersion = "3"
+    val expectedFloatVersion = 3.0f
+    val actualVersion = Version.parse(someVersion)
+
+    assert(expectedVersion == actualVersion.toString)
+    assert(expectedFloatVersion == actualVersion.toFloat)
+  }
+
+  it should "handle a version with 3 digits and additional suffix" taggedAs FastTest in {
+    val someVersion = "3.4.2-beta"
+    val expectedVersion = "3.4.2"
+    val expectedFloatVersion = 3.42f
+    val actualVersion = Version.parse(someVersion)
+
+    assert(expectedVersion == actualVersion.toString)
+    assert(expectedFloatVersion == actualVersion.toFloat)
+  }
+
+  it should "raise exception with non-numeric and no valid parts" taggedAs FastTest in {
+    val someVersion = "alpha.beta.gamma"
+
+    assertThrows[UnsupportedOperationException] {
+      Version.parse(someVersion).toFloat
+    }
+  }
+
+  it should "handle a version with mixed numeric and non-numeric parts" taggedAs FastTest in {
+    val someVersion = "3.4-alpha.2"
+    val expectedVersion = "3.4"
+    val expectedFloatVersion = 3.4f
+    val actualVersion = Version.parse(someVersion)
+
+    assert(expectedVersion == actualVersion.toString)
+    assert(expectedFloatVersion == actualVersion.toFloat)
   }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR introduces support for Microsoft Fabric for Word Embeddings storage index. The integration allows Microsoft Fabric to leverage its capabilities for efficient and scalable storage and retrieval of word embeddings along with Spark NLP.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Enable Microsoft Fabric support for Spark NLP

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- Google Colab notebooks
- Databricks notebooks
- Microsoft Fabric notebooks

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
