### PR TITLE
[SPARKNLP-1385] Add sentenceAwareFiltering param

### DIFF
--- a/python/sparknlp/annotator/embeddings/late_chunk_embeddings.py
+++ b/python/sparknlp/annotator/embeddings/late_chunk_embeddings.py
@@ -29,7 +29,10 @@ class LateChunkEmbeddings(AnnotatorModel):
     token representations. This annotator then locates the tokens that fall within
     each chunk's character span and mean-pools them into a single
     ``SENTENCE_EMBEDDINGS`` vector — so every chunk embedding is informed by the
-    complete document context rather than being isolated.
+    complete document context rather than being isolated. By default, token
+    selection is sentence-aware: selected token embeddings must fall inside the
+    chunk span and have the same sentence id as the chunk. Set
+    ``sentenceAwareFiltering`` to ``False`` to use span-only filtering.
 
     .. note::
         ``LateChunkEmbeddings`` **must** appear **after** the token-embedding stage
@@ -57,6 +60,9 @@ class LateChunkEmbeddings(AnnotatorModel):
     skipOOV
         Whether to discard default zero-vectors for OOV tokens from the pool,
         by default ``True``.
+    sentenceAwareFiltering
+        Whether to restrict token embeddings to the same sentence as the chunk
+        when pooling, by default ``True``.
 
     References
     ----------
@@ -134,7 +140,9 @@ class LateChunkEmbeddings(AnnotatorModel):
         super(LateChunkEmbeddings, self).__init__(
             classname="com.johnsnowlabs.nlp.embeddings.LateChunkEmbeddings"
         )
-        self._setDefault(poolingStrategy="AVERAGE", skipOOV=True)
+        self._setDefault(
+            poolingStrategy="AVERAGE", skipOOV=True, sentenceAwareFiltering=True
+        )
 
     poolingStrategy = Param(
         Params._dummy(),
@@ -147,6 +155,13 @@ class LateChunkEmbeddings(AnnotatorModel):
         Params._dummy(),
         "skipOOV",
         "Whether to discard default vectors for OOV words from the aggregation / pooling",
+        typeConverter=TypeConverters.toBoolean,
+    )
+
+    sentenceAwareFiltering = Param(
+        Params._dummy(),
+        "sentenceAwareFiltering",
+        "Whether to restrict token embeddings to the same sentence as the chunk when pooling",
         typeConverter=TypeConverters.toBoolean,
     )
 
@@ -173,4 +188,16 @@ class LateChunkEmbeddings(AnnotatorModel):
             they do not dilute the chunk embedding.
         """
         return self._set(skipOOV=value)
+
+    def setSentenceAwareFiltering(self, value):
+        """Sets whether token filtering should also require matching sentence id.
+
+        Parameters
+        ----------
+        value : bool
+            If ``True`` (default), selected token embeddings must fall within the
+            chunk span and have the same sentence id as the chunk. If ``False``,
+            filtering is span-only.
+        """
+        return self._set(sentenceAwareFiltering=value)
 

--- a/python/test/annotator/embeddings/late_chunk_embeddings_test.py
+++ b/python/test/annotator/embeddings/late_chunk_embeddings_test.py
@@ -203,12 +203,16 @@ class LateChunkEmbeddingsParamTest(unittest.TestCase):
         lce = LateChunkEmbeddings()
         self.assertEqual(lce.getOrDefault("poolingStrategy"), "AVERAGE")
         self.assertTrue(lce.getOrDefault("skipOOV"))
+        self.assertTrue(lce.getOrDefault("sentenceAwareFiltering"))
 
         lce.setPoolingStrategy("SUM")
         self.assertEqual(lce.getOrDefault("poolingStrategy"), "SUM")
 
         lce.setSkipOOV(False)
         self.assertFalse(lce.getOrDefault("skipOOV"))
+
+        lce.setSentenceAwareFiltering(False)
+        self.assertFalse(lce.getOrDefault("sentenceAwareFiltering"))
 
         lce.setPoolingStrategy("MAX")
         self.assertEqual(lce.getOrDefault("poolingStrategy"), "AVERAGE")

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/LateChunkEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/LateChunkEmbeddings.scala
@@ -33,7 +33,9 @@ import org.apache.spark.sql.{DataFrame, Dataset}
   * producing contextual token representations. This annotator then locates the tokens that fall
   * within each chunk's character span and mean-pools them into a single `SENTENCE_EMBEDDINGS`
   * vector — so every chunk embedding is informed by the complete document context rather than
-  * being isolated.
+  * being isolated. By default, token selection is sentence-aware: selected token embeddings must
+  * fall inside the chunk span and have the same sentence id as the chunk. Set
+  * `sentenceAwareFiltering` to `false` to use span-only filtering.
   *
   * ==Ordering requirement==
   * `LateChunkEmbeddings` '''must''' appear '''after''' the token-embedding stage in the pipeline.
@@ -181,6 +183,17 @@ class LateChunkEmbeddings(override val uid: String)
     "skipOOV",
     "Whether to discard default vectors for OOV words from the aggregation / pooling")
 
+  /** Whether to restrict token embeddings to the same sentence as the chunk when pooling
+    * (Default: `true`). When true, selected token embeddings must both fall inside the chunk span
+    * and have the same sentence id as the chunk.
+    *
+    * @group param
+    */
+  val sentenceAwareFiltering = new BooleanParam(
+    this,
+    "sentenceAwareFiltering",
+    "Whether to restrict token embeddings to the same sentence as the chunk when pooling")
+
   /** Sets pooling strategy. Must be `"AVERAGE"` or `"SUM"`.
     *
     * @group setParam
@@ -199,6 +212,12 @@ class LateChunkEmbeddings(override val uid: String)
     */
   def setSkipOOV(value: Boolean): this.type = set(skipOOV, value)
 
+  /** Sets whether token filtering should also require matching sentence id.
+    *
+    * @group setParam
+    */
+  def setSentenceAwareFiltering(value: Boolean): this.type = set(sentenceAwareFiltering, value)
+
   /** Returns the current pooling strategy.
     *
     * @group getParam
@@ -211,11 +230,18 @@ class LateChunkEmbeddings(override val uid: String)
     */
   def getSkipOOV: Boolean = $(skipOOV)
 
+  /** Returns whether token filtering requires matching sentence id.
+    *
+    * @group getParam
+    */
+  def getSentenceAwareFiltering: Boolean = $(sentenceAwareFiltering)
+
   setDefault(
     inputCols -> Array(DOCUMENT, CHUNK, WORD_EMBEDDINGS),
     outputCol -> "late_chunk_embeddings",
     poolingStrategy -> "AVERAGE",
     skipOOV -> true,
+    sentenceAwareFiltering -> true,
     dimension -> 0)
 
   /** Internal constructor to submit a random UID */
@@ -270,18 +296,27 @@ class LateChunkEmbeddings(override val uid: String)
     // is present), not for any algorithmic purpose in this method.
     val chunkAnnotations = annotations.filter(_.annotatorType == CHUNK)
 
-    // Unpack ALL token embeddings from the full document, flattening across sentence buckets.
-    // This is the key difference from ChunkEmbeddings: we never restrict the search to a single
-    // sentence, allowing every chunk to benefit from full-document contextual representations.
+    // Unpack ALL token embeddings from the full document, preserving the original sentence bucket.
+    // With sentenceAwareFiltering=true, candidate tokens come only from the chunk's sentence.
+    // With sentenceAwareFiltering=false, candidate tokens come from the full flattened document.
     val embeddingsSentences = WordpieceEmbeddingsSentence.unpack(annotations)
-    val allTokenEmbeddings = embeddingsSentences.flatMap(_.tokens)
+    lazy val allTokenEmbeddings = embeddingsSentences.flatMap(_.tokens)
+    val tokenEmbeddingsBySentence = embeddingsSentences
+      .map(sentence => sentence.sentenceId -> sentence.tokens.toSeq)
+      .toMap
 
     chunkAnnotations.flatMap { chunk =>
       val sentenceIdx = chunk.metadata.getOrElse("sentence", "0")
       val chunkIdx = chunk.metadata.getOrElse("chunk", "0")
 
-      // Select tokens whose character span falls inside the chunk span
-      val tokensInSpan = allTokenEmbeddings.filter { token =>
+      val candidateTokenEmbeddings =
+        if ($(sentenceAwareFiltering))
+          tokenEmbeddingsBySentence.getOrElse(sentenceIdx.toInt, Seq.empty)
+        else
+          allTokenEmbeddings
+
+      // Select tokens whose character span falls inside the chunk span.
+      val tokensInSpan = candidateTokenEmbeddings.filter { token =>
         token.begin >= chunk.begin && token.end <= chunk.end
       }
 

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/LateChunkEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/LateChunkEmbeddingsTestSpec.scala
@@ -16,7 +16,7 @@
 
 package com.johnsnowlabs.nlp.embeddings
 
-import com.johnsnowlabs.nlp.AnnotatorType.{CHUNK, DOCUMENT, SENTENCE_EMBEDDINGS}
+import com.johnsnowlabs.nlp.AnnotatorType.{CHUNK, DOCUMENT, SENTENCE_EMBEDDINGS, WORD_EMBEDDINGS}
 import com.johnsnowlabs.nlp.annotators.{NGramGenerator, Tokenizer}
 import com.johnsnowlabs.nlp.base.{Doc2Chunk, DocumentAssembler}
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
@@ -28,6 +28,79 @@ import org.apache.spark.sql.Row
 import org.scalatest.flatspec.AnyFlatSpec
 
 class LateChunkEmbeddingsTestSpec extends AnyFlatSpec {
+
+  private def mockWordEmbedding(sentenceId: Int, embeddings: Array[Float]): Annotation = {
+    Annotation(
+      WORD_EMBEDDINGS,
+      0,
+      3,
+      "foo",
+      Map(
+        "sentence" -> sentenceId.toString,
+        "token" -> "foo",
+        "pieceId" -> "0",
+        "isWordStart" -> "true",
+        "isOOV" -> "false"),
+      embeddings)
+  }
+
+  private def mockSentenceAwareFilteringAnnotations(
+      wordEmbeddings: Annotation*): Seq[Annotation] = {
+    Seq(
+      Annotation(DOCUMENT, 0, 3, "foo", Map("sentence" -> "0")),
+      Annotation(CHUNK, 0, 3, "foo", Map("sentence" -> "1", "chunk" -> "0"))) ++
+      wordEmbeddings
+  }
+
+  "LateChunkEmbeddings" should "use sentence-aware token filtering by default" taggedAs FastTest in {
+    val annotations = mockSentenceAwareFilteringAnnotations(
+      mockWordEmbedding(sentenceId = 0, embeddings = Array(2.0f, 4.0f)),
+      mockWordEmbedding(sentenceId = 1, embeddings = Array(6.0f, 8.0f)))
+
+    val lateChunkEmbeddings = new LateChunkEmbeddings()
+    val result = lateChunkEmbeddings.annotate(annotations)
+
+    assert(lateChunkEmbeddings.getSentenceAwareFiltering)
+    assert(result.length == 1)
+    assert(result.head.embeddings.sameElements(Array(6.0f, 8.0f)))
+  }
+
+  "LateChunkEmbeddings" should "use span-only token filtering when sentenceAwareFiltering is false" taggedAs FastTest in {
+    val annotations = mockSentenceAwareFilteringAnnotations(
+      mockWordEmbedding(sentenceId = 0, embeddings = Array(2.0f, 4.0f)),
+      mockWordEmbedding(sentenceId = 1, embeddings = Array(6.0f, 8.0f)))
+
+    val result = new LateChunkEmbeddings()
+      .setSentenceAwareFiltering(false)
+      .annotate(annotations)
+
+    assert(result.length == 1)
+    assert(result.head.embeddings.sameElements(Array(4.0f, 6.0f)))
+  }
+
+  "LateChunkEmbeddings" should "filter token embeddings by sentence id when sentenceAwareFiltering is true" taggedAs FastTest in {
+    val annotations = mockSentenceAwareFilteringAnnotations(
+      mockWordEmbedding(sentenceId = 0, embeddings = Array(2.0f, 4.0f)),
+      mockWordEmbedding(sentenceId = 1, embeddings = Array(6.0f, 8.0f)))
+
+    val result = new LateChunkEmbeddings()
+      .setSentenceAwareFiltering(true)
+      .annotate(annotations)
+
+    assert(result.length == 1)
+    assert(result.head.embeddings.sameElements(Array(6.0f, 8.0f)))
+  }
+
+  "LateChunkEmbeddings" should "drop chunks without same-sentence token embeddings when sentenceAwareFiltering is true" taggedAs FastTest in {
+    val annotations = mockSentenceAwareFilteringAnnotations(
+      mockWordEmbedding(sentenceId = 0, embeddings = Array(2.0f, 4.0f)))
+
+    val result = new LateChunkEmbeddings()
+      .setSentenceAwareFiltering(true)
+      .annotate(annotations)
+
+    assert(result.isEmpty)
+  }
 
   "LateChunkEmbeddings" should "produce SENTENCE_EMBEDDINGS with AVERAGE pooling" taggedAs FastTest in {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the `sentenceAwareFiltering` parameter to the `LateChunkEmbeddings` annotator. This parameter controls whether token embeddings are restricted to the chunk's sentence boundaries (true) or based on span boundaries only (false). 
                                                                                                                                                                                             
This is now the default behavior (true). 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, `LateChunkEmbeddings` pooled token embeddings based strictly on span boundaries. This caused issues where overlapping tokens (common in Healthcare, NER, and complex layouts) crossing sentence boundaries would incorrectly pull in noise from adjacent sentences.                                                       
By defaulting to `sentenceAwareFiltering=true`, the annotator now restricts token candidates to the chunk's own sentence ID. This significantly reduces cross-sentence artifacts and improves embedding fidelity for typical use cases.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

- Local Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
