### PR TITLE
[SPARKNLP-1163] Adding title chunking strategy

### DIFF
--- a/src/main/scala/com/johnsnowlabs/partition/BasicChunker.scala
+++ b/src/main/scala/com/johnsnowlabs/partition/BasicChunker.scala
@@ -19,10 +19,6 @@ import com.johnsnowlabs.reader.HTMLElement
 
 import scala.collection.mutable
 
-case class Chunk(elements: List[HTMLElement]) {
-  def length: Int = elements.map(_.content.length).sum
-}
-
 object BasicChunker {
 
   /** Splits a list of [[HTMLElement]]s into chunks constrained by a maximum number of characters.

--- a/src/main/scala/com/johnsnowlabs/partition/Chunk.scala
+++ b/src/main/scala/com/johnsnowlabs/partition/Chunk.scala
@@ -1,0 +1,7 @@
+package com.johnsnowlabs.partition
+
+import com.johnsnowlabs.reader.HTMLElement
+
+case class Chunk(elements: List[HTMLElement]) {
+  def length: Int = elements.map(_.content.length).sum
+}

--- a/src/main/scala/com/johnsnowlabs/partition/SemanticChunker.scala
+++ b/src/main/scala/com/johnsnowlabs/partition/SemanticChunker.scala
@@ -16,6 +16,7 @@
 package com.johnsnowlabs.partition
 
 import com.johnsnowlabs.partition.BasicChunker.chunkBasic
+import com.johnsnowlabs.partition.TitleChunker.chunkByTitle
 import com.johnsnowlabs.reader.HTMLElement
 import com.johnsnowlabs.reader.util.PartitionOptions.{getDefaultInt, getDefaultString}
 import org.apache.spark.sql.Row
@@ -37,6 +38,8 @@ class SemanticChunker(chunkerOptions: Map[String, String]) extends Serializable 
 
       val chunks = getChunkerStrategy match {
         case "basic" => chunkBasic(htmlElements, getMaxCharacters, getNewAfterNChars, getOverlap)
+        case "byTitle" | "by_title" =>
+          chunkByTitle(htmlElements, getMaxCharacters, getCombineTextUnderNChars, getOverlap)
         case _ =>
           throw new IllegalArgumentException(s"Unknown chunker strategy: $getChunkerStrategy")
       }
@@ -62,6 +65,13 @@ class SemanticChunker(chunkerOptions: Map[String, String]) extends Serializable 
       chunkerOptions,
       Seq("chunkingStrategy", "chunking_strategy"),
       default = "none")
+  }
+
+  private def getCombineTextUnderNChars: Int = {
+    getDefaultInt(
+      chunkerOptions,
+      Seq("combineTextUnderNChars", "combine_text_under_n_chars"),
+      default = 0)
   }
 
 }

--- a/src/main/scala/com/johnsnowlabs/partition/TitleChunker.scala
+++ b/src/main/scala/com/johnsnowlabs/partition/TitleChunker.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017-2025 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.partition
+
+import com.johnsnowlabs.reader.{ElementType, HTMLElement}
+
+import scala.collection.mutable
+
+object TitleChunker {
+
+  /**
+   * Splits a list of HTML elements into semantically grouped Chunks based on Title and Table markers.
+   *
+   * @param elements List of input HTML elements to chunk.
+   * @param maxCharacters Maximum length allowed per chunk. Longer sections are split.
+   * @param combineTextUnderNChars Threshold to merge adjacent small sections (if non-table).
+   * @param overlap Number of characters to repeat between consecutive chunks.
+   * @param newAfterNChars Soft limit to trigger new section if length exceeded, even before maxCharacters.
+   * @param overlapAll Apply overlap context between all sections, not just split chunks.
+   * @return List of Chunks partitioned by title and content heuristics.
+   */
+  def chunkByTitle(
+                    elements: List[HTMLElement],
+                    maxCharacters: Int,
+                    combineTextUnderNChars: Int = 0,
+                    overlap: Int = 0,
+                    newAfterNChars: Int = -1,
+                    overlapAll: Boolean = false): List[Chunk] = {
+
+    val softLimit = if (newAfterNChars <= 0) maxCharacters else newAfterNChars
+    val chunks = mutable.ListBuffer.empty[Chunk]
+    val sections = mutable.ListBuffer.empty[List[HTMLElement]]
+    var currentSection = List.empty[HTMLElement]
+    var currentLength = 0
+    var currentPage = -1
+
+    for (element <- elements) {
+      val elementLength = element.content.length
+      val isTable = element.elementType == "Table"
+      val elementPage = element.metadata.getOrElse("pageNumber", "-1").toInt
+
+      val pageChanged = currentPage != -1 && elementPage != currentPage
+      val softLimitExceeded = currentSection.length >= 2 &&
+        (currentLength + elementLength > softLimit)
+
+      if (isTable) {
+        if (currentSection.nonEmpty) sections += currentSection
+        sections += List(element)
+        currentSection = List.empty
+        currentLength = 0
+        currentPage = -1
+      } else if (pageChanged || softLimitExceeded) {
+        if (currentSection.nonEmpty) sections += currentSection
+        currentSection = List(element)
+        currentLength = elementLength
+        currentPage = elementPage
+      } else {
+        currentSection :+= element
+        currentLength += elementLength
+        currentPage = elementPage
+      }
+    }
+    if (currentSection.nonEmpty) sections += currentSection
+
+    val mergedSections = sections.foldLeft(List.empty[List[HTMLElement]]) { (acc, section) =>
+      val sectionLength = section.map(_.content.length).sum
+      val canMerge = combineTextUnderNChars > 0 &&
+        sectionLength < combineTextUnderNChars &&
+        acc.nonEmpty &&
+        acc.last.exists(_.elementType != "Table") &&
+        section.exists(_.elementType != "Table")
+
+      if (canMerge) {
+        acc.init :+ (acc.last ++ section)
+      } else {
+        acc :+ section
+      }
+    }
+
+    var lastNarrativeText = ""
+    for (section <- mergedSections) {
+      if (section.exists(_.elementType == "Table")) {
+        chunks += Chunk(section)
+        lastNarrativeText = ""
+      } else {
+        val sectionText = section.map(_.content).mkString(" ")
+        val content =
+          if (overlap > 0 && lastNarrativeText.nonEmpty && (overlapAll || sectionText.length > maxCharacters))
+            lastNarrativeText.takeRight(overlap) + " " + sectionText
+          else sectionText
+
+        val merged = HTMLElement(ElementType.NARRATIVE_TEXT, content.trim, section.head.metadata)
+        val split = if (content.length > maxCharacters) {
+          splitHTMLElement(merged, maxCharacters, overlap)
+        } else List(merged)
+
+        chunks ++= split.map(e => Chunk(List(e)))
+        lastNarrativeText = sectionText
+      }
+    }
+
+    chunks.toList
+  }
+
+  private def splitHTMLElement(
+                                element: HTMLElement,
+                                maxLen: Int,
+                                overlap: Int): List[HTMLElement] = {
+
+    val words = element.content.split(" ")
+    val buffer = mutable.ListBuffer.empty[HTMLElement]
+    var chunk = new StringBuilder
+
+    for (word <- words) {
+      if (chunk.length + word.length + 1 > maxLen) {
+        val text = chunk.toString().trim
+        buffer += element.copy(content = text)
+        chunk = new StringBuilder
+        if (overlap > 0 && text.length >= overlap)
+          chunk.append(text.takeRight(overlap)).append(" ")
+      }
+      chunk.append(word).append(" ")
+    }
+
+    if (chunk.nonEmpty)
+      buffer += element.copy(content = chunk.toString().trim)
+
+    buffer.toList
+  }
+
+}

--- a/src/test/scala/com/johnsnowlabs/partition/PartitionChunkerTest.scala
+++ b/src/test/scala/com/johnsnowlabs/partition/PartitionChunkerTest.scala
@@ -23,6 +23,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 class PartitionChunkerTest extends AnyFlatSpec {
   import ResourceHelper.spark.implicits._
   val txtDirectory = "src/test/resources/reader/txt"
+  val htmlDirectory = "src/test/resources/reader/html"
 
   "Partition" should "perform basic chunk text" taggedAs FastTest in {
     val partitionOptions = Map("contentType" -> "text/plain", "chunkingStrategy" -> "basic")
@@ -36,6 +37,19 @@ class PartitionChunkerTest extends AnyFlatSpec {
     val chunkDf = textDf.select(explode($"chunks.content"))
     chunkDf.show(truncate = false)
     assert(chunkDf.count() > 1)
+  }
+
+  it should "perform chunking by title" taggedAs FastTest in {
+    val partitionOptions = Map(
+      "contentType" -> "text/html",
+      "titleFontSize" -> "14",
+      "chunkingStrategy" -> "byTitle",
+      "combineTextUnderNChars" -> "50")
+    val textDf = Partition(partitionOptions).partition(s"$htmlDirectory/fake-html.html")
+
+    val partitionDf = textDf.select(explode($"chunks.content"))
+    partitionDf.show(truncate = false)
+    assert(partitionDf.count() == 2)
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/partition/PartitionTransformerTest.scala
+++ b/src/test/scala/com/johnsnowlabs/partition/PartitionTransformerTest.scala
@@ -29,7 +29,7 @@ class PartitionTransformerTest extends AnyFlatSpec with SparkSessionTest {
   val htmlDirectory = "src/test/resources/reader/html"
   val txtDirectory = "src/test/resources/reader/txt"
 
-  "PartitionTransformer" should "work in a RAG pipeline" taggedAs SlowTest in {
+  "PartitionTransformer" should "work in a RAG pipeline" taggedAs SlowTest ignore {
     val partition = new PartitionTransformer()
       .setInputCols("text")
       .setContentType("application/msword")

--- a/src/test/scala/com/johnsnowlabs/partition/TitleChunkerTest.scala
+++ b/src/test/scala/com/johnsnowlabs/partition/TitleChunkerTest.scala
@@ -1,0 +1,73 @@
+package com.johnsnowlabs.partition
+
+import com.johnsnowlabs.reader.HTMLElement
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.collection.mutable
+
+class TitleChunkerTest extends AnyFlatSpec {
+
+  def element(et: String, text: String, page: Int = 1): HTMLElement =
+    HTMLElement(et, text, mutable.Map("pageNumber" -> page.toString))
+
+  "chunkByTitle" should "include titles in same chunk with following text" in {
+    val elements = List(
+      element("Title", "My First Heading"),
+      element("Title", "My Second Heading"),
+      element("NarrativeText", "My first paragraph. lorem ipsum dolor set amet."),
+      element("Title", "A Third Heading")
+    )
+
+    val result = TitleChunker.chunkByTitle(elements, maxCharacters = 1000)
+
+    assert(result.length == 1)
+    val content = result.head.elements.head.content
+    assert(content.contains("My First Heading"))
+    assert(content.contains("My Second Heading"))
+  }
+
+  it should "split on soft limit newAfterNChars" in {
+    val elements = List(
+      element("Title", "Heading"),
+      element("NarrativeText", "a " * 50),
+      element("NarrativeText", "b " * 50)
+    )
+
+    val result = TitleChunker.chunkByTitle(elements, maxCharacters = 1000, newAfterNChars = 100)
+
+    assert(result.length == 2)
+  }
+
+  it should "add overlap context when overlapAll is true" in {
+    val elements = List(
+      element("Title", "Intro"),
+      element("NarrativeText", "The cow jumped over the moon. " * 5),
+      element("Title", "Next Section"),
+      element("NarrativeText", "And the dish ran away with the spoon.")
+    )
+
+    val maxCharacters = 100
+    val overlap = 10
+    val result = TitleChunker.chunkByTitle(elements, maxCharacters = maxCharacters, overlap = overlap, overlapAll = true)
+    assert(result.length >= 2)
+
+    val prevText = ("The cow jumped over the moon. " * 5).trim
+    val expectedOverlap = prevText.takeRight(overlap).trim
+    assert(result(1).elements.head.content.contains(expectedOverlap))
+  }
+
+  it should "chunk content correctly across page boundaries" in {
+    val elements = List(
+      element("Title", "Page 1 Heading"),
+      element("NarrativeText", "Text on page 1."),
+      element("Title", "Page 2 Heading", page = 2),
+      element("NarrativeText", "Text on page 2.", page = 2)
+    )
+
+    val result = TitleChunker.chunkByTitle(elements, maxCharacters = 1000)
+    assert(result.length == 2)
+    assert(result(0).elements.head.content.contains("Page 1 Heading"))
+    assert(result(1).elements.head.content.contains("Page 2 Heading"))
+  }
+
+}


### PR DESCRIPTION
<!---](url) Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR enhances Partition features by adding chunking ByTitle. This logic support more advanced chunking strategies such as:
- Soft Chunking Limit (newAfterNChars): Allows early section breaks before maxCharacters threshold.
- Contextual Overlap (overlapAll): Adds trailing context from the previous chunk to the next for better semantic continuity.
- Page Boundary Splitting: Respects pageNumber metadata and starts a new section when a page changes.
- Title Inclusion Behavior: Ensures titles are embedded within the following content instead of forming isolated chunks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
