### PR TITLE
[SPARKNLP-1378] HTMLReader Default Headers Error

### DIFF
--- a/python/test/partition/partition_test.py
+++ b/python/test/partition/partition_test.py
@@ -111,8 +111,11 @@ class PartitionHtmlTesSpec(unittest.TestCase):
         html_df = Partition(content_type = "text/html").partition(self.html_directory)
         html_file_df = Partition().partition(f"{self.html_directory}/fake-html.html")
 
-        self.assertTrue(html_df.select("html").count() > 0)
-        self.assertTrue(html_file_df.select("html").count() > 0)
+        html_rows = html_df.select("html").collect()
+        html_file_rows = html_file_df.select("html").collect()
+
+        self.assertTrue(len(html_rows) > 0)
+        self.assertTrue(len(html_file_rows) > 0)
 
 
 @pytest.mark.slow
@@ -122,8 +125,11 @@ class PartitionUrlTesSpec(unittest.TestCase):
         url_df = Partition().partition("https://www.wikipedia.org", headers={"User-Agent": "Mozilla/5.0"})
         urls_df = Partition().partition_urls(["https://www.wikipedia.org", "https://example.com/"])
 
-        self.assertTrue(url_df.select("html").count() > 0)
-        self.assertTrue(urls_df.select("html").count() > 0)
+        url_rows = url_df.select("html").collect()
+        urls_rows = urls_df.select("html").collect()
+
+        self.assertTrue(len(url_rows) > 0)
+        self.assertTrue(len(urls_rows) > 0)
 
 
 @pytest.mark.fast

--- a/python/test/partition/partition_transformer_test.py
+++ b/python/test/partition/partition_transformer_test.py
@@ -49,7 +49,8 @@ class PartitionTransformerTesSpec(unittest.TestCase):
         resultDf = pipelineModel.transform(self.testDataSet)
         resultDf.show(truncate=False)
 
-        self.assertTrue(resultDf.select("partition").count() > 0)
+        rows = resultDf.select("partition").collect()
+        self.assertTrue(len(rows) > 0)
 
 
 @pytest.mark.slow
@@ -80,7 +81,8 @@ class PartitionTransformerURLsTesSpec(unittest.TestCase):
 
         resultDf = pipelineModel.transform(self.testDataSet)
 
-        self.assertTrue(resultDf.select("partition").count() > 0)
+        rows = resultDf.select("partition").collect()
+        self.assertTrue(len(rows) > 0)
 
 
 @pytest.mark.fast
@@ -108,4 +110,5 @@ class PartitionTransformerChunkTestSpec(unittest.TestCase):
 
         resultDf = pipelineModel.transform(self.emptyDataSet)
 
-        self.assertTrue(resultDf.select("partition").count() >= 0)
+        rows = resultDf.select("partition").collect()
+        self.assertTrue(len(rows) >= 0)

--- a/python/test/reader/reader2doc_test.py
+++ b/python/test/reader/reader2doc_test.py
@@ -41,7 +41,8 @@ class Reader2DocTest(unittest.TestCase):
 
         result_df = model.transform(self.empty_df)
 
-        self.assertTrue(result_df.select("document").count() > 0)
+        rows = result_df.select("document").collect()
+        self.assertTrue(len(rows) > 0)
 
 
 @pytest.mark.fast
@@ -67,7 +68,8 @@ class Reader2DocTokenTest(unittest.TestCase):
 
         result_df = model.transform(self.empty_df)
 
-        self.assertTrue(result_df.select("document").count() > 0)
+        rows = result_df.select("document").collect()
+        self.assertTrue(len(rows) > 0)
 
 
 @pytest.mark.fast
@@ -89,7 +91,8 @@ class Reader2DocPdfTest(unittest.TestCase):
 
         result_df = model.transform(self.empty_df)
 
-        self.assertTrue(result_df.select("document").count() > 0)
+        rows = result_df.select("document").collect()
+        self.assertTrue(len(rows) > 0)
 
 
 @pytest.mark.fast
@@ -157,7 +160,8 @@ class Reader2DocTestInputColumn(unittest.TestCase):
 
         result_df = model.transform(self.html_df)
 
-        self.assertTrue(result_df.select("document").count() > 0)
+        rows = result_df.select("document").collect()
+        self.assertTrue(len(rows) > 0)
 
 
 @pytest.mark.fast

--- a/python/test/reader/reader2image_test.py
+++ b/python/test/reader/reader2image_test.py
@@ -41,7 +41,8 @@ class Reader2ImageTest(unittest.TestCase):
 
         result_df = model.transform(self.empty_df)
 
-        self.assertTrue(result_df.select("image").count() > 0)
+        rows = result_df.select("image").collect()
+        self.assertTrue(len(rows) > 0)
 
 
 @pytest.mark.slow

--- a/python/test/reader/reader2table_test.py
+++ b/python/test/reader/reader2table_test.py
@@ -41,7 +41,8 @@ class Reader2TableTest(unittest.TestCase):
 
         result_df = model.transform(self.empty_df)
 
-        self.assertTrue(result_df.select("document").count() > 0)
+        rows = result_df.select("document").collect()
+        self.assertTrue(len(rows) > 0)
 
 @pytest.mark.fast
 class Reader2TableMixedFilesTest(unittest.TestCase):
@@ -90,4 +91,5 @@ class Reader2TableInputColTest(unittest.TestCase):
 
         result_df = model.transform(self.html_df)
 
-        self.assertTrue(result_df.select("document").count() > 0)
+        rows = result_df.select("document").collect()
+        self.assertTrue(len(rows) > 0)

--- a/python/test/reader/readerassembler_test.py
+++ b/python/test/reader/readerassembler_test.py
@@ -33,12 +33,14 @@ class ReaderAssemblerTest(unittest.TestCase):
         reader_assembler = ReaderAssembler() \
             .setContentType("text/html") \
             .setContentPath(f"file:///{os.getcwd()}/../src/test/resources/reader/html/table-image.html") \
-            .setOutputCol("document")
+            .setOutputCol("document") \
+            .setOutputAsDocument(False) \
+            .setExplodeDocs(False)
 
         pipeline = Pipeline(stages=[reader_assembler])
         model = pipeline.fit(self.empty_df)
 
-        result_df = model.transform(self.empty_df)
+        rows = model.transform(self.empty_df).collect()
 
-        rows = result_df.collect()
         self.assertTrue(len(rows) > 0)
+        self.assertTrue(any(row.document_image for row in rows))

--- a/python/test/reader/readerassembler_test.py
+++ b/python/test/reader/readerassembler_test.py
@@ -40,4 +40,5 @@ class ReaderAssemblerTest(unittest.TestCase):
 
         result_df = model.transform(self.empty_df)
 
-        self.assertTrue(result_df.count() > 0)
+        rows = result_df.collect()
+        self.assertTrue(len(rows) > 0)

--- a/src/main/scala/com/johnsnowlabs/partition/HasHTMLReaderProperties.scala
+++ b/src/main/scala/com/johnsnowlabs/partition/HasHTMLReaderProperties.scala
@@ -37,6 +37,26 @@ trait HasHTMLReaderProperties extends ParamsAndFeaturesWritable {
     setHeaders(headers.asScala.toMap)
   }
 
+  protected def getHeadersAsJava: java.util.Map[String, String] = {
+    val headersCopy = new java.util.HashMap[String, String]()
+    val rawHeaders = getOrDefault(headers.asInstanceOf[Param[Any]])
+    rawHeaders match {
+      case null =>
+      case javaHeaders: java.util.Map[_, _] =>
+        javaHeaders.asScala.foreach { case (key, value) =>
+          if (key != null && value != null) headersCopy.put(key.toString, value.toString)
+        }
+      case scalaHeaders: scala.collection.Map[_, _] =>
+        scalaHeaders.foreach { case (key, value) =>
+          if (key != null && value != null) headersCopy.put(key.toString, value.toString)
+        }
+      case other =>
+        throw new IllegalArgumentException(
+          s"headers must be a Map[String, String], but got ${other.getClass.getName}")
+    }
+    headersCopy
+  }
+
   val includeTitleTag = new Param[Boolean](
     this,
     "includeTitleTag",

--- a/src/main/scala/com/johnsnowlabs/partition/PartitionTransformer.scala
+++ b/src/main/scala/com/johnsnowlabs/partition/PartitionTransformer.scala
@@ -171,8 +171,9 @@ class PartitionTransformer(override val uid: String)
     partitionInstance.setOutputColumn(inputColum)
 
     val partitionDf = if (isStringContent($(contentType))) {
-      val partitionUDF = udf((text: String) =>
-        partitionInstance.partitionStringContent(text, $(this.headers).asJava))
+      val requestHeaders = getHeadersAsJava
+      val partitionUDF =
+        udf((text: String) => partitionInstance.partitionStringContent(text, requestHeaders))
       val schemaFieldOpt = dataset.schema.find(_.name == inputColum)
 
       schemaFieldOpt match {

--- a/src/main/scala/com/johnsnowlabs/reader/HTMLReader.scala
+++ b/src/main/scala/com/johnsnowlabs/reader/HTMLReader.scala
@@ -276,9 +276,11 @@ class HTMLReader(
 
   private def extractElements(root: Node): Array[HTMLElement] = {
     var sentenceIndex = 0
+    var paragraphIndex = 0
     val elements = ArrayBuffer[HTMLElement]()
     val trackingNodes = mutable.Map[Node, NodeMetadata]()
     var pageNumber = 1
+    val paragraphSpacingY = 25
 
     // Track parent-child hierarchy
     var currentParentId: Option[String] = None
@@ -428,6 +430,10 @@ class HTMLReader(
             case "a" =>
               pageMetadata("sentence") = sentenceIndex.toString
               sentenceIndex += 1
+              pageMetadata("paragraph_index") = paragraphIndex.toString
+              pageMetadata("paragraph_y") = (paragraphIndex * paragraphSpacingY).toString
+              pageMetadata("page_y") = (paragraphIndex * paragraphSpacingY).toString
+              paragraphIndex += 1
               val href = element.attr("href").trim
               val linkText = element.text().trim
               if (href.nonEmpty && linkText.nonEmpty && !visitedNode) {
@@ -443,6 +449,10 @@ class HTMLReader(
             case "table" =>
               pageMetadata("sentence") = sentenceIndex.toString
               sentenceIndex += 1
+              pageMetadata("paragraph_index") = paragraphIndex.toString
+              pageMetadata("paragraph_y") = (paragraphIndex * paragraphSpacingY).toString
+              pageMetadata("page_y") = (paragraphIndex * paragraphSpacingY).toString
+              paragraphIndex += 1
               val tableContent = outputFormat match {
                 case "plain-text" => extractNestedTableContent(element).trim
                 case "html-table" =>
@@ -474,6 +484,10 @@ class HTMLReader(
             case "li" =>
               pageMetadata("sentence") = sentenceIndex.toString
               sentenceIndex += 1
+              pageMetadata("paragraph_index") = paragraphIndex.toString
+              pageMetadata("paragraph_y") = (paragraphIndex * paragraphSpacingY).toString
+              pageMetadata("page_y") = (paragraphIndex * paragraphSpacingY).toString
+              paragraphIndex += 1
               val itemText = element.text().trim
               if (itemText.nonEmpty && !visitedNode) {
                 trackingNodes(element).visited = true
@@ -493,6 +507,10 @@ class HTMLReader(
               if (codeText.nonEmpty && !visitedNode) {
                 pageMetadata("sentence") = sentenceIndex.toString
                 sentenceIndex += 1
+                pageMetadata("paragraph_index") = paragraphIndex.toString
+                pageMetadata("paragraph_y") = (paragraphIndex * paragraphSpacingY).toString
+                pageMetadata("page_y") = (paragraphIndex * paragraphSpacingY).toString
+                paragraphIndex += 1
                 trackingNodes(element).visited = true
                 pageMetadata("element_id") = newUUID()
                 currentParentId.foreach(pid => pageMetadata("parent_id") = pid)
@@ -519,6 +537,9 @@ class HTMLReader(
                       sentenceIndex += 1
                       trackingNodes(element).visited = true
                       pageMetadata("element_id") = newUUID()
+                      pageMetadata("paragraph_index") = paragraphIndex.toString
+                      pageMetadata("paragraph_y") = (paragraphIndex * paragraphSpacingY).toString
+                      pageMetadata("page_y") = (paragraphIndex * paragraphSpacingY).toString
                       currentParentId.foreach(pid => pageMetadata("parent_id") = pid)
                       elements += HTMLElement(
                         ElementType.NARRATIVE_TEXT,
@@ -534,11 +555,15 @@ class HTMLReader(
                       trackingNodes(element).visited = true
                       val titleId = newUUID()
                       pageMetadata("element_id") = titleId
+                      pageMetadata("paragraph_index") = paragraphIndex.toString
+                      pageMetadata("paragraph_y") = (paragraphIndex * paragraphSpacingY).toString
+                      pageMetadata("page_y") = (paragraphIndex * paragraphSpacingY).toString
                       elements += HTMLElement(
                         ElementType.TITLE,
                         content = titleText,
                         metadata = pageMetadata)
                       currentParentId = Some(titleId)
+                      paragraphIndex += 1
                     }
 
                   case ElementType.UNCATEGORIZED_TEXT =>
@@ -548,11 +573,15 @@ class HTMLReader(
                       sentenceIndex += 1
                       trackingNodes(element).visited = true
                       pageMetadata("element_id") = newUUID()
+                      pageMetadata("paragraph_index") = paragraphIndex.toString
+                      pageMetadata("paragraph_y") = (paragraphIndex * paragraphSpacingY).toString
+                      pageMetadata("page_y") = (paragraphIndex * paragraphSpacingY).toString
                       currentParentId.foreach(pid => pageMetadata("parent_id") = pid)
                       elements += HTMLElement(
                         ElementType.UNCATEGORIZED_TEXT,
                         content = text,
                         metadata = pageMetadata)
+                      paragraphIndex += 1
                     }
                 }
               }
@@ -565,6 +594,10 @@ class HTMLReader(
                 sentenceIndex += 1
                 val titleId = newUUID()
                 pageMetadata("element_id") = titleId
+                pageMetadata("paragraph_index") = paragraphIndex.toString
+                pageMetadata("paragraph_y") = (paragraphIndex * paragraphSpacingY).toString
+                pageMetadata("page_y") = (paragraphIndex * paragraphSpacingY).toString
+                paragraphIndex += 1
                 elements += HTMLElement(
                   ElementType.TITLE,
                   content = titleText,
@@ -585,6 +618,10 @@ class HTMLReader(
               if (divText.nonEmpty) {
                 pageMetadata("sentence") = sentenceIndex.toString
                 sentenceIndex += 1
+                pageMetadata("paragraph_index") = paragraphIndex.toString
+                pageMetadata("paragraph_y") = (paragraphIndex * paragraphSpacingY).toString
+                pageMetadata("page_y") = (paragraphIndex * paragraphSpacingY).toString
+                paragraphIndex += 1
                 trackingNodes(element).visited = true
                 pageMetadata("element_id") = newUUID()
                 currentParentId.foreach(pid => pageMetadata("parent_id") = pid)

--- a/src/main/scala/com/johnsnowlabs/reader/HasReaderContent.scala
+++ b/src/main/scala/com/johnsnowlabs/reader/HasReaderContent.scala
@@ -123,8 +123,9 @@ trait HasReaderContent extends HasReaderProperties with HasTagsReaderProperties 
         if (isDelimitedContentType($(contentType)) || isDelimitedExtension(ext)) {
           partitionDelimitedContent(partition, contentPath, $(contentType), ext)
         } else {
+          val requestHeaders = getHeadersAsJava
           val partitionUDF =
-            udf((text: String) => partition.partitionStringContent(text, $(this.headers).asJava))
+            udf((text: String) => partition.partitionStringContent(text, requestHeaders))
           datasetWithTextFile(dataset.sparkSession, contentPath)
             .withColumn(partition.getOutputColumn, partitionUDF(col("content")))
         }
@@ -172,8 +173,9 @@ trait HasReaderContent extends HasReaderProperties with HasTagsReaderProperties 
       partition: Partition,
       dataset: Dataset[_],
       inputCol: String): DataFrame = {
+    val requestHeaders = getHeadersAsJava
     val partitionUDF =
-      udf((text: String) => partition.partitionStringContent(text, $(this.headers).asJava))
+      udf((text: String) => partition.partitionStringContent(text, requestHeaders))
 
     dataset
       .withColumn(partition.getOutputColumn, partitionUDF(col(inputCol)))

--- a/src/main/scala/com/johnsnowlabs/reader/Reader2Image.scala
+++ b/src/main/scala/com/johnsnowlabs/reader/Reader2Image.scala
@@ -211,8 +211,9 @@ class Reader2Image(override val uid: String)
         .drop("content")
 
     } else if (isText) {
+      val requestHeaders = getHeadersAsJava
       val partitionUDF =
-        udf((text: String) => partition.partitionStringContent(text, $(this.headers).asJava))
+        udf((text: String) => partition.partitionStringContent(text, requestHeaders))
 
       datasetWithTextFile(dataset.sparkSession, contentPath)
         .withColumn(partition.getOutputColumn, partitionUDF(col("content")))

--- a/src/main/scala/com/johnsnowlabs/reader/ReaderAssembler.scala
+++ b/src/main/scala/com/johnsnowlabs/reader/ReaderAssembler.scala
@@ -245,16 +245,14 @@ class ReaderAssembler(override val uid: String)
     }
 
     val contentDf = datasetWithTextFile(dataset.sparkSession, $(contentPath))
+    val requestHeaders = getHeadersAsJava
 
     val partitionTextUDF =
-      udf((text: String) =>
-        partitionTextBuilder.partitionStringContent(text, $(this.headers).asJava))
+      udf((text: String) => partitionTextBuilder.partitionStringContent(text, requestHeaders))
     val partitionTableUDF =
-      udf((text: String) =>
-        partitionTableBuilder.partitionStringContent(text, $(this.headers).asJava))
+      udf((text: String) => partitionTableBuilder.partitionStringContent(text, requestHeaders))
     val partitionImageUDF =
-      udf((text: String) =>
-        partitionImageBuilder.partitionStringContent(text, $(this.headers).asJava))
+      udf((text: String) => partitionImageBuilder.partitionStringContent(text, requestHeaders))
 
     contentDf
       .withColumn("partition_text", partitionTextUDF(col("content")))
@@ -489,23 +487,24 @@ class ReaderAssembler(override val uid: String)
     val baseDf =
       if (isText) datasetWithTextFile(spark, pathsStr)
       else datasetWithBinaryFile(spark, pathsStr)
+    val requestHeaders = getHeadersAsJava
 
     val textUdf =
       if (isText)
         udf((content: String) =>
-          partitionTextBuilder.partitionStringContent(content, $(this.headers).asJava))
+          partitionTextBuilder.partitionStringContent(content, requestHeaders))
       else udf((bytes: Array[Byte]) => partitionTextBuilder.partitionBytesContent(bytes))
 
     val tableUdf =
       if (isText)
         udf((content: String) =>
-          partitionTableBuilder.partitionStringContent(content, $(this.headers).asJava))
+          partitionTableBuilder.partitionStringContent(content, requestHeaders))
       else udf((bytes: Array[Byte]) => partitionTableBuilder.partitionBytesContent(bytes))
 
     val imageUdf =
       if (isText)
         udf((content: String) =>
-          partitionImageBuilder.partitionStringContent(content, $(this.headers).asJava))
+          partitionImageBuilder.partitionStringContent(content, requestHeaders))
       else udf((bytes: Array[Byte]) => partitionImageBuilder.partitionBytesContent(bytes))
 
     val df = baseDf
@@ -584,13 +583,12 @@ class ReaderAssembler(override val uid: String)
       buildPartition(
         Map("inferTableStructure" -> "true", "contentType" -> mimeType),
         "partition_table")
+    val requestHeaders = getHeadersAsJava
 
     val textUdf =
-      udf((text: String) =>
-        partitionTextBuilder.partitionStringContent(text, $(this.headers).asJava))
+      udf((text: String) => partitionTextBuilder.partitionStringContent(text, requestHeaders))
     val tableUdf =
-      udf((text: String) =>
-        partitionTableBuilder.partitionStringContent(text, $(this.headers).asJava))
+      udf((text: String) => partitionTableBuilder.partitionStringContent(text, requestHeaders))
 
     val emptyImageArray = typedLit(Seq.empty[HTMLElement])
 
@@ -614,10 +612,10 @@ class ReaderAssembler(override val uid: String)
         buildPartition(
           Map("inferTableStructure" -> "true", "contentType" -> mimeType),
           "partition_table")
+      val requestHeaders = getHeadersAsJava
 
       val tableUdf =
-        udf((text: String) =>
-          partitionTableBuilder.partitionStringContent(text, $(this.headers).asJava))
+        udf((text: String) => partitionTableBuilder.partitionStringContent(text, requestHeaders))
 
       val emptyImageArray = typedLit(Seq.empty[HTMLElement])
 
@@ -641,18 +639,16 @@ class ReaderAssembler(override val uid: String)
       buildPartition(
         Map("inferTableStructure" -> "false", "readAsImage" -> "true", "contentType" -> mimeType),
         "partition_image")
+    val requestHeaders = getHeadersAsJava
 
     val textUdf =
-      udf((text: String) =>
-        partitionTextBuilder.partitionStringContent(text, $(this.headers).asJava))
+      udf((text: String) => partitionTextBuilder.partitionStringContent(text, requestHeaders))
 
     val tableUdf =
-      udf((text: String) =>
-        partitionTableBuilder.partitionStringContent(text, $(this.headers).asJava))
+      udf((text: String) => partitionTableBuilder.partitionStringContent(text, requestHeaders))
 
     val imageUdf =
-      udf((text: String) =>
-        partitionImageBuilder.partitionStringContent(text, $(this.headers).asJava))
+      udf((text: String) => partitionImageBuilder.partitionStringContent(text, requestHeaders))
 
     dataset
       .withColumn("partition_text", textUdf(col(getInputCol)))

--- a/src/test/scala/com/johnsnowlabs/reader/HTMLReaderTest.scala
+++ b/src/test/scala/com/johnsnowlabs/reader/HTMLReaderTest.scala
@@ -267,6 +267,36 @@ class HTMLReaderTest extends AnyFlatSpec {
       "Missing orderImageIndex in IMAGE metadata")
   }
 
+  it should "include paragraph_index and paragraph_y metadata fields for text elements" taggedAs FastTest in {
+    val htmlReader = new HTMLReader()
+    val htmlDF = htmlReader.read(s"$htmlFilesDirectory/table-image.html")
+
+    val explodedDf = htmlDF.withColumn("html_exploded", explode(col("html")))
+
+    val textDf = explodedDf.filter(
+      col("html_exploded.elementType")
+        .isin(ElementType.NARRATIVE_TEXT, ElementType.TITLE, ElementType.UNCATEGORIZED_TEXT))
+
+    assert(textDf.collect().nonEmpty, "No TEXT elements found in HTMLReader output")
+
+    val textMetaRows = textDf
+      .selectExpr(
+        "html_exploded.metadata.paragraph_index as paragraph_index",
+        "html_exploded.metadata.paragraph_y as paragraph_y",
+        "html_exploded.metadata.page_y as page_y")
+      .collect()
+
+    assert(
+      textMetaRows.forall(row => row.getAs[String]("paragraph_index") != null),
+      "Missing paragraph_index in TEXT metadata")
+    assert(
+      textMetaRows.forall(row => row.getAs[String]("paragraph_y") != null),
+      "Missing paragraph_y in TEXT metadata")
+    assert(
+      textMetaRows.forall(row => row.getAs[String]("page_y") != null),
+      "Missing page_y in TEXT metadata")
+  }
+
   it should "include coord metadata field in {x:...,y:...} format for images" taggedAs FastTest in {
     val htmlReader = new HTMLReader()
     val htmlDF = htmlReader.read(s"$htmlFilesDirectory/example-image-coordinates.html")

--- a/src/test/scala/com/johnsnowlabs/reader/ReaderAssemblerTest.scala
+++ b/src/test/scala/com/johnsnowlabs/reader/ReaderAssemblerTest.scala
@@ -309,4 +309,27 @@ class ReaderAssemblerTest extends AnyFlatSpec with SparkSessionTest {
     assert(actualImages.nonEmpty)
   }
 
+  it should "work for HTML and include paragraph metadata" taggedAs FastTest in {
+    val reader = new ReaderAssembler()
+      .setContentPath(s"$htmlFilesDirectory/table-image.html")
+      .setContentType("text/html")
+      .setOutputCol("document")
+      .setOutputAsDocument(false)
+
+    val pipeline = new Pipeline().setStages(Array(reader))
+    val resultDf = pipeline.fit(emptyDataSet).transform(emptyDataSet)
+
+    val rows = resultDf.collect()
+    assert(rows.nonEmpty)
+
+    val textResult = AssertAnnotations.getActualResult(resultDf, "document_text").flatten
+    val imageResult = AssertAnnotations.getActualImageResult(resultDf, "document_image").flatten
+
+    assert(textResult.nonEmpty)
+    assert(imageResult.nonEmpty)
+    assert(textResult.forall(_.metadata.contains("paragraph_index")))
+    assert(textResult.forall(_.metadata.contains("paragraph_y")))
+    assert(textResult.forall(_.metadata.contains("page_y")))
+  }
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes the HTML reader headers handling by normalizing Java and Scala map values into a Java map on the driver before they are used inside reader and partitioning code. It also adds paragraph metadata to `HTMLReader` text elements, including `paragraph_index`, `paragraph_y`, and `page_y`, so downstream layout-aware components can preserve text ordering and positioning.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
HTML reader pipelines could fail at Spark action time when headers were serialized as Java maps instead of Scala maps. We also needed paragraph-level position metadata from `HTMLReader` so layout-aware downstream stages can align text with images more reliably.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Reader and partition tests were updated to force materialization with `collect()`, which helps catch lazy Spark failures that  `count()` can miss.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
