### PR TITLE
[SPARKNLP-1288] AutoGGUF close model

### DIFF
--- a/python/sparknlp/annotator/embeddings/auto_gguf_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/auto_gguf_embeddings.py
@@ -532,3 +532,8 @@ class AutoGGUFEmbeddings(AnnotatorModel, HasBatchedAnnotate):
         return ResourceDownloader.downloadModel(
             AutoGGUFEmbeddings, name, lang, remote_loc
         )
+
+    def close(self):
+        """Closes the llama.cpp model backend freeing resources. The model is reloaded when used again.
+        """
+        self._java_obj.close()

--- a/python/sparknlp/annotator/seq2seq/auto_gguf_model.py
+++ b/python/sparknlp/annotator/seq2seq/auto_gguf_model.py
@@ -300,3 +300,8 @@ class AutoGGUFModel(AnnotatorModel, HasBatchedAnnotate, HasLlamaCppProperties):
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(AutoGGUFModel, name, lang, remote_loc)
+
+    def close(self):
+        """Closes the llama.cpp model backend freeing resources. The model is reloaded when used again.
+        """
+        self._java_obj.close()

--- a/python/sparknlp/annotator/seq2seq/auto_gguf_reranker.py
+++ b/python/sparknlp/annotator/seq2seq/auto_gguf_reranker.py
@@ -327,3 +327,8 @@ class AutoGGUFReranker(AnnotatorModel, HasBatchedAnnotate, HasLlamaCppProperties
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(AutoGGUFReranker, name, lang, remote_loc)
+
+    def close(self):
+        """Closes the llama.cpp model backend freeing resources. The model is reloaded when used again.
+        """
+        self._java_obj.close()

--- a/python/sparknlp/annotator/seq2seq/auto_gguf_vision_model.py
+++ b/python/sparknlp/annotator/seq2seq/auto_gguf_vision_model.py
@@ -329,3 +329,8 @@ class AutoGGUFVisionModel(AnnotatorModel, HasBatchedAnnotate, HasLlamaCppPropert
         """
         from sparknlp.pretrained import ResourceDownloader
         return ResourceDownloader.downloadModel(AutoGGUFVisionModel, name, lang, remote_loc)
+
+    def close(self):
+        """Closes the llama.cpp model backend freeing resources. The model is reloaded when used again.
+        """
+        self._java_obj.close()

--- a/python/test/util.py
+++ b/python/test/util.py
@@ -12,8 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from pyspark.sql import SparkSession
 import os
+
+from pyspark.sql import SparkSession
+import time
 
 
 class SparkSessionForTest:
@@ -38,4 +40,17 @@ class SparkContextForTest:
         .limit(100)
     data.cache()
     data.count()
-    
+
+
+def getFreeRAM():
+    """Returns the amount of free system RAM in Megabytes (MB)."""
+    import psutil # Not available no github runners
+    return psutil.virtual_memory().free / (1024 * 1024)
+
+
+def measureRAMChange(func, *args, **kwargs):
+    ramBefore = getFreeRAM()
+    func(*args, **kwargs)
+    time.sleep(0.5)
+    ramAfter = getFreeRAM()
+    return ramAfter - ramBefore

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFModel.scala
@@ -147,6 +147,10 @@ class AutoGGUFModel(override val uid: String)
     this
   }
 
+  /** Closes the llama.cpp model backend freeing resources. The model is reloaded when used again.
+    */
+  def close(): Unit = GGUFWrapper.closeBroadcastModel(_model)
+
   private[johnsnowlabs] def setEngine(engineName: String): this.type = set(engine, engineName)
 
   setDefault(

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFReranker.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFReranker.scala
@@ -155,6 +155,10 @@ class AutoGGUFReranker(override val uid: String)
     this
   }
 
+  /** Closes the llama.cpp model backend freeing resources. The model is reloaded when used again.
+   */
+  def close(): Unit = GGUFWrapper.closeBroadcastModel(_model)
+
   val query = new Param[String](
     this,
     "query",

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFVisionModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFVisionModel.scala
@@ -181,6 +181,10 @@ class AutoGGUFVisionModel(override val uid: String)
     this
   }
 
+  /** Closes the llama.cpp model backend freeing resources. The model is reloaded when used again.
+   */
+  def close(): Unit = GGUFWrapperMultiModal.closeBroadcastModel(_model)
+
   private[johnsnowlabs] def setEngine(engineName: String): this.type = set(engine, engineName)
 
   /** Sets the number of parallel processes for decoding. This is an alias for `setBatchSize`.

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/AutoGGUFEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/AutoGGUFEmbeddings.scala
@@ -138,6 +138,10 @@ class AutoGGUFEmbeddings(override val uid: String)
     this
   }
 
+  /** Closes the llama.cpp model backend freeing resources. The model is reloaded when used again.
+   */
+  def close(): Unit = GGUFWrapper.closeBroadcastModel(_model)
+
   private[johnsnowlabs] def setEngine(engineName: String): this.type = set(engine, engineName)
 
   /** Set the pooling type for embeddings, use model default if unspecified

--- a/src/test/scala/com/johnsnowlabs/util/TestUtils.scala
+++ b/src/test/scala/com/johnsnowlabs/util/TestUtils.scala
@@ -1,8 +1,11 @@
 package com.johnsnowlabs.util
 
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.sun.management.OperatingSystemMXBean
 import org.scalactic.{Equality, TolerantNumerics}
 
+import java.lang.Thread.sleep
+import java.lang.management.ManagementFactory
 import scala.io.Source
 
 private[johnsnowlabs] object TestUtils {
@@ -57,4 +60,24 @@ private[johnsnowlabs] object TestUtils {
   implicit val tolerantFloatEq: Equality[Float] = TolerantNumerics.tolerantFloatEquality(1e-4f)
   implicit val tolerantDoubleEq: Equality[Double] = TolerantNumerics.tolerantDoubleEquality(1e-5f)
 
+  /** Measures the change in available RAM (in MB) before and after executing the provided block
+    * of code.
+    *
+    * @param block
+    *   The block of code to execute.
+    * @return
+    *   The change in available RAM in MB (positive if RAM increased, negative if decreased).
+    */
+  def measureRAMChange(block: => Any): Long = {
+    def getFreeRAM: Long = {
+      val osBean = ManagementFactory.getOperatingSystemMXBean.asInstanceOf[OperatingSystemMXBean]
+      osBean.getFreePhysicalMemorySize / (1024 * 1024) // Convert to MB
+    }
+
+    val ramBefore = getFreeRAM
+    block
+    sleep(500) // Wait a bit to let the system update memory stats
+    val ramAfter = getFreeRAM
+    ramBefore - ramAfter
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR allows llama.cpp based annotators (AutoGGUF*) to be closed to free up resources.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users might want to test multiple models. This ensures that resources are not used up in the process.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local tests, databricks and colab passing.

