### PR TITLE
Properly close stream and avoid warning

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -176,6 +176,7 @@ object ResourceHelper {
 
     def close(): Unit = {
       openBuffers.foreach(_.close())
+      fileSystem.foreach(_.close())
       pipe.foreach(_.close)
     }
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/util/io/ResourceHelper.scala
@@ -209,7 +209,9 @@ object ResourceHelper {
         val pathWithProtocol: String =
           if (URI.create(path).getScheme == null) new File(path).toURI.toURL.toString else path
         val resource = SourceStream(pathWithProtocol)
-        resource.copyToLocal()
+        val localTmpPath = resource.copyToLocal()
+        resource.close()
+        localTmpPath
       }
 
     new File(localUri).getAbsolutePath // Platform independent path


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I just take care of closing a stream that is throwing exceptions(warning), it can make some depending pipelines to fail, even if it is a warning.


## Motivation and Context
It avoids leaking a file system.
Not aware of any previous report.

## How Has This Been Tested?
See #14773 .

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [?] All new and existing tests passed.
