### PR TITLE
Improved Error Handling for AutoGGUF models

### DIFF
--- a/examples/python/transformers/onnx/HuggingFace_ONNX_in_Spark_NLP_MPNetForQuestionAnswering.ipynb
+++ b/examples/python/transformers/onnx/HuggingFace_ONNX_in_Spark_NLP_MPNetForQuestionAnswering.ipynb
@@ -378,10 +378,10 @@
   "colab": {
    "provenance": []
   },
-  "kernelspec": ,{
+  "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"
-  }
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/examples/python/transformers/onnx/HuggingFace_ONNX_in_Spark_NLP_XlmRoBertaSentenceEmbeddings.ipynb
+++ b/examples/python/transformers/onnx/HuggingFace_ONNX_in_Spark_NLP_XlmRoBertaSentenceEmbeddings.ipynb
@@ -421,10 +421,10 @@
    "gpuType": "T4",
    "provenance": []
   },
-  "kernelspec": ,{
+  "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"
-  }
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR improves the Error handling of AutoGGUF type models, as discussed in #14530. 

There was an issue with how the error propagated to the user, resulting in an empty result dataframe. 

This is now fixed. In the case of an error on the llama.cpp side, the exception will be located in the metadata of each row (field `llamacpp_exception`).

Additionally, this PR contains some other minor fixes

- Added a `setNParallel` setter, as an alias for Spark NLPs `setBatchSize`. This controls the number of parallel decodings
- Changed the default AutoGGUFEmbedding model, so that the default download does not result in  an error.
- Some unrelated fixes with some example notebooks


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#14530

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New and old tests are passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
