### PR TITLE
fix duplicate loading in FeaturesFallbackReader

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/ParamsAndFeaturesReadable.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/ParamsAndFeaturesReadable.scala
@@ -91,13 +91,18 @@ class FeaturesFallbackReader[T <: HasFeatures](
       // Read params, features and model via FeaturesReader.load
       baseReader.load(path)
     } match {
-      case Failure(_) =>
-        // TODO: Logger warn instead?
+      case Success(value) => value
+      case Failure(_: java.util.NoSuchElementException) =>
         println(
           s"Failed to load all parameters from $path, attempting fallback loader. " +
             s"Parameters will be set to default values.")
         fallbackLoad(path, sparkSession)
-      case Success(value) => value
+      case Failure(_: java.lang.ClassCastException) =>
+        println(
+          s"Failed to cast to class of $path, attempting fallback loader. " +
+            s"Parameters will be set to default values.")
+        fallbackLoad(path, sparkSession)
+      case Failure(exception) => throw exception
     }
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/ParamsAndFeaturesReadable.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/ParamsAndFeaturesReadable.scala
@@ -88,12 +88,8 @@ class FeaturesFallbackReader[T <: HasFeatures](
 
   override def load(path: String): T = {
     Try {
-      // Read params, features and model
-      val instance = baseReader.load(path)
-      loadFeatures(path, instance)
-      onRead(instance, path, sparkSession)
-
-      instance
+      // Read params, features and model via FeaturesReader.load
+      baseReader.load(path)
     } match {
       case Failure(_) =>
         // TODO: Logger warn instead?
@@ -105,12 +101,6 @@ class FeaturesFallbackReader[T <: HasFeatures](
     }
   }
 
-  private def loadFeatures(path: String, instance: T): Unit = {
-    for (feature <- instance.features) {
-      val value = feature.deserialize(sparkSession, path, feature.name)
-      feature.setValue(value)
-    }
-  }
 }
 
 /** Enables loading models with params and features with a fallback mechanism. The `fallbackLoad`

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFModel.scala
@@ -16,6 +16,7 @@
 package com.johnsnowlabs.nlp.annotators.seq2seq
 
 import com.johnsnowlabs.ml.gguf.GGUFWrapper
+import com.johnsnowlabs.ml.gguf.GGUFWrapper.findGGUFModelInFolder
 import com.johnsnowlabs.ml.util.LlamaCPP
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.llama.LlamaExtensions
@@ -240,9 +241,10 @@ trait ReadAutoGGUFModel {
   this: ParamsAndFeaturesFallbackReadable[AutoGGUFModel] =>
 
   override def fallbackLoad(folder: String, spark: SparkSession): AutoGGUFModel = {
-    val localFolder: String = ResourceHelper.copyToLocal(folder)
-    val ggufFile = GGUFWrapper.findGGUFModelInFolder(localFolder)
-    loadSavedModel(ggufFile, spark)
+    val actualFolderPath: String = ResourceHelper.resolvePath(folder)
+    val localFolder = ResourceHelper.copyToLocal(actualFolderPath)
+    val modelFile = findGGUFModelInFolder(localFolder)
+    loadSavedModel(modelFile, spark)
   }
 
   def readModel(instance: AutoGGUFModel, path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFReranker.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFReranker.scala
@@ -20,15 +20,13 @@ import com.johnsnowlabs.ml.util.LlamaCPP
 import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.llama.LlamaExtensions
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import de.kherud.llama.{InferenceParameters, LlamaException, LlamaModel, Pair}
+import de.kherud.llama.{LlamaException, LlamaModel, Pair}
 import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.param.Param
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.ml.param.Param
-import scala.jdk.CollectionConverters._
 
-import java.util
-import java.util.{ArrayList, List}
+import scala.jdk.CollectionConverters._
 
 /** Annotator that uses the llama.cpp library to rerank text documents based on their relevance to
   * a given query using GGUF-format reranking models.
@@ -271,7 +269,8 @@ trait ReadAutoGGUFReranker {
   this: ParamsAndFeaturesFallbackReadable[AutoGGUFReranker] =>
 
   override def fallbackLoad(folder: String, spark: SparkSession): AutoGGUFReranker = {
-    val localFolder: String = ResourceHelper.copyToLocal(folder)
+    val actualFolderPath: String = ResourceHelper.resolvePath(folder)
+    val localFolder = ResourceHelper.copyToLocal(actualFolderPath)
     val ggufFile = GGUFWrapper.findGGUFModelInFolder(localFolder)
     loadSavedModel(ggufFile, spark)
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFVisionModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFVisionModel.scala
@@ -289,7 +289,9 @@ trait ReadAutoGGUFVisionModel {
   this: ParamsAndFeaturesFallbackReadable[AutoGGUFVisionModel] =>
 
   override def fallbackLoad(folder: String, spark: SparkSession): AutoGGUFVisionModel = {
-    val localFolder: String = ResourceHelper.copyToLocal(folder)
+    val actualFolderPath: String = ResourceHelper.resolvePath(folder)
+
+    val localFolder = ResourceHelper.copyToLocal(actualFolderPath)
     val (ggufFile, mmprojFile) = GGUFWrapperMultiModal.findGGUFModelsInFolder(localFolder)
     loadSavedModel(ggufFile, mmprojFile, spark)
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/AutoGGUFEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/AutoGGUFEmbeddings.scala
@@ -284,7 +284,8 @@ trait ReadAutoGGUFEmbeddings {
   this: ParamsAndFeaturesFallbackReadable[AutoGGUFEmbeddings] =>
 
   override def fallbackLoad(folder: String, spark: SparkSession): AutoGGUFEmbeddings = {
-    val localFolder: String = ResourceHelper.copyToLocal(folder)
+    val actualFolderPath: String = ResourceHelper.resolvePath(folder)
+    val localFolder = ResourceHelper.copyToLocal(actualFolderPath)
     val ggufFile = GGUFWrapper.findGGUFModelInFolder(localFolder)
     loadSavedModel(ggufFile, spark)
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -747,10 +747,30 @@ object ResourceHelper {
     }
   }
 
+  /** Get the Hadoop FileSystem from a given path
+    *
+    * @param path
+    *   Path to the resource
+    * @return
+    *   Hadoop FileSystem
+    */
   def fileSystemFromPath(path: String): FileSystem = {
     val uri = new URI(path.replaceAllLiterally("\\", "/"))
     FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
   }
+
+  /** Resolves the given path to its absolute form, handling different file systems.
+    *
+    * @param folder
+    *   The input path to resolve.
+    * @return
+    *   The resolved absolute path as a string.
+    */
+  def resolvePath(folder: String): String = {
+    val fileSystem: FileSystem = ResourceHelper.fileSystemFromPath(folder)
+    fileSystem.resolvePath(new Path(folder)).toString
+  }
+
   def isHTTPProtocol(urlStr: String): Boolean = {
     try {
       val url = new URL(urlStr)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFRerankerTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFRerankerTest.scala
@@ -1,10 +1,10 @@
 package com.johnsnowlabs.nlp.annotators.seq2seq
 
 import com.johnsnowlabs.nlp.Annotation
-import com.johnsnowlabs.nlp.finisher.GGUFRankingFinisher
 import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.finisher.GGUFRankingFinisher
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.tags.{SlowTest, FastTest}
+import com.johnsnowlabs.tags.SlowTest
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -134,5 +134,10 @@ class AutoGGUFRerankerTest extends AnyFlatSpec {
 
 //    assertAnnotationsNonEmpty(result)
     result.select("ranked_documents").show(truncate = false)
+  }
+
+  it should "load models with deprecated parameters" taggedAs SlowTest in {
+    // testing only, should be able to load
+    AutoGGUFReranker.pretrained("Nomic_Embed_Text_v1.5.Q8_0.gguf")
   }
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFVisionModelTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFVisionModelTestSpec.scala
@@ -15,11 +15,11 @@ class AutoGGUFVisionModelTestSpec extends AnyFlatSpec {
 
   behavior of "AutoGGUFVisionModel"
 
-  lazy val documentAssembler = new DocumentAssembler()
+  lazy val documentAssembler: DocumentAssembler = new DocumentAssembler()
     .setInputCol("caption")
     .setOutputCol("caption_document")
 
-  lazy val imageAssembler = new ImageAssembler()
+  lazy val imageAssembler: ImageAssembler = new ImageAssembler()
     .setInputCol("image")
     .setOutputCol("image_assembler")
 
@@ -44,7 +44,7 @@ class AutoGGUFVisionModelTestSpec extends AnyFlatSpec {
     "tractor.JPEG" -> "tractor")
 
   lazy val nPredict = 40
-  lazy val model = AutoGGUFVisionModel
+  lazy val model: AutoGGUFVisionModel = AutoGGUFVisionModel
 //    .loadSavedModel(
 //      "models/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf",
 //      "models/mmproj-Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
@@ -64,7 +64,8 @@ class AutoGGUFVisionModelTestSpec extends AnyFlatSpec {
     .setTopK(40)
     .setTopP(0.95f)
 
-  lazy val pipeline = new Pipeline().setStages(Array(documentAssembler, imageAssembler, model))
+  lazy val pipeline: Pipeline =
+    new Pipeline().setStages(Array(documentAssembler, imageAssembler, model))
 
   def checkBinaryContents(): Unit = {
     val imageData = data.select("image.data").limit(1).collect()(0).getAs[Array[Byte]](0)
@@ -134,5 +135,9 @@ class AutoGGUFVisionModelTestSpec extends AnyFlatSpec {
       .save(savePath)
 
     AutoGGUFVisionModel.load(savePath)
+  }
+
+  it should "load models with deprecated parameters" taggedAs SlowTest in {
+    AutoGGUFVisionModel.pretrained("llava_v1.5_7b_Q4_0_gguf")
   }
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/AutoGGUFEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/AutoGGUFEmbeddingsTestSpec.scala
@@ -5,6 +5,7 @@ import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.tags.SlowTest
 import org.apache.spark.ml.Pipeline
+import org.apache.spark.sql.{Dataset, Row}
 import org.scalatest.flatspec.AnyFlatSpec
 
 class AutoGGUFEmbeddingsTestSpec extends AnyFlatSpec {
@@ -12,11 +13,11 @@ class AutoGGUFEmbeddingsTestSpec extends AnyFlatSpec {
 
   behavior of "AutoGGUFEmbeddings"
 
-  lazy val documentAssembler = new DocumentAssembler()
+  lazy val documentAssembler: DocumentAssembler = new DocumentAssembler()
     .setInputCol("text")
     .setOutputCol("document")
 
-  lazy val data = Seq(
+  lazy val data: Dataset[Row] = Seq(
     "The moons of Jupiter are ", // "The moons of Jupiter are 77 in total, with 79 confirmed natural satellites and 2 man-made ones. The four"
     "Earth is ", // "Earth is 4.5 billion years old. It has been home to countless species, some of which have gone extinct, while others have evolved into"
     "The moon is ", // "The moon is 1/400th the size of the sun. The sun is 1.39 million kilometers in diameter, while"
@@ -24,7 +25,7 @@ class AutoGGUFEmbeddingsTestSpec extends AnyFlatSpec {
   ).toDF("text").repartition(1)
 
   lazy val longDataCopies = 16
-  lazy val longData = {
+  lazy val longData: Dataset[Row] = {
     val text = "All work and no play makes Jack a dull boy" * 100
     Seq.fill(longDataCopies)(text).toDF("text").repartition(4)
   }
@@ -137,4 +138,7 @@ class AutoGGUFEmbeddingsTestSpec extends AnyFlatSpec {
     AutoGGUFEmbeddings.load(savePath)
   }
 
+  it should "load models with deprecated parameters" taggedAs SlowTest in {
+    AutoGGUFEmbeddings.pretrained("Nomic_Embed_Text_v1.5.Q8_0.gguf")
+  }
 }


### PR DESCRIPTION





<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Trying to call .pretrained() on any GGUF- Model/Emedding / Reranker etc..   in databricks, gives exception, i.e. run 

```python
from sparknlp.annotator import AutoGGUFModel
AutoGGUFModel.pretrained("Phi_4_mini_instruct_Q4_K_M_gguf")
```

gives gives the following error:
```scala


ini_instruct_Q4_K_M_gguf download started this may take some time.
Approximate size to download 2.3 GB
[ | ]
An error occurred while calling z:com.johnsnowlabs.nlp.pretrained.PythonResourceDownloader.downloadModel.
: java.io.FileNotFoundException: file or folder: file:/root/cache_pretrained/Phi_4_mini_instruct_Q4_K_M_gguf_en_6.1.1_3.0_1754317230916 not found
	at com.johnsnowlabs.nlp.util.io.ResourceHelper$SourceStream.<init>(ResourceHelper.scala:112)
	at com.johnsnowlabs.nlp.util.io.ResourceHelper$.copyToLocal(ResourceHelper.scala:211)
	at com.johnsnowlabs.nlp.annotators.seq2seq.ReadAutoGGUFModel.fallbackLoad(AutoGGUFModel.scala:243)
	at com.johnsnowlabs.nlp.annotators.seq2seq.ReadAutoGGUFModel.fallbackLoad$(AutoGGUFModel.scala:242)
	at com.johnsnowlabs.nlp.annotators.seq2seq.AutoGGUFModel$.fallbackLoad(AutoGGUFModel.scala:272)
	at com.johnsnowlabs.nlp.annotators.seq2seq.AutoGGUFModel$.fallbackLoad(AutoGGUFModel.scala:272)
	at com.johnsnowlabs.nlp.ParamsAndFeaturesFallbackReadable.$anonfun$read$3(ParamsAndFeaturesReadable.scala:143)
	at com.johnsnowlabs.nlp.FeaturesFallbackReader.load(ParamsAndFeaturesReadable.scala:103)
	at com.johnsnowlabs.nlp.FeaturesFallbackReader.load(ParamsAndFeaturesReadable.scala:83)
	at com.johnsnowlabs.nlp.pretrained.ResourceDownloader$.downloadModel(ResourceDownloader.scala:508)
	at com.johnsnowlabs.nlp.pretrained.ResourceDownloader$.downloadModel(ResourceDownloader.scala:500)
	at com.johnsnowlabs.nlp.pretrained.PythonResourceDownloader$.downloadModel(ResourceDownloader.scala:737)
	at com.johnsnowlabs.nlp.pretrained.PythonResourceDownloader.downloadModel(ResourceDownloader.scala)
[OK!]
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes the problem described bove.


In here the exception clause is being triggered
https://github.com/JohnSnowLabs/spark-nlp/blob/d4e84d5051e6a9df0b8bd7e733e889d0a1c82da7/src/main/scala/com/johnsnowlabs/nlp/ParamsAndFeaturesReadable.scala#L83-L106

I wonder why fallback is beeing triggered, so I removed the try/except and only kept the core load function and made a jar from it and ran it to see the exception of the try block which was hidden because of the fallback.
The full exception when removing the try/except which hints to duplicate loading is this and debug logs confirmed this for databricks
```scala
 requirement failed: File Phi-4-mini-instruct-Q4_K_M.gguf was already registered with a different path (old path = /local_disk0/tmp/sparknlp_tmp_1105459981034811867/Phi-4-mini-instruct-Q4_K_M.gguf, new path = /local_disk0/tmp/sparknlp_tmp_6457393090599769875/Phi-4-mini-instruct-Q4_K_M.gguf
	at scala.Predef$.require(Predef.scala:281)
	at org.apache.spark.rpc.netty.NettyStreamManager.addFile(NettyStreamManager.scala:72)
	at org.apache.spark.SparkContext.addFile(SparkContext.scala:1939)
	at org.apache.spark.SparkContext.addFile(SparkContext.scala:1844)
	at com.johnsnowlabs.ml.gguf.GGUFWrapper$.read(GGUFWrapper.scala:99)
	at com.johnsnowlabs.ml.gguf.GGUFWrapper$.readModel(GGUFWrapper.scala:158)
	at com.johnsnowlabs.nlp.annotators.seq2seq.ReadAutoGGUFModel.readModel(AutoGGUFModel.scala:258)
	at com.johnsnowlabs.nlp.annotators.seq2seq.ReadAutoGGUFModel.readModel$(AutoGGUFModel.scala:256)
	at com.johnsnowlabs.nlp.annotators.seq2seq.AutoGGUFModel$.readModel(AutoGGUFModel.scala:287)
	at com.johnsnowlabs.nlp.annotators.seq2seq.ReadAutoGGUFModel.$anonfun$$init$$1(AutoGGUFModel.scala:262)
	at com.johnsnowlabs.nlp.annotators.seq2seq.ReadAutoGGUFModel.$anonfun$$init$$1$adapted(AutoGGUFModel.scala:262)
	at com.johnsnowlabs.nlp.ParamsAndFeaturesReadable.$anonfun$onRead$1(ParamsAndFeaturesReadable.scala:53)
	at com.johnsnowlabs.nlp.ParamsAndFeaturesReadable.$anonfun$onRead$1$adapted(ParamsAndFeaturesReadable.scala:51)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
	at com.johnsnowlabs.nlp.ParamsAndFeaturesReadable.onRead(ParamsAndFeaturesReadable.scala:51)
	at com.johnsnowlabs.nlp.ParamsAndFeaturesReadable.onRead$(ParamsAndFeaturesReadable.scala:50)
	at com.johnsnowlabs.nlp.annotators.seq2seq.AutoGGUFModel$.onRead(AutoGGUFModel.scala:287)
	at com.johnsnowlabs.nlp.ParamsAndFeaturesFallbackReadable.$anonfun$read$2(ParamsAndFeaturesReadable.scala:158)
	at com.johnsnowlabs.nlp.ParamsAndFeaturesFallbackReadable.$anonfun$read$2$adapted(ParamsAndFeaturesReadable.scala:158)
	at com.johnsnowlabs.nlp.FeaturesFallbackReader.load(ParamsAndFeaturesReadable.scala:107)
	at com.johnsnowlabs.nlp.FeaturesFallbackReader.load(ParamsAndFeaturesReadable.scala:84)
	at com.johnsnowlabs.nlp.pretrained.ResourceDownloader$.downloadModel(ResourceDownloader.scala:510)
```

Looking at debug logs I realized that the entire read/load procedure of AutoGGUFModel and GGUFWrapper runs twice!

Both during `FeaturesFallbackReader.load` call when it calls `baseReader.load(path)` and again in `onRead(instance, path, sparkSession)`.

Debugging further, I realize the class of `baseReader` at runtime is class `FeaturesReader`.

This is because `ParamsAndFeaturesFallbackReadable` is a child class of `ParamsAndFeaturesReadable`
and in read we use `new FeaturesFallbackReader(super.read, onRead, fallbackLoad)` which resolves to `FeaturesReader`

Thus the `baseReader.load(path) ` call resolves to `FeaturesReader.load()`.and will invoke
https://github.com/JohnSnowLabs/spark-nlp/blob/d4e84d5051e6a9df0b8bd7e733e889d0a1c82da7/src/main/scala/com/johnsnowlabs/nlp/ParamsAndFeaturesReadable.scala#L30-L42

But this exact same logic already runs in [FeaturesFallbackReader.load() and loadFeatures() ](https://github.com/JohnSnowLabs/spark-nlp/blob/d4e84d5051e6a9df0b8bd7e733e889d0a1c82da7/src/main/scala/com/johnsnowlabs/nlp/ParamsAndFeaturesReadable.scala#L89-L113)

Which triggers loading the model and copying it to local files twice and on crashes on databricks, see bottom full exception for this.


Simply removing those duplicate steps fixes the issue ! 
https://github.com/JohnSnowLabs/spark-nlp/blob/4cc8d52583aedac96b5ae4e944f4316694a35b36/src/main/scala/com/johnsnowlabs/nlp/ParamsAndFeaturesReadable.scala#L83-L104





## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running with my jar on databricks and on google colab, both environments work fine now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
