### PR TITLE
[SPARKNLP-1369] Fix cloud pretrained cache handling for large models

### DIFF
--- a/docs/api/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLGraphChecker.html
+++ b/docs/api/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLGraphChecker.html
@@ -268,7 +268,7 @@ annotators in the pipeline and will process the whole dataset to extract the req
 parameters.</p><p>This annotator requires a dataset with at least two columns: one with tokens and one with the
 labels. In addition, it requires the used embedding annotator in the pipeline to extract the
 suitable embedding dimension.</p><p>For extended examples of usage, see the
-<a href="https://github.com/JohnSnowLabs/spark-nlp/blob/master//home/ducha/Workspace/scala/spark-nlp-feature/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb" target="_blank">Examples</a>
+<a href="https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb" target="_blank">Examples</a>
 and the
 <a href="https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLGraphCheckerTestSpec.scala" target="_blank">NerDLGraphCheckerTestSpec</a>.</p><h4>Example</h4><pre><span class="kw">import</span> com.johnsnowlabs.nlp.annotator._
 <span class="kw">import</span> com.johnsnowlabs.nlp.training.CoNLL

--- a/docs/api/com/johnsnowlabs/nlp/annotators/ner/dl/index.html
+++ b/docs/api/com/johnsnowlabs/nlp/annotators/ner/dl/index.html
@@ -517,7 +517,7 @@ annotators in the pipeline and will process the whole dataset to extract the req
 parameters.</p><p>This annotator requires a dataset with at least two columns: one with tokens and one with the
 labels. In addition, it requires the used embedding annotator in the pipeline to extract the
 suitable embedding dimension.</p><p>For extended examples of usage, see the
-<a href="https://github.com/JohnSnowLabs/spark-nlp/blob/master//home/ducha/Workspace/scala/spark-nlp-feature/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb" target="_blank">Examples</a>
+<a href="https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb" target="_blank">Examples</a>
 and the
 <a href="https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLGraphCheckerTestSpec.scala" target="_blank">NerDLGraphCheckerTestSpec</a>.</p><h4>Example</h4><pre><span class="kw">import</span> com.johnsnowlabs.nlp.annotator._
 <span class="kw">import</span> com.johnsnowlabs.nlp.training.CoNLL

--- a/docs/api/python/_api/sparknlp.annotator.ner.ner_dl_graph_checker.html
+++ b/docs/api/python/_api/sparknlp.annotator.ner.ner_dl_graph_checker.html
@@ -719,7 +719,7 @@ annotators in the pipeline and will process the whole dataset to extract the req
 labels. In addition, it requires the used embedding annotator in the pipeline to extract the
 suitable embedding dimension.</p>
 <p>For extended examples of usage, see the`Examples 
-&lt;<a class="github reference external" href="https://github.com/JohnSnowLabs/spark-nlp/blob/master//home/ducha/Workspace/scala/spark-nlp-feature/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb">JohnSnowLabs/spark-nlp</a>&gt;`__ 
+&lt;<a class="github reference external" href="https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb">JohnSnowLabs/spark-nlp</a>&gt;`__
 and the <a class="reference external" href="https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLGraphCheckerTestSpec.scala">NerDLGraphCheckerTestSpec</a>.</p>
 <table class="table">
 <thead>

--- a/docs/api/python/modules/sparknlp/annotator/ner/ner_dl_graph_checker.html
+++ b/docs/api/python/modules/sparknlp/annotator/ner/ner_dl_graph_checker.html
@@ -405,7 +405,7 @@ document.write(`
 <span class="sd">    suitable embedding dimension.</span>
 
 <span class="sd">    For extended examples of usage, see the`Examples </span>
-<span class="sd">    &lt;https://github.com/JohnSnowLabs/spark-nlp/blob/master//home/ducha/Workspace/scala/spark-nlp-feature/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb&gt;`__ </span>
+<span class="sd">    &lt;https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb&gt;`__ </span>
 <span class="sd">    and the `NerDLGraphCheckerTestSpec </span>
 <span class="sd">    &lt;https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLGraphCheckerTestSpec.scala&gt;`__.</span>
 

--- a/docs/api/python/reference/autosummary/sparknlp/annotator/ner/ner_dl_graph_checker/index.html
+++ b/docs/api/python/reference/autosummary/sparknlp/annotator/ner/ner_dl_graph_checker/index.html
@@ -643,7 +643,7 @@ annotators in the pipeline and will process the whole dataset to extract the req
 labels. In addition, it requires the used embedding annotator in the pipeline to extract the
 suitable embedding dimension.</p>
 <p>For extended examples of usage, see the`Examples
-&lt;<a class="github reference external" href="https://github.com/JohnSnowLabs/spark-nlp/blob/master//home/ducha/Workspace/scala/spark-nlp-feature/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb">JohnSnowLabs/spark-nlp</a>&gt;`__
+&lt;<a class="github reference external" href="https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb">JohnSnowLabs/spark-nlp</a>&gt;`__
 and the <a class="reference external" href="https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLGraphCheckerTestSpec.scala">NerDLGraphCheckerTestSpec</a>.</p>
 <table class="table">
 <thead>

--- a/docs/en/annotator_entries/NerDLGraphChecker.md
+++ b/docs/en/annotator_entries/NerDLGraphChecker.md
@@ -15,7 +15,7 @@ labels. In addition, it requires the used embedding annotator in the pipeline to
 suitable embedding dimension.
 
 For extended examples of usage, see the
-[example notebook](https://github.com/JohnSnowLabs/spark-nlp/blob/master//home/ducha/Workspace/scala/spark-nlp-feature/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb)
+[example notebook](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb)
 and the
 [NerDLGraphCheckerTestSpec](https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLGraphCheckerTestSpec.scala).
 

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -829,6 +829,310 @@ aws emr create-cluster \
 
 </div><div class="h3-box" markdown="1">
 
+## EMR Serverless
+
+This setup is for Spark NLP Open Source jobs on Amazon EMR Serverless. EMR Serverless does not run bootstrap actions like an EMR cluster, so the job should load its Python runtime, Spark NLP assembly JAR, and any offline model artifacts from S3.
+
+The example below uses:
+
+- EMR Serverless release `emr-7.12.0`
+- Python `3.11`
+- Spark NLP `{{ site.sparknlp_version }}`
+- Scala `2.12`
+
+### 1. Prepare the S3 artifact layout
+
+Create an S3 bucket or prefix that the EMR Serverless runtime role can read from and write logs/cache files to:
+
+```text
+s3://<artifact-bucket>/spark-nlp-emr/
+  scripts/
+  envs/
+  models/
+  cache_pretrained/
+  logs/
+s3://<artifact-bucket>/jars/
+```
+
+Upload the Spark NLP assembly JAR to S3. You can use a JAR from the Spark NLP release notes or build one from source with `sbt assembly`.
+
+```bash
+aws s3 cp spark-nlp-assembly-{{ site.sparknlp_version }}.jar \
+  s3://<artifact-bucket>/jars/spark-nlp-assembly-{{ site.sparknlp_version }}.jar
+```
+
+Use `spark.jars` with this S3 path for EMR Serverless jobs. If the runtime cannot reach Maven repositories, avoid `spark.jars.packages`.
+
+### 2. Build the Python runtime archive
+
+Build the Python environment on Amazon Linux 2023 so it matches the EMR Serverless runtime. The `--copies` option avoids Python binary symlinks that point back to the build machine.
+
+```dockerfile
+FROM amazonlinux:2023
+
+RUN dnf update -y && \
+    dnf install -y \
+      python3.11 \
+      python3.11-pip \
+      python3.11-devel \
+      tar \
+      gzip \
+      findutils \
+      shadow-utils && \
+    dnf clean all
+
+WORKDIR /work
+CMD ["/bin/bash"]
+```
+
+Build and enter the container:
+
+```bash
+docker build -t emr-venv-builder -f Dockerfile .
+docker run --rm -it \
+  -u "$(id -u):$(id -g)" \
+  -v "$PWD":/work \
+  emr-venv-builder
+```
+
+Inside the container, create and pack the virtual environment:
+
+```bash
+cd /work
+rm -rf spark-nlp-env spark-nlp-env.tar.gz
+
+python3.11 -m venv --copies spark-nlp-env
+source spark-nlp-env/bin/activate
+
+python -m pip install --upgrade pip
+pip install "spark-nlp=={{ site.sparknlp_version }}" "numpy==1.26.4" venv-pack
+
+python -c "import numpy; print('numpy ok')"
+python -c "import sparknlp; print('sparknlp ok')"
+
+venv-pack -o spark-nlp-env.tar.gz
+```
+
+Upload the archive:
+
+```bash
+aws s3 cp spark-nlp-env.tar.gz \
+  s3://<artifact-bucket>/spark-nlp-emr/envs/spark-nlp-env.tar.gz
+```
+
+### 3. Choose how pretrained assets are loaded
+
+There are two common patterns for pretrained resources on EMR Serverless.
+
+The first pattern uses `cache_pretrained` with an S3 path. With this setup, calls such as `PretrainedPipeline("recognize_entities_dl", lang="en")` or `.pretrained(...)` download the compatible resource on the first run and store it in the configured S3 cache. Later runs reuse the cached copy.
+
+```bash
+--conf spark.jsl.settings.pretrained.cache_folder=s3a://<artifact-bucket>/spark-nlp-emr/cache_pretrained/
+```
+
+Use this pattern when the EMR Serverless job can reach the Spark NLP public model repository and the cache bucket is writable by the runtime role or by the temporary credentials passed to Spark.
+
+Then use the standard pretrained APIs:
+
+```python
+from pyspark.sql import SparkSession
+from sparknlp.pretrained import PretrainedPipeline
+
+spark = SparkSession.builder.appName("Spark NLP EMR Serverless").getOrCreate()
+pipeline = PretrainedPipeline("recognize_entities_dl", lang="en")
+```
+
+The second pattern loads a model or pipeline that was already downloaded and saved to S3. This does not populate `cache_pretrained`; it reads the exact saved path you provide. Use this when the resource is prepared ahead of time or when the job should not download from the public model repository at runtime.
+
+```python
+from pyspark.sql import SparkSession
+from sparknlp.pretrained import PretrainedPipeline
+
+spark = SparkSession.builder.appName("Spark NLP EMR Serverless").getOrCreate()
+pipeline = PretrainedPipeline.from_disk(
+    "s3a://<artifact-bucket>/spark-nlp-emr/models/recognize_entities_dl"
+)
+```
+
+To prepare a pipeline in an environment with internet access and upload it to S3:
+
+```python
+import sparknlp
+from sparknlp.pretrained import PretrainedPipeline
+
+spark = sparknlp.start()
+pipeline = PretrainedPipeline("recognize_entities_dl", lang="en")
+pipeline.model.write().overwrite().save("recognize_entities_dl")
+spark.stop()
+```
+
+```bash
+aws s3 cp --recursive recognize_entities_dl \
+  s3://<artifact-bucket>/spark-nlp-emr/models/recognize_entities_dl
+```
+
+The saved path should contain `metadata/` and `stages/` at the top level.
+
+If you prefer a fully offline local load, archive the folder, pass the archive in `spark.archives`, and load it with `PretrainedPipeline.from_disk("./recognize_entities_dl")`. AWS documents [`spark.archives`](https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/jobs-spark.html) as a comma-separated list of `.jar`, `.tar.gz`, `.tgz`, and `.zip` files extracted into each executor working directory, but it does not publish a model-archive-specific size quota. In Spark NLP EMR Serverless experiments, model archives larger than approximately 1 GB failed during archive distribution or extraction. Treat `spark.archives` as a small-model convenience path; for larger models, prefer direct S3 loading with `PretrainedPipeline.from_disk("s3a://...")` or the S3 `cache_pretrained` configuration.
+
+### 4. Create the job script
+
+Save the following as `ner_test.py`:
+
+```python
+from pyspark.sql import SparkSession
+from sparknlp.pretrained import PretrainedPipeline
+
+
+def main():
+    spark = SparkSession.builder.appName("Spark NLP EMR Serverless").getOrCreate()
+
+    text = "Barack Obama was born in Hawaii and was elected president of the United States."
+
+    # Use this when spark.jsl.settings.pretrained.cache_folder points to S3.
+    pipeline = PretrainedPipeline("recognize_entities_dl", lang="en")
+
+    # To load a pipeline already saved in S3, use:
+    # pipeline = PretrainedPipeline.from_disk(
+    #     "s3a://<artifact-bucket>/spark-nlp-emr/models/recognize_entities_dl"
+    # )
+    #
+    # For a fully offline local load, archive the pipeline in spark.archives and use:
+    # pipeline = PretrainedPipeline.from_disk("./recognize_entities_dl")
+
+    result = pipeline.fullAnnotate(text)[0]
+
+    print("=== INPUT ===")
+    print(text)
+
+    print("\n=== NER OUTPUT ===")
+    for entity in result.get("entities", []):
+        print(
+            f"text={entity.result!r}, "
+            f"label={entity.metadata.get('entity')!r}, "
+            f"begin={entity.begin}, end={entity.end}"
+        )
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Upload the script:
+
+```bash
+aws s3 cp ner_test.py \
+  s3://<artifact-bucket>/spark-nlp-emr/scripts/ner_test.py
+```
+
+### 5. Create the EMR Serverless application
+
+Create an EMR Serverless Spark application with a release label compatible with your Spark NLP build, for example `emr-7.12.0`. Keep the returned application id and use an execution role that can access the S3 paths above.
+
+```bash
+aws emr-serverless create-application \
+  --name spark-nlp-os \
+  --type SPARK \
+  --release-label emr-7.12.0
+```
+
+### 6. Submit the job
+
+Submit with the Python environment archive, the Spark NLP assembly JAR, and the S3 pretrained cache.
+
+The following Open Source example uses temporary AWS credentials. Replace every placeholder before running it. If the EMR Serverless runtime role already has read/write permissions for the artifact bucket and cache path, omit the temporary credential lines, including `spark.hadoop.fs.s3a.aws.credentials.provider`, `spark.hadoop.fs.s3a.access.key`, `spark.hadoop.fs.s3a.secret.key`, `spark.hadoop.fs.s3a.session.token`, and `spark.jsl.settings.aws.credentials.*`, and let S3A use the runtime role.
+
+```bash
+--conf spark.archives=s3://<artifact-bucket>/spark-nlp-emr/envs/spark-nlp-env.tar.gz#environment \
+--conf spark.emr-serverless.driverEnv.PYSPARK_DRIVER_PYTHON=./environment/bin/python \
+--conf spark.emr-serverless.driverEnv.PYSPARK_PYTHON=./environment/bin/python \
+--conf spark.executorEnv.PYSPARK_PYTHON=./environment/bin/python \
+--conf spark.jars=s3://<artifact-bucket>/jars/spark-nlp-assembly-{{ site.sparknlp_version }}.jar \
+--conf spark.jsl.settings.pretrained.cache_folder=s3a://<artifact-bucket>/spark-nlp-emr/cache_pretrained/ \
+--conf spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem \
+--conf spark.hadoop.fs.s3a.endpoint=s3.<aws-region>.amazonaws.com \
+--conf spark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider \
+--conf spark.hadoop.fs.s3a.access.key=<aws-access-key-id> \
+--conf spark.hadoop.fs.s3a.secret.key=<aws-secret-access-key> \
+--conf spark.hadoop.fs.s3a.session.token=<aws-session-token> \
+--conf spark.jsl.settings.aws.region=<aws-region> \
+--conf spark.jsl.settings.aws.credentials.access_key_id=<aws-access-key-id> \
+--conf spark.jsl.settings.aws.credentials.secret_access_key=<aws-secret-access-key> \
+--conf spark.jsl.settings.aws.credentials.session_token=<aws-session-token> \
+--conf spark.hadoop.hive.metastore.client.factory.class=com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory
+```
+
+For direct S3 loading of a previously downloaded Open Source pipeline, keep the Python, JAR, and S3A properties, remove `spark.jsl.settings.pretrained.cache_folder` unless the same job also downloads other pretrained resources, and load the saved pipeline path with `PretrainedPipeline.from_disk("s3a://<artifact-bucket>/spark-nlp-emr/models/<pipeline-name>")`.
+
+```bash
+--conf spark.archives=s3://<artifact-bucket>/spark-nlp-emr/envs/spark-nlp-env.tar.gz#environment \
+--conf spark.emr-serverless.driverEnv.PYSPARK_DRIVER_PYTHON=./environment/bin/python \
+--conf spark.emr-serverless.driverEnv.PYSPARK_PYTHON=./environment/bin/python \
+--conf spark.executorEnv.PYSPARK_PYTHON=./environment/bin/python \
+--conf spark.jars=s3://<artifact-bucket>/jars/spark-nlp-assembly-{{ site.sparknlp_version }}.jar \
+--conf spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem \
+--conf spark.hadoop.fs.s3a.endpoint=s3.<aws-region>.amazonaws.com \
+--conf spark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider \
+--conf spark.hadoop.fs.s3a.access.key=<aws-access-key-id> \
+--conf spark.hadoop.fs.s3a.secret.key=<aws-secret-access-key> \
+--conf spark.hadoop.fs.s3a.session.token=<aws-session-token> \
+--conf spark.hadoop.hive.metastore.client.factory.class=com.amazonaws.glue.catalog.metastore.AWSGlueDataCatalogHiveClientFactory
+```
+
+Pass the selected properties as the `sparkSubmitParameters` string:
+
+```bash
+aws emr-serverless start-job-run \
+  --application-id <application-id> \
+  --execution-role-arn <emr-serverless-runtime-role-arn> \
+  --job-driver '{
+    "sparkSubmit": {
+      "entryPoint": "s3://<artifact-bucket>/spark-nlp-emr/scripts/ner_test.py",
+      "sparkSubmitParameters": "<spark-submit-parameters>"
+    }
+  }' \
+  --configuration-overrides '{
+    "monitoringConfiguration": {
+      "s3MonitoringConfiguration": {
+        "logUri": "s3://<artifact-bucket>/spark-nlp-emr/logs/"
+      }
+    }
+  }'
+```
+
+For a fully offline local load, add the model archive to `spark.archives` and load it with `PretrainedPipeline.from_disk("./recognize_entities_dl")` in the script. Use this only for small model archives. AWS documents [`spark.archives`](https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/jobs-spark.html) extraction support, while EMR Serverless [worker disk](https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/app-behavior.html) defaults start at 20 GB and can be configured up to 200 GB per worker, but this is not the same as an AWS-supported archive size guarantee. Based on Spark NLP EMR Serverless testing, use direct S3 loading or `cache_pretrained` for model archives near or above 1 GB.
+
+```bash
+--conf spark.archives=s3://<artifact-bucket>/spark-nlp-emr/envs/spark-nlp-env.tar.gz#environment,s3://<artifact-bucket>/spark-nlp-emr/models/recognize_entities_dl.tar.gz#recognize_entities_dl
+```
+
+The required Spark properties are:
+
+{:.table-model-big}
+| Property | Purpose |
+|----------|---------|
+| `spark.archives` | Extracts the Python environment as `./environment` and, for small fully offline model archives, the pipeline as `./recognize_entities_dl`. Prefer direct S3 loading or `cache_pretrained` for larger models. |
+| `spark.emr-serverless.driverEnv.PYSPARK_DRIVER_PYTHON` | Forces the driver to use the packed Python interpreter. |
+| `spark.emr-serverless.driverEnv.PYSPARK_PYTHON` | Sets the driver-side PySpark Python interpreter. |
+| `spark.executorEnv.PYSPARK_PYTHON` | Sets the executor-side PySpark Python interpreter. |
+| `spark.jars` | Loads the Spark NLP assembly JAR from S3 without resolving Maven packages at job startup. |
+| `spark.jsl.settings.pretrained.cache_folder` | Stores pretrained models and pipelines in an S3 cache when using `PretrainedPipeline(...)` or `.pretrained(...)`. |
+| `spark.hadoop.fs.s3a.impl` | Enables Hadoop S3A paths such as `s3a://...` for loading models, pipelines, and cache contents. |
+| `spark.hadoop.fs.s3a.endpoint` | Points S3A to the AWS regional endpoint used by the bucket. |
+| `spark.hadoop.fs.s3a.aws.credentials.provider` | Selects the S3A credential provider. Use `TemporaryAWSCredentialsProvider` when passing access key, secret key, and session token. |
+| `spark.hadoop.fs.s3a.access.key` | Temporary AWS access key for Hadoop S3A access. Omit when using the EMR Serverless runtime role. |
+| `spark.hadoop.fs.s3a.secret.key` | Temporary AWS secret key for Hadoop S3A access. Omit when using the EMR Serverless runtime role. |
+| `spark.hadoop.fs.s3a.session.token` | Temporary AWS session token for Hadoop S3A access. Omit when using the EMR Serverless runtime role. |
+| `spark.jsl.settings.aws.region` | AWS region used by Spark NLP cloud cache operations. |
+| `spark.jsl.settings.aws.credentials.access_key_id` | Temporary AWS access key used by Spark NLP cloud cache operations. Omit when using the EMR Serverless runtime role. |
+| `spark.jsl.settings.aws.credentials.secret_access_key` | Temporary AWS secret key used by Spark NLP cloud cache operations. Omit when using the EMR Serverless runtime role. |
+| `spark.jsl.settings.aws.credentials.session_token` | Temporary AWS session token used by Spark NLP cloud cache operations. Omit when using the EMR Serverless runtime role. |
+| `spark.hadoop.hive.metastore.client.factory.class` | Optional AWS Glue Data Catalog integration when the job also needs Glue-backed Hive metadata. |
+
+</div><div class="h3-box" markdown="1">
+
 ## GCP Dataproc
 
 1. Create a cluster if you don't have one already as follows.
@@ -1232,7 +1536,7 @@ Finally, use **jupyter_notebook_config.json** for the password:
 ```bash
 {
   "NotebookApp": {
-    "password": "sha1:65adaa6ffb9c:36df1c2086ef294276da703667d1b8ff38f92614"
+    "password": "<sha1-password-hash-generated-by-jupyter>"
   }
 }
 ```

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -78,7 +78,8 @@ def start(gpu=False,
           cluster_tmp_dir="",
           params=None,
           real_time_output=False,
-          output_level=1):
+          output_level=1,
+          skip_sparknlp_maven=False):
     """Starts a PySpark instance with default parameters for Spark NLP.
 
     The default parameters would result in the equivalent of:
@@ -115,6 +116,8 @@ def start(gpu=False,
         not supported and it must be local, HDFS, or DBFS.
     params : dict, optional
         Custom parameters to set for the Spark configuration, by default None.
+        Set ``skip_sparknlp_maven`` to ``True`` or ``"true"`` to avoid adding the
+        default Spark NLP Maven package when a custom Spark NLP jar is provided.
     cluster_tmp_dir : str, optional
         The location to save logs from annotators during training. If not set, it will
         be in the users home directory under `annotator_logs`.
@@ -122,6 +125,9 @@ def start(gpu=False,
         Whether to read and print JVM output in real time, by default False
     output_level : int, optional
         Output level for logs, by default 1
+    skip_sparknlp_maven : bool, optional
+        Whether to avoid adding the default Spark NLP Maven package. Use this
+        when providing a custom Spark NLP jar with ``spark.jars``.
 
     Notes
     -----
@@ -135,6 +141,7 @@ def start(gpu=False,
 
     """
     current_version = __version__
+    maven_version = current_version.split("-")[0].split("+")[0]
 
     if params is None:
         params = {}
@@ -144,6 +151,18 @@ def start(gpu=False,
 
     if '_instantiatedSession' in dir(SparkSession) and SparkSession._instantiatedSession is not None:
         print('Warning::Spark Session already created, some configs may not take.')
+
+    skip_sparknlp_maven_param = "skip_sparknlp_maven"
+
+    def is_skip_sparknlp_maven_enabled():
+        value = params.get(skip_sparknlp_maven_param, False)
+        if isinstance(value, str):
+            value = value.strip().lower() == "true"
+        else:
+            value = bool(value)
+        return bool(skip_sparknlp_maven) or value
+
+    skip_sparknlp_maven = is_skip_sparknlp_maven_enabled()
 
     driver_cores = "*"
     for key, value in params.items():
@@ -159,12 +178,12 @@ def start(gpu=False,
             self.serializer, self.serializer_max_buffer = "org.apache.spark.serializer.KryoSerializer", "2000M"
             self.driver_max_result_size = "0"
             # Spark NLP on CPU or GPU
-            self.maven_spark3 = "com.johnsnowlabs.nlp:spark-nlp_2.12:{}".format(current_version)
-            self.maven_gpu_spark3 = "com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:{}".format(current_version)
+            self.maven_spark3 = "com.johnsnowlabs.nlp:spark-nlp_2.12:{}".format(maven_version)
+            self.maven_gpu_spark3 = "com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:{}".format(maven_version)
             # Spark NLP on Apple Silicon
-            self.maven_silicon = "com.johnsnowlabs.nlp:spark-nlp-silicon_2.12:{}".format(current_version)
+            self.maven_silicon = "com.johnsnowlabs.nlp:spark-nlp-silicon_2.12:{}".format(maven_version)
             # Spark NLP on Linux Aarch64
-            self.maven_aarch64 = "com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:{}".format(current_version)
+            self.maven_aarch64 = "com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:{}".format(maven_version)
 
     def start_without_realtime_output():
         builder = SparkSession.builder \
@@ -191,17 +210,21 @@ def start(gpu=False,
         if cluster_tmp_dir != '':
             builder.config("spark.jsl.settings.storage.cluster_tmp_dir", cluster_tmp_dir)
 
-        if params.get("spark.jars.packages") is None:
+        if not skip_sparknlp_maven and params.get("spark.jars.packages") is None:
             builder.config("spark.jars.packages", spark_jars_packages)
 
         for key, value in params.items():
-            if key == "spark.jars.packages":
+            if key == skip_sparknlp_maven_param:
+                continue
+            if key == "spark.jars.packages" and not skip_sparknlp_maven:
                 packages = spark_jars_packages + "," + value
                 builder.config(key, packages)
             else:
                 builder.config(key, value)
 
-        return builder.getOrCreate()
+        spark_session = builder.getOrCreate()
+        apply_hadoop_params(spark_session)
+        return spark_session
 
     def start_with_realtime_output():
 
@@ -232,11 +255,13 @@ def start(gpu=False,
                 if cluster_tmp_dir != '':
                     spark_conf.set("spark.jsl.settings.storage.cluster_tmp_dir", cluster_tmp_dir)
 
-                if params.get("spark.jars.packages") is None:
+                if not skip_sparknlp_maven and params.get("spark.jars.packages") is None:
                     spark_conf.set("spark.jars.packages", spark_jars_packages)
 
                 for key, value in params.items():
-                    if key == "spark.jars.packages":
+                    if key == skip_sparknlp_maven_param:
+                        continue
+                    if key == "spark.jars.packages" and not skip_sparknlp_maven:
                         packages = spark_jars_packages + "," + value
                         spark_conf.set(key, packages)
                     else:
@@ -255,6 +280,7 @@ def start(gpu=False,
                 # Use the gateway we launched
                 spark_context = SparkContext(gateway=self.gateway)
                 self.spark_session = SparkSession(spark_context)
+                apply_hadoop_params(self.spark_session)
 
                 self.out_thread = threading.Thread(target=self.output_reader)
                 self.error_thread = threading.Thread(target=self.error_reader)
@@ -287,6 +313,13 @@ def start(gpu=False,
                 self.error_thread.join()
 
         return SparkWithCustomGateway()
+
+    def apply_hadoop_params(spark_session):
+        hadoop_prefix = "spark.hadoop."
+        hadoop_configuration = spark_session.sparkContext._jsc.hadoopConfiguration()
+        for key, value in params.items():
+            if key.startswith(hadoop_prefix):
+                hadoop_configuration.set(key[len(hadoop_prefix):], value)
 
     spark_nlp_config = SparkNLPConfig()
 

--- a/python/sparknlp/annotator/ner/ner_dl_graph_checker.py
+++ b/python/sparknlp/annotator/ner/ner_dl_graph_checker.py
@@ -39,7 +39,7 @@ class NerDLGraphChecker(
     suitable embedding dimension.
 
     For extended examples of usage, see the`Examples 
-    <https://github.com/JohnSnowLabs/spark-nlp/blob/master//home/ducha/Workspace/scala/spark-nlp-feature/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb>`__ 
+    <https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb>`__
     and the `NerDLGraphCheckerTestSpec 
     <https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLGraphCheckerTestSpec.scala>`__.
 

--- a/src/main/scala/com/johnsnowlabs/client/CloudResources.scala
+++ b/src/main/scala/com/johnsnowlabs/client/CloudResources.scala
@@ -21,16 +21,20 @@ import com.johnsnowlabs.client.azure.AzureClient
 import com.johnsnowlabs.client.gcp.GCPClient
 import com.johnsnowlabs.client.util.CloudHelper
 import com.johnsnowlabs.client.util.CloudHelper.transformURIToWASB
+import com.johnsnowlabs.nlp.util.io.OutputHelper
 import com.johnsnowlabs.util.{ConfigHelper, ConfigLoader}
-import org.apache.commons.io.IOUtils
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.IOUtils
 import org.apache.spark.SparkFiles
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.io.{ByteArrayInputStream, FileInputStream, FileOutputStream, InputStream}
 import java.net.URI
-import java.nio.file.Paths
+import java.nio.file.{Files, Paths}
 import java.util.zip.ZipInputStream
 
 object CloudResources {
+
+  private val CloudCacheCompleteMarker = "_spark_nlp_cache_complete"
 
   def downloadModelFromCloud(
       awsGateway: AWSGateway,
@@ -51,9 +55,7 @@ object CloudResources {
           doesModelExistInExternalCloudStorage(modelName, destinationS3URI, awsClient)
 
         if (!modelExists) {
-          val destinationKey =
-            unzipInExternalCloudStorage(sourceKey, destinationS3URI, awsClient, zippedModel)
-          Option(destinationKey)
+          Option(unzipInExternalCloudStorage(sourceKey, destinationS3URI, awsClient, zippedModel))
         } else {
           Option(destinationS3URI + "/" + modelName)
         }
@@ -64,9 +66,7 @@ object CloudResources {
           doesModelExistInExternalCloudStorage(modelName, cachePath, gcpClient)
 
         if (!modelExists) {
-          val destination =
-            unzipInExternalCloudStorage(sourceS3URI, cachePath, gcpClient, zippedModel)
-          Option(destination)
+          Option(unzipInExternalCloudStorage(sourceS3URI, cachePath, gcpClient, zippedModel))
         } else {
           Option(cachePath + "/" + modelName)
         }
@@ -91,7 +91,7 @@ object CloudResources {
   }
 
   private def buildAzureModelPath(cachePath: String, destination: String): Option[String] = {
-    if (CloudHelper.isFabricAbfss(cachePath)) {
+    if (CloudHelper.isFabricAbfss(cachePath) || CloudHelper.isWasbsPath(cachePath)) {
       Some(destination)
     } else {
       Some(transformURIToWASB(destination))
@@ -101,7 +101,7 @@ object CloudResources {
   private def buildAzureModelPathWhenExists(
       cachePath: String,
       modelName: String): Option[String] = {
-    if (CloudHelper.isFabricAbfss(cachePath)) {
+    if (CloudHelper.isFabricAbfss(cachePath) || CloudHelper.isWasbsPath(cachePath)) {
       Some(cachePath + "/" + modelName)
     } else {
       Some(transformURIToWASB(cachePath + "/" + modelName))
@@ -118,28 +118,36 @@ object CloudResources {
         val (destinationBucketName, destinationKey) = CloudHelper.parseS3URI(destinationURI)
 
         val modelPath = destinationKey + "/" + modelName
+        val markerPath = modelPath + "/" + CloudCacheCompleteMarker
 
-        awsDestinationClient.doesBucketPathExist(destinationBucketName, modelPath)
+        awsDestinationClient.doesBucketPathExist(destinationBucketName, markerPath)
       }
       case gcpClient: GCPClient => {
         val (destinationBucketName, destinationStoragePath) =
           CloudHelper.parseGCPStorageURI(destinationURI)
         val modelPath = destinationStoragePath + "/" + modelName
+        val markerPath = modelPath + "/" + CloudCacheCompleteMarker
 
-        gcpClient.doesBucketPathExist(destinationBucketName, modelPath)
+        gcpClient.doesBucketPathExist(destinationBucketName, markerPath)
       }
       case azureClient: AzureClient => {
         if (CloudHelper.isFabricAbfss(destinationURI)) {
           val fabricUri =
             if (destinationURI.endsWith("/")) destinationURI + modelName
             else destinationURI + "/" + modelName
-          azureClient.doesBucketPathExist(fabricUri, "")
+          val markerUri = fabricUri + "/" + CloudCacheCompleteMarker
+          azureClient.doesBucketPathExist(markerUri, "")
+        } else if (CloudHelper.isWasbsPath(destinationURI)) {
+          val markerUri =
+            buildCloudPath(destinationURI, modelName, CloudCacheCompleteMarker, "_SUCCESS")
+          doesHadoopCloudPathExist(markerUri)
         } else {
           val (destinationBucketName, destinationStoragePath) =
             CloudHelper.parseAzureBlobURI(destinationURI)
           val modelPath = destinationStoragePath + "/" + modelName
+          val markerPath = modelPath + "/" + CloudCacheCompleteMarker
 
-          azureClient.doesBucketPathExist(destinationBucketName, modelPath)
+          azureClient.doesBucketPathExist(destinationBucketName, markerPath)
         }
       }
     }
@@ -160,56 +168,167 @@ object CloudResources {
 
     while (zipEntry != null) {
       if (!zipEntry.isDirectory) {
-
-        cloudClient match {
-          case awsClient: AWSClient => {
-            val (awsGatewayDestination, destinationBucketName, destinationKey) = getS3Config(
-              destinationStorageURI)
-            val fileName = s"$modelName/${zipEntry.getName}"
-            val destinationS3Path = destinationKey + "/" + fileName
-
-            awsGatewayDestination.copyFileToBucket(
-              destinationBucketName,
-              destinationS3Path,
-              zipInputStream)
-          }
-          case gcpClient: GCPClient => {
-            val (destinationBucketName, destinationStoragePath) =
-              CloudHelper.parseGCPStorageURI(destinationStorageURI)
-
-            val destinationGCPStoragePath =
-              s"$destinationStoragePath/$modelName/${zipEntry.getName}"
-
-            gcpClient.copyFileToBucket(
-              destinationBucketName,
-              destinationGCPStoragePath,
-              zipInputStream)
-          }
-          case azureClient: AzureClient => {
-            if (CloudHelper.isFabricAbfss(destinationStorageURI)) {
-              val fabricUri = (if (destinationStorageURI.endsWith("/")) destinationStorageURI
-                               else destinationStorageURI + "/") +
-                s"$modelName/${zipEntry.getName}"
-              azureClient.copyFileToBucket(fabricUri, "", zipInputStream)
-            } else {
-              val (destinationBucketName, destinationStoragePath) =
-                CloudHelper.parseAzureBlobURI(destinationStorageURI)
-
-              val destinationAzureStoragePath =
-                s"$destinationStoragePath/$modelName/${zipEntry.getName}".stripPrefix("/")
-
-              azureClient.copyFileToBucket(
-                destinationBucketName,
-                destinationAzureStoragePath,
-                zipInputStream)
-            }
-          }
-        }
+        uploadZipEntryToCloudStorage(
+          zipInputStream,
+          zipEntry.getName,
+          modelName,
+          destinationStorageURI,
+          cloudClient)
 
       }
       zipEntry = zipInputStream.getNextEntry
     }
-    destinationStorageURI + "/" + modelName
+    writeCloudCacheCompleteMarker(destinationStorageURI, modelName, cloudClient)
+    val destination = destinationStorageURI + "/" + modelName
+    destination
+  }
+
+  private def uploadZipEntryToCloudStorage(
+      zipInputStream: ZipInputStream,
+      zipEntryName: String,
+      modelName: String,
+      destinationStorageURI: String,
+      cloudClient: CloudClient): Unit = {
+    val tempFile = Files.createTempFile("sparknlp-cloud-cache-", ".entry").toFile
+
+    try {
+      val outputStream = new FileOutputStream(tempFile)
+      try {
+        val buffer = Array.ofDim[Byte](1024 * 1024)
+        var bytesRead = zipInputStream.read(buffer)
+        while (bytesRead != -1) {
+          outputStream.write(buffer, 0, bytesRead)
+          bytesRead = zipInputStream.read(buffer)
+        }
+      } finally {
+        outputStream.close()
+      }
+
+      val inputStream = new FileInputStream(tempFile)
+      try {
+        uploadFileToCloudStorage(
+          inputStream,
+          zipEntryName,
+          modelName,
+          destinationStorageURI,
+          cloudClient)
+      } finally {
+        inputStream.close()
+      }
+    } finally {
+      Files.deleteIfExists(tempFile.toPath)
+    }
+  }
+
+  private def uploadFileToCloudStorage(
+      inputStream: FileInputStream,
+      zipEntryName: String,
+      modelName: String,
+      destinationStorageURI: String,
+      cloudClient: CloudClient): Unit = {
+    cloudClient match {
+      case awsClient: AWSClient => {
+        val (awsGatewayDestination, destinationBucketName, destinationKey) =
+          getS3Config(destinationStorageURI)
+        val fileName = s"$modelName/$zipEntryName"
+        val destinationS3Path = destinationKey + "/" + fileName
+
+        awsGatewayDestination.copyFileToBucket(
+          destinationBucketName,
+          destinationS3Path,
+          inputStream)
+      }
+      case gcpClient: GCPClient => {
+        val (destinationBucketName, destinationStoragePath) =
+          CloudHelper.parseGCPStorageURI(destinationStorageURI)
+
+        val destinationGCPStoragePath =
+          s"$destinationStoragePath/$modelName/$zipEntryName"
+
+        gcpClient.copyFileToBucket(destinationBucketName, destinationGCPStoragePath, inputStream)
+      }
+      case azureClient: AzureClient => {
+        if (CloudHelper.isFabricAbfss(destinationStorageURI)) {
+          val fabricUri = (if (destinationStorageURI.endsWith("/")) destinationStorageURI
+                           else destinationStorageURI + "/") +
+            s"$modelName/$zipEntryName"
+          azureClient.copyFileToBucket(fabricUri, "", inputStream)
+        } else if (CloudHelper.isWasbsPath(destinationStorageURI)) {
+          val destinationWasbsPath =
+            buildCloudPath(destinationStorageURI, modelName, zipEntryName)
+          copyInputStreamToHadoopCloudPath(destinationWasbsPath, inputStream)
+        } else {
+          val (destinationBucketName, destinationStoragePath) =
+            CloudHelper.parseAzureBlobURI(destinationStorageURI)
+
+          val destinationAzureStoragePath =
+            s"$destinationStoragePath/$modelName/$zipEntryName".stripPrefix("/")
+
+          azureClient.copyFileToBucket(
+            destinationBucketName,
+            destinationAzureStoragePath,
+            inputStream)
+        }
+      }
+    }
+  }
+
+  private def writeCloudCacheCompleteMarker(
+      destinationStorageURI: String,
+      modelName: String,
+      cloudClient: CloudClient): Unit = {
+    val markerContent = new ByteArrayInputStream("complete".getBytes("UTF-8"))
+    val markerName = s"$CloudCacheCompleteMarker/_SUCCESS"
+
+    cloudClient match {
+      case awsClient: AWSClient => {
+        val (awsGatewayDestination, destinationBucketName, destinationKey) =
+          getS3Config(destinationStorageURI)
+        val markerPath = s"$destinationKey/$modelName/$markerName"
+        awsGatewayDestination.copyFileToBucket(destinationBucketName, markerPath, markerContent)
+      }
+      case gcpClient: GCPClient => {
+        val (destinationBucketName, destinationStoragePath) =
+          CloudHelper.parseGCPStorageURI(destinationStorageURI)
+        val markerPath = s"$destinationStoragePath/$modelName/$markerName"
+        gcpClient.copyFileToBucket(destinationBucketName, markerPath, markerContent)
+      }
+      case azureClient: AzureClient => {
+        if (CloudHelper.isFabricAbfss(destinationStorageURI)) {
+          val markerUri = (if (destinationStorageURI.endsWith("/")) destinationStorageURI
+                           else destinationStorageURI + "/") + s"$modelName/$markerName"
+          azureClient.copyFileToBucket(markerUri, "", markerContent)
+        } else if (CloudHelper.isWasbsPath(destinationStorageURI)) {
+          val markerUri = buildCloudPath(destinationStorageURI, modelName, markerName)
+          copyInputStreamToHadoopCloudPath(markerUri, markerContent)
+        } else {
+          val (destinationBucketName, destinationStoragePath) =
+            CloudHelper.parseAzureBlobURI(destinationStorageURI)
+          val markerPath = s"$destinationStoragePath/$modelName/$markerName".stripPrefix("/")
+          azureClient.copyFileToBucket(destinationBucketName, markerPath, markerContent)
+        }
+      }
+    }
+  }
+
+  private def buildCloudPath(basePath: String, pathParts: String*): String = {
+    val suffix = pathParts.map(_.stripPrefix("/")).mkString("/")
+    s"${basePath.stripSuffix("/")}/$suffix"
+  }
+
+  private def doesHadoopCloudPathExist(path: String): Boolean = {
+    val fileSystem = OutputHelper.getFileSystem(path)
+    fileSystem.exists(new Path(path))
+  }
+
+  private def copyInputStreamToHadoopCloudPath(path: String, inputStream: InputStream): Unit = {
+    val fileSystem = OutputHelper.getFileSystem(path)
+    val outputStream = fileSystem.create(new Path(path), true)
+    try {
+      IOUtils.copyBytes(inputStream, outputStream, 4096, false)
+    } finally {
+      outputStream.close()
+    }
   }
 
   private def getS3Config(destinationS3URI: String): (AWSClient, String, String) = {

--- a/src/main/scala/com/johnsnowlabs/client/aws/AWSGateway.scala
+++ b/src/main/scala/com/johnsnowlabs/client/aws/AWSGateway.scala
@@ -35,7 +35,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.jdk.CollectionConverters._
-import java.io.{File, InputStream}
+import java.io.{File, FileInputStream, InputStream}
 import java.nio.file.Files
 import scala.util.control.NonFatal
 
@@ -111,7 +111,13 @@ class AWSGateway(
       bucketName: String,
       destinationPath: String,
       inputStream: InputStream): Unit = {
-    client.putObject(bucketName, destinationPath, inputStream, new ObjectMetadata())
+    val metadata = new ObjectMetadata()
+    inputStream match {
+      case fileInputStream: FileInputStream =>
+        metadata.setContentLength(fileInputStream.getChannel.size())
+      case _ =>
+    }
+    client.putObject(bucketName, destinationPath, inputStream, metadata)
   }
 
   override def copyInputStreamToBucket(

--- a/src/main/scala/com/johnsnowlabs/client/azure/AzureGateway.scala
+++ b/src/main/scala/com/johnsnowlabs/client/azure/AzureGateway.scala
@@ -63,7 +63,12 @@ class AzureGateway(
         .getBlobClient(destinationPath)
         .getBlockBlobClient
 
-      val streamSize = inputStream.available()
+      val streamSize = inputStream match {
+        case fileInputStream: FileInputStream =>
+          fileInputStream.getChannel.size() - fileInputStream.getChannel.position()
+        case _ =>
+          inputStream.available().toLong
+      }
       blockBlobClient.upload(inputStream, streamSize)
     }
   }

--- a/src/main/scala/com/johnsnowlabs/client/util/CloudHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/client/util/CloudHelper.scala
@@ -43,10 +43,19 @@ object CloudHelper {
 
   def parseAzureBlobURI(azureBlobURI: String): (String, String) = {
     val uri = new URI(azureBlobURI)
-    val parts = uri.getPath.stripPrefix("/").split("/", 2)
-    val containerName = parts(0)
+    val (containerName, blobPath) =
+      if (isWasbsPath(azureBlobURI)) {
+        val container = Option(uri.getUserInfo)
+          .getOrElse(Option(uri.getAuthority).flatMap(_.split("@").headOption).getOrElse(""))
+        val path = uri.getPath.stripPrefix("/")
+        (container, path)
+      } else {
+        val parts = uri.getPath.stripPrefix("/").split("/", 2)
+        val container = parts(0)
+        val path = if (parts.length > 1) parts(1) else ""
+        (container, path)
+      }
     require(containerName.nonEmpty, "Azure container name is empty!")
-    val blobPath = if (parts.length > 1) parts(1) else ""
 
     (containerName, blobPath)
   }
@@ -60,6 +69,8 @@ object CloudHelper {
   }
 
   def transformURIToWASB(azureURI: String): String = {
+    if (isWasbsPath(azureURI)) return azureURI
+
     val url = new URL(azureURI)
     val host = url.getHost
     val pathParts = url.getPath.split("/").filter(_.nonEmpty)
@@ -81,9 +92,13 @@ object CloudHelper {
   private def isGCPStoragePath(uri: String): Boolean = uri.startsWith("gs://")
 
   private def isAzureBlobPath(uri: String): Boolean = {
-    (uri.startsWith("https://") && uri.contains(".blob.core.windows.net/")) || uri.startsWith(
-      "abfss://")
+    (uri.startsWith("https://") && uri.contains(".blob.core.windows.net/")) ||
+    uri.startsWith("abfss://") ||
+    isWasbsPath(uri)
   }
+
+  def isWasbsPath(uri: String): Boolean =
+    uri.startsWith("wasbs://") || uri.startsWith("wasb://")
 
   def isMicrosoftFabric: Boolean = {
     ResourceHelper.spark.conf.getAll.keys.exists(_.startsWith("spark.fabric"))

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLGraphChecker.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLGraphChecker.scala
@@ -44,7 +44,7 @@ import scala.util.{Failure, Success, Try}
   * suitable embedding dimension.
   *
   * For extended examples of usage, see the
-  * [[https://github.com/JohnSnowLabs/spark-nlp/blob/master//home/ducha/Workspace/scala/spark-nlp-feature/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb Examples]]
+  * [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/training/english/dl-ner/ner_dl_graph_checker.ipynb Examples]]
   * and the
   * [[https://github.com/JohnSnowLabs/spark-nlp/blob/master/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLGraphCheckerTestSpec.scala NerDLGraphCheckerTestSpec]].
   *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes failures when `cache_pretrained` points to cloud storage and pretrained resources are downloaded directly into S3, GCS, or Azure-backed cache locations. 
It also adds a  developer-focused option to start Spark NLP with a custom local jar, which helps debug behavior without resolving Spark NLP from Maven.

Changes

  - Fix cloud-cache extraction for large pretrained resources.
  - Add a cloud cache completion marker to avoid reusing partial caches.
  - Fix Azure `wasbs://` cache paths by routing them through Hadoop FS.
  - Add `skip_sparknlp_maven` to `sparknlp.start()` for custom jar debugging.
  - Explicitly propagate `spark.hadoop.*` params into Hadoop configuration.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Large models could fail during cloud-cache extraction or leave incomplete cache folders behind. Later runs could then treat those incomplete folders as valid caches, causing load failures.
This bug affected serverless and notebook environments where pretrained resources are cached directly in cloud storage.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- Verified on EMR Serverless with S3 cache.
- Verified on Dataproc Serverless with GCS bucket cache.
- Verified on Azure/Colab with `wasbs://` cache.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
