### PR TITLE
[SPARKNLP-1291] Adding support fort input string column on readers

### DIFF
--- a/python/sparknlp/partition/partition_properties.py
+++ b/python/sparknlp/partition/partition_properties.py
@@ -18,12 +18,39 @@ from pyspark.ml.param import Param, Params, TypeConverters
 
 class HasReaderProperties(Params):
 
+    inputCol = Param(
+        Params._dummy(),
+        "inputCol",
+        "input column name",
+        typeConverter=TypeConverters.toString
+    )
+
+    def setInputCol(self, value):
+        """Sets input column name.
+
+        Parameters
+        ----------
+        value : str
+            Name of the Input Column
+        """
+        return self._set(inputCol=value)
+
     outputCol = Param(
         Params._dummy(),
         "outputCol",
         "output column name",
         typeConverter=TypeConverters.toString
     )
+
+    def setOutputCol(self, value):
+        """Sets output column name.
+
+        Parameters
+        ----------
+        value : str
+            Name of the Output Column
+        """
+        return self._set(outputCol=value)
 
     contentPath = Param(
         Params._dummy(),
@@ -683,13 +710,3 @@ class HasPdfProperties(Params):
             True to read as images, False otherwise.
         """
         return self._set(readAsImage=value)
-
-    def setOutputCol(self, value):
-        """Sets output column name.
-
-        Parameters
-        ----------
-        value : str
-            Name of the Output Column
-        """
-        return self._set(outputCol=value)

--- a/python/test/reader/reader2doc_test.py
+++ b/python/test/reader/reader2doc_test.py
@@ -112,3 +112,23 @@ class Reader2DocTestOutputAsDoc(unittest.TestCase):
         result_df = model.transform(self.empty_df)
 
         self.assertTrue(result_df.select("document").count() > 0)
+
+@pytest.mark.fast
+class Reader2DocTestInputColumn(unittest.TestCase):
+
+    def setUp(self):
+        spark = SparkContextForTest.spark
+        content = "<html><head><title>Test<title><body><p>Unclosed tag"
+        self.html_df = spark.createDataFrame([(1, content)], ["id", "html"])
+
+    def runTest(self):
+        reader2doc = Reader2Doc() \
+            .setInputCol("html") \
+            .setOutputCol("document")
+
+        pipeline = Pipeline(stages=[reader2doc])
+        model = pipeline.fit(self.html_df)
+
+        result_df = model.transform(self.html_df)
+
+        self.assertTrue(result_df.select("document").count() > 0)

--- a/python/test/reader/reader2table_test.py
+++ b/python/test/reader/reader2table_test.py
@@ -40,7 +40,6 @@ class Reader2TableTest(unittest.TestCase):
         model = pipeline.fit(self.empty_df)
 
         result_df = model.transform(self.empty_df)
-        result_df.show(truncate=False)
 
         self.assertTrue(result_df.select("document").count() > 0)
 
@@ -61,3 +60,34 @@ class Reader2TableMixedFilesTest(unittest.TestCase):
         result_df = model.transform(self.empty_df)
 
         self.assertTrue(result_df.select("document").count() > 1)
+
+@pytest.mark.fast
+class Reader2TableInputColTest(unittest.TestCase):
+
+    def setUp(self):
+        content = """
+                <html>
+                  <body>
+                    <table>
+                      <tr>
+                        <td>Hello World</td>
+                      </tr>
+                    </table>
+                  </body>
+                </html>
+                """
+        spark = SparkContextForTest.spark
+        self.html_df = spark.createDataFrame([(1, content)], ["id", "html"])
+
+    def runTest(self):
+        reader2table = Reader2Table() \
+            .setInputCol("html") \
+            .setContentType("text/html") \
+            .setOutputCol("document")
+
+        pipeline = Pipeline(stages=[reader2table])
+        model = pipeline.fit(self.html_df)
+
+        result_df = model.transform(self.html_df)
+
+        self.assertTrue(result_df.select("document").count() > 0)

--- a/src/main/scala/com/johnsnowlabs/partition/HasReaderProperties.scala
+++ b/src/main/scala/com/johnsnowlabs/partition/HasReaderProperties.scala
@@ -19,6 +19,13 @@ import org.apache.spark.ml.param.{BooleanParam, Param}
 
 trait HasReaderProperties extends HasHTMLReaderProperties {
 
+  protected final val inputCol: Param[String] =
+    new Param(this, "inputCol", "input column to process")
+
+  final def setInputCol(value: String): this.type = set(inputCol, value)
+
+  final def getInputCol: String = $(inputCol)
+
   val contentPath = new Param[String](this, "contentPath", "Path to the content source")
 
   def setContentPath(value: String): this.type = set(contentPath, value)
@@ -75,6 +82,7 @@ trait HasReaderProperties extends HasHTMLReaderProperties {
     titleFontSize -> 9,
     inferTableStructure -> false,
     includePageBreaks -> false,
-    ignoreExceptions -> true)
+    ignoreExceptions -> true,
+    inputCol -> "")
 
 }

--- a/src/main/scala/com/johnsnowlabs/reader/Reader2Table.scala
+++ b/src/main/scala/com/johnsnowlabs/reader/Reader2Table.scala
@@ -16,6 +16,7 @@
 package com.johnsnowlabs.reader
 
 import com.johnsnowlabs.nlp.Annotation
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
@@ -84,7 +85,7 @@ class Reader2Table(override val uid: String) extends Reader2Doc {
   }
 
   private def getAcceptedTypes(fileName: String): Set[String] = {
-    if (fileName.isEmpty) {
+    if (fileName == null || fileName.isEmpty) {
       val officeDocTypes = Set(
         "application/msword",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -171,9 +172,12 @@ class Reader2Table(override val uid: String) extends Reader2Doc {
   }
 
   override def validateRequiredParameters(): Unit = {
-    require(
-      $(contentPath) != null && $(contentPath).trim.nonEmpty,
-      "contentPath must be set and not empty")
+    val hasContentPath = $(contentPath) != null && $(contentPath).trim.nonEmpty
+    if (hasContentPath) {
+      require(
+        ResourceHelper.validFile($(contentPath)),
+        "contentPath must point to a valid file or directory")
+    }
     require(
       Set("html-table", "json-table").contains($(outputFormat)),
       "outputFormat must be either 'html-table' or 'json-table'.")

--- a/src/test/scala/com/johnsnowlabs/reader/Reader2DocTest.scala
+++ b/src/test/scala/com/johnsnowlabs/reader/Reader2DocTest.scala
@@ -18,6 +18,7 @@ package com.johnsnowlabs.reader
 import com.johnsnowlabs.nlp.annotators.SparkSessionTest
 import com.johnsnowlabs.nlp.{Annotation, AssertAnnotations}
 import com.johnsnowlabs.tags.{FastTest, SlowTest}
+import org.apache.hadoop.mapreduce.lib.input.InvalidInputException
 import org.apache.spark.sql.functions.col
 import org.apache.spark.ml.Pipeline
 import org.scalatest.flatspec.AnyFlatSpec
@@ -212,10 +213,10 @@ class Reader2DocTest extends AnyFlatSpec with SparkSessionTest {
     val pipeline = new Pipeline().setStages(Array(reader2Doc))
     val pipelineModel = pipeline.fit(emptyDataSet)
 
-    val ex = intercept[IllegalArgumentException] {
+    val ex = intercept[InvalidInputException ] {
       pipelineModel.transform(emptyDataSet)
     }
-    ex.getMessage.contains("contentPath must be set")
+    ex.getMessage.contains("contentPath must point to a valid file or directory")
   }
 
   it should "return all sentences joined into a single document" in {
@@ -424,35 +425,6 @@ class Reader2DocTest extends AnyFlatSpec with SparkSessionTest {
 
     val pipeline = new Pipeline().setStages(Array(reader2Doc))
     val resultDf = pipeline.fit(htmlDf).transform(htmlDf)
-
-    resultDf.show(truncate = false)
-  }
-
-  it should "read XML as HTML" taggedAs FastTest in {
-
-    val reader2Doc = new Reader2Doc()
-      .setContentType("text/html")
-      .setContentPath(s"$xmlDirectory/malformed.xml")
-      .setOutputCol("document")
-
-    val pipeline = new Pipeline().setStages(Array(reader2Doc))
-
-    val pipelineModel = pipeline.fit(emptyDataSet)
-    val resultDf = pipelineModel.transform(emptyDataSet)
-
-    resultDf.show(truncate = false)
-  }
-
-  it should "read malformed XML as HTML" taggedAs FastTest in {
-    val reader2Doc = new Reader2Doc()
-      .setContentType("application/xml")
-      .setContentPath(s"$xmlDirectory/malformed.xml")
-      .setOutputCol("document")
-
-    val pipeline = new Pipeline().setStages(Array(reader2Doc))
-
-    val pipelineModel = pipeline.fit(emptyDataSet)
-    val resultDf = pipelineModel.transform(emptyDataSet)
 
     resultDf.show(truncate = false)
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

**Please merge before https://github.com/JohnSnowLabs/spark-nlp/pull/14668**

## Description
<!--- Describe your changes in detail -->
This change enables readers to accept a column of type String as input (in addition to existing types), so you can provide raw text directly rather than only files or external sources.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this patch, Spark NLP readers only supported inputs via file paths. That means if you already had a DataFrame with text content (say from another pipeline or a preliminary load), you had to write it to disk just to let the reader ingest it. This adds friction and overhead, especially in streaming or in-memory pipelines.

With this change, you can:

- Feed raw text stored in a DataFrame column directly into Spark NLP readers — zero I/O overhead when not needed.
- Simplify workflows and pipelines (no need for temporary file staging just to “read” back data).
- Improve performance and resource usage in scenarios where input is already available as strings (e.g. generated, preprocessed, or coming from another system).
- Make the reader APIs more flexible and general-purpose.

This enhancement broadens the usability of the readers and removes a common impedance mismatch in real-world ETL / NLP workflows.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- Local Tests
- Google Colab

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
