### PR TITLE
fix tags

### DIFF
--- a/docs/_posts/ahmedlone127/2024-08-30-camembert_base_qa_fquad_fr.md
+++ b/docs/_posts/ahmedlone127/2024-08-30-camembert_base_qa_fquad_fr.md
@@ -4,7 +4,7 @@ title: French CamemBertForQuestionAnswering Base squadFR (camembert_base_qa_fqua
 author: John Snow Labs
 name: camembert_base_qa_fquad
 date: 2024-08-30
-tags: [fr, french, question_answering, camembert, open_source, onnx, openvino]
+tags: [fr, french, question_answering, camembert, open_source, openvino]
 task: Question Answering
 language: fr
 edition: Spark NLP 5.4.2

--- a/docs/_posts/ahmedlone127/2024-09-10-distilbert_token_classifier_base_uncased_finetuned_conll03_english_en.md
+++ b/docs/_posts/ahmedlone127/2024-09-10-distilbert_token_classifier_base_uncased_finetuned_conll03_english_en.md
@@ -4,7 +4,7 @@ title: English DistilBertForTokenClassification Base Uncased model (from elastic
 author: John Snow Labs
 name: distilbert_token_classifier_base_uncased_finetuned_conll03_english
 date: 2024-09-10
-tags: [en, open_source, distilbert, token_classification, ner, onnx, openvino]
+tags: [en, open_source, distilbert, token_classification, ner, openvino]
 task: Named Entity Recognition
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-09-12-mpnet_base_question_answering_squad2_en.md
+++ b/docs/_posts/ahmedlone127/2024-09-12-mpnet_base_question_answering_squad2_en.md
@@ -4,7 +4,7 @@ title: MPNet Base For Question Answering - Squad2
 author: John Snow Labs
 name: mpnet_base_question_answering_squad2
 date: 2024-09-12
-tags: [mpnet, base, qa, question, answer, answering, squad, en, open_source, onnx, openvino]
+tags: [mpnet, base, qa, question, answer, answering, squad, en, open_source, openvino]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-09-12-mpnet_sequence_classifier_ukr_message_en.md
+++ b/docs/_posts/ahmedlone127/2024-09-12-mpnet_sequence_classifier_ukr_message_en.md
@@ -4,7 +4,7 @@ title: MPNet Sequence Classification - UKR Message Classifier
 author: John Snow Labs
 name: mpnet_sequence_classifier_ukr_message
 date: 2024-09-12
-tags: [en, mpnet, sequence, classification, open_source, onnx, openvino]
+tags: [en, mpnet, sequence, classification, open_source, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-09-13-roberta_base_imdb_textattack_en.md
+++ b/docs/_posts/ahmedlone127/2024-09-13-roberta_base_imdb_textattack_en.md
@@ -4,7 +4,7 @@ title: English roberta_base_imdb_textattack RoBertaForSequenceClassification fro
 author: John Snow Labs
 name: roberta_base_imdb_textattack
 date: 2024-09-13
-tags: [roberta, en, open_source, sequence_classification, onnx, openvino]
+tags: [roberta, en, open_source, sequence_classification, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-09-13-roberta_base_qa_squad2_en.md
+++ b/docs/_posts/ahmedlone127/2024-09-13-roberta_base_qa_squad2_en.md
@@ -4,7 +4,7 @@ title: English RoBertaForQuestionAnswering model (from deepset)
 author: John Snow Labs
 name: roberta_base_qa_squad2
 date: 2024-09-13
-tags: [open_source, roberta, question_answering, en, onnx, openvino]
+tags: [open_source, roberta, question_answering, en, openvino]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-09-14-roberta_ner_deid_roberta_i2b2_en.md
+++ b/docs/_posts/ahmedlone127/2024-09-14-roberta_ner_deid_roberta_i2b2_en.md
@@ -4,7 +4,7 @@ title: English RobertaForTokenClassification Cased model (from obi)
 author: John Snow Labs
 name: roberta_ner_deid_roberta_i2b2
 date: 2024-09-14
-tags: [bert, ner, open_source, en, onnx, openvino]
+tags: [bert, ner, open_source, en, openvino]
 task: Named Entity Recognition
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-09-19-albert_base_uncased_en.md
+++ b/docs/_posts/ahmedlone127/2024-09-19-albert_base_uncased_en.md
@@ -4,7 +4,7 @@ title: ALBERT Embeddings (Base Uncase)
 author: John Snow Labs
 name: albert_base_uncased
 date: 2024-09-19
-tags: [open_source, en, english, embeddings, albert, onnx, openvino]
+tags: [open_source, en, english, embeddings, albert, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-09-19-bge_base_en.md
+++ b/docs/_posts/ahmedlone127/2024-09-19-bge_base_en.md
@@ -4,7 +4,7 @@ title: BAAI general embedding English (bge_base)
 author: John Snow Labs
 name: bge_base
 date: 2024-09-19
-tags: [bert, bge, onnx, en, open_source, openvino]
+tags: [bert, bge, en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-09-20-albert_base_qa_squad2_en.md
+++ b/docs/_posts/ahmedlone127/2024-09-20-albert_base_qa_squad2_en.md
@@ -4,7 +4,7 @@ title: English AlbertForQuestionAnswering model (from twmkn9)
 author: John Snow Labs
 name: albert_base_qa_squad2
 date: 2024-09-20
-tags: [question_answering, albert, openvino, en, open_source, onnx]
+tags: [question_answering, albert, en, open_source, onnx]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-09-21-bert_classifier_bert_base_multilingual_uncased_sentiment_xx.md
+++ b/docs/_posts/ahmedlone127/2024-09-21-bert_classifier_bert_base_multilingual_uncased_sentiment_xx.md
@@ -4,7 +4,7 @@ title: Multilingual BertForSequenceClassification Base Uncased model (from nlpto
 author: John Snow Labs
 name: bert_classifier_bert_base_multilingual_uncased_sentiment
 date: 2024-09-21
-tags: [sequence_classification, bert, openvino, xx, open_source, onnx]
+tags: [sequence_classification, bert, xx, open_source, onnx]
 task: Zero-Shot Classification
 language: xx
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-09-21-camembert_base_fr.md
+++ b/docs/_posts/ahmedlone127/2024-09-21-camembert_base_fr.md
@@ -4,7 +4,7 @@ title: CamemBERT Base Model
 author: John Snow Labs
 name: camembert_base
 date: 2024-09-21
-tags: [fr, french, embeddings, camembert, base, open_source, onnx, openvino]
+tags: [fr, french, embeddings, camembert, base, open_source, openvino]
 task: Embeddings
 language: fr
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-09-22-deberta_embeddings_tapt_nbme_v3_base_en.md
+++ b/docs/_posts/ahmedlone127/2024-09-22-deberta_embeddings_tapt_nbme_v3_base_en.md
@@ -4,7 +4,7 @@ title: English Deberta Embeddings model (from ZZ99)
 author: John Snow Labs
 name: deberta_embeddings_tapt_nbme_v3_base
 date: 2024-09-22
-tags: [deberta, open_source, deberta_embeddings, debertav2formaskedlm, en, onnx, openvino]
+tags: [deberta, open_source, deberta_embeddings, debertav2formaskedlm, en, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-09-25-distilbert_base_cased_en.md
+++ b/docs/_posts/ahmedlone127/2024-09-25-distilbert_base_cased_en.md
@@ -4,7 +4,7 @@ title: DistilBERT base model (cased)
 author: John Snow Labs
 name: distilbert_base_cased
 date: 2024-09-25
-tags: [distilbert, en, english, open_source, embeddings, onnx, openvino]
+tags: [distilbert, en, english, open_source, embeddings, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_iq3_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_iq3_m_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_iq3_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_iq3_m
 date: 2024-10-10
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, tensorflow]
+tags: [en, open_source, conversational, text_generation, text_to_text, tensorflow]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_iq4_xs_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_iq4_xs_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_iq4_xs AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_iq4_xs
 date: 2024-10-10
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, tensorflow]
+tags: [en, open_source, conversational, text_generation, text_to_text, tensorflow]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_q3_k_l_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_q3_k_l_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_q3_k_l AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_q3_k_l
 date: 2024-10-10
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, tensorflow]
+tags: [en, open_source, conversational, text_generation, text_to_text, tensorflow]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_q4_k_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_q4_k_m
 date: 2024-10-10
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, tensorflow]
+tags: [en, open_source, conversational, text_generation, text_to_text, tensorflow]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_q5_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_q5_k_m_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_q5_k_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_q5_k_m
 date: 2024-10-10
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, tensorflow]
+tags: [en, open_source, conversational, text_generation, text_to_text, tensorflow]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_q6_k_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_q6_k AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_q6_k
 date: 2024-10-10
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, tensorflow]
+tags: [en, open_source, conversational, text_generation, text_to_text, tensorflow]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-10-gemma_2_2b_it_q8_0_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_q8_0 AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_q8_0
 date: 2024-10-10
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, tensorflow]
+tags: [en, open_source, conversational, text_generation, text_to_text, tensorflow]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-10-llama_3.2_3b_instruct_q3_k_l_xx.md
+++ b/docs/_posts/ahmedlone127/2024-10-10-llama_3.2_3b_instruct_q3_k_l_xx.md
@@ -4,7 +4,7 @@ title: Multilingual llama_3.2_3b_instruct_q3_k_l AutoGGUFModel from lmstudio-com
 author: John Snow Labs
 name: llama_3.2_3b_instruct_q3_k_l
 date: 2024-10-10
-tags: [xx, open_source, onnx, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, tensorflow]
+tags: [xx, open_source, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, tensorflow]
 task: Text Generation
 language: xx
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-10-llama_3.2_3b_instruct_q4_k_m_xx.md
+++ b/docs/_posts/ahmedlone127/2024-10-10-llama_3.2_3b_instruct_q4_k_m_xx.md
@@ -4,7 +4,7 @@ title: Multilingual llama_3.2_3b_instruct_q4_k_m AutoGGUFModel from lmstudio-com
 author: John Snow Labs
 name: llama_3.2_3b_instruct_q4_k_m
 date: 2024-10-10
-tags: [xx, open_source, onnx, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, tensorflow]
+tags: [xx, open_source, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, tensorflow]
 task: Text Generation
 language: xx
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-11-sent_roberta_base_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-11-sent_roberta_base_en.md
@@ -4,7 +4,7 @@ title: RoBERTa Base Sentence Embeddings(sent_roberta_base)
 author: John Snow Labs
 name: sent_roberta_base
 date: 2024-10-11
-tags: [sentence_embeddings, en, english, roberta, open_source, onnx, openvino]
+tags: [sentence_embeddings, en, english, roberta, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-11-snowflake_artic_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-11-snowflake_artic_m_en.md
@@ -4,7 +4,7 @@ title: SnowFlake Medium Model
 author: John Snow Labs
 name: snowflake_artic_m
 date: 2024-10-11
-tags: [embeddings, snowflake, en, open_source, onnx, openvino]
+tags: [embeddings, snowflake, en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-13-uae_large_v1_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-13-uae_large_v1_en.md
@@ -4,7 +4,7 @@ title: UAE-Large-V1 for Sentence Embeddings
 author: John Snow Labs
 name: uae_large_v1
 date: 2024-10-13
-tags: [uae, en, sentence, embeddings, open_source, onnx, openvino]
+tags: [uae, en, sentence, embeddings, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-16-asr_hubert_large_ls960_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-16-asr_hubert_large_ls960_en.md
@@ -4,7 +4,7 @@ title: ASR HubertForCTC - asr_hubert_large_ls960
 author: John Snow Labs
 name: asr_hubert_large_ls960
 date: 2024-10-16
-tags: [hubert, en, open_source, onnx, openvino]
+tags: [hubert, en, open_source, openvino]
 task: Automatic Speech Recognition
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-17-asr_wav2vec2_base_960h_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-17-asr_wav2vec2_base_960h_en.md
@@ -4,7 +4,7 @@ title: English asr_wav2vec2_base_960h TFWav2Vec2ForCTC from facebook
 author: John Snow Labs
 name: asr_wav2vec2_base_960h
 date: 2024-10-17
-tags: [wav2vec2, en, open_source, onnx, openvino]
+tags: [wav2vec2, en, open_source, openvino]
 task: Automatic Speech Recognition
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-19-image_classifier_convnext_tiny_224_local_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-19-image_classifier_convnext_tiny_224_local_en.md
@@ -4,7 +4,7 @@ title: English image_classifier_convnext_tiny_224_local ConvNextForImageClassifi
 author: John Snow Labs
 name: image_classifier_convnext_tiny_224_local
 date: 2024-10-19
-tags: [imagenet, image_classification, en, open_source, onnx, openvino]
+tags: [imagenet, image_classification, en, open_source, openvino]
 task: Image Classification
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-19-image_classifier_swin_base_patch4_window7_224_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-19-image_classifier_swin_base_patch4_window7_224_en.md
@@ -4,7 +4,7 @@ title: English image_classifier_swin_base_patch4_window7_224 SwinForImageClassif
 author: John Snow Labs
 name: image_classifier_swin_base_patch4_window7_224
 date: 2024-10-19
-tags: [swin, image_classification, en, open_source, onnx, openvino]
+tags: [swin, image_classification, en, open_source, openvino]
 task: Image Classification
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-19-image_classifier_vit_base_patch16_224_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-19-image_classifier_vit_base_patch16_224_en.md
@@ -4,7 +4,7 @@ title: English image_classifier_vit_base_patch16_224 ViTForImageClassification f
 author: John Snow Labs
 name: image_classifier_vit_base_patch16_224
 date: 2024-10-19
-tags: [vit, image_classification, en, open_source, onnx, openvino]
+tags: [vit, image_classification, en, open_source, openvino]
 task: Image Classification
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_iq3_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_iq3_m_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_iq3_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_iq3_m
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, tensorflow]
+tags: [en, open_source, conversational, text_generation, text_to_text, tensorflow]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_iq4_xs_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_iq4_xs_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_iq4_xs AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_iq4_xs
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, tensorflow]
+tags: [en, open_source, conversational, text_generation, text_to_text, tensorflow]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_q3_k_l_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_q3_k_l_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_q3_k_l AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_q3_k_l
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, tensorflow]
+tags: [en, open_source, conversational, text_generation, text_to_text, tensorflow]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_q4_k_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_q4_k_m
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, tensorflow]
+tags: [en, open_source, conversational, text_generation, text_to_text, tensorflow]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_q5_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_q5_k_m_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_q5_k_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_q5_k_m
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_q6_k_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_q6_k AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_q6_k
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-gemma_2_2b_it_q8_0_en.md
@@ -4,7 +4,7 @@ title: English gemma_2_2b_it_q8_0 AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: gemma_2_2b_it_q8_0
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_1b_instruct_q3_k_l_xx.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_1b_instruct_q3_k_l_xx.md
@@ -4,7 +4,7 @@ title: Multilingual llama_3.2_1b_instruct_q3_k_l AutoGGUFModel from lmstudio-com
 author: John Snow Labs
 name: llama_3.2_1b_instruct_q3_k_l
 date: 2024-10-29
-tags: [xx, open_source, onnx, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, llamacpp]
+tags: [xx, open_source, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, llamacpp]
 task: Text Generation
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_1b_instruct_q4_k_m_xx.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_1b_instruct_q4_k_m_xx.md
@@ -4,7 +4,7 @@ title: Multilingual llama_3.2_1b_instruct_q4_k_m AutoGGUFModel from lmstudio-com
 author: John Snow Labs
 name: llama_3.2_1b_instruct_q4_k_m
 date: 2024-10-29
-tags: [xx, open_source, onnx, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, llamacpp]
+tags: [xx, open_source, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, llamacpp]
 task: Text Generation
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_1b_instruct_q6_k_xx.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_1b_instruct_q6_k_xx.md
@@ -4,7 +4,7 @@ title: Multilingual llama_3.2_1b_instruct_q6_k AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: llama_3.2_1b_instruct_q6_k
 date: 2024-10-29
-tags: [xx, open_source, onnx, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, llamacpp]
+tags: [xx, open_source, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, llamacpp]
 task: Text Generation
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_1b_instruct_q8_0_xx.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_1b_instruct_q8_0_xx.md
@@ -4,7 +4,7 @@ title: Multilingual llama_3.2_1b_instruct_q8_0 AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: llama_3.2_1b_instruct_q8_0
 date: 2024-10-29
-tags: [xx, open_source, onnx, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, llamacpp]
+tags: [xx, open_source, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, llamacpp]
 task: Text Generation
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_3b_instruct_q3_k_l_xx.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_3b_instruct_q3_k_l_xx.md
@@ -4,7 +4,7 @@ title: Multilingual llama_3.2_3b_instruct_q3_k_l AutoGGUFModel from lmstudio-com
 author: John Snow Labs
 name: llama_3.2_3b_instruct_q3_k_l
 date: 2024-10-29
-tags: [xx, open_source, onnx, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, tensorflow]
+tags: [xx, open_source, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, tensorflow]
 task: Text Generation
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_3b_instruct_q4_k_m_xx.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_3b_instruct_q4_k_m_xx.md
@@ -4,7 +4,7 @@ title: Multilingual llama_3.2_3b_instruct_q4_k_m AutoGGUFModel from lmstudio-com
 author: John Snow Labs
 name: llama_3.2_3b_instruct_q4_k_m
 date: 2024-10-29
-tags: [xx, open_source, onnx, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, tensorflow]
+tags: [xx, open_source, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, tensorflow]
 task: Text Generation
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_3b_instruct_q6_k_xx.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_3b_instruct_q6_k_xx.md
@@ -4,7 +4,7 @@ title: Multilingual llama_3.2_3b_instruct_q6_k AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: llama_3.2_3b_instruct_q6_k
 date: 2024-10-29
-tags: [xx, open_source, onnx, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, tensorflow]
+tags: [xx, open_source, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, tensorflow]
 task: Text Generation
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_3b_instruct_q8_0_xx.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-llama_3.2_3b_instruct_q8_0_xx.md
@@ -4,7 +4,7 @@ title: Multilingual llama_3.2_3b_instruct_q8_0 AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: llama_3.2_3b_instruct_q8_0
 date: 2024-10-29
-tags: [xx, open_source, onnx, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, tensorflow]
+tags: [xx, open_source, conversational, text_generation, text_to_text, en, de, fr, it, pt, hi, es, th, tensorflow]
 task: Text Generation
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-mathstral_7b_v0.1_iq4_xs_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-mathstral_7b_v0.1_iq4_xs_en.md
@@ -4,7 +4,7 @@ title: English mathstral_7b_v0.1_iq4_xs AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: mathstral_7b_v0.1_iq4_xs
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-mathstral_7b_v0.1_q3_k_l_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-mathstral_7b_v0.1_q3_k_l_en.md
@@ -4,7 +4,7 @@ title: English mathstral_7b_v0.1_q3_k_l AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: mathstral_7b_v0.1_q3_k_l
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-meta_llama_3_8b_instruct_iq3_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-meta_llama_3_8b_instruct_iq3_m_en.md
@@ -4,7 +4,7 @@ title: English meta_llama_3_8b_instruct_iq3_m AutoGGUFModel from lmstudio-commun
 author: John Snow Labs
 name: meta_llama_3_8b_instruct_iq3_m
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-mistral_7b_instruct_v0.3_iq3_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-mistral_7b_instruct_v0.3_iq3_m_en.md
@@ -4,7 +4,7 @@ title: English mistral_7b_instruct_v0.3_iq3_m AutoGGUFModel from lmstudio-commun
 author: John Snow Labs
 name: mistral_7b_instruct_v0.3_iq3_m
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-mistral_7b_instruct_v0.3_q3_k_l_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-mistral_7b_instruct_v0.3_q3_k_l_en.md
@@ -4,7 +4,7 @@ title: English mistral_7b_instruct_v0.3_q3_k_l AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: mistral_7b_instruct_v0.3_q3_k_l
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-phi_3.1_mini_4k_instruct_iq3_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-phi_3.1_mini_4k_instruct_iq3_m_en.md
@@ -4,7 +4,7 @@ title: English phi_3.1_mini_4k_instruct_iq3_m AutoGGUFModel from lmstudio-commun
 author: John Snow Labs
 name: phi_3.1_mini_4k_instruct_iq3_m
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-qwen2_500m_instruct_f32_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-qwen2_500m_instruct_f32_en.md
@@ -4,7 +4,7 @@ title: English qwen2_500m_instruct_f32 AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2_500m_instruct_f32
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-qwen2_500m_instruct_iq4_xs_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-qwen2_500m_instruct_iq4_xs_en.md
@@ -4,7 +4,7 @@ title: English qwen2_500m_instruct_iq4_xs AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2_500m_instruct_iq4_xs
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-qwen2_500m_instruct_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-qwen2_500m_instruct_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English qwen2_500m_instruct_q4_k_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2_500m_instruct_q4_k_m
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-qwen2_500m_instruct_q5_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-qwen2_500m_instruct_q5_k_m_en.md
@@ -4,7 +4,7 @@ title: English qwen2_500m_instruct_q5_k_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2_500m_instruct_q5_k_m
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-qwen2_500m_instruct_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-qwen2_500m_instruct_q6_k_en.md
@@ -4,7 +4,7 @@ title: English qwen2_500m_instruct_q6_k AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2_500m_instruct_q6_k
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-qwen2_500m_instruct_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-qwen2_500m_instruct_q8_0_en.md
@@ -4,7 +4,7 @@ title: English qwen2_500m_instruct_q8_0 AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2_500m_instruct_q8_0
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-qwen2_math_1.5b_instruct_iq4_xs_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-qwen2_math_1.5b_instruct_iq4_xs_en.md
@@ -4,7 +4,7 @@ title: English qwen2_math_1.5b_instruct_iq4_xs AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: qwen2_math_1.5b_instruct_iq4_xs
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-qwen2_math_1.5b_instruct_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-qwen2_math_1.5b_instruct_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English qwen2_math_1.5b_instruct_q4_k_m AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: qwen2_math_1.5b_instruct_q4_k_m
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-qwen2_math_1.5b_instruct_q5_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-qwen2_math_1.5b_instruct_q5_k_m_en.md
@@ -4,7 +4,7 @@ title: English qwen2_math_1.5b_instruct_q5_k_m AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: qwen2_math_1.5b_instruct_q5_k_m
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-qwen2_math_1.5b_instruct_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-qwen2_math_1.5b_instruct_q6_k_en.md
@@ -4,7 +4,7 @@ title: English qwen2_math_1.5b_instruct_q6_k AutoGGUFModel from lmstudio-communi
 author: John Snow Labs
 name: qwen2_math_1.5b_instruct_q6_k
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-qwen2_math_1.5b_instruct_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-qwen2_math_1.5b_instruct_q8_0_en.md
@@ -4,7 +4,7 @@ title: English qwen2_math_1.5b_instruct_q8_0 AutoGGUFModel from lmstudio-communi
 author: John Snow Labs
 name: qwen2_math_1.5b_instruct_q8_0
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-yi_coder_1.5b_chat_q4_0_4_4_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-yi_coder_1.5b_chat_q4_0_4_4_en.md
@@ -4,7 +4,7 @@ title: English yi_coder_1.5b_chat_q4_0_4_4 AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: yi_coder_1.5b_chat_q4_0_4_4
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-yi_coder_1.5b_chat_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-yi_coder_1.5b_chat_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English yi_coder_1.5b_chat_q4_k_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: yi_coder_1.5b_chat_q4_k_m
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-yi_coder_1.5b_chat_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-yi_coder_1.5b_chat_q6_k_en.md
@@ -4,7 +4,7 @@ title: English yi_coder_1.5b_chat_q6_k AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: yi_coder_1.5b_chat_q6_k
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-29-yi_coder_1.5b_chat_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-29-yi_coder_1.5b_chat_q8_0_en.md
@@ -4,7 +4,7 @@ title: English yi_coder_1.5b_chat_q8_0 AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: yi_coder_1.5b_chat_q8_0
 date: 2024-10-29
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-alchemistcoder_ds_6.7b_iq4_xs_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-alchemistcoder_ds_6.7b_iq4_xs_en.md
@@ -4,7 +4,7 @@ title: English alchemistcoder_ds_6.7b_iq4_xs AutoGGUFModel from lmstudio-communi
 author: John Snow Labs
 name: alchemistcoder_ds_6.7b_iq4_xs
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-alchemistcoder_l_7b_iq4_xs_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-alchemistcoder_l_7b_iq4_xs_en.md
@@ -4,7 +4,7 @@ title: English alchemistcoder_l_7b_iq4_xs AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: alchemistcoder_l_7b_iq4_xs
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-codellama_7b_kstack_clean_iq3_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-codellama_7b_kstack_clean_iq3_m_en.md
@@ -4,7 +4,7 @@ title: English codellama_7b_kstack_clean_iq3_m AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: codellama_7b_kstack_clean_iq3_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-codellama_7b_kstack_iq3_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-codellama_7b_kstack_iq3_m_en.md
@@ -4,7 +4,7 @@ title: English codellama_7b_kstack_iq3_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: codellama_7b_kstack_iq3_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-deepseek_coder_1.3b_kexer_iq3_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-deepseek_coder_1.3b_kexer_iq3_m_en.md
@@ -4,7 +4,7 @@ title: English deepseek_coder_1.3b_kexer_iq3_m AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: deepseek_coder_1.3b_kexer_iq3_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-deepseek_coder_1.3b_kexer_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-deepseek_coder_1.3b_kexer_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English deepseek_coder_1.3b_kexer_q4_k_m AutoGGUFModel from lmstudio-comm
 author: John Snow Labs
 name: deepseek_coder_1.3b_kexer_q4_k_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-deepseek_coder_1.3b_kexer_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-deepseek_coder_1.3b_kexer_q6_k_en.md
@@ -4,7 +4,7 @@ title: English deepseek_coder_1.3b_kexer_q6_k AutoGGUFModel from lmstudio-commun
 author: John Snow Labs
 name: deepseek_coder_1.3b_kexer_q6_k
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-deepseek_coder_1.3b_kexer_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-deepseek_coder_1.3b_kexer_q8_0_en.md
@@ -4,7 +4,7 @@ title: English deepseek_coder_1.3b_kexer_q8_0 AutoGGUFModel from lmstudio-commun
 author: John Snow Labs
 name: deepseek_coder_1.3b_kexer_q8_0
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-deepseek_coder_6.7b_kexer_iq3_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-deepseek_coder_6.7b_kexer_iq3_m_en.md
@@ -4,7 +4,7 @@ title: English deepseek_coder_6.7b_kexer_iq3_m AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: deepseek_coder_6.7b_kexer_iq3_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-internlm2_5_1_8b_chat_iq4_xs_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-internlm2_5_1_8b_chat_iq4_xs_en.md
@@ -4,7 +4,7 @@ title: English internlm2_5_1_8b_chat_iq4_xs AutoGGUFModel from lmstudio-communit
 author: John Snow Labs
 name: internlm2_5_1_8b_chat_iq4_xs
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-internlm2_5_1_8b_chat_q3_k_l_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-internlm2_5_1_8b_chat_q3_k_l_en.md
@@ -4,7 +4,7 @@ title: English internlm2_5_1_8b_chat_q3_k_l AutoGGUFModel from lmstudio-communit
 author: John Snow Labs
 name: internlm2_5_1_8b_chat_q3_k_l
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-internlm2_5_1_8b_chat_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-internlm2_5_1_8b_chat_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English internlm2_5_1_8b_chat_q4_k_m AutoGGUFModel from lmstudio-communit
 author: John Snow Labs
 name: internlm2_5_1_8b_chat_q4_k_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-internlm2_5_1_8b_chat_q5_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-internlm2_5_1_8b_chat_q5_k_m_en.md
@@ -4,7 +4,7 @@ title: English internlm2_5_1_8b_chat_q5_k_m AutoGGUFModel from lmstudio-communit
 author: John Snow Labs
 name: internlm2_5_1_8b_chat_q5_k_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-internlm2_5_1_8b_chat_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-internlm2_5_1_8b_chat_q6_k_en.md
@@ -4,7 +4,7 @@ title: English internlm2_5_1_8b_chat_q6_k AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: internlm2_5_1_8b_chat_q6_k
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-internlm2_5_1_8b_chat_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-internlm2_5_1_8b_chat_q8_0_en.md
@@ -4,7 +4,7 @@ title: English internlm2_5_1_8b_chat_q8_0 AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: internlm2_5_1_8b_chat_q8_0
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-meta_llama_3_8b_instruct_iq3_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-meta_llama_3_8b_instruct_iq3_m_en.md
@@ -4,7 +4,7 @@ title: English meta_llama_3_8b_instruct_iq3_m AutoGGUFModel from lmstudio-commun
 author: John Snow Labs
 name: meta_llama_3_8b_instruct_iq3_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_0.5b_instruct_q3_k_l_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_0.5b_instruct_q3_k_l_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_0.5b_instruct_q3_k_l AutoGGUFModel from lmstudio-communit
 author: John Snow Labs
 name: qwen2.5_0.5b_instruct_q3_k_l
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_0.5b_instruct_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_0.5b_instruct_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_0.5b_instruct_q4_k_m AutoGGUFModel from lmstudio-communit
 author: John Snow Labs
 name: qwen2.5_0.5b_instruct_q4_k_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_0.5b_instruct_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_0.5b_instruct_q6_k_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_0.5b_instruct_q6_k AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2.5_0.5b_instruct_q6_k
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_0.5b_instruct_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_0.5b_instruct_q8_0_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_0.5b_instruct_q8_0 AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2.5_0.5b_instruct_q8_0
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_1.5b_instruct_q3_k_l_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_1.5b_instruct_q3_k_l_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_1.5b_instruct_q3_k_l AutoGGUFModel from lmstudio-communit
 author: John Snow Labs
 name: qwen2.5_1.5b_instruct_q3_k_l
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_1.5b_instruct_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_1.5b_instruct_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_1.5b_instruct_q4_k_m AutoGGUFModel from lmstudio-communit
 author: John Snow Labs
 name: qwen2.5_1.5b_instruct_q4_k_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_1.5b_instruct_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_1.5b_instruct_q6_k_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_1.5b_instruct_q6_k AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2.5_1.5b_instruct_q6_k
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_1.5b_instruct_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_1.5b_instruct_q8_0_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_1.5b_instruct_q8_0 AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2.5_1.5b_instruct_q8_0
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_3b_instruct_q3_k_l_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_3b_instruct_q3_k_l_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_3b_instruct_q3_k_l AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2.5_3b_instruct_q3_k_l
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_3b_instruct_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_3b_instruct_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_3b_instruct_q4_k_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2.5_3b_instruct_q4_k_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_3b_instruct_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_3b_instruct_q6_k_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_3b_instruct_q6_k AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2.5_3b_instruct_q6_k
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_3b_instruct_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_3b_instruct_q8_0_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_3b_instruct_q8_0 AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: qwen2.5_3b_instruct_q8_0
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_coder_1.5b_instruct_q3_k_l_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_coder_1.5b_instruct_q3_k_l_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_coder_1.5b_instruct_q3_k_l AutoGGUFModel from lmstudio-co
 author: John Snow Labs
 name: qwen2.5_coder_1.5b_instruct_q3_k_l
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_coder_1.5b_instruct_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_coder_1.5b_instruct_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_coder_1.5b_instruct_q4_k_m AutoGGUFModel from lmstudio-co
 author: John Snow Labs
 name: qwen2.5_coder_1.5b_instruct_q4_k_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_coder_1.5b_instruct_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_coder_1.5b_instruct_q6_k_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_coder_1.5b_instruct_q6_k AutoGGUFModel from lmstudio-comm
 author: John Snow Labs
 name: qwen2.5_coder_1.5b_instruct_q6_k
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_coder_1.5b_instruct_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_coder_1.5b_instruct_q8_0_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_coder_1.5b_instruct_q8_0 AutoGGUFModel from lmstudio-comm
 author: John Snow Labs
 name: qwen2.5_coder_1.5b_instruct_q8_0
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_math_1.5b_instruct_q3_k_l_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_math_1.5b_instruct_q3_k_l_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_math_1.5b_instruct_q3_k_l AutoGGUFModel from lmstudio-com
 author: John Snow Labs
 name: qwen2.5_math_1.5b_instruct_q3_k_l
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_math_1.5b_instruct_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_math_1.5b_instruct_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_math_1.5b_instruct_q4_k_m AutoGGUFModel from lmstudio-com
 author: John Snow Labs
 name: qwen2.5_math_1.5b_instruct_q4_k_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_math_1.5b_instruct_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_math_1.5b_instruct_q6_k_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_math_1.5b_instruct_q6_k AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: qwen2.5_math_1.5b_instruct_q6_k
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_math_1.5b_instruct_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-qwen2.5_math_1.5b_instruct_q8_0_en.md
@@ -4,7 +4,7 @@ title: English qwen2.5_math_1.5b_instruct_q8_0 AutoGGUFModel from lmstudio-commu
 author: John Snow Labs
 name: qwen2.5_math_1.5b_instruct_q8_0
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-yi_1.5_6b_chat_q3_k_l_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-yi_1.5_6b_chat_q3_k_l_en.md
@@ -4,7 +4,7 @@ title: English yi_1.5_6b_chat_q3_k_l AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: yi_1.5_6b_chat_q3_k_l
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-yi_1.5_6b_chat_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-yi_1.5_6b_chat_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English yi_1.5_6b_chat_q4_k_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: yi_1.5_6b_chat_q4_k_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-yi_coder_1.5b_q4_0_4_4_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-yi_coder_1.5b_q4_0_4_4_en.md
@@ -4,7 +4,7 @@ title: English yi_coder_1.5b_q4_0_4_4 AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: yi_coder_1.5b_q4_0_4_4
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-yi_coder_1.5b_q4_k_m_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-yi_coder_1.5b_q4_k_m_en.md
@@ -4,7 +4,7 @@ title: English yi_coder_1.5b_q4_k_m AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: yi_coder_1.5b_q4_k_m
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-yi_coder_1.5b_q6_k_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-yi_coder_1.5b_q6_k_en.md
@@ -4,7 +4,7 @@ title: English yi_coder_1.5b_q6_k AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: yi_coder_1.5b_q6_k
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-10-30-yi_coder_1.5b_q8_0_en.md
+++ b/docs/_posts/ahmedlone127/2024-10-30-yi_coder_1.5b_q8_0_en.md
@@ -4,7 +4,7 @@ title: English yi_coder_1.5b_q8_0 AutoGGUFModel from lmstudio-community
 author: John Snow Labs
 name: yi_coder_1.5b_q8_0
 date: 2024-10-30
-tags: [en, open_source, onnx, conversational, text_generation, text_to_text, llamacpp]
+tags: [en, open_source, conversational, text_generation, text_to_text, llamacpp]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-11-03-gpt2_en.md
+++ b/docs/_posts/ahmedlone127/2024-11-03-gpt2_en.md
@@ -4,7 +4,7 @@ title: GPT2 text-to-text model (Base)
 author: John Snow Labs
 name: gpt2
 date: 2024-11-03
-tags: [gpt2, en, open_source, onnx, openvino]
+tags: [gpt2, en, open_source, openvino]
 task: Text Generation
 language: en
 edition: Spark NLP 5.5.0

--- a/docs/_posts/ahmedlone127/2024-12-14-deberta_base_zero_shot_classifier_mnli_anli_v3_en.md
+++ b/docs/_posts/ahmedlone127/2024-12-14-deberta_base_zero_shot_classifier_mnli_anli_v3_en.md
@@ -4,7 +4,7 @@ title: DeBerta Zero-Shot Classification Base - MNLI ANLI  (deberta_base_zero_sho
 author: John Snow Labs
 name: deberta_base_zero_shot_classifier_mnli_anli_v3
 date: 2024-12-14
-tags: [zero_shot, deberta, en, open_source, openvino, onnx]
+tags: [zero_shot, deberta, en, open_source, onnx]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-12-15-image_captioning_vit_gpt2_en.md
+++ b/docs/_posts/ahmedlone127/2024-12-15-image_captioning_vit_gpt2_en.md
@@ -4,7 +4,7 @@ title: Image Caption with VisionEncoderDecoder ViT GPT2
 author: John Snow Labs
 name: image_captioning_vit_gpt2
 date: 2024-12-15
-tags: [en, image_classification, vit, gpt2, captioning, open_source, openvino, onnx]
+tags: [en, image_classification, vit, gpt2, captioning, open_source, onnx]
 task: Image Captioning
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2024-12-16-distilbert_base_zero_shot_classifier_uncased_mnli_en.md
+++ b/docs/_posts/ahmedlone127/2024-12-16-distilbert_base_zero_shot_classifier_uncased_mnli_en.md
@@ -4,7 +4,7 @@ title: DistilBERTZero-Shot Classification Base - MNLI(distilbert_base_zero_shot_
 author: John Snow Labs
 name: distilbert_base_zero_shot_classifier_uncased_mnli
 date: 2024-12-16
-tags: [zero_shot, en, mnli, distilbert, english, base, open_source, openvino, onnx]
+tags: [zero_shot, en, mnli, distilbert, english, base, open_source, onnx]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-01-16-bge_small_en_v1.5_en.md
+++ b/docs/_posts/ahmedlone127/2025-01-16-bge_small_en_v1.5_en.md
@@ -4,7 +4,7 @@ title: bge_small_en_v1.5 model from BAAI
 author: John Snow Labs
 name: bge_small_en_v1.5
 date: 2025-01-16
-tags: [en, open_source, openvino, onnx]
+tags: [en, open_source, onnx]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-01-23-bart_large_zero_shot_classifier_mnli_en.md
+++ b/docs/_posts/ahmedlone127/2025-01-23-bart_large_zero_shot_classifier_mnli_en.md
@@ -4,7 +4,7 @@ title: Bart Zero Shot Classifier Large -MNLI (bart_large_zero_shot_classifier_mn
 author: John Snow Labs
 name: bart_large_zero_shot_classifier_mnli
 date: 2025-01-23
-tags: [bart, zero_shot, en, open_source, openvino, onnx]
+tags: [bart, zero_shot, en, open_source, onnx]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-bce_reranker_base_v1_maidalun1020_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-bce_reranker_base_v1_maidalun1020_en.md
@@ -4,7 +4,7 @@ title: English bce_reranker_base_v1_maidalun1020 XlmRoBertaForSequenceClassifica
 author: John Snow Labs
 name: bce_reranker_base_v1_maidalun1020
 date: 2025-05-20
-tags: [en, open_source, onnx, sequence_classification, xlm_roberta, openvino]
+tags: [en, open_source, sequence_classification, xlm_roberta, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-bge_reranker_base_baai_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-bge_reranker_base_baai_en.md
@@ -4,7 +4,7 @@ title: English bge_reranker_base_baai XlmRoBertaForSequenceClassification from B
 author: John Snow Labs
 name: bge_reranker_base_baai
 date: 2025-05-20
-tags: [en, open_source, onnx, sequence_classification, xlm_roberta, openvino]
+tags: [en, open_source, sequence_classification, xlm_roberta, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-bge_reranker_v2_m3_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-bge_reranker_v2_m3_en.md
@@ -4,7 +4,7 @@ title: English bge_reranker_v2_m3 XlmRoBertaForSequenceClassification from BAAI
 author: John Snow Labs
 name: bge_reranker_v2_m3
 date: 2025-05-20
-tags: [en, open_source, onnx, sequence_classification, xlm_roberta, openvino]
+tags: [en, open_source, sequence_classification, xlm_roberta, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-fullstop_punctuation_multilang_large_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-fullstop_punctuation_multilang_large_en.md
@@ -4,7 +4,7 @@ title: English fullstop_punctuation_multilang_large XlmRoBertaForTokenClassifica
 author: John Snow Labs
 name: fullstop_punctuation_multilang_large
 date: 2025-05-20
-tags: [en, open_source, onnx, token_classification, xlm_roberta, ner, openvino]
+tags: [en, open_source, token_classification, xlm_roberta, ner, openvino]
 task: Named Entity Recognition
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-korean_reranker_ko.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-korean_reranker_ko.md
@@ -4,7 +4,7 @@ title: Korean korean_reranker XlmRoBertaForSequenceClassification from Dongjin-k
 author: John Snow Labs
 name: korean_reranker
 date: 2025-05-20
-tags: [ko, open_source, onnx, sequence_classification, xlm_roberta, openvino]
+tags: [ko, open_source, sequence_classification, xlm_roberta, openvino]
 task: Text Classification
 language: ko
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-mmarco_mminilmv2_l12_h384_v1_nreimers_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-mmarco_mminilmv2_l12_h384_v1_nreimers_en.md
@@ -4,7 +4,7 @@ title: English mmarco_mminilmv2_l12_h384_v1_nreimers XlmRoBertaForSequenceClassi
 author: John Snow Labs
 name: mmarco_mminilmv2_l12_h384_v1_nreimers
 date: 2025-05-20
-tags: [en, open_source, onnx, sequence_classification, xlm_roberta, openvino]
+tags: [en, open_source, sequence_classification, xlm_roberta, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-multilingual_iptc_news_topic_classifier_xx.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-multilingual_iptc_news_topic_classifier_xx.md
@@ -4,7 +4,7 @@ title: Multilingual multilingual_iptc_news_topic_classifier XlmRoBertaForSequenc
 author: John Snow Labs
 name: multilingual_iptc_news_topic_classifier
 date: 2025-05-20
-tags: [xx, open_source, onnx, sequence_classification, xlm_roberta, openvino]
+tags: [xx, open_source, sequence_classification, xlm_roberta, openvino]
 task: Text Classification
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-sent_infoxlm_base_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-sent_infoxlm_base_en.md
@@ -4,7 +4,7 @@ title: English sent_infoxlm_base XlmRoBertaSentenceEmbeddings from microsoft
 author: John Snow Labs
 name: sent_infoxlm_base
 date: 2025-05-20
-tags: [en, open_source, onnx, sentence_embeddings, xlm_roberta, openvino]
+tags: [en, open_source, sentence_embeddings, xlm_roberta, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-sent_infoxlm_large_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-sent_infoxlm_large_en.md
@@ -4,7 +4,7 @@ title: English sent_infoxlm_large XlmRoBertaSentenceEmbeddings from microsoft
 author: John Snow Labs
 name: sent_infoxlm_large
 date: 2025-05-20
-tags: [en, open_source, onnx, sentence_embeddings, xlm_roberta, openvino]
+tags: [en, open_source, sentence_embeddings, xlm_roberta, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-sent_mminilmv2_l12_h384_distilled_from_xlmr_large_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-sent_mminilmv2_l12_h384_distilled_from_xlmr_large_en.md
@@ -4,7 +4,7 @@ title: English sent_mminilmv2_l12_h384_distilled_from_xlmr_large XlmRoBertaSente
 author: John Snow Labs
 name: sent_mminilmv2_l12_h384_distilled_from_xlmr_large
 date: 2025-05-20
-tags: [en, open_source, onnx, sentence_embeddings, xlm_roberta, openvino]
+tags: [en, open_source, sentence_embeddings, xlm_roberta, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-sent_twitter_xlm_roberta_base_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-sent_twitter_xlm_roberta_base_en.md
@@ -4,7 +4,7 @@ title: English sent_twitter_xlm_roberta_base XlmRoBertaSentenceEmbeddings from c
 author: John Snow Labs
 name: sent_twitter_xlm_roberta_base
 date: 2025-05-20
-tags: [en, open_source, onnx, sentence_embeddings, xlm_roberta, openvino]
+tags: [en, open_source, sentence_embeddings, xlm_roberta, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-sent_xlm_roberta_large_xx.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-sent_xlm_roberta_large_xx.md
@@ -4,7 +4,7 @@ title: Multilingual sent_xlm_roberta_large XlmRoBertaSentenceEmbeddings from Fac
 author: John Snow Labs
 name: sent_xlm_roberta_large
 date: 2025-05-20
-tags: [xx, open_source, onnx, sentence_embeddings, xlm_roberta, openvino]
+tags: [xx, open_source, sentence_embeddings, xlm_roberta, openvino]
 task: Embeddings
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-twitter_xlm_roberta_base_sentiment_multilingual_xx.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-twitter_xlm_roberta_base_sentiment_multilingual_xx.md
@@ -4,7 +4,7 @@ title: Multilingual twitter_xlm_roberta_base_sentiment_multilingual XlmRoBertaFo
 author: John Snow Labs
 name: twitter_xlm_roberta_base_sentiment_multilingual
 date: 2025-05-20
-tags: [xx, open_source, onnx, sequence_classification, xlm_roberta, openvino]
+tags: [xx, open_source, sequence_classification, xlm_roberta, openvino]
 task: Text Classification
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-xlm_roberta_base_language_detection_xx.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-xlm_roberta_base_language_detection_xx.md
@@ -4,7 +4,7 @@ title: Multilingual xlm_roberta_base_language_detection XlmRoBertaForSequenceCla
 author: John Snow Labs
 name: xlm_roberta_base_language_detection
 date: 2025-05-20
-tags: [xx, open_source, onnx, sequence_classification, xlm_roberta, openvino]
+tags: [xx, open_source, sequence_classification, xlm_roberta, openvino]
 task: Text Classification
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-xlm_roberta_base_romanian_ner_ronec_ro.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-xlm_roberta_base_romanian_ner_ronec_ro.md
@@ -4,7 +4,7 @@ title: Moldavian, Moldovan, Romanian xlm_roberta_base_romanian_ner_ronec XlmRoBe
 author: John Snow Labs
 name: xlm_roberta_base_romanian_ner_ronec
 date: 2025-05-20
-tags: [ro, open_source, onnx, token_classification, xlm_roberta, ner, openvino]
+tags: [ro, open_source, token_classification, xlm_roberta, ner, openvino]
 task: Named Entity Recognition
 language: ro
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-xlm_roberta_large_finetuned_conll03_english_xx.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-xlm_roberta_large_finetuned_conll03_english_xx.md
@@ -4,7 +4,7 @@ title: Multilingual xlm_roberta_large_finetuned_conll03_english XlmRoBertaForTok
 author: John Snow Labs
 name: xlm_roberta_large_finetuned_conll03_english
 date: 2025-05-20
-tags: [xx, open_source, onnx, token_classification, xlm_roberta, ner, openvino]
+tags: [xx, open_source, token_classification, xlm_roberta, ner, openvino]
 task: Named Entity Recognition
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-xlm_roberta_large_finetuned_conll03_german_xx.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-xlm_roberta_large_finetuned_conll03_german_xx.md
@@ -4,7 +4,7 @@ title: Multilingual xlm_roberta_large_finetuned_conll03_german XlmRoBertaForToke
 author: John Snow Labs
 name: xlm_roberta_large_finetuned_conll03_german
 date: 2025-05-20
-tags: [xx, open_source, onnx, token_classification, xlm_roberta, ner, openvino]
+tags: [xx, open_source, token_classification, xlm_roberta, ner, openvino]
 task: Named Entity Recognition
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-xlm_roberta_large_ner_spanish_es.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-xlm_roberta_large_ner_spanish_es.md
@@ -4,7 +4,7 @@ title: Castilian, Spanish xlm_roberta_large_ner_spanish XlmRoBertaForTokenClassi
 author: John Snow Labs
 name: xlm_roberta_large_ner_spanish
 date: 2025-05-20
-tags: [es, open_source, onnx, token_classification, xlm_roberta, ner, openvino]
+tags: [es, open_source, token_classification, xlm_roberta, ner, openvino]
 task: Named Entity Recognition
 language: es
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-20-xlm_roberta_ner_japanese_ja.md
+++ b/docs/_posts/ahmedlone127/2025-05-20-xlm_roberta_ner_japanese_ja.md
@@ -4,7 +4,7 @@ title: Japanese xlm_roberta_ner_japanese XlmRoBertaForTokenClassification from t
 author: John Snow Labs
 name: xlm_roberta_ner_japanese
 date: 2025-05-20
-tags: [ja, open_source, onnx, token_classification, xlm_roberta, ner, openvino]
+tags: [ja, open_source, token_classification, xlm_roberta, ner, openvino]
 task: Named Entity Recognition
 language: ja
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-clip_vit_base_patch16_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-clip_vit_base_patch16_en.md
@@ -4,7 +4,7 @@ title: English clip_vit_base_patch16 CLIPForZeroShotClassification from openai
 author: John Snow Labs
 name: clip_vit_base_patch16
 date: 2025-05-21
-tags: [en, open_source, onnx, zero_shot, clip, image, openvino]
+tags: [en, open_source, zero_shot, clip, image, openvino]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-clip_vit_large_patch14_336_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-clip_vit_large_patch14_336_en.md
@@ -4,7 +4,7 @@ title: English clip_vit_large_patch14_336 CLIPForZeroShotClassification from ope
 author: John Snow Labs
 name: clip_vit_large_patch14_336
 date: 2025-05-21
-tags: [en, open_source, onnx, zero_shot, clip, image, openvino]
+tags: [en, open_source, zero_shot, clip, image, openvino]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-fashion_clip_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-fashion_clip_en.md
@@ -4,7 +4,7 @@ title: English fashion_clip CLIPForZeroShotClassification from patrickjohncyh
 author: John Snow Labs
 name: fashion_clip
 date: 2025-05-21
-tags: [en, open_source, onnx, zero_shot, clip, image, openvino]
+tags: [en, open_source, zero_shot, clip, image, openvino]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-infoxlm_base_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-infoxlm_base_en.md
@@ -4,7 +4,7 @@ title: English infoxlm_base XlmRoBertaEmbeddings from microsoft
 author: John Snow Labs
 name: infoxlm_base
 date: 2025-05-21
-tags: [en, open_source, onnx, embeddings, xlm_roberta, openvino]
+tags: [en, open_source, embeddings, xlm_roberta, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-infoxlm_large_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-infoxlm_large_en.md
@@ -4,7 +4,7 @@ title: English infoxlm_large XlmRoBertaEmbeddings from microsoft
 author: John Snow Labs
 name: infoxlm_large
 date: 2025-05-21
-tags: [en, open_source, onnx, embeddings, xlm_roberta, openvino]
+tags: [en, open_source, embeddings, xlm_roberta, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-mminilmv2_l12_h384_distilled_from_xlmr_large_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-mminilmv2_l12_h384_distilled_from_xlmr_large_en.md
@@ -4,7 +4,7 @@ title: English mminilmv2_l12_h384_distilled_from_xlmr_large XlmRoBertaEmbeddings
 author: John Snow Labs
 name: mminilmv2_l12_h384_distilled_from_xlmr_large
 date: 2025-05-21
-tags: [en, open_source, onnx, embeddings, xlm_roberta, openvino]
+tags: [en, open_source, embeddings, xlm_roberta, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-persian_xlm_roberta_large_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-persian_xlm_roberta_large_en.md
@@ -4,7 +4,7 @@ title: English persian_xlm_roberta_large XlmRoBertaForQuestionAnswering from ped
 author: John Snow Labs
 name: persian_xlm_roberta_large
 date: 2025-05-21
-tags: [en, open_source, onnx, question_answering, xlm_roberta, openvino]
+tags: [en, open_source, question_answering, xlm_roberta, openvino]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-robbert_v2_dutch_ner_nl.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-robbert_v2_dutch_ner_nl.md
@@ -4,7 +4,7 @@ title: Dutch, Flemish robbert_v2_dutch_ner RoBertaForTokenClassification from pd
 author: John Snow Labs
 name: robbert_v2_dutch_ner
 date: 2025-05-21
-tags: [nl, open_source, onnx, token_classification, roberta, ner, openvino]
+tags: [nl, open_source, token_classification, roberta, ner, openvino]
 task: Named Entity Recognition
 language: nl
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-roberta_large_ner_english_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-roberta_large_ner_english_en.md
@@ -4,7 +4,7 @@ title: English roberta_large_ner_english RoBertaForTokenClassification from Jean
 author: John Snow Labs
 name: roberta_large_ner_english
 date: 2025-05-21
-tags: [en, open_source, onnx, token_classification, roberta, ner, openvino]
+tags: [en, open_source, token_classification, roberta, ner, openvino]
 task: Named Entity Recognition
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-roberta_large_tweetner7_all_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-roberta_large_tweetner7_all_en.md
@@ -4,7 +4,7 @@ title: English roberta_large_tweetner7_all RoBertaForTokenClassification from tn
 author: John Snow Labs
 name: roberta_large_tweetner7_all
 date: 2025-05-21
-tags: [roberta, en, open_source, token_classification, onnx, openvino]
+tags: [roberta, en, open_source, token_classification, openvino]
 task: Named Entity Recognition
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-roberta_token_classifier_sayula_popoluca_tagger_id.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-roberta_token_classifier_sayula_popoluca_tagger_id.md
@@ -4,7 +4,7 @@ title: Indonesian roberta_token_classifier_sayula_popoluca_tagger RoBertaForToke
 author: John Snow Labs
 name: roberta_token_classifier_sayula_popoluca_tagger
 date: 2025-05-21
-tags: [id, open_source, onnx, token_classification, roberta, ner, openvino]
+tags: [id, open_source, token_classification, roberta, ner, openvino]
 task: Named Entity Recognition
 language: id
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-twitter_xlm_roberta_base_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-twitter_xlm_roberta_base_en.md
@@ -4,7 +4,7 @@ title: English twitter_xlm_roberta_base XlmRoBertaForSequenceClassification from
 author: John Snow Labs
 name: twitter_xlm_roberta_base
 date: 2025-05-21
-tags: [en, open_source, onnx, sequence_classification, xlm_roberta, openvino]
+tags: [en, open_source, sequence_classification, xlm_roberta, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-xlm_roberta_base_xx.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-xlm_roberta_base_xx.md
@@ -4,7 +4,7 @@ title: XLM-RoBERTa Base (xlm_roberta_base)
 author: John Snow Labs
 name: xlm_roberta_base
 date: 2025-05-21
-tags: [xx, multilingual, embeddings, xlm_roberta, open_source, onnx, openvino]
+tags: [xx, multilingual, embeddings, xlm_roberta, open_source, openvino]
 task: Embeddings
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-xlm_roberta_large_qa_multilingual_finedtuned_russian_xx.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-xlm_roberta_large_qa_multilingual_finedtuned_russian_xx.md
@@ -4,7 +4,7 @@ title: Multilingual xlm_roberta_large_qa_multilingual_finedtuned_russian XlmRoBe
 author: John Snow Labs
 name: xlm_roberta_large_qa_multilingual_finedtuned_russian
 date: 2025-05-21
-tags: [xx, open_source, onnx, question_answering, xlm_roberta, openvino]
+tags: [xx, open_source, question_answering, xlm_roberta, openvino]
 task: Question Answering
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-xlm_roberta_large_xquad_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-xlm_roberta_large_xquad_en.md
@@ -4,7 +4,7 @@ title: English xlm_roberta_large_xquad XlmRoBertaForQuestionAnswering from alon-
 author: John Snow Labs
 name: xlm_roberta_large_xquad
 date: 2025-05-21
-tags: [en, open_source, onnx, question_answering, xlm_roberta, openvino]
+tags: [en, open_source, question_answering, xlm_roberta, openvino]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-xlm_roberta_qa_xlm_roberta_base_arabic_ar.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-xlm_roberta_qa_xlm_roberta_base_arabic_ar.md
@@ -4,7 +4,7 @@ title: Arabic XlmRoBertaForQuestionAnswering (from bhavikardeshna)
 author: John Snow Labs
 name: xlm_roberta_qa_xlm_roberta_base_arabic
 date: 2025-05-21
-tags: [ar, open_source, question_answering, xlmroberta, onnx, openvino]
+tags: [ar, open_source, question_answering, xlmroberta, openvino]
 task: Question Answering
 language: ar
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-xlm_roberta_qa_xlm_roberta_base_squad2_distilled_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-xlm_roberta_qa_xlm_roberta_base_squad2_distilled_en.md
@@ -4,7 +4,7 @@ title: English XlmRoBertaForQuestionAnswering (from deepset)
 author: John Snow Labs
 name: xlm_roberta_qa_xlm_roberta_base_squad2_distilled
 date: 2025-05-21
-tags: [en, open_source, question_answering, xlmroberta, onnx, openvino]
+tags: [en, open_source, question_answering, xlmroberta, openvino]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-xlm_v_base_xx.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-xlm_v_base_xx.md
@@ -4,7 +4,7 @@ title: Multilingual xlm_v_base XlmRoBertaEmbeddings from facebook
 author: John Snow Labs
 name: xlm_v_base
 date: 2025-05-21
-tags: [xx, open_source, onnx, embeddings, xlm_roberta, openvino]
+tags: [xx, open_source, embeddings, xlm_roberta, openvino]
 task: Embeddings
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-xlmr_large_qa_persian_farsi_fa.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-xlmr_large_qa_persian_farsi_fa.md
@@ -4,7 +4,7 @@ title: Persian xlmr_large_qa_persian_farsi XlmRoBertaForQuestionAnswering from m
 author: John Snow Labs
 name: xlmr_large_qa_persian_farsi
 date: 2025-05-21
-tags: [fa, open_source, onnx, question_answering, xlm_roberta, openvino]
+tags: [fa, open_source, question_answering, xlm_roberta, openvino]
 task: Question Answering
 language: fa
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-xlmroberta_qa_ukrainian_uk.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-xlmroberta_qa_ukrainian_uk.md
@@ -4,7 +4,7 @@ title: Ukrainian XlmRoBertaForQuestionAnswering model (from robinhad)
 author: John Snow Labs
 name: xlmroberta_qa_ukrainian
 date: 2025-05-21
-tags: [uk, open_source, xlmroberta, question_answering, onnx, openvino]
+tags: [uk, open_source, xlmroberta, question_answering, openvino]
 task: Question Answering
 language: uk
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-21-zero_shot_classifier_clip_vit_base_patch32_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-21-zero_shot_classifier_clip_vit_base_patch32_en.md
@@ -4,7 +4,7 @@ title: Image Zero Shot Classification with CLIP
 author: John Snow Labs
 name: zero_shot_classifier_clip_vit_base_patch32
 date: 2025-05-21
-tags: [classification, image, en, zero_shot, open_source, onnx, openvino]
+tags: [classification, image, en, zero_shot, open_source, openvino]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-all_mpnet_base_v2_sentence_transformers_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-all_mpnet_base_v2_sentence_transformers_en.md
@@ -4,7 +4,7 @@ title: English all_mpnet_base_v2_sentence_transformers MPNetEmbeddings from sent
 author: John Snow Labs
 name: all_mpnet_base_v2_sentence_transformers
 date: 2025-05-22
-tags: [mpnet, en, open_source, onnx, openvino]
+tags: [mpnet, en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-amd_full_phonetree_v1_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-amd_full_phonetree_v1_en.md
@@ -4,7 +4,7 @@ title: English amd_full_phonetree_v1 MPNetForSequenceClassification from nikchee
 author: John Snow Labs
 name: amd_full_phonetree_v1
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, mpnet, openvino]
+tags: [en, open_source, sequence_classification, mpnet, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-amd_partial_phonetree_v1_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-amd_partial_phonetree_v1_en.md
@@ -4,7 +4,7 @@ title: English amd_partial_phonetree_v1 MPNetForSequenceClassification from nikc
 author: John Snow Labs
 name: amd_partial_phonetree_v1
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, mpnet, openvino]
+tags: [en, open_source, sequence_classification, mpnet, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-amd_partial_v1_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-amd_partial_v1_en.md
@@ -4,7 +4,7 @@ title: English amd_partial_v1 MPNetForSequenceClassification from nikcheerla
 author: John Snow Labs
 name: amd_partial_v1
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, mpnet, openvino]
+tags: [en, open_source, sequence_classification, mpnet, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-amd_power_dialer_v1_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-amd_power_dialer_v1_en.md
@@ -4,7 +4,7 @@ title: English amd_power_dialer_v1 MPNetForSequenceClassification from nikcheerl
 author: John Snow Labs
 name: amd_power_dialer_v1
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, mpnet, openvino]
+tags: [en, open_source, sequence_classification, mpnet, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-autotrain_kjxi3_hql8x_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-autotrain_kjxi3_hql8x_en.md
@@ -4,7 +4,7 @@ title: English autotrain_kjxi3_hql8x MPNetForQuestionAnswering from Ai4des
 author: John Snow Labs
 name: autotrain_kjxi3_hql8x
 date: 2025-05-22
-tags: [en, open_source, onnx, question_answering, mpnet, openvino]
+tags: [en, open_source, question_answering, mpnet, openvino]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-biolord_2023_c_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-biolord_2023_c_en.md
@@ -4,7 +4,7 @@ title: English biolord_2023_c MPNetEmbeddings from FremyCompany
 author: John Snow Labs
 name: biolord_2023_c
 date: 2025-05-22
-tags: [en, open_source, onnx, embeddings, mpnet, openvino]
+tags: [en, open_source, embeddings, mpnet, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-biolord_2023_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-biolord_2023_en.md
@@ -4,7 +4,7 @@ title: English biolord_2023 MPNetEmbeddings from FremyCompany
 author: John Snow Labs
 name: biolord_2023
 date: 2025-05-22
-tags: [en, open_source, onnx, embeddings, mpnet, openvino]
+tags: [en, open_source, embeddings, mpnet, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-burmese_setfit_classifier_threat_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-burmese_setfit_classifier_threat_en.md
@@ -4,7 +4,7 @@ title: English burmese_setfit_classifier_threat MPNetForSequenceClassification f
 author: John Snow Labs
 name: burmese_setfit_classifier_threat
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, mpnet, openvino]
+tags: [en, open_source, sequence_classification, mpnet, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-chemberta_zinc_base_v1_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-chemberta_zinc_base_v1_en.md
@@ -4,7 +4,7 @@ title: English chemberta_zinc_base_v1 RoBertaEmbeddings from seyonec
 author: John Snow Labs
 name: chemberta_zinc_base_v1
 date: 2025-05-22
-tags: [en, open_source, onnx, embeddings, roberta, openvino]
+tags: [en, open_source, embeddings, roberta, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-codebert_python_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-codebert_python_en.md
@@ -4,7 +4,7 @@ title: English codebert_python RoBertaEmbeddings from neulab
 author: John Snow Labs
 name: codebert_python
 date: 2025-05-22
-tags: [en, open_source, onnx, embeddings, roberta, openvino]
+tags: [en, open_source, embeddings, roberta, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-coherence_all_mpnet_base_v2_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-coherence_all_mpnet_base_v2_en.md
@@ -4,7 +4,7 @@ title: English coherence_all_mpnet_base_v2 MPNetForSequenceClassification from e
 author: John Snow Labs
 name: coherence_all_mpnet_base_v2
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, mpnet, openvino]
+tags: [en, open_source, sequence_classification, mpnet, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-covid_qa_mpnet_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-covid_qa_mpnet_en.md
@@ -4,7 +4,7 @@ title: English covid_qa_mpnet MPNetEmbeddings from shaina
 author: John Snow Labs
 name: covid_qa_mpnet
 date: 2025-05-22
-tags: [mpnet, en, open_source, onnx, openvino]
+tags: [mpnet, en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-e5_base_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-e5_base_en.md
@@ -4,7 +4,7 @@ title: E5 Base Sentence Embeddings
 author: John Snow Labs
 name: e5_base
 date: 2025-05-22
-tags: [en, open_source, onnx, openvino]
+tags: [en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-e5_base_v2_intfloat_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-e5_base_v2_intfloat_en.md
@@ -4,7 +4,7 @@ title: English e5_base_v2_intfloat E5Embeddings from intfloat
 author: John Snow Labs
 name: e5_base_v2_intfloat
 date: 2025-05-22
-tags: [en, open_source, onnx, embeddings, e5, openvino]
+tags: [en, open_source, embeddings, e5, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-e5_large_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-e5_large_en.md
@@ -4,7 +4,7 @@ title: E5 Large Sentence Embeddings
 author: John Snow Labs
 name: e5_large
 date: 2025-05-22
-tags: [en, open_source, onnx, openvino]
+tags: [en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-e5_large_v2_intfloat_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-e5_large_v2_intfloat_en.md
@@ -4,7 +4,7 @@ title: English e5_large_v2_intfloat E5Embeddings from intfloat
 author: John Snow Labs
 name: e5_large_v2_intfloat
 date: 2025-05-22
-tags: [en, open_source, onnx, embeddings, e5, openvino]
+tags: [en, open_source, embeddings, e5, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-e5_small_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-e5_small_en.md
@@ -4,7 +4,7 @@ title: E5 Small Sentence Embeddings
 author: John Snow Labs
 name: e5_small
 date: 2025-05-22
-tags: [en, open_source, onnx, openvino]
+tags: [en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-e5_small_v2_intfloat_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-e5_small_v2_intfloat_en.md
@@ -4,7 +4,7 @@ title: English e5_small_v2_intfloat E5Embeddings from intfloat
 author: John Snow Labs
 name: e5_small_v2_intfloat
 date: 2025-05-22
-tags: [en, open_source, onnx, embeddings, e5, openvino]
+tags: [en, open_source, embeddings, e5, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-fin_mpnet_base_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-fin_mpnet_base_en.md
@@ -4,7 +4,7 @@ title: English fin_mpnet_base MPNetEmbeddings from mukaj
 author: John Snow Labs
 name: fin_mpnet_base
 date: 2025-05-22
-tags: [en, open_source, onnx, embeddings, mpnet, openvino]
+tags: [en, open_source, embeddings, mpnet, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-hub_report_20241202125641_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-hub_report_20241202125641_en.md
@@ -4,7 +4,7 @@ title: English hub_report_20241202125641 MPNetForSequenceClassification from Kev
 author: John Snow Labs
 name: hub_report_20241202125641
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, mpnet, openvino]
+tags: [en, open_source, sequence_classification, mpnet, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-icelandic_nepal_bhasa_dataset_teacher_model_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-icelandic_nepal_bhasa_dataset_teacher_model_en.md
@@ -4,7 +4,7 @@ title: English icelandic_nepal_bhasa_dataset_teacher_model MPNetForSequenceClass
 author: John Snow Labs
 name: icelandic_nepal_bhasa_dataset_teacher_model
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, mpnet, openvino]
+tags: [en, open_source, sequence_classification, mpnet, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-information_content_model_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-information_content_model_en.md
@@ -4,7 +4,7 @@ title: English information_content_model MPNetForSequenceClassification from ony
 author: John Snow Labs
 name: information_content_model
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, mpnet, openvino]
+tags: [en, open_source, sequence_classification, mpnet, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-multi_qa_mpnet_base_cos_v1_sentence_transformers_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-multi_qa_mpnet_base_cos_v1_sentence_transformers_en.md
@@ -4,7 +4,7 @@ title: English multi_qa_mpnet_base_cos_v1_sentence_transformers MPNetEmbeddings 
 author: John Snow Labs
 name: multi_qa_mpnet_base_cos_v1_sentence_transformers
 date: 2025-05-22
-tags: [mpnet, en, open_source, onnx, openvino]
+tags: [mpnet, en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-multi_qa_mpnet_base_dot_v1_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-multi_qa_mpnet_base_dot_v1_en.md
@@ -4,7 +4,7 @@ title: English multi_qa_mpnet_base_dot_v1 MPNetEmbeddings from sentence-transfor
 author: John Snow Labs
 name: multi_qa_mpnet_base_dot_v1
 date: 2025-05-22
-tags: [mpnet, en, open_source, onnx, openvino]
+tags: [mpnet, en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-multi_qa_mpnet_base_dot_v1_finetuned_squad2_all_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-multi_qa_mpnet_base_dot_v1_finetuned_squad2_all_en.md
@@ -4,7 +4,7 @@ title: English multi_qa_mpnet_base_dot_v1_finetuned_squad2_all MPNetForQuestionA
 author: John Snow Labs
 name: multi_qa_mpnet_base_dot_v1_finetuned_squad2_all
 date: 2025-05-22
-tags: [en, open_source, onnx, question_answering, mpnet, openvino]
+tags: [en, open_source, question_answering, mpnet, openvino]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-nli_mpnet_base_v2_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-nli_mpnet_base_v2_en.md
@@ -4,7 +4,7 @@ title: English nli_mpnet_base_v2 MPNetEmbeddings from sentence-transformers
 author: John Snow Labs
 name: nli_mpnet_base_v2
 date: 2025-05-22
-tags: [mpnet, en, open_source, onnx, openvino]
+tags: [mpnet, en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-paraphrase_mpnet_base_v2_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-paraphrase_mpnet_base_v2_en.md
@@ -4,7 +4,7 @@ title: English paraphrase_mpnet_base_v2 MPNetEmbeddings from sentence-transforme
 author: John Snow Labs
 name: paraphrase_mpnet_base_v2
 date: 2025-05-22
-tags: [mpnet, en, open_source, onnx, openvino]
+tags: [mpnet, en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-patentsberta_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-patentsberta_en.md
@@ -4,7 +4,7 @@ title: English patentsberta MPNetEmbeddings from AI-Growth-Lab
 author: John Snow Labs
 name: patentsberta
 date: 2025-05-22
-tags: [mpnet, en, open_source, onnx, openvino]
+tags: [mpnet, en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-roberta_base_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-roberta_base_en.md
@@ -4,7 +4,7 @@ title: RoBERTa base model
 author: John Snow Labs
 name: roberta_base
 date: 2025-05-22
-tags: [en, english, roberta, embeddings, open_source, onnx, openvino]
+tags: [en, english, roberta, embeddings, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-roberta_base_go_emotions_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-roberta_base_go_emotions_en.md
@@ -4,7 +4,7 @@ title: English roberta_base_go_emotions RoBertaForSequenceClassification from Sa
 author: John Snow Labs
 name: roberta_base_go_emotions
 date: 2025-05-22
-tags: [roberta, en, open_source, sequence_classification, onnx, openvino]
+tags: [roberta, en, open_source, sequence_classification, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-roberta_classifier_emotion_english_distil_base_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-roberta_classifier_emotion_english_distil_base_en.md
@@ -4,7 +4,7 @@ title: English roberta_classifier_emotion_english_distil_base RoBertaForSequence
 author: John Snow Labs
 name: roberta_classifier_emotion_english_distil_base
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, roberta, openvino]
+tags: [en, open_source, sequence_classification, roberta, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-roberta_hate_speech_dynabench_r4_target_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-roberta_hate_speech_dynabench_r4_target_en.md
@@ -4,7 +4,7 @@ title: English roberta_hate_speech_dynabench_r4_target RoBertaForSequenceClassif
 author: John Snow Labs
 name: roberta_hate_speech_dynabench_r4_target
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, roberta, openvino]
+tags: [en, open_source, sequence_classification, roberta, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-roberta_large_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-roberta_large_en.md
@@ -4,7 +4,7 @@ title: RoBERTa large model
 author: John Snow Labs
 name: roberta_large
 date: 2025-05-22
-tags: [en, english, embeddings, roberta, open_source, onnx, openvino]
+tags: [en, english, embeddings, roberta, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-roberta_large_mnli_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-roberta_large_mnli_en.md
@@ -4,7 +4,7 @@ title: English roberta_large_mnli RoBertaForSequenceClassification from Facebook
 author: John Snow Labs
 name: roberta_large_mnli
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, roberta, openvino]
+tags: [en, open_source, sequence_classification, roberta, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-robertuito_sentiment_analysis_es.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-robertuito_sentiment_analysis_es.md
@@ -4,7 +4,7 @@ title: Castilian, Spanish robertuito_sentiment_analysis RoBertaForSequenceClassi
 author: John Snow Labs
 name: robertuito_sentiment_analysis
 date: 2025-05-22
-tags: [es, open_source, onnx, sequence_classification, roberta, openvino]
+tags: [es, open_source, sequence_classification, roberta, openvino]
 task: Text Classification
 language: es
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-sentence_transformers_e5_large_v2_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-sentence_transformers_e5_large_v2_en.md
@@ -4,7 +4,7 @@ title: English sentence_transformers_e5_large_v2 E5Embeddings from embaas
 author: John Snow Labs
 name: sentence_transformers_e5_large_v2
 date: 2025-05-22
-tags: [en, open_source, onnx, embeddings, e5, openvino]
+tags: [en, open_source, embeddings, e5, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-setfit_model_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-setfit_model_en.md
@@ -4,7 +4,7 @@ title: English setfit_model MPNetForSequenceClassification from WeksteinEyal
 author: John Snow Labs
 name: setfit_model
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, mpnet, openvino]
+tags: [en, open_source, sequence_classification, mpnet, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-twitter_roberta_base_sentiment_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-twitter_roberta_base_sentiment_en.md
@@ -4,7 +4,7 @@ title: English twitter_roberta_base_sentiment RoBertaForSequenceClassification f
 author: John Snow Labs
 name: twitter_roberta_base_sentiment
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, roberta, openvino]
+tags: [en, open_source, sequence_classification, roberta, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-22-twitter_roberta_base_sentiment_latest_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-22-twitter_roberta_base_sentiment_latest_en.md
@@ -4,7 +4,7 @@ title: English twitter_roberta_base_sentiment_latest RoBertaForSequenceClassific
 author: John Snow Labs
 name: twitter_roberta_base_sentiment_latest
 date: 2025-05-22
-tags: [en, open_source, onnx, sequence_classification, roberta, openvino]
+tags: [en, open_source, sequence_classification, roberta, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-24-e5_base_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-24-e5_base_en.md
@@ -4,7 +4,7 @@ title: E5 Base Sentence Embeddings
 author: John Snow Labs
 name: e5_base
 date: 2025-05-24
-tags: [en, open_source, onnx, openvino]
+tags: [en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-24-e5_base_v2_intfloat_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-24-e5_base_v2_intfloat_en.md
@@ -4,7 +4,7 @@ title: English e5_base_v2_intfloat E5Embeddings from intfloat
 author: John Snow Labs
 name: e5_base_v2_intfloat
 date: 2025-05-24
-tags: [en, open_source, onnx, embeddings, e5, openvino]
+tags: [en, open_source, embeddings, e5, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-24-e5_large_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-24-e5_large_en.md
@@ -4,7 +4,7 @@ title: E5 Large Sentence Embeddings
 author: John Snow Labs
 name: e5_large
 date: 2025-05-24
-tags: [en, open_source, onnx, openvino]
+tags: [en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-24-e5_large_v2_intfloat_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-24-e5_large_v2_intfloat_en.md
@@ -4,7 +4,7 @@ title: English e5_large_v2_intfloat E5Embeddings from intfloat
 author: John Snow Labs
 name: e5_large_v2_intfloat
 date: 2025-05-24
-tags: [en, open_source, onnx, embeddings, e5, openvino]
+tags: [en, open_source, embeddings, e5, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-24-e5_small_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-24-e5_small_en.md
@@ -4,7 +4,7 @@ title: E5 Small Sentence Embeddings
 author: John Snow Labs
 name: e5_small
 date: 2025-05-24
-tags: [en, open_source, onnx, openvino]
+tags: [en, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-24-e5_small_v2_intfloat_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-24-e5_small_v2_intfloat_en.md
@@ -4,7 +4,7 @@ title: English e5_small_v2_intfloat E5Embeddings from intfloat
 author: John Snow Labs
 name: e5_small_v2_intfloat
 date: 2025-05-24
-tags: [en, open_source, onnx, embeddings, e5, openvino]
+tags: [en, open_source, embeddings, e5, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-24-sentence_transformers_e5_large_v2_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-24-sentence_transformers_e5_large_v2_en.md
@@ -4,7 +4,7 @@ title: English sentence_transformers_e5_large_v2 E5Embeddings from embaas
 author: John Snow Labs
 name: sentence_transformers_e5_large_v2
 date: 2025-05-24
-tags: [en, open_source, onnx, embeddings, e5, openvino]
+tags: [en, open_source, embeddings, e5, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-biomedical_ner_all_d4data_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-biomedical_ner_all_d4data_en.md
@@ -4,7 +4,7 @@ title: English biomedical_ner_all_d4data DistilBertForTokenClassification from d
 author: John Snow Labs
 name: biomedical_ner_all_d4data
 date: 2025-05-25
-tags: [bert, en, open_source, token_classification, onnx, openvino]
+tags: [bert, en, open_source, token_classification, openvino]
 task: Named Entity Recognition
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-chonky_distilbert_base_uncased_1_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-chonky_distilbert_base_uncased_1_en.md
@@ -4,7 +4,7 @@ title: English chonky_distilbert_base_uncased_1 DistilBertForTokenClassification
 author: John Snow Labs
 name: chonky_distilbert_base_uncased_1
 date: 2025-05-25
-tags: [en, open_source, onnx, token_classification, distilbert, ner, openvino]
+tags: [en, open_source, token_classification, distilbert, ner, openvino]
 task: Named Entity Recognition
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-distilbert_base_multilingual_cased_pii_xx.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-distilbert_base_multilingual_cased_pii_xx.md
@@ -4,7 +4,7 @@ title: Multilingual distilbert_base_multilingual_cased_pii DistilBertForTokenCla
 author: John Snow Labs
 name: distilbert_base_multilingual_cased_pii
 date: 2025-05-25
-tags: [xx, open_source, onnx, token_classification, distilbert, ner, openvino]
+tags: [xx, open_source, token_classification, distilbert, ner, openvino]
 task: Named Entity Recognition
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-distilbert_base_uncased_go_emotions_student_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-distilbert_base_uncased_go_emotions_student_en.md
@@ -4,7 +4,7 @@ title: English distilbert_base_uncased_go_emotions_student DistilBertForSequence
 author: John Snow Labs
 name: distilbert_base_uncased_go_emotions_student
 date: 2025-05-25
-tags: [en, open_source, onnx, sequence_classification, distilbert, openvino]
+tags: [en, open_source, sequence_classification, distilbert, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-distilbert_finetuned_ai4privacy_v2_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-distilbert_finetuned_ai4privacy_v2_en.md
@@ -4,7 +4,7 @@ title: English distilbert_finetuned_ai4privacy_v2 DistilBertForTokenClassificati
 author: John Snow Labs
 name: distilbert_finetuned_ai4privacy_v2
 date: 2025-05-25
-tags: [en, open_source, onnx, token_classification, distilbert, ner, openvino]
+tags: [en, open_source, token_classification, distilbert, ner, openvino]
 task: Named Entity Recognition
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-distilbert_ner_distilbert_base_multilingual_cased_ner_hrl_nl.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-distilbert_ner_distilbert_base_multilingual_cased_ner_hrl_nl.md
@@ -4,7 +4,7 @@ title: Dutch Named Entity Recognition (from Davlan)
 author: John Snow Labs
 name: distilbert_ner_distilbert_base_multilingual_cased_ner_hrl
 date: 2025-05-25
-tags: [distilbert, ner, token_classification, nl, open_source, onnx, openvino]
+tags: [distilbert, ner, token_classification, nl, open_source, openvino]
 task: Named Entity Recognition
 language: nl
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-distilbert_ner_dslim_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-distilbert_ner_dslim_en.md
@@ -4,7 +4,7 @@ title: English distilbert_ner_dslim DistilBertForTokenClassification from dslim
 author: John Snow Labs
 name: distilbert_ner_dslim
 date: 2025-05-25
-tags: [en, open_source, onnx, token_classification, distilbert, ner, openvino]
+tags: [en, open_source, token_classification, distilbert, ner, openvino]
 task: Named Entity Recognition
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-distilbert_nsfw_text_classifier_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-distilbert_nsfw_text_classifier_en.md
@@ -4,7 +4,7 @@ title: English distilbert_nsfw_text_classifier DistilBertForSequenceClassificati
 author: John Snow Labs
 name: distilbert_nsfw_text_classifier
 date: 2025-05-25
-tags: [en, open_source, onnx, sequence_classification, distilbert, openvino]
+tags: [en, open_source, sequence_classification, distilbert, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-distilbert_tok_classifier_typo_detector_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-distilbert_tok_classifier_typo_detector_en.md
@@ -4,7 +4,7 @@ title: English DistilBertForTokenClassification Cased model (from m3hrdadfi)
 author: John Snow Labs
 name: distilbert_tok_classifier_typo_detector
 date: 2025-05-25
-tags: [en, open_source, distilbert, token_classification, ner, onnx, openvino]
+tags: [en, open_source, distilbert, token_classification, ner, openvino]
 task: Named Entity Recognition
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-distilbert_token_classifier_keyphrase_extraction_inspec_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-distilbert_token_classifier_keyphrase_extraction_inspec_en.md
@@ -4,7 +4,7 @@ title: English DistilBertForTokenClassification Cased model (from ml6team)
 author: John Snow Labs
 name: distilbert_token_classifier_keyphrase_extraction_inspec
 date: 2025-05-25
-tags: [en, open_source, distilbert, token_classification, ner, onnx, openvino]
+tags: [en, open_source, distilbert, token_classification, ner, openvino]
 task: Named Entity Recognition
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-multilingual_sentiment_analysis_xx.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-multilingual_sentiment_analysis_xx.md
@@ -4,7 +4,7 @@ title: Multilingual multilingual_sentiment_analysis DistilBertForSequenceClassif
 author: John Snow Labs
 name: multilingual_sentiment_analysis
 date: 2025-05-25
-tags: [xx, open_source, onnx, sequence_classification, distilbert, openvino]
+tags: [xx, open_source, sequence_classification, distilbert, openvino]
 task: Text Classification
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-nsfw_text_classifier_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-nsfw_text_classifier_en.md
@@ -4,7 +4,7 @@ title: English nsfw_text_classifier DistilBertForSequenceClassification from mic
 author: John Snow Labs
 name: nsfw_text_classifier
 date: 2025-05-25
-tags: [bert, en, open_source, sequence_classification, onnx, openvino]
+tags: [bert, en, open_source, sequence_classification, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-25-toxic_comment_model_en.md
+++ b/docs/_posts/ahmedlone127/2025-05-25-toxic_comment_model_en.md
@@ -4,7 +4,7 @@ title: English toxic_comment_model DistilBertForSequenceClassification from mart
 author: John Snow Labs
 name: toxic_comment_model
 date: 2025-05-25
-tags: [en, open_source, onnx, sequence_classification, distilbert, openvino]
+tags: [en, open_source, sequence_classification, distilbert, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-27-cas_biomedical_sayula_popoluca_tagging_fr.md
+++ b/docs/_posts/ahmedlone127/2025-05-27-cas_biomedical_sayula_popoluca_tagging_fr.md
@@ -4,7 +4,7 @@ title: French cas_biomedical_sayula_popoluca_tagging CamemBertForTokenClassifica
 author: John Snow Labs
 name: cas_biomedical_sayula_popoluca_tagging
 date: 2025-05-27
-tags: [fr, open_source, onnx, token_classification, camembert, ner, openvino]
+tags: [fr, open_source, token_classification, camembert, ner, openvino]
 task: Named Entity Recognition
 language: fr
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-27-nermembert_base_4entities_fr.md
+++ b/docs/_posts/ahmedlone127/2025-05-27-nermembert_base_4entities_fr.md
@@ -4,7 +4,7 @@ title: French nermembert_base_4entities CamemBertForTokenClassification from CAT
 author: John Snow Labs
 name: nermembert_base_4entities
 date: 2025-05-27
-tags: [fr, open_source, onnx, token_classification, camembert, ner, openvino]
+tags: [fr, open_source, token_classification, camembert, ner, openvino]
 task: Named Entity Recognition
 language: fr
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-27-nermembert_large_3entities_fr.md
+++ b/docs/_posts/ahmedlone127/2025-05-27-nermembert_large_3entities_fr.md
@@ -4,7 +4,7 @@ title: French nermembert_large_3entities CamemBertForTokenClassification from CA
 author: John Snow Labs
 name: nermembert_large_3entities
 date: 2025-05-27
-tags: [fr, open_source, onnx, token_classification, camembert, ner, openvino]
+tags: [fr, open_source, token_classification, camembert, ner, openvino]
 task: Named Entity Recognition
 language: fr
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-27-phayathaibert_thainer_th.md
+++ b/docs/_posts/ahmedlone127/2025-05-27-phayathaibert_thainer_th.md
@@ -4,7 +4,7 @@ title: Thai phayathaibert_thainer CamemBertForTokenClassification from Pavarissy
 author: John Snow Labs
 name: phayathaibert_thainer
 date: 2025-05-27
-tags: [th, open_source, onnx, token_classification, camembert, ner, openvino]
+tags: [th, open_source, token_classification, camembert, ner, openvino]
 task: Named Entity Recognition
 language: th
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-27-rubert_base_cased_nli_threeway_ru.md
+++ b/docs/_posts/ahmedlone127/2025-05-27-rubert_base_cased_nli_threeway_ru.md
@@ -4,7 +4,7 @@ title: Russian rubert_base_cased_nli_threeway BertForZeroShotClassification from
 author: John Snow Labs
 name: rubert_base_cased_nli_threeway
 date: 2025-05-27
-tags: [ru, open_source, onnx, zero_shot, bert, openvino]
+tags: [ru, open_source, zero_shot, bert, openvino]
 task: Zero-Shot Classification
 language: ru
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-05-27-thainer_corpus_v2_base_model_th.md
+++ b/docs/_posts/ahmedlone127/2025-05-27-thainer_corpus_v2_base_model_th.md
@@ -4,7 +4,7 @@ title: Thai thainer_corpus_v2_base_model CamemBertForTokenClassification from py
 author: John Snow Labs
 name: thainer_corpus_v2_base_model
 date: 2025-05-27
-tags: [camembert, th, open_source, token_classification, onnx, openvino]
+tags: [camembert, th, open_source, token_classification, openvino]
 task: Named Entity Recognition
 language: th
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-ag_nli_dets_sentence_similarity_v4_xx.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-ag_nli_dets_sentence_similarity_v4_xx.md
@@ -4,7 +4,7 @@ title: Multilingual ag_nli_dets_sentence_similarity_v4 CamemBertForSequenceClass
 author: John Snow Labs
 name: ag_nli_dets_sentence_similarity_v4
 date: 2025-06-22
-tags: [xx, open_source, onnx, sequence_classification, camembert, openvino]
+tags: [xx, open_source, sequence_classification, camembert, openvino]
 task: Text Classification
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-bert_base_cased_google_bert_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-bert_base_cased_google_bert_en.md
@@ -4,7 +4,7 @@ title: English bert_base_cased_google_bert BertEmbeddings from google-bert
 author: John Snow Labs
 name: bert_base_cased_google_bert
 date: 2025-06-22
-tags: [en, open_source, onnx, embeddings, bert, openvino]
+tags: [en, open_source, embeddings, bert, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-bert_base_multilingual_cased_google_bert_xx.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-bert_base_multilingual_cased_google_bert_xx.md
@@ -4,7 +4,7 @@ title: Multilingual bert_base_multilingual_cased_google_bert BertEmbeddings from
 author: John Snow Labs
 name: bert_base_multilingual_cased_google_bert
 date: 2025-06-22
-tags: [xx, open_source, onnx, embeddings, bert, openvino]
+tags: [xx, open_source, embeddings, bert, openvino]
 task: Embeddings
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-bert_base_multilingual_uncased_sentiment_xx.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-bert_base_multilingual_uncased_sentiment_xx.md
@@ -4,7 +4,7 @@ title: Multilingual bert_base_multilingual_uncased_sentiment BertForSequenceClas
 author: John Snow Labs
 name: bert_base_multilingual_uncased_sentiment
 date: 2025-06-22
-tags: [xx, open_source, onnx, sequence_classification, bert, openvino]
+tags: [xx, open_source, sequence_classification, bert, openvino]
 task: Text Classification
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-bert_base_uncased_google_bert_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-bert_base_uncased_google_bert_en.md
@@ -4,7 +4,7 @@ title: English bert_base_uncased_google_bert BertEmbeddings from google-bert
 author: John Snow Labs
 name: bert_base_uncased_google_bert
 date: 2025-06-22
-tags: [en, open_source, onnx, embeddings, bert, openvino]
+tags: [en, open_source, embeddings, bert, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-camembert_base_fr.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-camembert_base_fr.md
@@ -4,7 +4,7 @@ title: CamemBERT Base Model
 author: John Snow Labs
 name: camembert_base
 date: 2025-06-22
-tags: [fr, french, embeddings, camembert, base, open_source, onnx, openvino]
+tags: [fr, french, embeddings, camembert, base, open_source, openvino]
 task: Embeddings
 language: fr
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-camembert_bio_base_fr.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-camembert_bio_base_fr.md
@@ -4,7 +4,7 @@ title: French camembert_bio_base CamemBertEmbeddings from almanach
 author: John Snow Labs
 name: camembert_bio_base
 date: 2025-06-22
-tags: [fr, open_source, onnx, embeddings, camembert, openvino]
+tags: [fr, open_source, embeddings, camembert, openvino]
 task: Embeddings
 language: fr
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-drbert_7gb_fr.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-drbert_7gb_fr.md
@@ -4,7 +4,7 @@ title: French drbert_7gb CamemBertEmbeddings from Dr-BERT
 author: John Snow Labs
 name: drbert_7gb
 date: 2025-06-22
-tags: [fr, open_source, onnx, embeddings, camembert, openvino]
+tags: [fr, open_source, embeddings, camembert, openvino]
 task: Embeddings
 language: fr
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-feel_italian_italian_emotion_it.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-feel_italian_italian_emotion_it.md
@@ -4,7 +4,7 @@ title: Italian feel_italian_italian_emotion CamemBertForSequenceClassification f
 author: John Snow Labs
 name: feel_italian_italian_emotion
 date: 2025-06-22
-tags: [camembert, it, open_source, sequence_classification, onnx, openvino]
+tags: [camembert, it, open_source, sequence_classification, openvino]
 task: Text Classification
 language: it
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-feel_italian_italian_sentiment_it.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-feel_italian_italian_sentiment_it.md
@@ -4,7 +4,7 @@ title: Italian feel_italian_italian_sentiment CamemBertForSequenceClassification
 author: John Snow Labs
 name: feel_italian_italian_sentiment
 date: 2025-06-22
-tags: [camembert, it, open_source, sequence_classification, onnx, openvino]
+tags: [camembert, it, open_source, sequence_classification, openvino]
 task: Text Classification
 language: it
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-finance_sentiment_french_base_fr.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-finance_sentiment_french_base_fr.md
@@ -4,7 +4,7 @@ title: French finance_sentiment_french_base CamemBertForSequenceClassification f
 author: John Snow Labs
 name: finance_sentiment_french_base
 date: 2025-06-22
-tags: [camembert, fr, open_source, sequence_classification, onnx, openvino]
+tags: [camembert, fr, open_source, sequence_classification, openvino]
 task: Text Classification
 language: fr
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-finbert_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-finbert_en.md
@@ -4,7 +4,7 @@ title: English finbert BertForSequenceClassification from ProsusAI
 author: John Snow Labs
 name: finbert
 date: 2025-06-22
-tags: [en, open_source, onnx, sequence_classification, bert, openvino]
+tags: [en, open_source, sequence_classification, bert, openvino]
 task: Text Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-sent_bert_base_multilingual_cased_xx.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-sent_bert_base_multilingual_cased_xx.md
@@ -4,7 +4,7 @@ title: Multilingual sent_bert_base_multilingual_cased BertSentenceEmbeddings fro
 author: John Snow Labs
 name: sent_bert_base_multilingual_cased
 date: 2025-06-22
-tags: [xx, open_source, onnx, sentence_embeddings, bert, openvino]
+tags: [xx, open_source, sentence_embeddings, bert, openvino]
 task: Embeddings
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-sloberta_sl.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-sloberta_sl.md
@@ -4,7 +4,7 @@ title: Slovenian sloberta CamemBertEmbeddings from EMBEDDIA
 author: John Snow Labs
 name: sloberta
 date: 2025-06-22
-tags: [sl, open_source, onnx, embeddings, camembert, openvino]
+tags: [sl, open_source, embeddings, camembert, openvino]
 task: Embeddings
 language: sl
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-umberto_commoncrawl_cased_v1_it.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-umberto_commoncrawl_cased_v1_it.md
@@ -4,7 +4,7 @@ title: Italian umberto_commoncrawl_cased_v1 CamemBertEmbeddings from Musixmatch
 author: John Snow Labs
 name: umberto_commoncrawl_cased_v1
 date: 2025-06-22
-tags: [it, open_source, onnx, embeddings, camembert, openvino]
+tags: [it, open_source, embeddings, camembert, openvino]
 task: Embeddings
 language: it
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-22-wangchanberta_finetuned_sentiment_th.md
+++ b/docs/_posts/ahmedlone127/2025-06-22-wangchanberta_finetuned_sentiment_th.md
@@ -4,7 +4,7 @@ title: Thai wangchanberta_finetuned_sentiment CamemBertForSequenceClassification
 author: John Snow Labs
 name: wangchanberta_finetuned_sentiment
 date: 2025-06-22
-tags: [camembert, th, open_source, sequence_classification, onnx, openvino]
+tags: [camembert, th, open_source, sequence_classification, openvino]
 task: Text Classification
 language: th
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-awesome_fb_model_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-awesome_fb_model_en.md
@@ -4,7 +4,7 @@ title: English awesome_fb_model BartForZeroShotClassification from ClaudeYang
 author: John Snow Labs
 name: awesome_fb_model
 date: 2025-06-24
-tags: [en, open_source, onnx, zero_shot, bart, openvino]
+tags: [en, open_source, zero_shot, bart, openvino]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-bart_large_mnli_yahoo_answers_joeddav_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-bart_large_mnli_yahoo_answers_joeddav_en.md
@@ -4,7 +4,7 @@ title: English bart_large_mnli_yahoo_answers_joeddav BartForZeroShotClassificati
 author: John Snow Labs
 name: bart_large_mnli_yahoo_answers_joeddav
 date: 2025-06-24
-tags: [en, open_source, onnx, zero_shot, bart, openvino]
+tags: [en, open_source, zero_shot, bart, openvino]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-bart_mnli_cnn_256_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-bart_mnli_cnn_256_en.md
@@ -4,7 +4,7 @@ title: English bart_mnli_cnn_256 BartForZeroShotClassification from AyoubChLin
 author: John Snow Labs
 name: bart_mnli_cnn_256
 date: 2025-06-24
-tags: [en, open_source, onnx, zero_shot, bart, openvino]
+tags: [en, open_source, zero_shot, bart, openvino]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-clinicalbert_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-clinicalbert_en.md
@@ -4,7 +4,7 @@ title: English clinicalbert DistilBertEmbeddings from DHEIVER
 author: John Snow Labs
 name: clinicalbert
 date: 2025-06-24
-tags: [en, open_source, onnx, embeddings, distilbert, openvino]
+tags: [en, open_source, embeddings, distilbert, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-distilbart_mnli_12_1_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-distilbart_mnli_12_1_en.md
@@ -4,7 +4,7 @@ title: English distilbart_mnli_12_1 BartForZeroShotClassification from valhalla
 author: John Snow Labs
 name: distilbart_mnli_12_1
 date: 2025-06-24
-tags: [en, open_source, onnx, zero_shot, bart, openvino]
+tags: [en, open_source, zero_shot, bart, openvino]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-distilbart_mnli_12_3_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-distilbart_mnli_12_3_en.md
@@ -4,7 +4,7 @@ title: English distilbart_mnli_12_3 BartForZeroShotClassification from valhalla
 author: John Snow Labs
 name: distilbart_mnli_12_3
 date: 2025-06-24
-tags: [en, open_source, onnx, zero_shot, bart, openvino]
+tags: [en, open_source, zero_shot, bart, openvino]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-distilbart_mnli_12_6_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-distilbart_mnli_12_6_en.md
@@ -4,7 +4,7 @@ title: English distilbart_mnli_12_6 BartForZeroShotClassification from valhalla
 author: John Snow Labs
 name: distilbart_mnli_12_6
 date: 2025-06-24
-tags: [en, open_source, onnx, zero_shot, bart, openvino]
+tags: [en, open_source, zero_shot, bart, openvino]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-distilbart_mnli_12_9_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-distilbart_mnli_12_9_en.md
@@ -4,7 +4,7 @@ title: English distilbart_mnli_12_9 BartForZeroShotClassification from valhalla
 author: John Snow Labs
 name: distilbart_mnli_12_9
 date: 2025-06-24
-tags: [en, open_source, onnx, zero_shot, bart, openvino]
+tags: [en, open_source, zero_shot, bart, openvino]
 task: Zero-Shot Classification
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_cased_distilled_squad_distilbert_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_cased_distilled_squad_distilbert_en.md
@@ -4,7 +4,7 @@ title: English distilbert_base_cased_distilled_squad_distilbert DistilBertForQue
 author: John Snow Labs
 name: distilbert_base_cased_distilled_squad_distilbert
 date: 2025-06-24
-tags: [en, open_source, onnx, question_answering, distilbert, openvino]
+tags: [en, open_source, question_answering, distilbert, openvino]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_cased_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_cased_en.md
@@ -4,7 +4,7 @@ title: DistilBERT base model (cased)
 author: John Snow Labs
 name: distilbert_base_cased
 date: 2025-06-24
-tags: [distilbert, en, english, open_source, embeddings, onnx, openvino]
+tags: [distilbert, en, english, open_source, embeddings, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_german_cased_de.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_german_cased_de.md
@@ -4,7 +4,7 @@ title: German distilbert_base_german_cased DistilBertEmbeddings from huggingface
 author: John Snow Labs
 name: distilbert_base_german_cased
 date: 2025-06-24
-tags: [distilbert, de, open_source, fill_mask, onnx, openvino]
+tags: [distilbert, de, open_source, fill_mask, openvino]
 task: Embeddings
 language: de
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_multilingual_cased_xx.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_multilingual_cased_xx.md
@@ -4,7 +4,7 @@ title: DistilBERT base multilingual model (cased)
 author: John Snow Labs
 name: distilbert_base_multilingual_cased
 date: 2025-06-24
-tags: [distilbert, embeddings, xx, multilingual, open_source, onnx, openvino]
+tags: [distilbert, embeddings, xx, multilingual, open_source, openvino]
 task: Embeddings
 language: xx
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_uncased_distilled_squad_distilbert_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_uncased_distilled_squad_distilbert_en.md
@@ -4,7 +4,7 @@ title: English distilbert_base_uncased_distilled_squad_distilbert DistilBertForQ
 author: John Snow Labs
 name: distilbert_base_uncased_distilled_squad_distilbert
 date: 2025-06-24
-tags: [en, open_source, onnx, question_answering, distilbert, openvino]
+tags: [en, open_source, question_answering, distilbert, openvino]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_uncased_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_uncased_en.md
@@ -4,7 +4,7 @@ title: DistilBERT base model (uncased)
 author: John Snow Labs
 name: distilbert_base_uncased
 date: 2025-06-24
-tags: [distilbert, en, english, embeddings, open_source, onnx, openvino]
+tags: [distilbert, en, english, embeddings, open_source, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_uncased_finetuned_squad_full_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-distilbert_base_uncased_finetuned_squad_full_en.md
@@ -4,7 +4,7 @@ title: English distilbert_base_uncased_finetuned_squad_full DistilBertForQuestio
 author: John Snow Labs
 name: distilbert_base_uncased_finetuned_squad_full
 date: 2025-06-24
-tags: [en, open_source, onnx, question_answering, distilbert, openvino]
+tags: [en, open_source, question_answering, distilbert, openvino]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-efficient_splade_vietnamese_bt_large_doc_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-efficient_splade_vietnamese_bt_large_doc_en.md
@@ -4,7 +4,7 @@ title: English efficient_splade_vietnamese_bt_large_doc DistilBertEmbeddings fro
 author: John Snow Labs
 name: efficient_splade_vietnamese_bt_large_doc
 date: 2025-06-24
-tags: [en, open_source, onnx, embeddings, distilbert, openvino]
+tags: [en, open_source, embeddings, distilbert, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-opensearch_neural_sparse_encoding_doc_v2_distill_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-opensearch_neural_sparse_encoding_doc_v2_distill_en.md
@@ -4,7 +4,7 @@ title: English opensearch_neural_sparse_encoding_doc_v2_distill DistilBertEmbedd
 author: John Snow Labs
 name: opensearch_neural_sparse_encoding_doc_v2_distill
 date: 2025-06-24
-tags: [en, open_source, onnx, embeddings, distilbert, openvino]
+tags: [en, open_source, embeddings, distilbert, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-opensearch_neural_sparse_encoding_v2_distill_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-opensearch_neural_sparse_encoding_v2_distill_en.md
@@ -4,7 +4,7 @@ title: English opensearch_neural_sparse_encoding_v2_distill DistilBertEmbeddings
 author: John Snow Labs
 name: opensearch_neural_sparse_encoding_v2_distill
 date: 2025-06-24
-tags: [en, open_source, onnx, embeddings, distilbert, openvino]
+tags: [en, open_source, embeddings, distilbert, openvino]
 task: Embeddings
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-question_answering_v2_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-question_answering_v2_en.md
@@ -4,7 +4,7 @@ title: English question_answering_v2 DistilBertForQuestionAnswering from Falcons
 author: John Snow Labs
 name: question_answering_v2
 date: 2025-06-24
-tags: [distilbert, en, open_source, question_answering, onnx, openvino]
+tags: [distilbert, en, open_source, question_answering, openvino]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/ahmedlone127/2025-06-24-tiny_distilbert_base_cased_distilled_squad_en.md
+++ b/docs/_posts/ahmedlone127/2025-06-24-tiny_distilbert_base_cased_distilled_squad_en.md
@@ -4,7 +4,7 @@ title: English tiny_distilbert_base_cased_distilled_squad DistilBertForQuestionA
 author: John Snow Labs
 name: tiny_distilbert_base_cased_distilled_squad
 date: 2025-06-24
-tags: [en, open_source, onnx, question_answering, distilbert, openvino]
+tags: [en, open_source, question_answering, distilbert, openvino]
 task: Question Answering
 language: en
 edition: Spark NLP 5.5.1

--- a/docs/_posts/gadde5300/2023-02-21-bert_embeddings_legalbert_adept_en.md
+++ b/docs/_posts/gadde5300/2023-02-21-bert_embeddings_legalbert_adept_en.md
@@ -4,7 +4,7 @@ title: English Legal BERT Embeddings
 author: John Snow Labs
 name: bert_embeddings_legalbert_adept
 date: 2023-02-21
-tags: [bert, en, english, embeddings, transformer, open_source]
+tags: [bert, en, english, embeddings, transformer, open_source, tensorflow]
 task: Embeddings
 language: en
 nav_key: models


### PR DESCRIPTION
Ensured that each Markdown file’s engine tag matches the value specified in its engine field.
Removed any extra engine tags from the tags section.

Limitations
Most model cards (60k+) do not have an engine field defined in their YAML front matter.