### PR TITLE
[SPARKNLP-1283] Add remove thinking flag

### DIFF
--- a/python/sparknlp/annotator/seq2seq/auto_gguf_model.py
+++ b/python/sparknlp/annotator/seq2seq/auto_gguf_model.py
@@ -12,12 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Contains classes for the AutoGGUFModel."""
-from typing import List, Dict
-
 from sparknlp.common import *
 
 
-class AutoGGUFModel(AnnotatorModel, HasBatchedAnnotate, HasLlamaCppProperties):
+class AutoGGUFModel(AnnotatorModel, HasBatchedAnnotate, HasLlamaCppProperties, CompletionPostProcessing):
     """
     Annotator that uses the llama.cpp library to generate text completions with large language
     models.
@@ -242,7 +240,6 @@ class AutoGGUFModel(AnnotatorModel, HasBatchedAnnotate, HasLlamaCppProperties):
     name = "AutoGGUFModel"
     inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
     outputAnnotatorType = AnnotatorType.DOCUMENT
-
 
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.seq2seq.AutoGGUFModel", java_model=None):

--- a/python/sparknlp/annotator/seq2seq/auto_gguf_vision_model.py
+++ b/python/sparknlp/annotator/seq2seq/auto_gguf_vision_model.py
@@ -15,7 +15,7 @@
 from sparknlp.common import *
 
 
-class AutoGGUFVisionModel(AnnotatorModel, HasBatchedAnnotate, HasLlamaCppProperties):
+class AutoGGUFVisionModel(AnnotatorModel, HasBatchedAnnotate, HasLlamaCppProperties, CompletionPostProcessing):
     """Multimodal annotator that uses the llama.cpp library to generate text completions with large
     language models. It supports ingesting images for captioning.
 

--- a/python/sparknlp/common/__init__.py
+++ b/python/sparknlp/common/__init__.py
@@ -23,3 +23,4 @@ from sparknlp.common.storage import *
 from sparknlp.common.utils import *
 from sparknlp.common.annotator_type import *
 from sparknlp.common.match_strategy import *
+from sparknlp.common.completion_post_processing import *

--- a/python/sparknlp/common/completion_post_processing.py
+++ b/python/sparknlp/common/completion_post_processing.py
@@ -1,0 +1,37 @@
+#  Copyright 2017-2025 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from pyspark.ml.param import Param, Params, TypeConverters
+
+
+class CompletionPostProcessing:
+    removeThinkingTag = Param(
+        Params._dummy(),
+        "removeThinkingTag",
+        "Set a thinking tag (e.g. think) to be removed from output. Will match <TAG>...</TAG>",
+        typeConverter=TypeConverters.toString,
+    )
+
+    def setRemoveThinkingTag(self, value: str):
+        """Set a thinking tag (e.g. `think`) to be removed from output.
+        Will produce the regex: `(?s)<$TAG>.+?</$TAG>`
+        """
+        self._set(removeThinkingTag=value)
+        return self
+
+    def getRemoveThinkingTag(self):
+        """Get the thinking tag to be removed from output."""
+        value = None
+        if self.removeThinkingTag in self._paramMap:
+            value = self._paramMap[self.removeThinkingTag]
+        return value

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFModel.scala
@@ -124,7 +124,8 @@ class AutoGGUFModel(override val uid: String)
     with HasEngine
     with HasLlamaCppModelProperties
     with HasLlamaCppInferenceProperties
-    with HasProtectedParams {
+    with HasProtectedParams
+    with CompletionPostProcessing {
 
   override val outputAnnotatorType: AnnotatorType = AnnotatorType.DOCUMENT
   override val inputAnnotatorTypes: Array[AnnotatorType] = Array(AnnotatorType.DOCUMENT)
@@ -204,7 +205,8 @@ class AutoGGUFModel(override val uid: String)
             inferenceParams,
             getSystemPrompt,
             annotationsText)
-          (results, Map.empty)
+          val resultsCleaned = processCompletions(results)
+          (resultsCleaned, Map.empty)
         } catch {
           case e: LlamaException =>
             logger.error("Error in llama.cpp batch completion", e)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/CompletionPostProcessing.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/CompletionPostProcessing.scala
@@ -1,0 +1,31 @@
+package com.johnsnowlabs.nlp.annotators.seq2seq
+
+import org.apache.spark.ml.param.{Param, Params}
+
+private[nlp] trait CompletionPostProcessing {
+  this: Params =>
+
+  /** @group param */
+  val removeThinkingTag =
+    new Param[String](
+      this,
+      "removeThinkingTag",
+      "Set a thinking tag (e.g. think) to be removed from output. Will match <TAG>...</TAG>")
+
+  /** Set a thinking tag (e.g. `think`) to be removed from output. Will produce the regex
+    * `(?s)<$TAG>.+?</$TAG>`
+    * @group setParam
+    */
+  def setRemoveThinkingTag(value: String): this.type = set(removeThinkingTag, value)
+
+  /** @group getParam */
+  def getRemoveThinkingTag: Option[String] = get(removeThinkingTag)
+
+  protected def processCompletions(results: Array[String]): Array[String] = {
+    getRemoveThinkingTag match {
+      case Some(thinkingTag) =>
+        results.map(text => text.replaceFirst(s"(?s)<$thinkingTag>.*?</$thinkingTag>", "").trim)
+      case None => results
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a flag to remove thinking tags (`<think>...</think>`) in AutoGGUFModel responses. Users can use `setRemoveThinkingTag(tag: String)` to set a tag to be removed. The matching regex corresponds to `(?s)<$tag>.+?</$tag>`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
new tests passing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
