### PR TITLE
Add multimodal image support to VectorDBConnector

### DIFF
--- a/docs/en/annotator_entries/VectorDBConnector.md
+++ b/docs/en/annotator_entries/VectorDBConnector.md
@@ -5,38 +5,34 @@ VectorDBConnector
 {%- capture description -%}
 Connector for storing and retrieving embeddings from vector databases.
 
-This annotator takes embeddings from previous annotators (like `BertEmbeddings`,
-`SentenceEmbeddings`, `OpenAIEmbeddings`, etc.) and stores them in a vector database for
+This annotator takes embeddings from previous annotators (like `BertSentenceEmbeddings`,
+`SentenceEmbeddings`, `E5VEmbeddings`, etc.) and stores them in a vector database for
 similarity search and retrieval. Currently supports [**Pinecone**](https://app.pinecone.io/) with more providers planned.
 
 The annotator automatically manages vector IDs, metadata, and batch operations, making it easy
 to integrate vector database capabilities into your Spark NLP pipelines without additional
 boilerplate code.
 
-**Key Features:**
-- **Automatic ID Management**: Generates UUIDs or uses custom ID columns
-- **Metadata Support**: Store additional context with vectors (e.g., text, category, source)
-- **Batch Processing**: Efficiently upsert vectors to Pinecone with configurable batch sizes
-- **Namespace Support**: Organize vectors within index partitions
-- **Error Handling**: Graceful handling of connection and processing errors
+**Supports two modality modes:**
+- **`text`** (default): expects `DOCUMENT + SENTENCE_EMBEDDINGS` input columns.
+- **`image`**: expects `IMAGE + SENTENCE_EMBEDDINGS` input columns (e.g. from `ImageAssembler` +
+  `E5VEmbeddings`).
 
 For more extended examples see the
 [VectorDBConnector_Pinecone_Demo.ipynb](https://github.com/JohnSnowLabs/spark-nlp/tree/master/examples/python/annotation/text/english/vector-db/VectorDBConnector_Pinecone_Demo.ipynb) and [VectorDBConnectorTest](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/ml/ai/VectorDBConnectorTest.scala).
 {%- endcapture -%}
 
 {%- capture python_example -%}
-import sparknlp
 from sparknlp.base import *
 from sparknlp.annotator import *
 from pyspark.ml import Pipeline
+from pyspark.sql.functions import lit
+
+## Upserted Text Embeddings
 
 documentAssembler = DocumentAssembler() \
     .setInputCol("text") \
     .setOutputCol("document")
-
-tokenizer = Tokenizer() \
-    .setInputCols(["document"]) \
-    .setOutputCol("token")
 
 embeddings = BertSentenceEmbeddings.pretrained("sent_small_bert_L2_768") \
     .setInputCols(["document"]) \
@@ -46,16 +42,14 @@ vectorDB = VectorDBConnector() \
     .setInputCols(["document", "sentence_embeddings"]) \
     .setOutputCol("vectordb_result") \
     .setProvider("pinecone") \
-    .setIndexName("my-semantic-index") \
-    .setNamespace("production") \
+    .setIndexName('text-mode') \
+    .setNamespace('upserted-test-embeddings') \
     .setIdColumn("doc_id") \
     .setMetadataColumns(["text", "category"]) \
-    .setBatchSize(100)
 
 pipeline = Pipeline() \
     .setStages([
       documentAssembler,
-      tokenizer,
       embeddings,
       vectorDB
     ])
@@ -68,29 +62,57 @@ data = spark.createDataFrame([
 
 result = pipeline.fit(data).transform(data)
 
-# View the output - contains vector IDs returned from Pinecone
-result.select("vectordb_result").show(truncate=False)
-+-----------------------------------------------------------+
-|vectordb_result                                            |
-+-----------------------------------------------------------+
-|[[document, 0, 29, doc_001, {vectordb_status -> upserted}, |
-|[[document, 31, 64, doc_002, {vectordb_status -> upserted},|
-|[[document, 65, 95, doc_003, {vectordb_status -> upserted},|
-+-----------------------------------------------------------+
+## Upserted Image Embeddings
+
+image_folder = "/content/test_images"
+image_df = spark.read.format("image") \
+    .option("dropInvalid", True) \
+    .load(image_folder)
+
+image_prompt = (
+    "<|start_header_id|>user<|end_header_id|>\n\n"
+    "<image>\\nSummary above image in one word: "
+    "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+)
+
+test_df = image_df.withColumn("text", lit(image_prompt))
+
+image_assembler = ImageAssembler() \
+    .setInputCol("image") \
+    .setOutputCol("image_assembler")
+
+e5v_embeddings = E5VEmbeddings.pretrained() \
+    .setInputCols(["image_assembler"]) \
+    .setOutputCol("image_embeddings")
+
+vector_db = VectorDBConnector() \
+    .setInputCols(['image_assembler', 'image_embeddings']) \
+    .setOutputCol('vectordb_result') \
+    .setProvider('pinecone') \
+    .setIndexName('e5v-test') \
+    .setNamespace('image-integration-test-updated-metadata') \
+    .setModalityMode('image')
+
+pipeline = Pipeline().setStages([
+    image_assembler,
+    e5v_embeddings,
+    vector_db
+])
+
+image_result = pipeline.fit(test_df).transform(test_df)
 {%- endcapture -%}
 
 {%- capture scala_example -%}
-import spark.implicits._
-import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.nlp.base._
+import com.johnsnowlabs.nlp.annotator._
 import org.apache.spark.ml.Pipeline
+import org.apache.spark.sql.functions.lit
+
+// Upserted Text Embeddings
 
 val documentAssembler = new DocumentAssembler()
   .setInputCol("text")
   .setOutputCol("document")
-
-val tokenizer = new Tokenizer()
-  .setInputCols(Array("document"))
-  .setOutputCol("token")
 
 val embeddings = BertSentenceEmbeddings.pretrained("sent_small_bert_L2_768")
   .setInputCols(Array("document"))
@@ -100,37 +122,64 @@ val vectorDB = new VectorDBConnector()
   .setInputCols(Array("document", "sentence_embeddings"))
   .setOutputCol("vectordb_result")
   .setProvider("pinecone")
-  .setIndexName("my-semantic-index")
-  .setNamespace("production")
+  .setIndexName("text-mode")
+  .setNamespace("upserted-test-embeddings")
   .setIdColumn("doc_id")
   .setMetadataColumns(Array("text", "category"))
-  .setBatchSize(100)
 
 val pipeline = new Pipeline()
   .setStages(Array(
     documentAssembler,
-    tokenizer,
     embeddings,
     vectorDB
   ))
 
-val data = Seq(
-  ("doc_001", "Spark NLP is a powerful library", "technology"),
-  ("doc_002", "Vector databases enable semantic search", "technology"),
-  ("doc_003", "Machine learning requires quality data", "data-science")
-).toDF("doc_id", "text", "category")
+val data = spark.createDataFrame(Seq(
+  ("doc_001", "Spark NLP is a powerful library",          "technology"),
+  ("doc_002", "Vector databases enable semantic search",  "technology"),
+  ("doc_003", "Machine learning requires quality data",   "data-science")
+)).toDF("doc_id", "text", "category")
 
 val result = pipeline.fit(data).transform(data)
 
-// View the output - contains vector IDs returned from Pinecone
-result.select("vectordb_result").show(false)
-+-----------------------------------------------------------+
-|vectordb_result                                            |
-+-----------------------------------------------------------+
-|[[document, 0, 29, doc_001, {vectordb_status -> upserted},_|
-|[[document, 31, 64, doc_002, {vectordb_status -> upserted},|
-|[[document, 65, 95, doc_003, {vectordb_status -> upserted},|
-+-----------------------------------------------------------+
+// Upserted Image Embeddings
+
+val imageFolder = "/content/test_images"
+val imageDf = spark.read.format("image")
+  .option("dropInvalid", value = true)
+  .load(imageFolder)
+
+val imagePrompt =
+  "<|start_header_id|>user<|end_header_id|>\n\n" +
+  "<image>\nSummary above image in one word: " +
+  "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+
+val testDf = imageDf.withColumn("text", lit(imagePrompt))
+
+val imageAssembler = new ImageAssembler()
+  .setInputCol("image")
+  .setOutputCol("image_assembler")
+
+val e5vEmbeddings = E5VEmbeddings.pretrained()
+  .setInputCols(Array("image_assembler"))
+  .setOutputCol("image_embeddings")
+
+val vectorDbImage = new VectorDBConnector()
+  .setInputCols(Array("image_assembler", "image_embeddings"))
+  .setOutputCol("vectordb_result")
+  .setProvider("pinecone")
+  .setIndexName("e5v-test")
+  .setNamespace("image-integration-test-updated-metadata")
+  .setModalityMode("image")
+
+val imagePipeline = new Pipeline()
+  .setStages(Array(
+    imageAssembler,
+    e5vEmbeddings,
+    vectorDbImage
+  ))
+
+val imageResult = imagePipeline.fit(testDf).transform(testDf)
 {%- endcapture -%}
 
 {%- capture note -%}
@@ -146,18 +195,24 @@ The annotator returns annotations with the vector ID stored in the `result` fiel
 
 **ID Management:**
 - If `idColumn` is set, values from that column are used as vector IDs
-- If `idColumn` is not set, UUIDs are automatically generated
+- In text mode, if `idColumn` is not set, random UUIDs are automatically generated
+- In image mode, if `idColumn` is not set, a deterministic UUID-v3 derived from the image file path (origin) is used, ensuring stable re-indexing of the same image
 - The ID is returned in the output annotation's `result` field
+
+**Modality Modes:**
+- `text` (default): Pipeline must include a `DocumentAssembler` followed by a sentence embeddings annotator. Input columns must be `[document_col, embeddings_col]`.
+- `image`: Pipeline must include an `ImageAssembler` followed by an image embeddings annotator (e.g. `E5VEmbeddings`). Input columns must be `[image_col, embeddings_col]`. Output annotations are synthesized DOCUMENT annotations carrying image metadata (`modality`, `image_origin`, `image_filename`, `image_width`, `image_height`, `image_nChannels`).
 
 **Namespace Support:**
 The `namespace` parameter is optional and provider-specific. In Pinecone, it's used to partition vectors within an index, enabling multi-tenant scenarios or logical data separation.
 
 **Batch Processing:**
 Vectors are automatically grouped into batches (default: 100) before being sent to Pinecone. This improves performance and reduces network overhead. The batch size can be customized with `setBatchSize()`.
+
 {%- endcapture -%}
 
 {%- capture input_anno -%}
-DOCUMENT, SENTENCE_EMBEDDINGS
+DOCUMENT, SENTENCE_EMBEDDINGS or IMAGE, SENTENCE_EMBEDDINGS
 {%- endcapture -%}
 
 {%- capture output_anno -%}
@@ -165,11 +220,11 @@ DOCUMENT
 {%- endcapture -%}
 
 {%- capture api_link -%}
-[VectorDBConnector](/api/com/johnsnowlabs/nlp/ml/ai/VectorDBConnector)
+[VectorDBConnector](/api/com/johnsnowlabs/ml/ai/VectorDBConnector)
 {%- endcapture -%}
 
 {%- capture python_api_link -%}
-[VectorDBConnector](/api/python/reference/autosummary/sparknlp/annotator/vector_db_connector/index.html)
+[VectorDBConnector](/api/python/reference/autosummary/sparknlp/annotator/vector_db/vector_db_connector/index.html)
 {%- endcapture -%}
 
 {%- capture source_link -%}

--- a/docs/en/annotator_entries/VectorDBConnector.md
+++ b/docs/en/annotator_entries/VectorDBConnector.md
@@ -15,8 +15,7 @@ boilerplate code.
 
 **Supports two modality modes:**
 - **`text`** (default): expects `DOCUMENT + SENTENCE_EMBEDDINGS` input columns.
-- **`image`**: expects `IMAGE + SENTENCE_EMBEDDINGS` input columns (e.g. from `ImageAssembler` +
-  `E5VEmbeddings`).
+- **`image`**: expects `IMAGE + IMAGE_EMBEDDINGS` input columns.
 
 For more extended examples see the
 [VectorDBConnector_Pinecone_Demo.ipynb](https://github.com/JohnSnowLabs/spark-nlp/tree/master/examples/python/annotation/text/english/vector-db/VectorDBConnector_Pinecone_Demo.ipynb) and [VectorDBConnectorTest](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/test/scala/com/johnsnowlabs/ml/ai/VectorDBConnectorTest.scala).

--- a/python/sparknlp/annotator/vector_db/vector_db_connector.py
+++ b/python/sparknlp/annotator/vector_db/vector_db_connector.py
@@ -19,14 +19,25 @@ class VectorDBConnector(AnnotatorModel):
     """Connector for storing and retrieving embeddings from vector databases.
 
     This annotator takes embeddings from previous annotators (like BertEmbeddings,
-    SentenceEmbeddings, OpenAIEmbeddings, etc.) and stores them in a vector database for
+    SentenceEmbeddings, E5VEmbeddings, etc.) and stores them in a vector database for
     similarity search and retrieval. Currently supports Pinecone with more providers planned.
 
-    ====================== =======================
-    Input Annotation types Output Annotation type
-    ====================== =======================
-    ``DOCUMENT, SENTENCE_EMBEDDINGS`` ``DOCUMENT``
-    ====================== =======================
+    Two modality modes are supported via setModalityMode:
+
+    * **text** (default) – expects DOCUMENT, SENTENCE_EMBEDDINGS input columns.
+      Upserted metadata is augmented with modality=text.
+    * **image** – expects MAGE, SENTENCE_EMBEDDINGS input columns (e.g. from
+      ImageAssembler + E5VEmbeddings). Upserted metadata is augmented with
+      modality=image, image_origin, image_width, image_height, and
+      image_nChannels. Vector IDs are deterministic UUID-v3 values derived from the
+      image file-path (origin), ensuring stable re-indexing.
+
+    ========================= =======================
+    Input Annotation types    Output Annotation type
+    ========================= =======================
+    DOCUMENT, SENTENCE_EMBEDDINGS (text mode)  DOCUMENT
+    IMAGE, SENTENCE_EMBEDDINGS    (image mode) DOCUMENT
+    ========================= =======================
 
     Parameters
     ----------
@@ -37,14 +48,19 @@ class VectorDBConnector(AnnotatorModel):
     namespace
         Namespace/partition within the index (optional)
     idColumn
-        Column name to use as vector ID (if not set, generates UUID)
+        Column name to use as vector ID (if not set, generates UUID; for image mode a
+        stable UUID-v3 derived from the image origin path is used)
     metadataColumns
         Column names to include as metadata with vectors
     batchSize
         Number of vectors to upsert in a single batch
+    modalityMode
+        Modality mode: 'text' (default) or 'image'
 
     Examples
     --------
+    **Text mode example:**
+
     >>> import sparknlp
     >>> from sparknlp.base import *
     >>> from sparknlp.annotator import *
@@ -80,6 +96,30 @@ class VectorDBConnector(AnnotatorModel):
     ... ]).toDF("id", "text", "category")
 
     >>> result = pipeline.fit(data).transform(data)
+
+    **Image mode example:**
+
+    >>> imageAssembler = ImageAssembler() \\
+    ...     .setInputCol("image") \\
+    ...     .setOutputCol("image_assembler")
+
+    >>> e5vEmbeddings = E5VEmbeddings.pretrained() \\
+    ...     .setInputCols(["image_assembler"]) \\
+    ...     .setOutputCol("image_embeddings")
+
+    >>> vectorDB = VectorDBConnector() \\
+    ...     .setInputCols(["image_assembler", "image_embeddings"]) \\
+    ...     .setOutputCol("vectordb_result") \\
+    ...     .setProvider("pinecone") \\
+    ...     .setIndexName("my-multimodal-index") \\
+    ...     .setModalityMode("image") \\
+    ...     .setBatchSize(50)
+
+    >>> pipeline = Pipeline().setStages([
+    ...     imageAssembler,
+    ...     e5vEmbeddings,
+    ...     vectorDB
+    ... ])
     """
 
     name = "VectorDBConnector"
@@ -117,6 +157,11 @@ class VectorDBConnector(AnnotatorModel):
                       "batchSize",
                       "Number of vectors to upsert in a single batch",
                       typeConverter=TypeConverters.toInt)
+
+    modalityMode = Param(Params._dummy(),
+                         "modalityMode",
+                         "Modality mode for indexing. Supported values: 'text' (default), 'image'.",
+                         typeConverter=TypeConverters.toString)
 
     def setProvider(self, value):
         """Sets the vector database provider.
@@ -178,6 +223,33 @@ class VectorDBConnector(AnnotatorModel):
         """
         return self._set(batchSize=value)
 
+    def setModalityMode(self, value):
+        """Sets the modality mode for indexing.
+
+        Use 'text' (default) for DOCUMENT + SENTENCE_EMBEDDINGS pipelines and
+        'image' for IMAGE + SENTENCE_EMBEDDINGS pipelines (e.g. ImageAssembler +
+        E5VEmbeddings).  In image mode vector IDs are stable UUID-v3 values derived from
+        the image origin path, and upserted metadata automatically includes
+        modality, image_origin, image_width, image_height, and
+        image_nChannels fields.
+
+        Parameters
+        ----------
+        value : str
+            'text' or 'image'
+        """
+        return self._set(modalityMode=value)
+
+    def getModalityMode(self):
+        """Gets the current modality mode.
+
+        Returns
+        -------
+        str
+            'text' or 'image'
+        """
+        return self.getOrDefault(self.modalityMode)
+
     @keyword_only
     def __init__(self, classname="com.johnsnowlabs.ml.ai.VectorDBConnector", java_model=None):
         super(VectorDBConnector, self).__init__(
@@ -188,5 +260,6 @@ class VectorDBConnector(AnnotatorModel):
             provider="pinecone",
             batchSize=100,
             namespace="",
-            metadataColumns=[]
+            metadataColumns=[],
+            modalityMode="text"
         )

--- a/src/main/scala/com/johnsnowlabs/ml/ai/VectorDBConnector.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/VectorDBConnector.scala
@@ -16,8 +16,8 @@
 
 package com.johnsnowlabs.ml.ai
 
-import com.johnsnowlabs.nlp.AnnotatorType.{DOCUMENT, SENTENCE_EMBEDDINGS}
-import com.johnsnowlabs.nlp.{Annotation, AnnotatorModel, HasBatchedAnnotate}
+import com.johnsnowlabs.nlp.AnnotatorType.{DOCUMENT, IMAGE, SENTENCE_EMBEDDINGS}
+import com.johnsnowlabs.nlp.{Annotation, AnnotationImage, AnnotatorModel, HasBatchedAnnotate}
 import com.johnsnowlabs.util.{ConfigHelper, ConfigLoader}
 import org.apache.http.client.methods.{HttpGet, HttpPost}
 import org.apache.http.entity.{ContentType, StringEntity}
@@ -26,25 +26,36 @@ import org.apache.http.util.EntityUtils
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.param.{IntParam, Param, StringArrayParam}
 import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 
+import java.time.Instant
 import java.util.UUID
 
 /** Connector for storing and retrieving embeddings from vector databases.
   *
   * This annotator takes embeddings from previous annotators (like BertEmbeddings,
-  * SentenceEmbeddings, OpenAIEmbeddings, etc.) and stores them in a vector database for
-  * similarity search and retrieval. Currently supports Pinecone with more providers planned.
+  * SentenceEmbeddings, E5VEmbeddings, etc.) and stores them in a vector database for similarity
+  * search and retrieval. Currently supports Pinecone with more providers planned.
+  *
+  * Supports two modality modes:
+  *   - 'text' (default): expects `DOCUMENT + SENTENCE_EMBEDDINGS` input columns. Metadata is
+  *     augmented with `modality=text`.
+  *   - 'image': expects `IMAGE + SENTENCE_EMBEDDINGS` input columns (e.g. from `ImageAssembler` +
+  *     `E5VEmbeddings`). Metadata is augmented with `modality=image`, `image_origin`,
+  *     `image_width`, `image_height`, and `image_nChannels`. Vector IDs are generated as
+  *     deterministic UUID-v3 values derived from the image file path (origin), ensuring stable
+  *     re-indexing.
   *
   * ==Supported Providers==
   *   - '''pinecone''': Pinecone vector database (default)
   *
-  * ==Example==
+  * ==Text Example==
   * {{{
   * import spark.implicits._
   * import com.johnsnowlabs.nlp.base.DocumentAssembler
   * import com.johnsnowlabs.nlp.embeddings.BertSentenceEmbeddings
-  * import com.johnsnowlabs.nlp.annotators.VectorDBConnector
+  * import com.johnsnowlabs.ml.ai.VectorDBConnector
   * import org.apache.spark.ml.Pipeline
   *
   * val documentAssembler = new DocumentAssembler()
@@ -79,6 +90,36 @@ import java.util.UUID
   * val result = pipeline.fit(data).transform(data)
   * }}}
   *
+  * ==Image Example==
+  * {{{
+  * import com.johnsnowlabs.nlp.base.ImageAssembler
+  * import com.johnsnowlabs.nlp.embeddings.E5VEmbeddings
+  * import com.johnsnowlabs.ml.ai.VectorDBConnector
+  * import org.apache.spark.ml.Pipeline
+  *
+  * val imageAssembler = new ImageAssembler()
+  *   .setInputCol("image")
+  *   .setOutputCol("image_assembler")
+  *
+  * val e5vEmbeddings = E5VEmbeddings.pretrained()
+  *   .setInputCols("image_assembler")
+  *   .setOutputCol("image_embeddings")
+  *
+  * val vectorDB = new VectorDBConnector()
+  *   .setInputCols("image_assembler", "image_embeddings")
+  *   .setOutputCol("vectordb_result")
+  *   .setProvider("pinecone")
+  *   .setIndexName("my-multimodal-index")
+  *   .setModalityMode("image")
+  *   .setBatchSize(50)
+  *
+  * val pipeline = new Pipeline().setStages(Array(
+  *   imageAssembler,
+  *   e5vEmbeddings,
+  *   vectorDB
+  * ))
+  * }}}
+  *
   * @param uid
   *   required uid for storing annotator to disk
   * @groupname anno Annotator types
@@ -104,8 +145,51 @@ class VectorDBConnector(override val uid: String)
 
   def this() = this(Identifiable.randomUID("VECTOR_DB_CONNECTOR"))
 
+  /** Input annotator types.
+    *
+    * In 'text' mode (default): `DOCUMENT, SENTENCE_EMBEDDINGS`
+    *
+    * In 'image' mode: `IMAGE, SENTENCE_EMBEDDINGS`
+    *
+    * @group anno
+    */
   override val inputAnnotatorTypes: Array[String] = Array(DOCUMENT, SENTENCE_EMBEDDINGS)
   override val outputAnnotatorType: String = DOCUMENT
+
+  /** Modality mode for indexing: "text" (default) or "image".
+    *
+    * Set to "image" when the first input column contains IMAGE annotations (e.g. from
+    * `ImageAssembler` + `E5VEmbeddings`). In image mode vector IDs are stable UUID-v3 values
+    * derived from the image origin path and upserted records carry image-specific metadata
+    * fields.
+    *
+    * @group param
+    */
+  val modalityMode = new Param[String](
+    this,
+    "modalityMode",
+    "Modality mode for indexing. Supported values: 'text' (default), 'image'.")
+
+  /** @group setParam */
+  def setModalityMode(value: String): this.type = {
+    require(
+      Set("text", "image").contains(value),
+      s"modalityMode must be 'text' or 'image', got: $value")
+    set(modalityMode, value)
+  }
+
+  /** @group getParam */
+  def getModalityMode: String = $(modalityMode)
+
+  /** Override schema validation to accept IMAGE in the first input column when modalityMode is
+    * set to "image", while still requiring SENTENCE_EMBEDDINGS in the second input column.
+    */
+  override protected def validate(schema: StructType): Boolean = {
+    $(modalityMode) match {
+      case "image" => checkSchema(schema, IMAGE) && checkSchema(schema, SENTENCE_EMBEDDINGS)
+      case _ => checkSchema(schema, DOCUMENT) && checkSchema(schema, SENTENCE_EMBEDDINGS)
+    }
+  }
 
   /** Vector database provider (e.g., 'pinecone')
     * @group param
@@ -192,7 +276,8 @@ class VectorDBConnector(override val uid: String)
     provider -> "pinecone",
     batchSize -> 100,
     namespace -> "",
-    metadataColumns -> Array.empty[String])
+    metadataColumns -> Array.empty[String],
+    modalityMode -> "text")
 
   // Provider-specific state
   private var apiKey: Option[Broadcast[String]] = None
@@ -289,7 +374,7 @@ class VectorDBConnector(override val uid: String)
         if (host.startsWith("https://")) host else s"https://$host"
       }
     } catch {
-      case ex: Exception =>
+      case ex: Exception if !ex.getMessage.startsWith("Failed to fetch") =>
         throw new Exception(s"Error fetching Pinecone index host: ${ex.getMessage}", ex)
     } finally {
       httpclient.close()
@@ -300,6 +385,9 @@ class VectorDBConnector(override val uid: String)
     *
     * This is necessary because we need access to additional columns (idColumn, metadataColumns)
     * beyond just the annotations. The standard batchAnnotate only receives annotations.
+    *
+    * Branches on `modalityMode`: in "text" mode the first input column is expected to carry
+    * DOCUMENT annotations; in "image" mode it carries IMAGE annotations (AnnotationImage).
     *
     * @param rows
     *   Iterator of rows to process
@@ -316,42 +404,9 @@ class VectorDBConnector(override val uid: String)
     val processedBatches = allRows.grouped($(batchSize)).flatMap { batchRows =>
       val vectorsWithRows = batchRows.flatMap { row =>
         try {
-          val embeddingAnnotations = getAnnotationsFromRow(row, getInputCols.last)
-          val documentAnnotations = getAnnotationsFromRow(row, getInputCols.head)
-
-          if (embeddingAnnotations.nonEmpty) {
-            val embeddings = embeddingAnnotations.head.embeddings
-
-            val vectorId = if (isSet(idColumn)) {
-              try {
-                val idIdx = row.fieldIndex($(idColumn))
-                row.get(idIdx).toString
-              } catch {
-                case _: Exception => UUID.randomUUID().toString
-              }
-            } else {
-              UUID.randomUUID().toString
-            }
-
-            val vectorMetadata = if (isSet(metadataColumns) && $(metadataColumns).nonEmpty) {
-              $(metadataColumns).flatMap { col =>
-                try {
-                  val colIdx = row.fieldIndex(col)
-                  Option(row.get(colIdx)).map(v => col -> v.toString)
-                } catch {
-                  case _: Exception => None
-                }
-              }.toMap
-            } else {
-              Map.empty[String, String]
-            }
-
-            val vector =
-              Map("id" -> vectorId, "values" -> embeddings.toList, "metadata" -> vectorMetadata)
-
-            Some((row, vector, documentAnnotations))
-          } else {
-            Some((row, null, documentAnnotations))
+          $(modalityMode) match {
+            case "image" => processImageRow(row)
+            case _ => processTextRow(row)
           }
         } catch {
           case e: Exception =>
@@ -362,6 +417,10 @@ class VectorDBConnector(override val uid: String)
 
       val vectors = vectorsWithRows.collect { case (_, v, _) if v != null => v }
 
+      // Track whether the batch upsert actually succeeded on the remote provider.
+      // A failed upsert must be reflected in the output annotation so callers are not
+      // misled into thinking vectors were stored when they were not.
+      var upsertError: Option[String] = None
       if (vectors.nonEmpty) {
         try {
           $(provider) match {
@@ -370,12 +429,17 @@ class VectorDBConnector(override val uid: String)
           }
         } catch {
           case e: Exception =>
+            upsertError = Some(e.getMessage)
             println(s"[VectorDBConnector] Error upserting batch: ${e.getMessage}")
         }
       }
 
       vectorsWithRows.map { case (row, vector, docAnnotations) =>
         val outputAnnotations = if (vector != null) {
+          val status = upsertError match {
+            case None => "upserted"
+            case Some(err) => s"failed: $err"
+          }
           docAnnotations.map { ann =>
             Annotation(
               annotatorType = outputAnnotatorType,
@@ -383,7 +447,7 @@ class VectorDBConnector(override val uid: String)
               end = ann.end,
               result = vector("id").asInstanceOf[String],
               metadata =
-                ann.metadata + ("vectordb_status" -> "upserted") + ("provider" -> $(provider)))
+                ann.metadata + ("vectordb_status" -> status) + ("provider" -> $(provider)))
           }
         } else {
           Seq.empty[Annotation]
@@ -402,7 +466,142 @@ class VectorDBConnector(override val uid: String)
     batchedAnnotations.map(_ => Seq.empty[Annotation])
   }
 
-  /** Helper method to get annotations from a row
+  /** Build and return a vector payload for a text-mode row (DOCUMENT + SENTENCE_EMBEDDINGS).
+    *
+    * Metadata always contains `modality=text` in addition to any user-specified columns.
+    */
+  private def processTextRow(row: Row): Option[(Row, Map[String, Any], Seq[Annotation])] = {
+    val embeddingAnnotations = getAnnotationsFromRow(row, getInputCols.last)
+    val documentAnnotations = getAnnotationsFromRow(row, getInputCols.head)
+    if (embeddingAnnotations.nonEmpty) {
+      val embeddings = embeddingAnnotations.head.embeddings
+      val vectorId = resolveVectorId(row, None)
+      val metadata: Map[String, String] =
+        resolveUserMetadata(row) + ("modality" -> "text") + ("indexed_at" -> Instant.now().toString)
+      val vector: Map[String, Any] =
+        Map("id" -> vectorId, "values" -> embeddings.toList, "metadata" -> metadata)
+      Some((row, vector, documentAnnotations))
+    } else {
+      Some((row, null, documentAnnotations))
+    }
+  }
+
+  /** Build and return a vector payload for an image-mode row (IMAGE + SENTENCE_EMBEDDINGS).
+    *
+    * Metadata always contains `modality=image`, `image_origin`, `image_width`, `image_height`,
+    * and `image_nChannels` in addition to any user-specified columns. When no explicit `idColumn`
+    * is configured the vector ID is a deterministic UUID-v3 derived from the image origin path,
+    * ensuring stable re-indexing of the same asset.
+    *
+    * Synthetic DOCUMENT output annotations are produced from the IMAGE annotations so that
+    * downstream pipeline stages receive valid annotation rows. Each synthesised annotation
+    * carries the image metadata so callers can inspect it after the transform.
+    */
+  private def processImageRow(row: Row): Option[(Row, Map[String, Any], Seq[Annotation])] = {
+    val embeddingAnnotations = getAnnotationsFromRow(row, getInputCols.last)
+    val imageAnnotations = getImageAnnotationsFromRow(row, getInputCols.head)
+
+    // Synthesise output annotations regardless of whether we have embeddings so that empty
+    // rows still produce a well-formed output column.
+    val syntheticAnns: Seq[Annotation] = imageAnnotations.map { imgAnn =>
+      Annotation(
+        annotatorType = outputAnnotatorType,
+        begin = 0,
+        end = 0,
+        result = imgAnn.origin,
+        metadata = Map(
+          "modality" -> "image",
+          "image_origin" -> imgAnn.origin,
+          "image_filename" -> extractFilename(imgAnn.origin),
+          "image_width" -> imgAnn.width.toString,
+          "image_height" -> imgAnn.height.toString,
+          "image_nChannels" -> imgAnn.nChannels.toString))
+    }
+
+    if (embeddingAnnotations.nonEmpty && imageAnnotations.nonEmpty) {
+      val embeddings = embeddingAnnotations.head.embeddings
+      val firstImage = imageAnnotations.head
+      val vectorId = resolveVectorId(row, Some(firstImage.origin))
+      val imageMeta: Map[String, String] = Map(
+        "modality" -> "image",
+        "image_origin" -> firstImage.origin,
+        "image_filename" -> extractFilename(firstImage.origin),
+        "image_width" -> firstImage.width.toString,
+        "image_height" -> firstImage.height.toString,
+        "image_nChannels" -> firstImage.nChannels.toString,
+        "indexed_at" -> Instant.now().toString)
+      val metadata: Map[String, String] = resolveUserMetadata(row) ++ imageMeta
+      val vector: Map[String, Any] =
+        Map("id" -> vectorId, "values" -> embeddings.toList, "metadata" -> metadata)
+      Some((row, vector, syntheticAnns))
+    } else {
+      Some((row, null, syntheticAnns))
+    }
+  }
+
+  /** Resolve the vector ID for a row.
+    *
+    * Priority:
+    *   1. Value from `idColumn` DataFrame column (if set and present). 2. Stable UUID-v3 derived
+    *      from `fallbackOrigin` (used for image paths). 3. Random UUID.
+    */
+  private def resolveVectorId(row: Row, fallbackOrigin: Option[String]): String = {
+    if (isSet(idColumn)) {
+      try {
+        val idIdx = row.fieldIndex($(idColumn))
+        Option(row.get(idIdx))
+          .map(_.toString)
+          .getOrElse(fallbackOrigin.map(stableImageId).getOrElse(UUID.randomUUID().toString))
+      } catch {
+        case _: Exception =>
+          fallbackOrigin.map(stableImageId).getOrElse(UUID.randomUUID().toString)
+      }
+    } else {
+      fallbackOrigin.map(stableImageId).getOrElse(UUID.randomUUID().toString)
+    }
+  }
+
+  /** Collect user-specified metadata columns from the row. Returns an empty map when
+    * `metadataColumns` is not set.
+    */
+  private def resolveUserMetadata(row: Row): Map[String, String] = {
+    if (isSet(metadataColumns) && $(metadataColumns).nonEmpty) {
+      $(metadataColumns).flatMap { col =>
+        try {
+          val colIdx = row.fieldIndex(col)
+          Option(row.get(colIdx)).map(v => col -> v.toString)
+        } catch {
+          case _: Exception => None
+        }
+      }.toMap
+    } else {
+      Map.empty[String, String]
+    }
+  }
+
+  /** Generate a deterministic, stable UUID-v3 from an image origin path.
+    *
+    * Repeated calls with the same `origin` always produce the same ID, which makes re-indexing
+    * idempotent without an explicit `idColumn`.
+    */
+  private def stableImageId(origin: String): String =
+    UUID.nameUUIDFromBytes(origin.getBytes("UTF-8")).toString
+
+  /** Extract the filename (last path segment) from an image origin URI or file-system path.
+    *
+    * Examples:
+    *   - `"file:///content/test_images/cat.jpg"` → `"cat.jpg"`
+    *   - `"s3://my-bucket/images/dog.png"` → `"dog.png"`
+    *   - `"/local/path/photo.jpeg"` → `"photo.jpeg"`
+    */
+  private def extractFilename(origin: String): String = {
+    val stripped = origin.replaceAll("^file://", "")
+    val lastSlash = stripped.lastIndexOf('/')
+    if (lastSlash >= 0 && lastSlash < stripped.length - 1) stripped.substring(lastSlash + 1)
+    else stripped
+  }
+
+  /** Helper method to get Annotation items from a row (text / embeddings columns).
     *
     * @param row
     *   Input row
@@ -418,6 +617,25 @@ class VectorDBConnector(override val uid: String)
       if (annotations != null) annotations.map(Annotation(_)) else Seq.empty
     } catch {
       case _: Exception => Seq.empty[Annotation]
+    }
+  }
+
+  /** Helper method to get AnnotationImage items from a row (IMAGE columns).
+    *
+    * @param row
+    *   Input row
+    * @param column
+    *   Column name – must reference an IMAGE-typed annotation column
+    * @return
+    *   Sequence of AnnotationImage
+    */
+  private def getImageAnnotationsFromRow(row: Row, column: String): Seq[AnnotationImage] = {
+    try {
+      val colIdx = row.fieldIndex(column)
+      val annotations = row.getAs[Seq[Row]](colIdx)
+      if (annotations != null) annotations.map(AnnotationImage(_)) else Seq.empty
+    } catch {
+      case _: Exception => Seq.empty[AnnotationImage]
     }
   }
 
@@ -460,7 +678,7 @@ class VectorDBConnector(override val uid: String)
         throw new Exception(s"Pinecone upsert failed with status $statusCode: $responseBody")
       }
     } catch {
-      case ex: Exception =>
+      case ex: Exception if !ex.getMessage.startsWith("Pinecone upsert failed") =>
         throw new Exception(s"Error upserting to Pinecone: ${ex.getMessage}", ex)
     } finally {
       httpclient.close()
@@ -492,7 +710,7 @@ class VectorDBConnector(override val uid: String)
       }
 
       val valuesJson = values.mkString(", ")
-      s"""{"id": "$id", "values": [$valuesJson]$metadataJson}"""
+      s"""{"id": "${escapeJsonString(id)}", "values": [$valuesJson]$metadataJson}"""
     }
 
     s"[${vectorsJson.mkString(", ")}]"

--- a/src/test/scala/com/johnsnowlabs/ml/ai/VectorDBConnectorMultimodalTest.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/ai/VectorDBConnectorMultimodalTest.scala
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2017-2024 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.ml.ai
+
+import com.johnsnowlabs.nlp.AnnotatorType.{DOCUMENT, IMAGE, SENTENCE_EMBEDDINGS}
+import com.johnsnowlabs.tags.{FastTest, SlowTest}
+import org.apache.spark.ml.Pipeline
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types._
+import org.scalatest.flatspec.AnyFlatSpec
+
+private class TestableVectorDBConnector extends VectorDBConnector {
+  def testValidate(schema: StructType): Boolean = validate(schema)
+}
+
+class VectorDBConnectorMultimodalTest extends AnyFlatSpec {
+
+  private lazy val spark: SparkSession = SparkSession
+    .builder()
+    .appName("VectorDBConnectorMultimodalTest")
+    .master("local[*]")
+    .config("spark.driver.memory", "4G")
+    .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+    .config(
+      "spark.jsl.settings.vectordb.api.key",
+      "pcsk_553ube_NNjrehQJbcxeNwMZaNWqWumwuLP2N3VNRExdVagShXxkGmJXsb7W3u5wKYR34Be")
+    .getOrCreate()
+
+  "VectorDBConnector" should "default to text modality mode" taggedAs FastTest in {
+    val connector = new VectorDBConnector()
+    assert(connector.getModalityMode === "text")
+  }
+
+  it should "accept and return image modality mode" taggedAs FastTest in {
+    val connector = new VectorDBConnector().setModalityMode("image")
+    assert(connector.getModalityMode === "image")
+  }
+
+  it should "accept and return text modality mode explicitly" taggedAs FastTest in {
+    val connector = new VectorDBConnector().setModalityMode("text")
+    assert(connector.getModalityMode === "text")
+  }
+
+  it should "reject an unsupported modality mode value" taggedAs FastTest in {
+    intercept[IllegalArgumentException] {
+      new VectorDBConnector().setModalityMode("audio")
+    }
+  }
+
+  it should "validate schema correctly for text mode (DOCUMENT + SENTENCE_EMBEDDINGS)" taggedAs FastTest in {
+    val connector = new TestableVectorDBConnector()
+      .setInputCols("document", "sentence_embeddings")
+      .setOutputCol("out")
+      .setModalityMode("text")
+
+    val schema = buildSchema("document" -> DOCUMENT, "sentence_embeddings" -> SENTENCE_EMBEDDINGS)
+
+    assert(
+      connector.testValidate(schema),
+      "text-mode validate should pass with DOCUMENT + SENTENCE_EMBEDDINGS")
+  }
+
+  it should "fail schema validation in text mode when first col is IMAGE" taggedAs FastTest in {
+    val connector = new TestableVectorDBConnector()
+      .setInputCols("image_col", "sentence_embeddings")
+      .setOutputCol("out")
+      .setModalityMode("text")
+
+    val schema = buildSchema("image_col" -> IMAGE, "sentence_embeddings" -> SENTENCE_EMBEDDINGS)
+
+    assert(
+      !connector.testValidate(schema),
+      "text-mode validate should fail with IMAGE + SENTENCE_EMBEDDINGS")
+  }
+
+  it should "validate schema correctly for image mode (IMAGE + SENTENCE_EMBEDDINGS)" taggedAs FastTest in {
+    val connector = new TestableVectorDBConnector()
+      .setInputCols("image_assembler", "image_embeddings")
+      .setOutputCol("out")
+      .setModalityMode("image")
+
+    val schema =
+      buildSchema("image_assembler" -> IMAGE, "image_embeddings" -> SENTENCE_EMBEDDINGS)
+
+    assert(
+      connector.testValidate(schema),
+      "image-mode validate should pass with IMAGE + SENTENCE_EMBEDDINGS")
+  }
+
+  it should "fail schema validation in image mode when first col is DOCUMENT" taggedAs FastTest in {
+    val connector = new TestableVectorDBConnector()
+      .setInputCols("document", "sentence_embeddings")
+      .setOutputCol("out")
+      .setModalityMode("image")
+
+    val schema = buildSchema("document" -> DOCUMENT, "sentence_embeddings" -> SENTENCE_EMBEDDINGS)
+
+    assert(
+      !connector.testValidate(schema),
+      "image-mode validate should fail with DOCUMENT + SENTENCE_EMBEDDINGS")
+  }
+
+  it should "preserve text-mode backward compatibility (modality key in Pinecone metadata)" taggedAs FastTest in {
+    val connector = new VectorDBConnector()
+    assert(connector.getProvider === "pinecone")
+    assert(connector.getBatchSize === 100)
+    assert(connector.getModalityMode === "text")
+  }
+
+  it should "allow chaining setModalityMode with other setters" taggedAs FastTest in {
+    val connector = new VectorDBConnector()
+      .setInputCols("image_assembler", "image_embeddings")
+      .setOutputCol("result")
+      .setProvider("pinecone")
+      .setIndexName("my-multimodal-index")
+      .setModalityMode("image")
+      .setBatchSize(25)
+
+    assert(connector.getModalityMode === "image")
+    assert(connector.getBatchSize === 25)
+    assert(connector.getIndexName === "my-multimodal-index")
+  }
+
+  "VectorDBConnector in image mode" should "index image embeddings from E5VEmbeddings end-to-end" taggedAs SlowTest in {
+    import com.johnsnowlabs.nlp.base.ImageAssembler
+    import com.johnsnowlabs.nlp.embeddings.E5VEmbeddings
+
+    val imageFolder = "src/test/resources/image/"
+
+    val imageDF = spark.read
+      .format("image")
+      .option("dropInvalid", value = true)
+      .load(imageFolder)
+
+    val imageAssembler = new ImageAssembler()
+      .setInputCol("image")
+      .setOutputCol("image_assembler")
+
+    val e5vEmbeddings = E5VEmbeddings
+      .pretrained("e5v_int4")
+      .setInputCols("image_assembler")
+      .setOutputCol("image_embeddings")
+
+    val vectorDB = new VectorDBConnector()
+      .setInputCols("image_assembler", "image_embeddings")
+      .setOutputCol("vectordb_result")
+      .setProvider("pinecone")
+      .setIndexName("multimodal-test-index")
+      .setNamespace("image-integration-test")
+      .setModalityMode("image")
+      .setBatchSize(10)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(imageAssembler, e5vEmbeddings, vectorDB))
+
+    val result = pipeline.fit(imageDF).transform(imageDF)
+    result.select("vectordb_result").show(false)
+
+    val resultCount = result.count()
+    assert(resultCount > 0, "Should process at least one image")
+
+    val firstRow = result.select("vectordb_result.metadata").head()
+    val metaList = firstRow.getSeq[Map[String, String]](0)
+    assert(
+      metaList.exists(m => m.getOrElse("vectordb_status", "") == "upserted"),
+      "Output annotation should carry vectordb_status=upserted")
+  }
+
+  "VectorDBConnector in text mode" should "still upsert text embeddings with modality metadata" taggedAs SlowTest in {
+    import spark.implicits._
+    import com.johnsnowlabs.nlp.base.DocumentAssembler
+    import com.johnsnowlabs.nlp.annotator.Tokenizer
+    import com.johnsnowlabs.nlp.embeddings.{AlbertEmbeddings, SentenceEmbeddings}
+
+    val testData = Seq(
+      ("mm_text_1", "Multimodal document one", "tech"),
+      ("mm_text_2", "Multimodal document two", "ai"))
+      .toDF("id", "text", "category")
+
+    val documentAssembler = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("document"))
+      .setOutputCol("token")
+
+    val embeddings = AlbertEmbeddings
+      .pretrained("albert_embeddings_albert_xlarge_v1")
+      .setInputCols("document", "token")
+      .setOutputCol("word_embeddings")
+
+    val sentenceEmbeddings = new SentenceEmbeddings()
+      .setInputCols("document", "word_embeddings")
+      .setOutputCol("sentence_embeddings")
+      .setPoolingStrategy("AVERAGE")
+
+    val vectorDB = new VectorDBConnector()
+      .setInputCols("document", "sentence_embeddings")
+      .setOutputCol("vectordb_result")
+      .setProvider("pinecone")
+      .setIndexName("multimodal-test-index")
+      .setNamespace("text-integration-test")
+      .setIdColumn("id")
+      .setMetadataColumns(Array("text", "category"))
+      .setModalityMode("text") // explicit – same as default
+      .setBatchSize(10)
+
+    val pipeline = new Pipeline()
+      .setStages(Array(documentAssembler, tokenizer, embeddings, sentenceEmbeddings, vectorDB))
+
+    val result = pipeline.fit(testData).transform(testData)
+    result.select("vectordb_result.result").show(false)
+
+    assert(result.count() == 2, "Should process both text documents")
+  }
+
+  private def buildSchema(cols: (String, String)*): StructType = {
+    val fields = cols.map { case (name, annotatorType) =>
+      val metaBuilder = new MetadataBuilder()
+      metaBuilder.putString("annotatorType", annotatorType)
+      StructField(name, ArrayType(StringType), nullable = false, metaBuilder.build())
+    }
+    StructType(fields)
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/ml/ai/VectorDBConnectorMultimodalTest.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/ai/VectorDBConnectorMultimodalTest.scala
@@ -37,7 +37,7 @@ class VectorDBConnectorMultimodalTest extends AnyFlatSpec {
     .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
     .config(
       "spark.jsl.settings.vectordb.api.key",
-      "pcsk_553ube_NNjrehQJbcxeNwMZaNWqWumwuLP2N3VNRExdVagShXxkGmJXsb7W3u5wKYR34Be")
+      "")
     .getOrCreate()
 
   "VectorDBConnector" should "default to text modality mode" taggedAs FastTest in {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Introduces a `modalityMode` parameter (`text` | `image`) to `VectorDBConnector`, enabling IMAGE + SENTENCE_EMBEDDINGS pipelines alongside the existing DOCUMENT + SENTENCE_EMBEDDINGS flow.


## Motivation and Context
VectorDBConnector previously only supported text-based indexing. This change was requested to support image indexing.

## How Has This Been Tested?
Changes were packaged into a JAR and tested end2end on google colab + local tests

## Screenshots (if appropriate):
<img width="1721" height="738" alt="image" src="https://github.com/user-attachments/assets/5e68bf3c-84bf-4944-92f4-30d8d31390a1" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
