### PR TITLE
[SPARKNLP-1359] Implement BiEncoderMultimodalEmbeddings

### DIFF
--- a/python/sparknlp/annotator/embeddings/__init__.py
+++ b/python/sparknlp/annotator/embeddings/__init__.py
@@ -44,3 +44,4 @@ from sparknlp.annotator.embeddings.snowflake_embeddings import *
 from sparknlp.annotator.embeddings.nomic_embeddings import *
 from sparknlp.annotator.embeddings.auto_gguf_embeddings import *
 from sparknlp.annotator.embeddings.e5v_embeddings import *
+from sparknlp.annotator.embeddings.bi_encoder_multimodal_embeddings import *

--- a/python/sparknlp/annotator/embeddings/bi_encoder_multimodal_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bi_encoder_multimodal_embeddings.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from pyspark import keyword_only
+from pyspark.ml.wrapper import JavaTransformer
 from pyspark.ml.param import Param, Params, TypeConverters
 
 from sparknlp.common import AnnotatorType, AnnotatorProperties
@@ -45,10 +46,17 @@ class BiEncoderMultimodalEmbeddings(AnnotatorTransformer, AnnotatorProperties):
     )
 
     @keyword_only
-    def __init__(self):
-        super(BiEncoderMultimodalEmbeddings, self).__init__(
-            classname="com.johnsnowlabs.nlp.embeddings.BiEncoderMultimodalEmbeddings"
-        )
+    def __init__(
+        self,
+        classname="com.johnsnowlabs.nlp.embeddings.BiEncoderMultimodalEmbeddings",
+        java_model=None,
+    ):
+        if java_model is not None:
+            JavaTransformer.__init__(self, java_model)
+            self._create_params_from_java()
+            self._transfer_params_from_java()
+        else:
+            super(BiEncoderMultimodalEmbeddings, self).__init__(classname=classname)
         self._setDefault(outputCol="bi_encoder_multimodal", batchSize=8)
 
     @keyword_only
@@ -58,3 +66,54 @@ class BiEncoderMultimodalEmbeddings(AnnotatorTransformer, AnnotatorProperties):
 
     def setBatchSize(self, value):
         return self._set(batchSize=value)
+
+    @staticmethod
+    def _from_java(java_stage):
+        return BiEncoderMultimodalEmbeddings(java_model=java_stage)
+
+    @staticmethod
+    def loadSavedModel(folder, spark_session):
+        """Loads a locally saved external dual ONNX model.
+
+        Parameters
+        ----------
+        folder : str
+            Folder of the external model bundle.
+        spark_session : pyspark.sql.SparkSession
+            The current SparkSession.
+
+        Returns
+        -------
+        BiEncoderMultimodalEmbeddings
+            The restored model.
+        """
+        from sparknlp.internal import _BiEncoderMultimodalEmbeddingsLoader
+
+        jModel = _BiEncoderMultimodalEmbeddingsLoader(
+            folder, spark_session._jsparkSession
+        )._java_obj
+        return BiEncoderMultimodalEmbeddings(java_model=jModel)
+
+    @staticmethod
+    def pretrained(name="ops_mm_embedding_v1_2b", lang="en", remote_loc=None):
+        """Downloads and loads a pretrained model.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name of the pretrained model, by default "ops_mm_embedding_v1_2b".
+        lang : str, optional
+            Language of the pretrained model, by default "en".
+        remote_loc : str, optional
+            Optional remote address of the resource. Will use Spark NLP repositories otherwise.
+
+        Returns
+        -------
+        BiEncoderMultimodalEmbeddings
+            The restored model.
+        """
+        from sparknlp.pretrained import ResourceDownloader
+
+        return ResourceDownloader.downloadModel(
+            BiEncoderMultimodalEmbeddings, name, lang, remote_loc
+        )

--- a/python/sparknlp/annotator/embeddings/bi_encoder_multimodal_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/bi_encoder_multimodal_embeddings.py
@@ -1,0 +1,60 @@
+#  Copyright 2017-2026 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from pyspark import keyword_only
+from pyspark.ml.param import Param, Params, TypeConverters
+
+from sparknlp.common import AnnotatorType, AnnotatorProperties
+from sparknlp.internal import AnnotatorTransformer
+
+
+class BiEncoderMultimodalEmbeddings(AnnotatorTransformer, AnnotatorProperties):
+    """Dual-encoder multimodal embeddings annotator.
+
+    The output is written to two derived columns based on ``outputCol``:
+    ``<outputCol>_doc_embeddings`` and ``<outputCol>_image_embeddings``.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT, IMAGE``    ``SENTENCE_EMBEDDINGS``
+    ====================== ======================
+    """
+
+    name = "BiEncoderMultimodalEmbeddings"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT, AnnotatorType.IMAGE]
+    outputAnnotatorType = AnnotatorType.SENTENCE_EMBEDDINGS
+
+    batchSize = Param(
+        Params._dummy(),
+        "batchSize",
+        "Size of every batch.",
+        typeConverter=TypeConverters.toInt,
+    )
+
+    @keyword_only
+    def __init__(self):
+        super(BiEncoderMultimodalEmbeddings, self).__init__(
+            classname="com.johnsnowlabs.nlp.embeddings.BiEncoderMultimodalEmbeddings"
+        )
+        self._setDefault(outputCol="bi_encoder_multimodal", batchSize=8)
+
+    @keyword_only
+    def setParams(self):
+        kwargs = self._input_kwargs
+        return self._set(**kwargs)
+
+    def setBatchSize(self, value):
+        return self._set(batchSize=value)

--- a/python/sparknlp/internal/__init__.py
+++ b/python/sparknlp/internal/__init__.py
@@ -1206,6 +1206,14 @@ class _E5VEmbeddingsLoader(ExtendedJavaWrapper):
             use_openvino
         )
 
+class _BiEncoderMultimodalEmbeddingsLoader(ExtendedJavaWrapper):
+    def __init__(self, path, jspark):
+        super(_BiEncoderMultimodalEmbeddingsLoader, self).__init__(
+            "com.johnsnowlabs.nlp.embeddings.BiEncoderMultimodalEmbeddings.loadSavedModel",
+            path,
+            jspark,
+        )
+
 class _Phi4Loader(ExtendedJavaWrapper):
     def __init__(self, path, jspark, use_openvino=False):
         super(_Phi4Loader, self).__init__(

--- a/python/test/annotator/embeddings/bi_encoder_multimodal_embeddings_test.py
+++ b/python/test/annotator/embeddings/bi_encoder_multimodal_embeddings_test.py
@@ -1,0 +1,40 @@
+#  Copyright 2017-2026 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import unittest
+
+import pytest
+
+from sparknlp.annotator import BiEncoderMultimodalEmbeddings
+from sparknlp.common import AnnotatorType
+
+
+@pytest.mark.fast
+class BiEncoderMultimodalEmbeddingsWrapperTestSpec(unittest.TestCase):
+    def test_wrapper_api_and_defaults(self):
+        self.assertEqual(BiEncoderMultimodalEmbeddings.name, "BiEncoderMultimodalEmbeddings")
+        self.assertEqual(
+            BiEncoderMultimodalEmbeddings.inputAnnotatorTypes,
+            [AnnotatorType.DOCUMENT, AnnotatorType.IMAGE],
+        )
+        self.assertEqual(
+            BiEncoderMultimodalEmbeddings.outputAnnotatorType,
+            AnnotatorType.SENTENCE_EMBEDDINGS,
+        )
+        self.assertEqual(
+            BiEncoderMultimodalEmbeddings.pretrained.__defaults__,
+            ("ops_mm_embedding_v1_2b", "en", None),
+        )
+        self.assertTrue(hasattr(BiEncoderMultimodalEmbeddings, "loadSavedModel"))
+        self.assertTrue(hasattr(BiEncoderMultimodalEmbeddings, "_from_java"))

--- a/src/main/scala/com/johnsnowlabs/ml/ai/BiEncoderMultimodal.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/BiEncoderMultimodal.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.ml.ai
+
+import com.johnsnowlabs.nlp.{Annotation, AnnotationImage}
+
+private[johnsnowlabs] final case class BiEncoderEmbeddingPair(
+    docEmbedding: Array[Float],
+    imageEmbedding: Array[Float])
+    extends Serializable
+
+private[johnsnowlabs] trait BiEncoderMultimodal extends Serializable {
+
+  def predict(
+      documentAnnotations: Seq[Annotation],
+      imageAnnotations: Seq[AnnotationImage]): Seq[BiEncoderEmbeddingPair]
+}

--- a/src/main/scala/com/johnsnowlabs/ml/ai/BiEncoderMultimodalOnnx.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/BiEncoderMultimodalOnnx.scala
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.ml.ai
+
+import ai.onnxruntime.OnnxTensor
+import com.johnsnowlabs.ml.onnx.{OnnxSession, OnnxWrapper}
+import com.johnsnowlabs.nlp.annotators.common.Sentence
+import com.johnsnowlabs.nlp.annotators.cv.feature_extractor.Preprocessor
+import com.johnsnowlabs.nlp.annotators.cv.util.io.ImageIOUtils
+import com.johnsnowlabs.nlp.annotators.cv.util.transform.ImageResizeUtils
+import com.johnsnowlabs.nlp.annotators.cv.util.transform.Qwen2VLUtils.smartResize
+import com.johnsnowlabs.nlp.annotators.tokenizer.bpe.{
+  BpeTokenizer,
+  Qwen2VLTokenizer,
+  SpecialTokens
+}
+import com.johnsnowlabs.nlp.{Annotation, AnnotationImage}
+
+import scala.collection.JavaConverters._
+
+private[johnsnowlabs] final class BiEncoderMultimodalOnnx(
+    val textOnnxWrapper: OnnxWrapper,
+    val imageOnnxWrapper: OnnxWrapper,
+    vocabulary: Map[String, Int],
+    merges: Map[(String, String), Int],
+    addedTokens: Map[String, Int],
+    preprocessor: Preprocessor,
+    bosTokenId: Int,
+    eosTokenId: Int,
+    padTokenId: Int,
+    imageTokenId: Int,
+    spatialMergeSize: Int,
+    patchSize: Int,
+    temporalPatchSize: Int,
+    minPixels: Int,
+    maxPixels: Int,
+    instruction: String,
+    imagePromptFixTokenIds: Array[Int])
+    extends BiEncoderMultimodal
+    with Serializable {
+
+  private val onnxSessionOptions: Map[String, String] = new OnnxSession().getSessionOptions
+
+  private val reversedVocabulary: Map[Int, String] = vocabulary.map(_.swap)
+
+  private val specialTokens = SpecialTokens(
+    vocabulary,
+    startTokenString = reversedVocabulary(bosTokenId),
+    endTokenString = reversedVocabulary(eosTokenId),
+    unkTokenString = reversedVocabulary(padTokenId),
+    maskTokenString = reversedVocabulary(padTokenId),
+    padTokenString = reversedVocabulary(padTokenId),
+    additionalStrings = addedTokens.keys.toArray)
+
+  private val tokenizer = BpeTokenizer
+    .forModel(
+      "qwen2vl",
+      merges = merges,
+      vocab = vocabulary,
+      specialTokens = Some(specialTokens),
+      addPrefixSpaceToSentence = false,
+      alwaysAddPrefix = false,
+      prependString = "")
+    .asInstanceOf[Qwen2VLTokenizer]
+
+  override def predict(
+      documentAnnotations: Seq[Annotation],
+      imageAnnotations: Seq[AnnotationImage]): Seq[BiEncoderEmbeddingPair] = {
+    require(
+      documentAnnotations.length == imageAnnotations.length,
+      s"BiEncoderMultimodalOnnx requires aligned text and image inputs. Found ${documentAnnotations.length} text annotations and ${imageAnnotations.length} image annotations.")
+
+    if (documentAnnotations.isEmpty) {
+      Seq.empty
+    } else {
+      val textEmbeddings = predictText(documentAnnotations)
+      val imageEmbeddings = predictImage(imageAnnotations)
+      textEmbeddings.zip(imageEmbeddings).map { case (textEmbedding, imageEmbedding) =>
+        BiEncoderEmbeddingPair(textEmbedding, imageEmbedding)
+      }
+    }
+  }
+
+  private def predictText(documentAnnotations: Seq[Annotation]): Seq[Array[Float]] = {
+    val prompts =
+      documentAnnotations.map(annotation => encodeTextPrompt(buildTextPrompt(annotation)))
+    val (inputIds, attentionMask) = leftPad(prompts)
+    runModel(textOnnxWrapper, Map("input_ids" -> inputIds, "attention_mask" -> attentionMask))
+  }
+
+  private def predictImage(imageAnnotations: Seq[AnnotationImage]): Seq[Array[Float]] = {
+    val imageInputs = imageAnnotations.map(buildImageTowerInput)
+    val (inputIds, attentionMask) = leftPad(imageInputs.map(_.inputIds))
+    val pixelValues = imageInputs.flatMap(_.pixelValues).toArray
+    val imageGridThw = imageInputs.map(_.imageGridThw).toArray
+
+    runModel(
+      imageOnnxWrapper,
+      Map(
+        "input_ids" -> inputIds,
+        "attention_mask" -> attentionMask,
+        "pixel_values" -> pixelValues,
+        "image_grid_thw" -> imageGridThw))
+  }
+
+  private def runModel(wrapper: OnnxWrapper, rawInputs: Map[String, Any]): Seq[Array[Float]] = {
+    val (session, env) = wrapper.getSession(onnxSessionOptions)
+    val tensors = rawInputs.map { case (name, value) =>
+      name -> OnnxTensor.createTensor(env, value)
+    }
+
+    val results = session.run(tensors.asJava)
+    try {
+      val outputName = session.getOutputInfo.asScala.keys.toSeq.sorted.headOption.getOrElse {
+        throw new IllegalStateException("No ONNX outputs found for multimodal embedding model.")
+      }
+
+      val outputTensor = results.get(outputName).get().asInstanceOf[OnnxTensor]
+      val outputShape = outputTensor.getInfo.getShape
+      require(
+        outputShape.nonEmpty,
+        s"Unexpected output shape ${outputShape.mkString("[", ", ", "]")} for multimodal embedding model.")
+
+      val embeddingDim = outputShape.last.toInt
+      val buffer = outputTensor.getFloatBuffer
+      val values = new Array[Float](buffer.remaining())
+      buffer.get(values)
+      values.grouped(embeddingDim).toSeq
+    } finally {
+      results.close()
+      tensors.values.foreach(_.close())
+    }
+  }
+
+  private def buildTextPrompt(annotation: Annotation): String = {
+    s"<|im_start|>system\n$instruction<|im_end|>\n" +
+      s"<|im_start|>user\n${annotation.result}<|im_end|>\n" +
+      "<|im_start|>assistant\n<|endoftext|>"
+  }
+
+  private def buildImagePrompt: String = {
+    s"<|im_start|>system\n$instruction<|im_end|>\n" +
+      "<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|><|im_end|>\n" +
+      "<|im_start|>assistant\n<|endoftext|>"
+  }
+
+  private def encodeTextPrompt(prompt: String): Array[Int] =
+    Array(bosTokenId) ++ tokenizeChunk(prompt)
+
+  private def encodeImagePrompt(prompt: String, imageTokenLength: Int): Array[Int] = {
+    val imagePadPattern = raw"<\|image_pad\|>".r
+    require(
+      imagePadPattern.findFirstIn(prompt).isDefined,
+      "Image prompt is missing <|image_pad|>.")
+
+    val promptChunks = imagePadPattern
+      .split(prompt)
+      .toSeq
+      .map(tokenizeChunk)
+
+    val imagePaddingTokens = Array.fill(imageTokenLength)(imageTokenId)
+    val combinedChunks =
+      promptChunks.map(_.toArray).reduce(_ ++ imagePaddingTokens ++ _)
+
+    Array(bosTokenId) ++ combinedChunks ++ imagePromptFixTokenIds
+  }
+
+  private def tokenizeChunk(text: String): Array[Int] = {
+    val sentence =
+      Sentence(content = text, start = 0, end = math.max(text.length - 1, 0), index = 0)
+    tokenizer
+      .tokenize(sentence)
+      .map(tokenizer.encode)
+      .flatMap(_.map(_.pieceId))
+  }
+
+  private def leftPad(sequences: Seq[Array[Int]]): (Array[Array[Long]], Array[Array[Long]]) = {
+    val maxLength = sequences.map(_.length).max
+    val inputIds = sequences.map { sequence =>
+      Array.fill(maxLength - sequence.length)(padTokenId.toLong) ++ sequence.map(_.toLong)
+    }.toArray
+    val attentionMask = sequences.map { sequence =>
+      Array.fill(maxLength - sequence.length)(0L) ++ Array.fill(sequence.length)(1L)
+    }.toArray
+    (inputIds, attentionMask)
+  }
+
+  private def buildImageTowerInput(annotation: AnnotationImage): ImageTowerInput = {
+    val (pixelValues, gridH, gridW) = preprocessImage(annotation)
+    val imagePromptTokenLength = (gridH * gridW) / (spatialMergeSize * spatialMergeSize)
+
+    ImageTowerInput(
+      inputIds = encodeImagePrompt(buildImagePrompt, imagePromptTokenLength),
+      pixelValues = pixelValues,
+      imageGridThw = Array(1L, gridH.toLong, gridW.toLong))
+  }
+
+  private def preprocessImage(annotation: AnnotationImage): (Array[Array[Float]], Int, Int) = {
+    val (resizedHeight, resizedWidth) =
+      smartResize(
+        annotation.height,
+        annotation.width,
+        minPixels = minPixels,
+        maxPixels = maxPixels)
+
+    val bufferedImage = ImageIOUtils.byteToBufferedImage(
+      bytes = annotation.result,
+      w = annotation.width,
+      h = annotation.height,
+      nChannels = annotation.nChannels)
+
+    val resizedImage = ImageResizeUtils.resizeBufferedImage(
+      width = resizedWidth,
+      height = resizedHeight,
+      resample = preprocessor.resample)(bufferedImage)
+
+    val normalizedImage = ImageResizeUtils.normalizeAndConvertBufferedImage(
+      img = resizedImage,
+      mean = preprocessor.image_mean,
+      std = preprocessor.image_std,
+      doNormalize = preprocessor.do_normalize,
+      doRescale = preprocessor.do_rescale,
+      rescaleFactor = preprocessor.rescale_factor)
+
+    val gridH = resizedHeight / patchSize
+    val gridW = resizedWidth / patchSize
+    val temporalFrames = Array.fill(temporalPatchSize)(normalizedImage)
+    val patchVectors =
+      Array.ofDim[Float](gridH * gridW, 3 * temporalPatchSize * patchSize * patchSize)
+
+    var patchIndex = 0
+    var row = 0
+    while (row < gridH) {
+      var col = 0
+      while (col < gridW) {
+        var featureIndex = 0
+        var time = 0
+        while (time < temporalFrames.length) {
+          var channel = 0
+          while (channel < temporalFrames(time).length) {
+            var patchRow = 0
+            while (patchRow < patchSize) {
+              var patchCol = 0
+              while (patchCol < patchSize) {
+                patchVectors(patchIndex)(featureIndex) = temporalFrames(time)(channel)(
+                  row * patchSize + patchRow)(col * patchSize + patchCol)
+                featureIndex += 1
+                patchCol += 1
+              }
+              patchRow += 1
+            }
+            channel += 1
+          }
+          time += 1
+        }
+        patchIndex += 1
+        col += 1
+      }
+      row += 1
+    }
+
+    (patchVectors, gridH, gridW)
+  }
+
+  private case class ImageTowerInput(
+      inputIds: Array[Int],
+      pixelValues: Array[Array[Float]],
+      imageGridThw: Array[Long])
+}

--- a/src/main/scala/com/johnsnowlabs/ml/util/LoadExternalModel.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/util/LoadExternalModel.scala
@@ -85,21 +85,28 @@ object LoadExternalModel {
       modelPath: String,
       isEncoderDecoder: Boolean = false,
       withPast: Boolean = false,
-      isDecoder: Boolean = false): Boolean = {
-    if (isEncoderDecoder) {
-      val onnxEncoderModel = new File(modelPath, ONNX.encoderModel)
-      val onnxDecoderModel =
-        if (withPast) new File(modelPath, ONNX.decoderWithPastModel)
-        else new File(modelPath, ONNX.decoderModel)
-      onnxEncoderModel.exists() && onnxDecoderModel.exists()
-    } else if (isDecoder) {
-      val onnxDecoderModel =
-        if (withPast) new File(modelPath, ONNX.decoderWithPastModel)
-        else new File(modelPath, ONNX.decoderModel)
-      onnxDecoderModel.exists()
-    } else {
-      val onnxModel = new File(modelPath, ONNX.modelName)
-      onnxModel.exists()
+      isDecoder: Boolean = false,
+      customModelNames: Option[List[String]] = None): Boolean = {
+    customModelNames match {
+      case Some(modelNames) if modelNames.nonEmpty =>
+        modelNames.forall(modelName => new File(modelPath, modelName).exists())
+      case Some(_) => false
+      case None =>
+        if (isEncoderDecoder) {
+          val onnxEncoderModel = new File(modelPath, ONNX.encoderModel)
+          val onnxDecoderModel =
+            if (withPast) new File(modelPath, ONNX.decoderWithPastModel)
+            else new File(modelPath, ONNX.decoderModel)
+          onnxEncoderModel.exists() && onnxDecoderModel.exists()
+        } else if (isDecoder) {
+          val onnxDecoderModel =
+            if (withPast) new File(modelPath, ONNX.decoderWithPastModel)
+            else new File(modelPath, ONNX.decoderModel)
+          onnxDecoderModel.exists()
+        } else {
+          val onnxModel = new File(modelPath, ONNX.modelName)
+          onnxModel.exists()
+        }
     }
 
   }
@@ -148,7 +155,8 @@ object LoadExternalModel {
       isEncoderDecoder: Boolean = false,
       withPast: Boolean = false,
       isDecoder: Boolean = false,
-      custom: Option[List[String]] = None): String = {
+      custom: Option[List[String]] = None,
+      customOnnxModelNames: Option[List[String]] = None): String = {
 
     /** Check if the path is correct */
     val f = new File(modelPath)
@@ -165,7 +173,13 @@ object LoadExternalModel {
     val tfSavedModelExist = isTensorFlowModel(modelPath)
 
     /*ONNX required model's name*/
-    val onnxModelExist = isOnnxModel(modelPath, isEncoderDecoder, withPast, isDecoder)
+    val onnxModelExist =
+      isOnnxModel(
+        modelPath,
+        isEncoderDecoder,
+        withPast,
+        isDecoder,
+        customModelNames = customOnnxModelNames)
 
     /*Openvino required model files*/
     val openvinoModelExist = isOpenvinoModel(modelPath, isEncoderDecoder, custom)
@@ -199,10 +213,19 @@ object LoadExternalModel {
       isEncoderDecoder: Boolean = false,
       withPast: Boolean = false,
       isDecoder: Boolean = false,
-      custom: Option[List[String]] = None): (String, String) = {
+      custom: Option[List[String]] = None,
+      customOnnxModelNames: Option[List[String]] = None): (String, String) = {
     val localPath: String = ResourceHelper.copyToLocal(path)
 
-    (localPath, detectEngine(localPath, isEncoderDecoder, withPast, isDecoder, custom))
+    (
+      localPath,
+      detectEngine(
+        localPath,
+        isEncoderDecoder,
+        withPast,
+        isDecoder,
+        custom,
+        customOnnxModelNames))
   }
 
   def loadTextAsset(assetPath: String, assetName: String): Array[String] = {

--- a/src/main/scala/com/johnsnowlabs/ml/util/LoadExternalModel.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/util/LoadExternalModel.scala
@@ -164,8 +164,12 @@ object LoadExternalModel {
     require(f.isDirectory, s"Folder $modelPath is not folder")
 
     /*Check if the assets path is correct*/
-    val assetsPath = Paths.get(modelPath, "/assets").toString
-    val assetsPathFile = new File(assetsPath)
+    val legacyAssetsPath = Paths.get(modelPath, "/assets").toString
+    val fallbackAssetsPath = Paths.get(modelPath, "assets").toString
+    val legacyAssetsPathFile = new File(legacyAssetsPath)
+    val assetsPathFile =
+      if (legacyAssetsPathFile.exists()) legacyAssetsPathFile else new File(fallbackAssetsPath)
+    val assetsPath = assetsPathFile.getPath
     require(assetsPathFile.exists, s"Folder $assetsPath not found")
     require(assetsPathFile.isDirectory, s"Folder $assetsPath is not folder")
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -835,7 +835,9 @@ package object annotator {
 
   type BiEncoderMultimodalEmbeddings =
     com.johnsnowlabs.nlp.embeddings.BiEncoderMultimodalEmbeddings
-  object BiEncoderMultimodalEmbeddings extends ReadBiEncoderMultimodalEmbeddingsDLModel
+  object BiEncoderMultimodalEmbeddings
+      extends ReadablePretrainedBiEncoderMultimodalEmbeddings
+      with ReadBiEncoderMultimodalEmbeddingsDLModel
 
   type AutoGGUFVisionModel = com.johnsnowlabs.nlp.annotators.seq2seq.AutoGGUFVisionModel
   object AutoGGUFVisionModel

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -833,6 +833,10 @@ package object annotator {
       extends ReadablePretrainedAutoGGUFEmbeddings
       with ReadAutoGGUFEmbeddings
 
+  type BiEncoderMultimodalEmbeddings =
+    com.johnsnowlabs.nlp.embeddings.BiEncoderMultimodalEmbeddings
+  object BiEncoderMultimodalEmbeddings extends ReadBiEncoderMultimodalEmbeddingsDLModel
+
   type AutoGGUFVisionModel = com.johnsnowlabs.nlp.annotators.seq2seq.AutoGGUFVisionModel
   object AutoGGUFVisionModel
       extends ReadablePretrainedAutoGGUFVisionModel

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BiEncoderMultimodalEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BiEncoderMultimodalEmbeddings.scala
@@ -48,6 +48,7 @@ import org.json4s.jackson.JsonMethods.parse
 
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.util.UUID
 import scala.collection.{Map => CMap}
 
@@ -651,7 +652,12 @@ trait ReadBiEncoderMultimodalEmbeddingsDLModel
       dataFileName: Option[String]): OnnxWrapper = {
     val modelFile = new File(modelPath, modelFileName)
     require(modelFile.exists(), s"ONNX model file $modelFileName not found under $modelPath")
-    spark.sparkContext.addFile(modelFile.getAbsolutePath)
+    val stagedModelFileName = s"${UUID.randomUUID().toString.takeRight(12)}_$modelFileName"
+    val stagedModelDir =
+      Files.createTempDirectory(s"${UUID.randomUUID().toString.takeRight(12)}_onnx")
+    val stagedModelFile = stagedModelDir.resolve(stagedModelFileName).toFile
+    Files.copy(modelFile.toPath, stagedModelFile.toPath, REPLACE_EXISTING)
+    spark.sparkContext.addFile(stagedModelFile.getAbsolutePath)
 
     val dataPath = dataFileName.map { fileName =>
       val dataFile = new File(modelPath, fileName)
@@ -660,7 +666,7 @@ trait ReadBiEncoderMultimodalEmbeddingsDLModel
       dataFile.getAbsolutePath
     }
 
-    new OnnxWrapper(Some(modelFile.getName), dataPath)
+    new OnnxWrapper(Some(stagedModelFileName), dataPath)
   }
 
   private def readSavedOnnxWrapper(
@@ -694,12 +700,18 @@ trait ReadBiEncoderMultimodalEmbeddingsDLModel
     val unzippedFolder = ZipArchiveUtil.unzip(localArchive, Some(tmpFolder.getAbsolutePath))
     val extractedModelFile = Option(new File(unzippedFolder).listFiles())
       .getOrElse(Array.empty[File])
-      .find(file => file.isFile && file.getName.endsWith(".onnx"))
+      .find(file =>
+        file.isFile && file.getName.endsWith(
+          ".onnx") && file.getAbsolutePath != localArchive.getAbsolutePath)
       .getOrElse(throw new IllegalStateException(
         s"No extracted ONNX file found inside serialized archive $modelFileName."))
 
-    spark.sparkContext.addFile(extractedModelFile.getAbsolutePath)
-    new OnnxWrapper(Some(extractedModelFile.getName), localDataPath)
+    val stagedModelFileName =
+      s"${UUID.randomUUID().toString.takeRight(12)}_${extractedModelFile.getName}"
+    val stagedModelFile = new File(tmpFolder, stagedModelFileName)
+    Files.copy(extractedModelFile.toPath, stagedModelFile.toPath, REPLACE_EXISTING)
+    spark.sparkContext.addFile(stagedModelFile.getAbsolutePath)
+    new OnnxWrapper(Some(stagedModelFileName), localDataPath)
   }
 
   def readModel(
@@ -797,7 +809,30 @@ trait ReadBiEncoderMultimodalEmbeddingsDLModel
   }
 }
 
-object BiEncoderMultimodalEmbeddings extends ReadBiEncoderMultimodalEmbeddingsDLModel {
+trait ReadablePretrainedBiEncoderMultimodalEmbeddings
+    extends ParamsAndFeaturesReadable[BiEncoderMultimodalEmbeddings]
+    with HasPretrained[BiEncoderMultimodalEmbeddings] {
+
+  override val defaultModelName: Some[String] = Some("ops_mm_embedding_v1_2b")
+
+  /** Java compliant-overrides */
+  override def pretrained(): BiEncoderMultimodalEmbeddings = super.pretrained()
+
+  override def pretrained(name: String): BiEncoderMultimodalEmbeddings = super.pretrained(name)
+
+  override def pretrained(name: String, lang: String): BiEncoderMultimodalEmbeddings =
+    super.pretrained(name, lang)
+
+  override def pretrained(
+      name: String,
+      lang: String,
+      remoteLoc: String): BiEncoderMultimodalEmbeddings =
+    super.pretrained(name, lang, remoteLoc)
+}
+
+object BiEncoderMultimodalEmbeddings
+    extends ReadablePretrainedBiEncoderMultimodalEmbeddings
+    with ReadBiEncoderMultimodalEmbeddingsDLModel {
   val suffix: String = "_bi_encoder_multimodal"
   val textModelFile: String = "text_model.onnx"
   val imageModelFile: String = "image_model.onnx"

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BiEncoderMultimodalEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BiEncoderMultimodalEmbeddings.scala
@@ -1,0 +1,804 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.nlp.embeddings
+
+import com.johnsnowlabs.ml.ai.{
+  BiEncoderEmbeddingPair,
+  BiEncoderMultimodal,
+  BiEncoderMultimodalOnnx
+}
+import com.johnsnowlabs.ml.onnx.{OnnxWrapper, WriteOnnxModel}
+import com.johnsnowlabs.ml.util.LoadExternalModel.{
+  loadJsonStringAsset,
+  loadTextAsset,
+  modelSanityCheck,
+  notSupportedEngineError
+}
+import com.johnsnowlabs.ml.util.ONNX
+import com.johnsnowlabs.nlp.AnnotatorType.{DOCUMENT, IMAGE, SENTENCE_EMBEDDINGS}
+import com.johnsnowlabs.nlp.annotators.cv.feature_extractor.Preprocessor
+import com.johnsnowlabs.nlp.serialization.MapFeature
+import com.johnsnowlabs.nlp.util.SparkNlpConfig
+import com.johnsnowlabs.nlp._
+import com.johnsnowlabs.util.ZipArchiveUtil
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.param.{IntArrayParam, IntParam, Param, ParamMap}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
+import org.json4s.{DefaultFormats, JValue}
+import org.json4s.jackson.JsonMethods.parse
+
+import java.io.File
+import java.nio.file.Files
+import java.util.UUID
+import scala.collection.{Map => CMap}
+
+/** Dual-encoder multimodal embeddings annotator.
+  *
+  * The output is written to two derived columns based on `outputCol`:
+  * `${outputCol}_doc_embeddings` and `${outputCol}_image_embeddings`.
+  */
+class BiEncoderMultimodalEmbeddings(override val uid: String)
+    extends Transformer
+    with HasInputAnnotationCols
+    with HasOutputAnnotatorType
+    with HasOutputAnnotationCol
+    with HasImageFeatureProperties
+    with HasEngine
+    with WriteOnnxModel {
+
+  def this() = this(Identifiable.randomUID("BI_ENCODER_MULTIMODAL_EMBEDDINGS"))
+
+  override val inputAnnotatorTypes: Array[String] = Array(DOCUMENT, IMAGE)
+  override val outputAnnotatorType: AnnotatorType = SENTENCE_EMBEDDINGS
+
+  val batchSize: IntParam = new IntParam(this, "batchSize", "Size of every batch.")
+
+  val vocabulary: MapFeature[String, Int] =
+    new MapFeature[String, Int](this, "vocabulary").setProtected()
+
+  val merges: MapFeature[(String, String), Int] =
+    new MapFeature[(String, String), Int](this, "merges").setProtected()
+
+  val addedTokens: MapFeature[String, Int] =
+    new MapFeature[String, Int](this, "addedTokens").setProtected()
+
+  val instruction: Param[String] = new Param[String](
+    this,
+    "instruction",
+    "Instruction prompt prepended to both text and image encoder inputs.")
+
+  val minPixels: IntParam =
+    new IntParam(this, "minPixels", "Minimum number of pixels allowed after smart resize.")
+
+  val maxPixels: IntParam =
+    new IntParam(this, "maxPixels", "Maximum number of pixels allowed after smart resize.")
+
+  val spatialMergeSize: IntParam = new IntParam(
+    this,
+    "spatialMergeSize",
+    "Spatial merge size used to map image patches into prompt image tokens.")
+
+  val patchSize: IntParam =
+    new IntParam(this, "patchSize", "Patch size used by the vision tower.")
+
+  val temporalPatchSize: IntParam =
+    new IntParam(this, "temporalPatchSize", "Temporal patch size used by the vision tower.")
+
+  val bosTokenId: IntParam = new IntParam(this, "bosTokenId", "Beginning-of-sequence token id.")
+
+  val eosTokenId: IntParam = new IntParam(this, "eosTokenId", "End-of-sequence token id.")
+
+  val padTokenId: IntParam = new IntParam(this, "padTokenId", "Padding token id.")
+
+  val imageTokenId: IntParam =
+    new IntParam(this, "imageTokenId", "Special token id used for image placeholders.")
+
+  val textModelFile: Param[String] =
+    new Param[String](this, "textModelFile", "Serialized ONNX file name for the text encoder.")
+
+  val imageModelFile: Param[String] =
+    new Param[String](this, "imageModelFile", "Serialized ONNX file name for the image encoder.")
+
+  val textDataFile: Param[String] =
+    new Param[String](
+      this,
+      "textDataFile",
+      "Optional ONNX external data file for the text encoder.")
+
+  val imageDataFile: Param[String] = new Param[String](
+    this,
+    "imageDataFile",
+    "Optional ONNX external data file for the image encoder.")
+
+  val imagePromptFixTokenIds: IntArrayParam = new IntArrayParam(
+    this,
+    "imagePromptFixTokenIds",
+    "Additional token ids appended to image prompts to match exported processor output.")
+
+  def setBatchSize(value: Int): this.type = {
+    require(value > 0, "batchSize must be greater than 0")
+    set(batchSize, value)
+  }
+
+  def setVocabulary(value: Map[String, Int]): this.type = set(vocabulary, value)
+
+  def setMerges(value: Map[(String, String), Int]): this.type = set(merges, value)
+
+  def setAddedTokens(value: Map[String, Int]): this.type = set(addedTokens, value)
+
+  def setInstruction(value: String): this.type = set(instruction, value)
+
+  def setMinPixels(value: Int): this.type = set(minPixels, value)
+
+  def setMaxPixels(value: Int): this.type = set(maxPixels, value)
+
+  def setSpatialMergeSize(value: Int): this.type = set(spatialMergeSize, value)
+
+  def setPatchSize(value: Int): this.type = set(patchSize, value)
+
+  def setTemporalPatchSize(value: Int): this.type = set(temporalPatchSize, value)
+
+  def setBosTokenId(value: Int): this.type = set(bosTokenId, value)
+
+  def setEosTokenId(value: Int): this.type = set(eosTokenId, value)
+
+  def setPadTokenId(value: Int): this.type = set(padTokenId, value)
+
+  def setImageTokenId(value: Int): this.type = set(imageTokenId, value)
+
+  private[johnsnowlabs] def setTextModelFile(value: String): this.type = set(textModelFile, value)
+
+  private[johnsnowlabs] def setImageModelFile(value: String): this.type =
+    set(imageModelFile, value)
+
+  private[johnsnowlabs] def setTextDataFile(value: String): this.type = set(textDataFile, value)
+
+  private[johnsnowlabs] def setImageDataFile(value: String): this.type =
+    set(imageDataFile, value)
+
+  def setImagePromptFixTokenIds(value: Array[Int]): this.type = set(imagePromptFixTokenIds, value)
+
+  def getBatchSize: Int = $(batchSize)
+
+  def getVocabulary: Map[String, Int] = $$(vocabulary)
+
+  def getMerges: Map[(String, String), Int] = $$(merges)
+
+  def getAddedTokens: Map[String, Int] = $$(addedTokens)
+
+  def getInstruction: String = $(instruction)
+
+  def getMinPixels: Int = $(minPixels)
+
+  def getMaxPixels: Int = $(maxPixels)
+
+  def getSpatialMergeSize: Int = $(spatialMergeSize)
+
+  def getPatchSize: Int = $(patchSize)
+
+  def getTemporalPatchSize: Int = $(temporalPatchSize)
+
+  def getBosTokenId: Int = $(bosTokenId)
+
+  def getEosTokenId: Int = $(eosTokenId)
+
+  def getPadTokenId: Int = $(padTokenId)
+
+  def getImageTokenId: Int = $(imageTokenId)
+
+  def getTextModelFile: String = $(textModelFile)
+
+  def getImageModelFile: String = $(imageModelFile)
+
+  def getTextDataFile: Option[String] = get(textDataFile)
+
+  def getImageDataFile: Option[String] = get(imageDataFile)
+
+  def getImagePromptFixTokenIds: Array[Int] = $(imagePromptFixTokenIds)
+
+  def getOutputDocEmbeddingsCol: String = s"${getOutputCol}_doc_embeddings"
+
+  def getOutputImageEmbeddingsCol: String = s"${getOutputCol}_image_embeddings"
+
+  setDefault(
+    batchSize -> 8,
+    engine -> ONNX.name,
+    instruction -> "You are a helpful assistant.",
+    textModelFile -> BiEncoderMultimodalEmbeddings.textModelFile,
+    imageModelFile -> BiEncoderMultimodalEmbeddings.imageModelFile,
+    imagePromptFixTokenIds -> Array.empty[Int])
+
+  private var _model: Option[Broadcast[BiEncoderMultimodal]] = None
+
+  private val outputTypeMetadata: Metadata =
+    new MetadataBuilder().putString("annotatorType", SENTENCE_EMBEDDINGS).build()
+
+  private case class RowBatchInput(
+      baseValues: Seq[Any],
+      documents: Seq[Annotation],
+      images: Seq[AnnotationImage])
+
+  private val itemIdPrimaryKeys =
+    Seq("item_id", "source_file", "source", "file_name", "file", "origin")
+
+  private val pageMetadataKeys = Seq("page_number", "page_num", "page")
+
+  private[johnsnowlabs] def setModelIfNotSet(
+      spark: SparkSession,
+      model: BiEncoderMultimodal): this.type = {
+    if (_model.isEmpty) {
+      _model = Some(spark.sparkContext.broadcast(model))
+    }
+    this
+  }
+
+  private def createPreprocessor: Preprocessor =
+    Preprocessor(
+      do_normalize = getDoNormalize,
+      do_resize = getDoResize,
+      feature_extractor_type = getFeatureExtractorType,
+      image_mean = getImageMean,
+      image_std = getImageStd,
+      resample = getResample,
+      size = getSize)
+
+  private[johnsnowlabs] def setModelIfNotSet(
+      spark: SparkSession,
+      textOnnxWrapper: OnnxWrapper,
+      imageOnnxWrapper: OnnxWrapper): this.type = {
+    if (_model.isEmpty) {
+      _model = Some(
+        spark.sparkContext.broadcast(
+          new BiEncoderMultimodalOnnx(
+            textOnnxWrapper = textOnnxWrapper,
+            imageOnnxWrapper = imageOnnxWrapper,
+            vocabulary = getVocabulary,
+            merges = getMerges,
+            addedTokens = getAddedTokens,
+            preprocessor = createPreprocessor,
+            bosTokenId = getBosTokenId,
+            eosTokenId = getEosTokenId,
+            padTokenId = getPadTokenId,
+            imageTokenId = getImageTokenId,
+            spatialMergeSize = getSpatialMergeSize,
+            patchSize = getPatchSize,
+            temporalPatchSize = getTemporalPatchSize,
+            minPixels = getMinPixels,
+            maxPixels = getMaxPixels,
+            instruction = getInstruction,
+            imagePromptFixTokenIds = getImagePromptFixTokenIds)))
+    }
+    this
+  }
+
+  private[johnsnowlabs] def getModelIfNotSet: BiEncoderMultimodal =
+    _model
+      .map(_.value)
+      .getOrElse(
+        throw new IllegalStateException(
+          s"No multimodal model backend has been configured for $uid"))
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    require(
+      validateSchema(dataset.schema),
+      s"Wrong or missing inputCols annotators in $uid.\n" +
+        msgHelper(dataset.schema) +
+        s"\nMake sure such annotators exist with types: ${inputAnnotatorTypes.mkString(", ")}")
+
+    val inputDataFrame = dataset.toDF()
+    val outputSchema = transformSchema(inputDataFrame.schema)
+    val (docInputCol, imageInputCol) = resolveInputCols(inputDataFrame.schema)
+    val outputDocCol = getOutputDocEmbeddingsCol
+    val outputImageCol = getOutputImageEmbeddingsCol
+
+    val baseColumnNames =
+      outputSchema.fields
+        .map(_.name)
+        .filterNot(name => name == outputDocCol || name == outputImageCol)
+    val baseColumnIndexes = baseColumnNames.map(inputDataFrame.schema.fieldIndex)
+    val docInputIndex = inputDataFrame.schema.fieldIndex(docInputCol)
+    val imageInputIndex = inputDataFrame.schema.fieldIndex(imageInputCol)
+
+    implicit val encoder: ExpressionEncoder[Row] =
+      SparkNlpConfig.getEncoder(inputDataFrame, outputSchema)
+
+    val mappedDataFrame = inputDataFrame.mapPartitions { rows =>
+      rows.grouped($(batchSize)).flatMap { batchRows =>
+        val batchInputs =
+          batchRows.map(
+            extractRowBatchInput(
+              _,
+              baseColumnIndexes,
+              docInputIndex,
+              imageInputIndex,
+              docInputCol,
+              imageInputCol))
+        val flatDocuments = batchInputs.flatMap(_.documents)
+        val flatImages = batchInputs.flatMap(_.images)
+
+        require(
+          flatDocuments.length == flatImages.length,
+          s"Aligned multimodal inputs must have the same number of DOCUMENT and IMAGE annotations. " +
+            s"Found ${flatDocuments.length} documents and ${flatImages.length} images.")
+
+        val predictions =
+          if (flatDocuments.nonEmpty) getModelIfNotSet.predict(flatDocuments, flatImages)
+          else Seq.empty[BiEncoderEmbeddingPair]
+
+        require(
+          predictions.length == flatDocuments.length,
+          s"Model backend returned ${predictions.length} predictions for ${flatDocuments.length} aligned pairs.")
+
+        predictions.foreach { prediction =>
+          require(
+            prediction.docEmbedding.length == prediction.imageEmbedding.length,
+            "Text and image embeddings must share the same dimension.")
+        }
+
+        var offset = 0
+        batchInputs.iterator.map { rowInput =>
+          val count = rowInput.documents.length
+          val rowPredictions = predictions.slice(offset, offset + count)
+          offset += count
+
+          val docOutputs = rowInput.documents.zip(rowPredictions).map { case (annotation, pair) =>
+            annotationToRow(buildDocumentEmbeddingAnnotation(annotation, pair.docEmbedding))
+          }
+          val imageOutputs = rowInput.images.zip(rowPredictions).map { case (annotation, pair) =>
+            annotationToRow(buildImageEmbeddingAnnotation(annotation, pair.imageEmbedding))
+          }
+
+          Row.fromSeq(rowInput.baseValues ++ Seq(docOutputs, imageOutputs))
+        }
+      }
+    }
+
+    val withInputMetadata = inputDataFrame.schema.fields
+      .filter(field => mappedDataFrame.columns.contains(field.name))
+      .foldLeft(mappedDataFrame) { (dataFrame, field) =>
+        dataFrame.withColumn(field.name, dataFrame.col(field.name).as(field.name, field.metadata))
+      }
+
+    withInputMetadata
+      .withColumn(outputDocCol, col(outputDocCol).as(outputDocCol, outputTypeMetadata))
+      .withColumn(outputImageCol, col(outputImageCol).as(outputImageCol, outputTypeMetadata))
+  }
+
+  override def transformSchema(schema: StructType): StructType = {
+    require(
+      validateSchema(schema),
+      s"Wrong or missing inputCols annotators in $uid.\n" +
+        msgHelper(schema) +
+        s"\nMake sure such annotators exist with types: ${inputAnnotatorTypes.mkString(", ")}")
+
+    val outputDoc =
+      StructField(
+        getOutputDocEmbeddingsCol,
+        Annotation.arrayType,
+        nullable = false,
+        outputTypeMetadata)
+    val outputImage =
+      StructField(
+        getOutputImageEmbeddingsCol,
+        Annotation.arrayType,
+        nullable = false,
+        outputTypeMetadata)
+
+    val baseFields =
+      schema.fields
+        .filterNot(field =>
+          field.name == getOutputDocEmbeddingsCol || field.name == getOutputImageEmbeddingsCol)
+    StructType(baseFields ++ Array(outputDoc, outputImage))
+  }
+
+  override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
+
+  override def onWrite(path: String, spark: SparkSession): Unit = {
+    super.onWrite(path, spark)
+
+    getEngine match {
+      case ONNX.name =>
+        getModelIfNotSet match {
+          case onnxModel: BiEncoderMultimodalOnnx =>
+            writeOnnxModels(
+              path,
+              spark,
+              Seq(
+                (onnxModel.textOnnxWrapper, getTextModelFile),
+                (onnxModel.imageOnnxWrapper, getImageModelFile)),
+              BiEncoderMultimodalEmbeddings.suffix)
+          case other =>
+            throw new IllegalStateException(
+              s"Cannot serialize multimodal backend ${other.getClass.getSimpleName} as ONNX.")
+        }
+      case _ =>
+        throw new Exception(notSupportedEngineError)
+    }
+  }
+
+  private def validateSchema(schema: StructType): Boolean =
+    inputAnnotatorTypes.forall(checkSchema(schema, _))
+
+  private def resolveInputCols(schema: StructType): (String, String) = {
+    val colsByType =
+      getInputCols.map(name => name -> schema(name).metadata.getString("annotatorType")).toMap
+    val docCol = colsByType.collectFirst {
+      case (name, annotatorType) if annotatorType == DOCUMENT => name
+    }.get
+    val imageCol = colsByType.collectFirst {
+      case (name, annotatorType) if annotatorType == IMAGE => name
+    }.get
+    (docCol, imageCol)
+  }
+
+  private def extractRowBatchInput(
+      row: Row,
+      baseColumnIndexes: Seq[Int],
+      docInputIndex: Int,
+      imageInputIndex: Int,
+      docInputCol: String,
+      imageInputCol: String): RowBatchInput = {
+    val documentAnnotations = toTextAnnotations(row.getAs[Seq[Row]](docInputIndex))
+    val imageAnnotations = toImageAnnotations(row.getAs[Seq[Row]](imageInputIndex))
+
+    require(
+      documentAnnotations.length == imageAnnotations.length,
+      s"Aligned columns $docInputCol and $imageInputCol must contain the same number of annotations per row. " +
+        s"Found ${documentAnnotations.length} documents and ${imageAnnotations.length} images.")
+
+    RowBatchInput(
+      baseValues = baseColumnIndexes.map(row.get),
+      documents = documentAnnotations,
+      images = imageAnnotations)
+  }
+
+  private def buildDocumentEmbeddingAnnotation(
+      annotation: Annotation,
+      embedding: Array[Float]): Annotation = {
+    val metadata = Option(annotation.metadata).getOrElse(Map.empty[String, String])
+    val itemId =
+      existingNonEmpty(metadata, Seq("item_id")).getOrElse(buildDocumentItemId(annotation))
+
+    Annotation(
+      annotatorType = SENTENCE_EMBEDDINGS,
+      begin = annotation.begin,
+      end = annotation.end,
+      result = annotation.result,
+      metadata = metadata ++ Map(
+        "modality" -> "text",
+        "item_id" -> itemId,
+        "embedding_dim" -> embedding.length.toString),
+      embeddings = embedding)
+  }
+
+  private def buildImageEmbeddingAnnotation(
+      annotation: AnnotationImage,
+      embedding: Array[Float]): Annotation = {
+    val metadata = Option(annotation.metadata).getOrElse(Map.empty[String, String])
+    val itemId =
+      existingNonEmpty(metadata, Seq("item_id")).getOrElse(buildImageItemId(annotation))
+    val resultText = Option(annotation.origin).filter(_.nonEmpty).getOrElse(itemId)
+
+    Annotation(
+      annotatorType = SENTENCE_EMBEDDINGS,
+      begin = 0,
+      end = math.max(resultText.length - 1, 0),
+      result = resultText,
+      metadata = metadata ++ Map(
+        "modality" -> "image",
+        "item_id" -> itemId,
+        "embedding_dim" -> embedding.length.toString),
+      embeddings = embedding)
+  }
+
+  private def buildDocumentItemId(annotation: Annotation): String = {
+    val metadata = Option(annotation.metadata).getOrElse(Map.empty[String, String])
+    val prefix = existingNonEmpty(metadata, itemIdPrimaryKeys).getOrElse("text")
+    val parts = Seq(
+      Some(prefix),
+      firstPresentMetadata(metadata, pageMetadataKeys).map(page => s"page=$page"),
+      existingNonEmpty(metadata, Seq("slide_index")).map(slide => s"slide=$slide"),
+      existingNonEmpty(metadata, Seq("paragraph_index")).map(paragraph =>
+        s"paragraph=$paragraph"),
+      existingNonEmpty(metadata, Seq("chunk_index")).map(chunk => s"chunk=$chunk"),
+      Some(s"span=${annotation.begin}-${annotation.end}"),
+      Some("modality=text")).flatten
+    parts.mkString("|")
+  }
+
+  private def buildImageItemId(annotation: AnnotationImage): String = {
+    val metadata = Option(annotation.metadata).getOrElse(Map.empty[String, String])
+    val prefix =
+      existingNonEmpty(metadata, itemIdPrimaryKeys)
+        .orElse(Option(annotation.origin).filter(_.nonEmpty))
+        .getOrElse("image")
+    val parts = Seq(
+      Some(prefix),
+      Option(annotation.origin)
+        .filter(origin => origin.nonEmpty && origin != prefix)
+        .map(origin => s"origin=$origin"),
+      firstPresentMetadata(metadata, pageMetadataKeys).map(page => s"page=$page"),
+      existingNonEmpty(metadata, Seq("slide_index")).map(slide => s"slide=$slide"),
+      existingNonEmpty(metadata, Seq("coord")).map(coord => s"coord=$coord"),
+      existingNonEmpty(metadata, Seq("orderImageIndex")).map(idx => s"image_index=$idx"),
+      Some(s"size=${annotation.width}x${annotation.height}"),
+      Some("modality=image")).flatten
+    parts.mkString("|")
+  }
+
+  private def firstPresentMetadata(
+      metadata: CMap[String, String],
+      keys: Seq[String]): Option[String] =
+    keys.iterator.flatMap(key => metadata.get(key).filter(_.nonEmpty)).toSeq.headOption
+
+  private def existingNonEmpty(
+      metadata: CMap[String, String],
+      keys: Seq[String]): Option[String] =
+    firstPresentMetadata(metadata, keys)
+
+  private def toTextAnnotations(rows: Seq[Row]): Seq[Annotation] =
+    Option(rows).getOrElse(Seq.empty).map(Annotation(_))
+
+  private def toImageAnnotations(rows: Seq[Row]): Seq[AnnotationImage] =
+    Option(rows).getOrElse(Seq.empty).map(AnnotationImage(_))
+
+  private def annotationToRow(annotation: Annotation): Row =
+    Row(
+      annotation.annotatorType,
+      annotation.begin,
+      annotation.end,
+      annotation.result,
+      annotation.metadata,
+      annotation.embeddings)
+}
+
+trait ReadBiEncoderMultimodalEmbeddingsDLModel
+    extends ParamsAndFeaturesReadable[BiEncoderMultimodalEmbeddings] {
+
+  private def discoverOnnxDataFile(modelPath: String, prefix: String): Option[String] =
+    Option(new File(modelPath).listFiles())
+      .getOrElse(Array.empty[File])
+      .find(file =>
+        file.isFile && file.getName.endsWith(".onnx.data") && file.getName.toLowerCase.contains(
+          prefix.toLowerCase))
+      .map(_.getName)
+
+  private def loadTokenizerAssets(localModelPath: String)
+      : (Map[String, Int], Map[String, Int], Map[(String, String), Int]) = {
+    implicit val formats: DefaultFormats.type = DefaultFormats
+    val tokenizerPath = s"$localModelPath/assets/tokenizer.json"
+    val tokenizerExists = new File(tokenizerPath).exists()
+
+    if (tokenizerExists) {
+      val tokenizerConfig: JValue = parse(loadJsonStringAsset(localModelPath, "tokenizer.json"))
+      var vocab: Map[String, Int] =
+        (tokenizerConfig \ "model" \ "vocab").extract[Map[String, Int]]
+
+      val merges = (tokenizerConfig \ "model" \ "merges")
+        .extract[List[Array[String]]]
+        .filter(_.length == 2)
+        .map { case Array(left, right) => (left, right) }
+        .zipWithIndex
+        .toMap
+
+      val addedTokens = (tokenizerConfig \ "added_tokens")
+        .extractOpt[List[Map[String, Any]]]
+        .getOrElse(Nil)
+        .map { token =>
+          token("content").asInstanceOf[String] -> token("id").asInstanceOf[BigInt].intValue()
+        }
+        .toMap
+
+      addedTokens.foreach { case (content, id) =>
+        vocab += (content -> id)
+      }
+
+      (vocab, addedTokens, merges)
+    } else {
+      var vocab: Map[String, Int] =
+        parse(loadJsonStringAsset(localModelPath, "vocab.json")).extract[Map[String, Int]]
+
+      val addedTokensPath = s"$localModelPath/assets/added_tokens.json"
+      val addedTokens =
+        if (new File(addedTokensPath).exists()) {
+          parse(loadJsonStringAsset(localModelPath, "added_tokens.json"))
+            .extract[Map[String, BigInt]]
+            .map { case (token, id) => token -> id.intValue() }
+        } else {
+          Map.empty[String, Int]
+        }
+
+      addedTokens.foreach { case (content, id) =>
+        vocab += (content -> id)
+      }
+
+      val merges = loadTextAsset(localModelPath, "merges.txt")
+        .map(_.trim)
+        .filter(line => line.nonEmpty && !line.startsWith("#"))
+        .map(_.split(" "))
+        .filter(_.length == 2)
+        .map { case Array(left, right) => (left, right) }
+        .zipWithIndex
+        .toMap
+
+      (vocab, addedTokens, merges)
+    }
+  }
+
+  private def loadLocalOnnxWrapper(
+      modelPath: String,
+      spark: SparkSession,
+      modelFileName: String,
+      dataFileName: Option[String]): OnnxWrapper = {
+    val modelFile = new File(modelPath, modelFileName)
+    require(modelFile.exists(), s"ONNX model file $modelFileName not found under $modelPath")
+    spark.sparkContext.addFile(modelFile.getAbsolutePath)
+
+    val dataPath = dataFileName.map { fileName =>
+      val dataFile = new File(modelPath, fileName)
+      require(dataFile.exists(), s"ONNX external data file $fileName not found under $modelPath")
+      spark.sparkContext.addFile(dataFile.getAbsolutePath)
+      dataFile.getAbsolutePath
+    }
+
+    new OnnxWrapper(Some(modelFile.getName), dataPath)
+  }
+
+  private def readSavedOnnxWrapper(
+      path: String,
+      spark: SparkSession,
+      modelFileName: String,
+      dataFileName: Option[String]): OnnxWrapper = {
+    val uri = new java.net.URI(path.replaceAllLiterally("\\", "/"))
+    val fileSystem = FileSystem.get(uri, spark.sparkContext.hadoopConfiguration)
+    val tmpFolder = Files
+      .createTempDirectory(
+        s"${UUID.randomUUID().toString.takeRight(12)}${BiEncoderMultimodalEmbeddings.suffix}")
+      .toFile
+
+    val localArchive = new File(tmpFolder, modelFileName)
+    fileSystem.copyToLocalFile(
+      new Path(path, modelFileName),
+      new Path(localArchive.getAbsolutePath))
+
+    val localDataPath = dataFileName.map { fileName =>
+      val dataSource = new Path(path, fileName)
+      require(
+        fileSystem.exists(dataSource),
+        s"ONNX external data file $fileName not found under $path")
+      val localDataFile = new File(tmpFolder, fileName)
+      fileSystem.copyToLocalFile(dataSource, new Path(localDataFile.getAbsolutePath))
+      spark.sparkContext.addFile(localDataFile.getAbsolutePath)
+      localDataFile.getAbsolutePath
+    }
+
+    val unzippedFolder = ZipArchiveUtil.unzip(localArchive, Some(tmpFolder.getAbsolutePath))
+    val extractedModelFile = Option(new File(unzippedFolder).listFiles())
+      .getOrElse(Array.empty[File])
+      .find(file => file.isFile && file.getName.endsWith(".onnx"))
+      .getOrElse(throw new IllegalStateException(
+        s"No extracted ONNX file found inside serialized archive $modelFileName."))
+
+    spark.sparkContext.addFile(extractedModelFile.getAbsolutePath)
+    new OnnxWrapper(Some(extractedModelFile.getName), localDataPath)
+  }
+
+  def readModel(
+      instance: BiEncoderMultimodalEmbeddings,
+      path: String,
+      spark: SparkSession): Unit = {
+    instance.getEngine match {
+      case ONNX.name =>
+        val textOnnxWrapper =
+          readSavedOnnxWrapper(path, spark, instance.getTextModelFile, instance.getTextDataFile)
+        val imageOnnxWrapper =
+          readSavedOnnxWrapper(path, spark, instance.getImageModelFile, instance.getImageDataFile)
+        instance.setModelIfNotSet(spark, textOnnxWrapper, imageOnnxWrapper)
+      case _ =>
+        throw new Exception(notSupportedEngineError)
+    }
+  }
+
+  addReader(readModel)
+
+  def loadSavedModel(modelPath: String, spark: SparkSession): BiEncoderMultimodalEmbeddings = {
+    implicit val formats: DefaultFormats.type = DefaultFormats
+
+    val (localModelPath, detectedEngine) =
+      modelSanityCheck(
+        modelPath,
+        customOnnxModelNames = Some(
+          List(
+            BiEncoderMultimodalEmbeddings.textModelFile,
+            BiEncoderMultimodalEmbeddings.imageModelFile)))
+
+    if (detectedEngine != ONNX.name) {
+      throw new Exception(notSupportedEngineError)
+    }
+
+    val modelConfig: JValue = parse(loadJsonStringAsset(localModelPath, "config.json"))
+    val generationConfig: JValue =
+      parse(loadJsonStringAsset(localModelPath, "generation_config.json"))
+    val preprocessorConfigJsonString =
+      loadJsonStringAsset(localModelPath, "preprocessor_config.json")
+    val preprocessorConfigJson: JValue = parse(preprocessorConfigJsonString)
+    val preprocessorConfig = Preprocessor.loadPreprocessorConfig(preprocessorConfigJsonString)
+
+    val (vocabulary, addedTokens, merges) = loadTokenizerAssets(localModelPath)
+
+    val bosTokenId = (modelConfig \ "bos_token_id").extract[Int]
+    val eosTokenId = (modelConfig \ "eos_token_id").extract[Int]
+    val padTokenId =
+      (generationConfig \ "pad_token_id").extractOpt[Int].getOrElse(bosTokenId)
+    val imageTokenId = (modelConfig \ "image_token_id").extract[Int]
+    val spatialMergeSize = (modelConfig \ "vision_config" \ "spatial_merge_size").extract[Int]
+    val patchSize = (modelConfig \ "vision_config" \ "patch_size").extract[Int]
+    val temporalPatchSize = (modelConfig \ "vision_config" \ "temporal_patch_size").extract[Int]
+    val minPixels = (preprocessorConfigJson \ "min_pixels").extract[Int]
+    val maxPixels = (preprocessorConfigJson \ "max_pixels").extract[Int]
+
+    val textDataFile = discoverOnnxDataFile(localModelPath, "text")
+    val imageDataFile = discoverOnnxDataFile(localModelPath, "image")
+
+    val annotatorModel = new BiEncoderMultimodalEmbeddings()
+      .setVocabulary(vocabulary)
+      .setMerges(merges)
+      .setAddedTokens(addedTokens)
+      .setDoNormalize(preprocessorConfig.do_normalize)
+      .setDoResize(preprocessorConfig.do_resize)
+      .setFeatureExtractorType(preprocessorConfig.feature_extractor_type)
+      .setImageMean(preprocessorConfig.image_mean)
+      .setImageStd(preprocessorConfig.image_std)
+      .setResample(preprocessorConfig.resample)
+      .setSize(preprocessorConfig.size)
+      .setMinPixels(minPixels)
+      .setMaxPixels(maxPixels)
+      .setSpatialMergeSize(spatialMergeSize)
+      .setPatchSize(patchSize)
+      .setTemporalPatchSize(temporalPatchSize)
+      .setBosTokenId(bosTokenId)
+      .setEosTokenId(eosTokenId)
+      .setPadTokenId(padTokenId)
+      .setImageTokenId(imageTokenId)
+      .setTextModelFile(BiEncoderMultimodalEmbeddings.textModelFile)
+      .setImageModelFile(BiEncoderMultimodalEmbeddings.imageModelFile)
+      .setImagePromptFixTokenIds(Array(bosTokenId, bosTokenId))
+
+    textDataFile.foreach(annotatorModel.setTextDataFile)
+    imageDataFile.foreach(annotatorModel.setImageDataFile)
+
+    annotatorModel.set(annotatorModel.engine, detectedEngine)
+
+    val textOnnxWrapper =
+      loadLocalOnnxWrapper(localModelPath, spark, annotatorModel.getTextModelFile, textDataFile)
+    val imageOnnxWrapper =
+      loadLocalOnnxWrapper(localModelPath, spark, annotatorModel.getImageModelFile, imageDataFile)
+
+    annotatorModel.setModelIfNotSet(spark, textOnnxWrapper, imageOnnxWrapper)
+  }
+}
+
+object BiEncoderMultimodalEmbeddings extends ReadBiEncoderMultimodalEmbeddingsDLModel {
+  val suffix: String = "_bi_encoder_multimodal"
+  val textModelFile: String = "text_model.onnx"
+  val imageModelFile: String = "image_model.onnx"
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/BiEncoderMultimodalEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/BiEncoderMultimodalEmbeddingsTestSpec.scala
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.nlp.embeddings
+
+import com.johnsnowlabs.ml.ai.{BiEncoderEmbeddingPair, BiEncoderMultimodal}
+import com.johnsnowlabs.nlp.annotators.SparkSessionTest
+import com.johnsnowlabs.nlp.{Annotation, AnnotationImage, AnnotatorType}
+import com.johnsnowlabs.tags.FastTest
+import org.apache.spark.SparkException
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
+import org.scalatest.flatspec.AnyFlatSpec
+
+private object StubBiEncoderMultimodal extends BiEncoderMultimodal {
+  override def predict(
+      documentAnnotations: Seq[Annotation],
+      imageAnnotations: Seq[AnnotationImage]): Seq[BiEncoderEmbeddingPair] = {
+    documentAnnotations.zip(imageAnnotations).map { case (document, image) =>
+      val sharedSpaceDoc = Array(
+        document.result.length.toFloat,
+        document.begin.toFloat,
+        document.end.toFloat,
+        image.width.toFloat)
+      val sharedSpaceImage = Array(
+        image.width.toFloat,
+        image.height.toFloat,
+        image.result.length.toFloat,
+        document.result.length.toFloat)
+      BiEncoderEmbeddingPair(sharedSpaceDoc, sharedSpaceImage)
+    }
+  }
+}
+
+class BiEncoderMultimodalEmbeddingsTestSpec extends AnyFlatSpec with SparkSessionTest {
+
+  private val documentColumnMetadata =
+    new MetadataBuilder().putString("annotatorType", AnnotatorType.DOCUMENT).build()
+  private val imageColumnMetadata =
+    new MetadataBuilder().putString("annotatorType", AnnotatorType.IMAGE).build()
+
+  private val inputSchema = StructType(
+    Array(
+      StructField(
+        "vision_pair_doc",
+        Annotation.arrayType,
+        nullable = false,
+        documentColumnMetadata),
+      StructField(
+        "vision_pair_image",
+        AnnotationImage.arrayType,
+        nullable = false,
+        imageColumnMetadata)))
+
+  private def annotationRow(annotation: Annotation): Row =
+    Row(
+      annotation.annotatorType,
+      annotation.begin,
+      annotation.end,
+      annotation.result,
+      annotation.metadata,
+      annotation.embeddings)
+
+  private def imageAnnotationRow(annotation: AnnotationImage): Row =
+    Row(
+      annotation.annotatorType,
+      annotation.origin,
+      annotation.height,
+      annotation.width,
+      annotation.nChannels,
+      annotation.mode,
+      annotation.result,
+      annotation.metadata,
+      annotation.text)
+
+  "BiEncoderMultimodalEmbeddings" should "emit separate text and image embedding columns" taggedAs FastTest in {
+    val firstDoc = Annotation(
+      AnnotatorType.DOCUMENT,
+      begin = 0,
+      end = 10,
+      result = "Finding one",
+      metadata =
+        Map("source_file" -> "report_2417.pdf", "page_number" -> "1", "paragraph_index" -> "3"))
+    val secondDoc = Annotation(
+      AnnotatorType.DOCUMENT,
+      begin = 12,
+      end = 22,
+      result = "Finding two",
+      metadata =
+        Map("source_file" -> "report_2418.pdf", "page_number" -> "2", "paragraph_index" -> "0"))
+    val thirdDoc = Annotation(
+      AnnotatorType.DOCUMENT,
+      begin = 24,
+      end = 33,
+      result = "Finding three",
+      metadata =
+        Map("source_file" -> "report_2418.pdf", "page_number" -> "2", "paragraph_index" -> "1"))
+
+    val firstImage = AnnotationImage(
+      annotatorType = AnnotatorType.IMAGE,
+      origin = "img_1.png",
+      height = 256,
+      width = 512,
+      nChannels = 3,
+      mode = 16,
+      result = Array[Byte](1, 2, 3),
+      metadata =
+        Map("source_file" -> "report_2417.pdf", "page_number" -> "1", "coord" -> "10,20"),
+      text = "")
+    val secondImage = AnnotationImage(
+      annotatorType = AnnotatorType.IMAGE,
+      origin = "img_2.png",
+      height = 128,
+      width = 320,
+      nChannels = 3,
+      mode = 16,
+      result = Array[Byte](4, 5),
+      metadata =
+        Map("source_file" -> "report_2418.pdf", "page_number" -> "2", "coord" -> "30,40"),
+      text = "")
+    val thirdImage = AnnotationImage(
+      annotatorType = AnnotatorType.IMAGE,
+      origin = "img_3.png",
+      height = 96,
+      width = 192,
+      nChannels = 3,
+      mode = 16,
+      result = Array[Byte](6, 7, 8, 9),
+      metadata =
+        Map("source_file" -> "report_2418.pdf", "page_number" -> "2", "coord" -> "50,60"),
+      text = "")
+
+    val inputRows = Seq(
+      Row(Seq(annotationRow(firstDoc)), Seq(imageAnnotationRow(firstImage))),
+      Row(
+        Seq(annotationRow(secondDoc), annotationRow(thirdDoc)),
+        Seq(imageAnnotationRow(secondImage), imageAnnotationRow(thirdImage))))
+
+    val inputDf = spark.createDataFrame(spark.sparkContext.parallelize(inputRows), inputSchema)
+
+    val embeddings = new BiEncoderMultimodalEmbeddings()
+      .setInputCols("vision_pair_doc", "vision_pair_image")
+      .setOutputCol("mm")
+      .setBatchSize(2)
+      .setModelIfNotSet(spark, StubBiEncoderMultimodal)
+
+    val resultDf = embeddings.transform(inputDf)
+    val collected = resultDf.collect()
+
+    assert(resultDf.columns.contains("mm_doc_embeddings"))
+    assert(resultDf.columns.contains("mm_image_embeddings"))
+    assert(
+      resultDf.schema("mm_doc_embeddings").metadata.getString("annotatorType") ==
+        AnnotatorType.SENTENCE_EMBEDDINGS)
+    assert(
+      resultDf.schema("mm_image_embeddings").metadata.getString("annotatorType") ==
+        AnnotatorType.SENTENCE_EMBEDDINGS)
+
+    val firstRowDocEmbeddings =
+      collected.head.getAs[Seq[Row]]("mm_doc_embeddings").map(Annotation(_))
+    val firstRowImageEmbeddings =
+      collected.head.getAs[Seq[Row]]("mm_image_embeddings").map(Annotation(_))
+    assert(firstRowDocEmbeddings.length == 1)
+    assert(firstRowImageEmbeddings.length == 1)
+    assert(firstRowDocEmbeddings.head.result == "Finding one")
+    assert(firstRowDocEmbeddings.head.metadata("modality") == "text")
+    assert(firstRowDocEmbeddings.head.metadata("embedding_dim") == "4")
+    assert(firstRowDocEmbeddings.head.metadata("item_id").contains("report_2417.pdf"))
+    assert(firstRowImageEmbeddings.head.result == "img_1.png")
+    assert(firstRowImageEmbeddings.head.metadata("modality") == "image")
+    assert(firstRowImageEmbeddings.head.metadata("embedding_dim") == "4")
+    assert(firstRowImageEmbeddings.head.metadata("item_id").contains("img_1.png"))
+
+    val secondRowDocEmbeddings =
+      collected(1).getAs[Seq[Row]]("mm_doc_embeddings").map(Annotation(_))
+    val secondRowImageEmbeddings =
+      collected(1).getAs[Seq[Row]]("mm_image_embeddings").map(Annotation(_))
+    assert(secondRowDocEmbeddings.length == 2)
+    assert(secondRowImageEmbeddings.length == 2)
+    assert(secondRowDocEmbeddings.map(_.metadata("modality")).forall(_ == "text"))
+    assert(secondRowImageEmbeddings.map(_.metadata("modality")).forall(_ == "image"))
+    assert(secondRowDocEmbeddings.map(_.embeddings.length).forall(_ == 4))
+    assert(secondRowImageEmbeddings.map(_.embeddings.length).forall(_ == 4))
+  }
+
+  it should "fail fast when aligned inputs are not paired by row" taggedAs FastTest in {
+    val misalignedRow = Row(
+      Seq(
+        annotationRow(
+          Annotation(
+            AnnotatorType.DOCUMENT,
+            begin = 0,
+            end = 4,
+            result = "Text",
+            metadata = Map("source_file" -> "report.pdf")))),
+      Seq(
+        imageAnnotationRow(
+          AnnotationImage(
+            annotatorType = AnnotatorType.IMAGE,
+            origin = "img_1.png",
+            height = 100,
+            width = 100,
+            nChannels = 3,
+            mode = 16,
+            result = Array[Byte](1),
+            metadata = Map("source_file" -> "report.pdf"),
+            text = "")),
+        imageAnnotationRow(
+          AnnotationImage(
+            annotatorType = AnnotatorType.IMAGE,
+            origin = "img_2.png",
+            height = 120,
+            width = 120,
+            nChannels = 3,
+            mode = 16,
+            result = Array[Byte](2),
+            metadata = Map("source_file" -> "report.pdf"),
+            text = ""))))
+
+    val inputDf =
+      spark.createDataFrame(spark.sparkContext.parallelize(Seq(misalignedRow)), inputSchema)
+
+    val embeddings = new BiEncoderMultimodalEmbeddings()
+      .setInputCols("vision_pair_doc", "vision_pair_image")
+      .setOutputCol("mm")
+      .setModelIfNotSet(spark, StubBiEncoderMultimodal)
+
+    val error = intercept[SparkException] {
+      embeddings.transform(inputDf).collect()
+    }
+
+    val errorMessages =
+      Iterator
+        .iterate(Option(error): Option[Throwable])(_.flatMap(t => Option(t.getCause)))
+        .takeWhile(_.isDefined)
+        .flatten
+        .map(_.getMessage)
+        .filter(_ != null)
+        .mkString("\n")
+
+    assert(errorMessages.contains("must contain the same number of annotations per row"))
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds `BiEncoderMultimodalEmbeddings`, a new Spark NLP annotator for dual-encoder multimodal embedding workflows.

The annotator accepts aligned `DOCUMENT` and `IMAGE` annotation columns and produces two embedding output columns derived from `outputCol`:

  - `<outputCol>_doc_embeddings`
  - `<outputCol>_image_embeddings`

The initial implementation targets [Ops-MM](https://huggingface.co/OpenSearch-AI/Ops-MM-embedding-v1-7B) / Qwen2VL-style dual ONNX exports, using separate text and image ONNX models packaged in the same external model bundle.

Pipeline example:
```python
from pyspark.ml import Pipeline                                                                                                                                                             
from pyspark.sql.types import StructType                                                                                                                                                    
                                                                                                                                                                                              
from sparknlp.reader import ReaderAssembler, LayoutAlignerForVision                                                                                                                         
from sparknlp.annotator import BiEncoderMultimodalEmbeddings                                                                                                                                
                                                                                                                                                                                            
                                                                                                                                                                                              
# ReaderAssembler extracts reader_text and reader_image from the document.                                                                                                                  
reader = (                                                                                                                                                                                  
    ReaderAssembler()                                                                                                                                                                       
    .setContentPath("/data/reports/report_2417.pdf")                                                                                                                                        
    .setOutputCol("reader")                                                                                                                                                                 
    .setOutputAsDocument(False)                                                                                                                                                             
    .setExplodeDocs(False)                                                                                                                                                                  
)                                                                                                                                                                                           
                                                                                                                                                                                              
# LayoutAlignerForVision emits:                                                                                                                                                             
# vision_pair_doc, vision_pair_image, vision_pair_prompt                                                                                                                                                                      
align = (                                                                                                                                                                                   
    LayoutAlignerForVision()                                                                                                                                                                
    .setInputCols("reader_text", "reader_image")                                                                                                                                            
    .setOutputCol("vision_pair")                                                                                                                                                            
)                                                                                                                                                                                           
                                                                                                                                                                                              
# BiEncoderMultimodalEmbeddings consumes vision_pair_doc + vision_pair_image                                                                                                                
# and emits:  mm_doc_embeddings, mm_image_embeddings                                                                                                                                                                     
mm = (                                                                                                                                                                                      
    BiEncoderMultimodalEmbeddings.pretrained("ops_mm_embedding_v1_2b", "en")                                                                                                                
    .setInputCols("vision_pair_doc", "vision_pair_image")                                                                                                                                   
    .setOutputCol("mm")                                                                                                                                                                     
    .setBatchSize(1)                                                                                                                                                                        
)                                                                                                                                                                                           
                                                                                                                                                                                            
pipeline = Pipeline(stages=[reader, align, mm])    
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Spark NLP already supports several single-modality embedding models and multimodal generation/classification models, but retrieval and indexing use cases need a dedicated multimodal bi-encoder interface.

 This annotator enables workflows where text and images are embedded into the same vector space for:

  - image-to-text retrieval
  - text-to-image retrieval
  - visual document search
  - multimodal indexing
  - document page/image semantic matching

The first supported model family is based on Ops-MM-embedding-v1-2B, which provides unified multimodal embeddings for text, images, text-image pairs, visual documents, and related retrieval tasks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- Unit Tests
- Local Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
