### PR TITLE
[SPARKNLP-1145] Add BM25 lexical retrieval annotator (Approach + Model)

### DIFF
--- a/docs/en/annotator_entries/BM25.md
+++ b/docs/en/annotator_entries/BM25.md
@@ -7,10 +7,20 @@ Fitted model produced by `BM25Approach`. It holds the corpus-level statistics (I
 document length and document count) and scores every document in a dataset against a query using
 the Okapi BM25 ranking function.
 
-The query is provided at query time with `setQuery(...)`, so the same fitted model can be reused
-for many different queries ("fit once, query many times"). For every input document the model emits
-a single `BM25_RANKINGS` annotation whose `result` is the BM25 score and whose metadata contains
-`bm25_score`, `num_query_terms_matched`, `query` and `doc_len`.
+The query is provided at query time, so the same fitted model can be reused for many different
+queries ("fit once, query many times"). Provide it either as a raw string with `setQuery(...)` or —
+recommended when the corpus was analyzed by a non-trivial pipeline — as already-analyzed tokens with
+`setQueryTokens(...)`. For every input document the model emits a single `BM25_RANKINGS` annotation
+whose `result` is the BM25 score and whose metadata contains `bm25_score`,
+`num_query_terms_matched`, `query` and `doc_len`.
+
+**Analyzer symmetry.** BM25 only scores a query term when it matches a key in the learned IDF
+vocabulary, and those keys were produced by the pipeline in front of `BM25Approach` (`Tokenizer`,
+`Normalizer`, a stemmer/lemmatizer, ...). A raw-string `setQuery` is only split on non-word
+characters and lowercased, so if the corpus pipeline *transforms* tokens (stemming, lemmatization,
+punctuation stripping, ...) a raw query can silently fail to match. In that case run the query
+through the **same** pipeline (e.g. with a `LightPipeline`) and pass the resulting tokens to
+`setQueryTokens`. `caseSensitive` is fixed at fit time and is read-only on the model.
 
 For training and examples see `BM25Approach`.
 {%- endcapture -%}
@@ -71,7 +81,12 @@ The IDF uses the non-negative (Lucene / Elasticsearch) variant
 `Q` as `score(D, Q) = sum over t in Q of idf(t) * (tf(t, D) * (k1 + 1)) / (tf(t, D) + k1 * (1 - b + b * |D| / avgdl))`.
 
 The input is a column of `TOKEN` annotations, so BM25 is normally placed after a `Tokenizer`
-(optionally followed by a `Normalizer` and/or `StopWordsCleaner`).
+(optionally followed by a `Normalizer` and/or `StopWordsCleaner`). Whatever stages you use to
+analyze the corpus must also be used to analyze the query: BM25 can only score a query term when
+it matches a key in the learned IDF vocabulary, and those keys hold the pipeline's transformed
+forms (stems, lemmas, normalized spellings, etc.). A raw-string `setQuery` is only split on
+non-word characters and lowercased, so if any stage *transforms* tokens, use `setQueryTokens(...)`
+with the query analyzed by the same pipeline instead (for example via a `LightPipeline`).
 
 For extended examples of usage, see the jupyter notebook
 [BM25 Retrieval for Spark NLP](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-similarity/bm25-retrieval/BM25_Retrieval.ipynb).

--- a/docs/en/annotator_entries/BM25.md
+++ b/docs/en/annotator_entries/BM25.md
@@ -1,0 +1,270 @@
+{%- capture title -%}
+BM25
+{%- endcapture -%}
+
+{%- capture model_description -%}
+Fitted model produced by `BM25Approach`. It holds the corpus-level statistics (IDF map, average
+document length and document count) and scores every document in a dataset against a query using
+the Okapi BM25 ranking function.
+
+The query is provided at query time with `setQuery(...)`, so the same fitted model can be reused
+for many different queries ("fit once, query many times"). For every input document the model emits
+a single `BM25_RANKINGS` annotation whose `result` is the BM25 score and whose metadata contains
+`bm25_score`, `num_query_terms_matched`, `query` and `doc_len`.
+
+For training and examples see `BM25Approach`.
+{%- endcapture -%}
+
+{%- capture model_input_anno -%}
+TOKEN
+{%- endcapture -%}
+
+{%- capture model_output_anno -%}
+BM25_RANKINGS
+{%- endcapture -%}
+
+{%- capture model_python_example -%}
+from sparknlp.annotator import BM25Model
+
+# A BM25Model is produced by BM25Approach.fit(...). It can be saved once and reloaded to be
+# re-queried many times, without re-scanning the corpus.
+loaded_bm25 = BM25Model.load("/tmp/bm25_corpus_model")
+loaded_bm25.setQuery("neural networks deep learning")
+{%- endcapture -%}
+
+{%- capture model_scala_example -%}
+import com.johnsnowlabs.nlp.annotators.similarity.BM25Model
+
+// A BM25Model is produced by BM25Approach.fit(...). It can be saved once and reloaded to be
+// re-queried many times, without re-scanning the corpus.
+val loadedBm25 = BM25Model.load("/tmp/bm25_corpus_model")
+loadedBm25.setQuery("neural networks deep learning")
+{%- endcapture -%}
+
+{%- capture model_api_link -%}
+[BM25Model](/api/com/johnsnowlabs/nlp/annotators/similarity/BM25Model)
+{%- endcapture -%}
+
+{%- capture model_python_api_link -%}
+[BM25Model](/api/python/reference/autosummary/sparknlp/annotator/similarity/bm25/index.html#sparknlp.annotator.similarity.bm25.BM25Model)
+{%- endcapture -%}
+
+{%- capture model_source_link -%}
+[BM25Model](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25Model.scala)
+{%- endcapture -%}
+
+{%- capture approach_description -%}
+Trains an Okapi BM25 lexical ranker over a corpus of tokenized documents.
+
+BM25 is a bag-of-words retrieval function that ranks documents against a query based on the query
+terms appearing in each document. Because a document's score depends on corpus-level statistics
+(how many documents contain a term, and the average document length), BM25 is implemented as a
+two-phase Estimator/Model pair:
+
+- `BM25Approach` (this annotator) scans the full corpus once during `fit()` and learns the total
+  document count `N`, the document frequency `df(t)` of every term, the average document length
+  `avgdl`, and the inverse document frequency `idf(t)` of every term.
+- `BM25Model` reuses those statistics at query time to score every document against a query.
+
+The IDF uses the non-negative (Lucene / Elasticsearch) variant
+`idf(t) = ln(1 + (N - df(t) + 0.5) / (df(t) + 0.5))`, and each document `D` is scored against query
+`Q` as `score(D, Q) = sum over t in Q of idf(t) * (tf(t, D) * (k1 + 1)) / (tf(t, D) + k1 * (1 - b + b * |D| / avgdl))`.
+
+The input is a column of `TOKEN` annotations, so BM25 is normally placed after a `Tokenizer`
+(optionally followed by a `Normalizer` and/or `StopWordsCleaner`).
+
+For extended examples of usage, see the jupyter notebook
+[BM25 Retrieval for Spark NLP](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-similarity/bm25-retrieval/BM25_Retrieval.ipynb).
+{%- endcapture -%}
+
+{%- capture approach_input_anno -%}
+TOKEN
+{%- endcapture -%}
+
+{%- capture approach_output_anno -%}
+BM25_RANKINGS
+{%- endcapture -%}
+
+{%- capture approach_python_example -%}
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+from pyspark.sql.functions import col, explode
+
+corpus = spark.createDataFrame([
+    (1,  "Apples are a great source of dietary fiber and vitamin C."),
+    (2,  "Bananas are rich in potassium and natural sugars."),
+    (3,  "Machine learning is a subset of artificial intelligence."),
+    (4,  "Deep learning uses neural networks with many layers."),
+    (5,  "Florence in Italy is one of the most beautiful cities in Europe."),
+    (6,  "The French Riviera is a warm coastal region in southern France."),
+    (7,  "Vitamin C deficiency can lead to scurvy and immune system problems."),
+    (8,  "Neural networks are inspired by the human brain's structure."),
+    (9,  "Potassium is an essential mineral for heart and muscle function."),
+    (10, "Italy is home to some of the world's greatest Renaissance art."),
+], ["id", "text"])
+
+document_assembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+tokenizer = Tokenizer() \
+    .setInputCols(["document"]) \
+    .setOutputCol("token")
+stop_words_cleaner = StopWordsCleaner() \
+    .setInputCols(["token"]) \
+    .setOutputCol("clean_token") \
+    .setCaseSensitive(False)
+bm25 = BM25Approach() \
+    .setInputCols(["clean_token"]) \
+    .setOutputCol("bm25_rankings") \
+    .setK1(1.2) \
+    .setB(0.75) \
+    .setMinDocFreq(1) \
+    .setCaseSensitive(False)
+
+pipeline = Pipeline(stages=[document_assembler, tokenizer, stop_words_cleaner, bm25])
+
+# FIT: scan the corpus once to learn IDF + avgdl
+model = pipeline.fit(corpus)
+
+# Query time: score all documents against a query
+model.stages[-1].setQuery("vitamin C health benefits fruits")
+
+result = model.transform(corpus)
+(
+    result
+    .select(col("id"), explode(col("bm25_rankings")).alias("ranking"))
+    .select(
+        col("id"),
+        col("ranking.metadata")["bm25_score"].cast("double").alias("bm25_score"),
+        col("ranking.metadata")["num_query_terms_matched"].cast("int").alias("terms_matched"))
+    .orderBy(col("bm25_score").desc())
+    .show(truncate=False)
+)
++---+------------------+-------------+
+|id |bm25_score        |terms_matched|
++---+------------------+-------------+
+|1  |2.8513563723478614|2            |
+|7  |2.705465483484128 |2            |
+|2  |0.0               |0            |
+|3  |0.0               |0            |
+|4  |0.0               |0            |
+|5  |0.0               |0            |
+|6  |0.0               |0            |
+|8  |0.0               |0            |
+|9  |0.0               |0            |
+|10 |0.0               |0            |
++---+------------------+-------------+
+
+{%- endcapture -%}
+
+{%- capture approach_scala_example -%}
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotators.{StopWordsCleaner, Tokenizer}
+import com.johnsnowlabs.nlp.annotators.similarity.{BM25Approach, BM25Model}
+import org.apache.spark.ml.Pipeline
+import org.apache.spark.sql.functions.{col, explode}
+
+import spark.implicits._
+
+val corpus = Seq(
+  (1, "Apples are a great source of dietary fiber and vitamin C."),
+  (2, "Bananas are rich in potassium and natural sugars."),
+  (3, "Machine learning is a subset of artificial intelligence."),
+  (4, "Deep learning uses neural networks with many layers."),
+  (5, "Florence in Italy is one of the most beautiful cities in Europe."),
+  (6, "The French Riviera is a warm coastal region in southern France."),
+  (7, "Vitamin C deficiency can lead to scurvy and immune system problems."),
+  (8, "Neural networks are inspired by the human brain's structure."),
+  (9, "Potassium is an essential mineral for heart and muscle function."),
+  (10, "Italy is home to some of the world's greatest Renaissance art."))
+  .toDF("id", "text")
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val tokenizer = new Tokenizer()
+  .setInputCols("document")
+  .setOutputCol("token")
+
+val stopWordsCleaner = new StopWordsCleaner()
+  .setInputCols("token")
+  .setOutputCol("clean_token")
+  .setCaseSensitive(false)
+
+val bm25 = new BM25Approach()
+  .setInputCols("clean_token")
+  .setOutputCol("bm25_rankings")
+  .setK1(1.2)
+  .setB(0.75)
+  .setMinDocFreq(1)
+  .setCaseSensitive(false)
+
+val pipeline = new Pipeline()
+  .setStages(Array(documentAssembler, tokenizer, stopWordsCleaner, bm25))
+
+// FIT: scan the corpus once to learn IDF + avgdl
+val model = pipeline.fit(corpus)
+
+// Query time: score all documents against a query
+model.stages.last.asInstanceOf[BM25Model].setQuery("vitamin C health benefits fruits")
+
+model.transform(corpus)
+  .select(col("id"), explode(col("bm25_rankings")).alias("ranking"))
+  .select(
+    col("id"),
+    col("ranking.metadata")("bm25_score").cast("double").alias("bm25_score"),
+    col("ranking.metadata")("num_query_terms_matched").cast("int").alias("terms_matched"))
+  .orderBy(col("bm25_score").desc)
+  .show(truncate = false)
++---+------------------+-------------+
+|id |bm25_score        |terms_matched|
++---+------------------+-------------+
+|1  |2.8513563723478614|2            |
+|7  |2.705465483484128 |2            |
+|2  |0.0               |0            |
+|3  |0.0               |0            |
+|4  |0.0               |0            |
+|5  |0.0               |0            |
+|6  |0.0               |0            |
+|8  |0.0               |0            |
+|9  |0.0               |0            |
+|10 |0.0               |0            |
++---+------------------+-------------+
+
+{%- endcapture -%}
+
+{%- capture approach_api_link -%}
+[BM25Approach](/api/com/johnsnowlabs/nlp/annotators/similarity/BM25Approach)
+{%- endcapture -%}
+
+{%- capture approach_python_api_link -%}
+[BM25Approach](/api/python/reference/autosummary/sparknlp/annotator/similarity/bm25/index.html#sparknlp.annotator.similarity.bm25.BM25Approach)
+{%- endcapture -%}
+
+{%- capture approach_source_link -%}
+[BM25Approach](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25Approach.scala)
+{%- endcapture -%}
+
+
+{% include templates/approach_model_template.md
+title=title
+model_description=model_description
+model_input_anno=model_input_anno
+model_output_anno=model_output_anno
+model_python_example=model_python_example
+model_scala_example=model_scala_example
+model_api_link=model_api_link
+model_python_api_link=model_python_api_link
+model_source_link=model_source_link
+approach_description=approach_description
+approach_input_anno=approach_input_anno
+approach_output_anno=approach_output_anno
+approach_python_example=approach_python_example
+approach_scala_example=approach_scala_example
+approach_api_link=approach_api_link
+approach_python_api_link=approach_python_api_link
+approach_source_link=approach_source_link
+%}

--- a/docs/en/annotators.md
+++ b/docs/en/annotators.md
@@ -52,6 +52,7 @@ There are two types of Annotators:
 {% include templates/anno_table_entry.md path="" name="AutoGGUFVisionModel" summary="Multimodal annotator that uses the llama.cpp library to generate text completions with large language models."%}
 {% include templates/anno_table_entry.md path="" name="BGEEmbeddings" summary="Sentence embeddings using BGE."%}
 {% include templates/anno_table_entry.md path="" name="BigTextMatcher" summary="Annotator to match exact phrases (by token) provided in a file against a Document."%}
+{% include templates/anno_table_entry.md path="" name="BM25" summary="Okapi BM25 lexical ranker that scores documents against a query using corpus-level statistics (IDF and average document length) learned during fit."%}
 {% include templates/anno_table_entry.md path="" name="Chunk2Doc" summary="Converts a `CHUNK` type column back into `DOCUMENT`. Useful when trying to re-tokenize or do further analysis on a `CHUNK` result."%}
 {% include templates/anno_table_entry.md path="" name="ChunkEmbeddings" summary="This annotator utilizes WordEmbeddings, BertEmbeddings etc. to generate chunk embeddings from either Chunker, NGramGenerator, or NerConverter outputs."%}
 {% include templates/anno_table_entry.md path="" name="ChunkTokenizer" summary="Tokenizes and flattens extracted NER chunks."%}

--- a/examples/python/annotation/text/english/text-similarity/bm25-retrieval/BM25_Retrieval.ipynb
+++ b/examples/python/annotation/text/english/text-similarity/bm25-retrieval/BM25_Retrieval.ipynb
@@ -89,13 +89,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 8,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "24rVfDonVS2v",
-        "outputId": "757e8efa-2c19-430e-9566-f00b24176526"
+        "outputId": "641027a1-7814-42cd-fbe0-c9244653a129"
       },
       "outputs": [
         {
@@ -150,13 +150,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 9,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "bxGYXvfnVS2w",
-        "outputId": "00474381-8efb-45f7-bdb6-1daee4cd3ae2"
+        "outputId": "fdb8ac92-ed50-4ad2-c8e5-8d5cd27141c6"
       },
       "outputs": [
         {
@@ -215,13 +215,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": 10,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "71sVqds9VS2x",
-        "outputId": "8fdc0229-1efd-48c4-fa55-eea230c90dc5"
+        "outputId": "fcd356b9-41d0-42d4-9367-8ad9d2c811bd"
       },
       "outputs": [
         {
@@ -292,13 +292,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 11,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "okBSwpHXVS2y",
-        "outputId": "d0a603b6-0e4a-428f-e6c2-c9a939a66338"
+        "outputId": "17c97e2d-e2c0-42d1-ed75-a7e5a93c9879"
       },
       "outputs": [
         {
@@ -356,13 +356,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": 12,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "xI8LuPg0VS20",
-        "outputId": "bf15eb79-c18c-48d6-84db-bcf4a26b0e90"
+        "outputId": "ad7e2524-dd6e-4b1b-8d44-bfddc751cc7d"
       },
       "outputs": [
         {
@@ -456,13 +456,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 13,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "PvtNs5NnVS20",
-        "outputId": "dbe06244-f321-4147-ef4c-7c6153479adc"
+        "outputId": "c185504b-c256-4487-bbdc-8078887f37c2"
       },
       "outputs": [
         {
@@ -536,6 +536,100 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "bm25QueryTokensMd"
+      },
+      "source": [
+        "## 5. Keep the query analyzer in sync (`setQueryTokens`)\n",
+        "\n",
+        "`setQuery(\"...\")` is a convenience: the model tokenizes the string itself by splitting on non-word characters and lowercasing. That stays correct only while the corpus pipeline doesn't *transform* tokens beyond that.\n",
+        "\n",
+        "Once a stage rewrites tokens — a **stemmer**, **lemmatizer**, or aggressive **`Normalizer`** — the learned IDF vocabulary holds the *transformed* forms, but a raw-string query is **not** transformed, so its terms silently fail to match and contribute nothing.\n",
+        "\n",
+        "The robust pattern is to analyze the query with the **same** stages used for the documents (for example with a `LightPipeline`) and pass the resulting tokens to `setQueryTokens(...)`; when set, `queryTokens` overrides `query`. Below, a Porter-stemmed corpus only matches `\"deficiency\"` when the query is stemmed the same way."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {
+        "id": "bm25QueryTokensCode",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "71686696-2537-4da4-a375-2f1fc8033737"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Raw setQuery(\"deficiency\"):\n",
+            "+---+----------+-------------+\n",
+            "|id |bm25_score|terms_matched|\n",
+            "+---+----------+-------------+\n",
+            "|6  |0.0       |0            |\n",
+            "|1  |0.0       |0            |\n",
+            "|7  |0.0       |0            |\n",
+            "+---+----------+-------------+\n",
+            "only showing top 3 rows\n",
+            "\n",
+            "Analyzed query tokens: ['defici']\n",
+            "setQueryTokens(query_tokens):\n",
+            "+---+------------------+-------------+\n",
+            "|id |bm25_score        |terms_matched|\n",
+            "+---+------------------+-------------+\n",
+            "|7  |1.9134351361342068|1            |\n",
+            "|1  |0.0               |0            |\n",
+            "|6  |0.0               |0            |\n",
+            "+---+------------------+-------------+\n",
+            "only showing top 3 rows\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "from sparknlp.base import LightPipeline\n",
+        "\n",
+        "# A token-transforming stage (here a Porter stemmer) is where a raw-string query breaks:\n",
+        "# the corpus vocabulary holds stems, but setQuery only splits on non-word chars + lowercases.\n",
+        "stemmer = (\n",
+        "    Stemmer()\n",
+        "    .setInputCols([\"token\"])\n",
+        "    .setOutputCol(\"stem\")\n",
+        ")\n",
+        "\n",
+        "stem_bm25 = (\n",
+        "    BM25Approach()\n",
+        "    .setInputCols([\"stem\"])\n",
+        "    .setOutputCol(\"bm25_rankings\")\n",
+        ")\n",
+        "\n",
+        "stem_model = Pipeline(stages=[\n",
+        "    document_assembler,\n",
+        "    tokenizer,\n",
+        "    stemmer,\n",
+        "    stem_bm25,\n",
+        "]).fit(corpus)\n",
+        "stem_bm25_model = stem_model.stages[-1]\n",
+        "\n",
+        "# (a) Raw-string query: \"deficiency\" is never stemmed, so it misses the stemmed vocabulary.\n",
+        "stem_bm25_model.setQuery(\"deficiency\")\n",
+        "print('Raw setQuery(\"deficiency\"):')\n",
+        "ranked(stem_model, corpus).select(\"id\", \"bm25_score\", \"terms_matched\").show(3, truncate=False)\n",
+        "\n",
+        "# (b) Analyze the query with the SAME stages, then pass the tokens via setQueryTokens.\n",
+        "analyzer = Pipeline(stages=[document_assembler, tokenizer, stemmer]).fit(corpus)\n",
+        "query_tokens = LightPipeline(analyzer).annotate(\"deficiency\")[\"stem\"]\n",
+        "print(\"Analyzed query tokens:\", query_tokens)\n",
+        "\n",
+        "stem_bm25_model.setQueryTokens(query_tokens)\n",
+        "print(\"setQueryTokens(query_tokens):\")\n",
+        "ranked(stem_model, corpus).select(\"id\", \"bm25_score\", \"terms_matched\").show(3, truncate=False)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "I_Dvv3k7VS20"
       },
       "source": [
@@ -543,7 +637,8 @@
         "\n",
         "* **Purely lexical.** BM25 has no notion of synonyms or semantics, *car* and *automobile* are unrelated terms. For semantic ranking, see `DocumentSimilarityRankerApproach` (embedding + LSH based).\n",
         "* **Vocabulary drift.** If the corpus grows significantly after the model is fit, the IDF map becomes stale and the model should be refit.\n",
-        "* **Annotation output.** Each document yields a single `bm25_rankings` annotation whose `result` is the score and whose `metadata` contains `bm25_score`, `num_query_terms_matched`, `query` and `doc_len`."
+        "* **Annotation output.** Each document yields a single `bm25_rankings` annotation whose `result` is the score and whose `metadata` contains `bm25_score`, `num_query_terms_matched`, `query` and `doc_len`.\n",
+        "* **Analyzer symmetry.** `setQuery` only splits on non-word characters and lowercases; if your pipeline transforms tokens (stemming, lemmatization, aggressive normalization) the learned vocabulary holds the transformed forms, so analyze the query through the same pipeline and pass the result to `setQueryTokens` — otherwise query terms can silently miss the vocabulary and score 0."
       ]
     }
   ],

--- a/examples/python/annotation/text/english/text-similarity/bm25-retrieval/BM25_Retrieval.ipynb
+++ b/examples/python/annotation/text/english/text-similarity/bm25-retrieval/BM25_Retrieval.ipynb
@@ -1,0 +1,565 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "I4oXbSqpVS2r"
+      },
+      "source": [
+        "![JohnSnowLabs](https://nlp.johnsnowlabs.com/assets/images/logo.png)\n",
+        "\n",
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-similarity/bm25-retrieval/BM25_Retrieval.ipynb)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lMhCeW5YVS2s"
+      },
+      "source": [
+        "# BM25 Retrieval with Spark NLP\n",
+        "\n",
+        "**BM25** (Okapi BM25) is a classic *lexical* ranking function used by search engines such as Lucene and Elasticsearch. It scores how relevant each document in a corpus is to a query, based purely on the query terms that appear in the document.\n",
+        "\n",
+        "Because a document's score depends on **corpus-level statistics** (how many documents contain a term, and the average document length), BM25 is implemented in Spark NLP as a two-phase **Estimator/Model** pair:\n",
+        "\n",
+        "* `BM25Approach`: scans the corpus once during `fit()` and learns the document count `N`, the document frequency `df(t)` of every term, the average document length `avgdl`, and the inverse document frequency `idf(t)`.\n",
+        "* `BM25Model`: reuses those statistics at query time to score every document against a user-provided query.\n",
+        "\n",
+        "Spark NLP uses the non-negative (Lucene/Elasticsearch) IDF variant:\n",
+        "\n",
+        "$$ idf(t) = \\ln\\left(1 + \\frac{N - df(t) + 0.5}{df(t) + 0.5}\\right) $$\n",
+        "\n",
+        "and scores each document `D` against query `Q` as:\n",
+        "\n",
+        "$$ score(D, Q) = \\sum_{t \\in Q} idf(t) \\cdot \\frac{tf(t, D) \\cdot (k_1 + 1)}{tf(t, D) + k_1 \\cdot \\left(1 - b + b \\cdot \\frac{|D|}{avgdl}\\right)} $$\n",
+        "\n",
+        "| Parameter | Meaning | Default | Typical range |\n",
+        "|-----------|---------|---------|---------------|\n",
+        "| `k1` | Term-frequency saturation | `1.2` | `[1.0, 2.0]` |\n",
+        "| `b` | Document-length normalization | `0.75` | `[0.0, 1.0]` |\n",
+        "| `minDocFreq` | Drop terms seen in fewer than N docs | `1` | |\n",
+        "| `caseSensitive` | Treat tokens case-sensitively | `False` | |\n",
+        "\n",
+        "The input is a column of `TOKEN` annotations, so BM25 is placed after a `Tokenizer` (optionally a `Normalizer` and/or `StopWordsCleaner`)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "moU7F0j5VS2u"
+      },
+      "outputs": [],
+      "source": [
+        "# Only run this cell when you are using Spark NLP on Google Colab\n",
+        "!wget http://setup.johnsnowlabs.com/colab.sh -O - | bash"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "CzQWLD_1VS2u"
+      },
+      "outputs": [],
+      "source": [
+        "import sparknlp\n",
+        "from sparknlp.base import *\n",
+        "from sparknlp.annotator import *\n",
+        "from pyspark.ml import Pipeline\n",
+        "from pyspark.sql.functions import col, explode\n",
+        "\n",
+        "spark = sparknlp.start()\n",
+        "\n",
+        "print(\"Spark NLP version:\", sparknlp.version())\n",
+        "print(\"Apache Spark version:\", spark.version)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7hlm2EiJVS2u"
+      },
+      "source": [
+        "## The corpus\n",
+        "\n",
+        "A small toy corpus of 10 documents spanning a few topics (nutrition, machine learning, travel)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "24rVfDonVS2v",
+        "outputId": "757e8efa-2c19-430e-9566-f00b24176526"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "+---+-------------------------------------------------------------------+\n",
+            "|id |text                                                               |\n",
+            "+---+-------------------------------------------------------------------+\n",
+            "|1  |Apples are a great source of dietary fiber and vitamin C.          |\n",
+            "|2  |Bananas are rich in potassium and natural sugars.                  |\n",
+            "|3  |Machine learning is a subset of artificial intelligence.           |\n",
+            "|4  |Deep learning uses neural networks with many layers.               |\n",
+            "|5  |Florence in Italy is one of the most beautiful cities in Europe.   |\n",
+            "|6  |The French Riviera is a warm coastal region in southern France.    |\n",
+            "|7  |Vitamin C deficiency can lead to scurvy and immune system problems.|\n",
+            "|8  |Neural networks are inspired by the human brain's structure.       |\n",
+            "|9  |Potassium is an essential mineral for heart and muscle function.   |\n",
+            "|10 |Italy is home to some of the world's greatest Renaissance art.     |\n",
+            "+---+-------------------------------------------------------------------+\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "corpus = spark.createDataFrame([\n",
+        "    (1,  \"Apples are a great source of dietary fiber and vitamin C.\"),\n",
+        "    (2,  \"Bananas are rich in potassium and natural sugars.\"),\n",
+        "    (3,  \"Machine learning is a subset of artificial intelligence.\"),\n",
+        "    (4,  \"Deep learning uses neural networks with many layers.\"),\n",
+        "    (5,  \"Florence in Italy is one of the most beautiful cities in Europe.\"),\n",
+        "    (6,  \"The French Riviera is a warm coastal region in southern France.\"),\n",
+        "    (7,  \"Vitamin C deficiency can lead to scurvy and immune system problems.\"),\n",
+        "    (8,  \"Neural networks are inspired by the human brain's structure.\"),\n",
+        "    (9,  \"Potassium is an essential mineral for heart and muscle function.\"),\n",
+        "    (10, \"Italy is home to some of the world's greatest Renaissance art.\"),\n",
+        "], [\"id\", \"text\"])\n",
+        "\n",
+        "corpus.show(truncate=False)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "okW6X9jqVS2w"
+      },
+      "source": [
+        "## 1. Basic BM25 document ranking with a global query\n",
+        "\n",
+        "Build the training pipeline (`DocumentAssembler` &rarr; `Tokenizer` &rarr; `StopWordsCleaner` &rarr; `BM25Approach`), `fit` it on the corpus to learn the IDF/avgdl statistics, set a query, then `transform`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "bxGYXvfnVS2w",
+        "outputId": "00474381-8efb-45f7-bdb6-1daee4cd3ae2"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "N (documents): 10\n",
+            "avgdl        : 7.3\n"
+          ]
+        }
+      ],
+      "source": [
+        "document_assembler = (\n",
+        "    DocumentAssembler()\n",
+        "    .setInputCol(\"text\")\n",
+        "    .setOutputCol(\"document\")\n",
+        ")\n",
+        "\n",
+        "tokenizer = (\n",
+        "    Tokenizer()\n",
+        "    .setInputCols([\"document\"])\n",
+        "    .setOutputCol(\"token\")\n",
+        ")\n",
+        "\n",
+        "stop_words_cleaner = (\n",
+        "    StopWordsCleaner()\n",
+        "    .setInputCols([\"token\"])\n",
+        "    .setOutputCol(\"clean_token\")\n",
+        "    .setCaseSensitive(False)\n",
+        ")\n",
+        "\n",
+        "bm25 = (\n",
+        "    BM25Approach()\n",
+        "    .setInputCols([\"clean_token\"])\n",
+        "    .setOutputCol(\"bm25_rankings\")\n",
+        "    .setK1(1.2)        # TF saturation   [1.0 - 2.0]\n",
+        "    .setB(0.75)        # length norm     [0.0 - 1.0]\n",
+        "    .setMinDocFreq(1)  # drop terms seen in fewer than N docs\n",
+        "    .setCaseSensitive(False)\n",
+        ")\n",
+        "\n",
+        "fit_pipeline = Pipeline(stages=[\n",
+        "    document_assembler,\n",
+        "    tokenizer,\n",
+        "    stop_words_cleaner,\n",
+        "    bm25,\n",
+        "])\n",
+        "\n",
+        "# FIT: scan corpus once, learn IDF + avgdl\n",
+        "pipeline_model = fit_pipeline.fit(corpus)\n",
+        "\n",
+        "bm25_model = pipeline_model.stages[-1]\n",
+        "print(\"N (documents):\", bm25_model.getNumDocuments())\n",
+        "print(\"avgdl        :\", round(bm25_model.getAvgDocLength(), 3))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "71sVqds9VS2x",
+        "outputId": "8fdc0229-1efd-48c4-fa55-eea230c90dc5"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "|id |text                                                               |bm25_score        |terms_matched|\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "|1  |Apples are a great source of dietary fiber and vitamin C.          |2.8513563723478614|2            |\n",
+            "|7  |Vitamin C deficiency can lead to scurvy and immune system problems.|2.705465483484128 |2            |\n",
+            "|2  |Bananas are rich in potassium and natural sugars.                  |0.0               |0            |\n",
+            "|6  |The French Riviera is a warm coastal region in southern France.    |0.0               |0            |\n",
+            "|3  |Machine learning is a subset of artificial intelligence.           |0.0               |0            |\n",
+            "|8  |Neural networks are inspired by the human brain's structure.       |0.0               |0            |\n",
+            "|4  |Deep learning uses neural networks with many layers.               |0.0               |0            |\n",
+            "|9  |Potassium is an essential mineral for heart and muscle function.   |0.0               |0            |\n",
+            "|5  |Florence in Italy is one of the most beautiful cities in Europe.   |0.0               |0            |\n",
+            "|10 |Italy is home to some of the world's greatest Renaissance art.     |0.0               |0            |\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "def ranked(model, df):\n",
+        "    \"\"\"Explode the bm25_rankings annotation and sort documents by score.\"\"\"\n",
+        "    return (\n",
+        "        model.transform(df)\n",
+        "        .select(\n",
+        "            col(\"id\"),\n",
+        "            col(\"text\"),\n",
+        "            explode(col(\"bm25_rankings\")).alias(\"ranking\"),\n",
+        "        )\n",
+        "        .select(\n",
+        "            col(\"id\"),\n",
+        "            col(\"text\"),\n",
+        "            col(\"ranking.metadata\")[\"bm25_score\"].cast(\"double\").alias(\"bm25_score\"),\n",
+        "            col(\"ranking.metadata\")[\"num_query_terms_matched\"].cast(\"int\").alias(\"terms_matched\"),\n",
+        "        )\n",
+        "        .orderBy(col(\"bm25_score\").desc())\n",
+        "    )\n",
+        "\n",
+        "\n",
+        "bm25_model.setQuery(\"vitamin C health benefits fruits\")\n",
+        "ranked(pipeline_model, corpus).show(truncate=False)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "K41cvIvnVS2y"
+      },
+      "source": [
+        "The two documents mentioning *vitamin C* (ids 1 and 7) rise to the top, documents with no query term score exactly `0.0`, and `terms_matched` reports how many distinct query terms occurred in each document."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "oy5khz8CVS2y"
+      },
+      "source": [
+        "## 2. Saving and loading a fitted BM25 model\n",
+        "\n",
+        "A fitted `BM25Model` carries the learned IDF map, `avgdl` and document count. It can be persisted once and reloaded later for many queries, no need to re-scan the corpus."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "okBSwpHXVS2y",
+        "outputId": "d0a603b6-0e4a-428f-e6c2-c9a939a66338"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Reloaded N (documents): 10\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "|id |text                                                               |bm25_score        |terms_matched|\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "|4  |Deep learning uses neural networks with many layers.               |6.194256154982231 |4            |\n",
+            "|8  |Neural networks are inspired by the human brain's structure.       |3.0138782681751617|2            |\n",
+            "|3  |Machine learning is a subset of artificial intelligence.           |1.5980234336630559|1            |\n",
+            "|6  |The French Riviera is a warm coastal region in southern France.    |0.0               |0            |\n",
+            "|1  |Apples are a great source of dietary fiber and vitamin C.          |0.0               |0            |\n",
+            "|7  |Vitamin C deficiency can lead to scurvy and immune system problems.|0.0               |0            |\n",
+            "|2  |Bananas are rich in potassium and natural sugars.                  |0.0               |0            |\n",
+            "|9  |Potassium is an essential mineral for heart and muscle function.   |0.0               |0            |\n",
+            "|5  |Florence in Italy is one of the most beautiful cities in Europe.   |0.0               |0            |\n",
+            "|10 |Italy is home to some of the world's greatest Renaissance art.     |0.0               |0            |\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "bm25_model.write().overwrite().save(\"/tmp/bm25_corpus_model\")\n",
+        "\n",
+        "loaded_bm25 = BM25Model.load(\"/tmp/bm25_corpus_model\")\n",
+        "loaded_bm25.setQuery(\"neural networks deep learning\")\n",
+        "\n",
+        "print(\"Reloaded N (documents):\", loaded_bm25.getNumDocuments())\n",
+        "\n",
+        "infer_pipeline = Pipeline(stages=[\n",
+        "    document_assembler,\n",
+        "    tokenizer,\n",
+        "    stop_words_cleaner,\n",
+        "    loaded_bm25,\n",
+        "])\n",
+        "\n",
+        "infer_model = infer_pipeline.fit(corpus)\n",
+        "ranked(infer_model, corpus).show(truncate=False)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DqANdcswVS20"
+      },
+      "source": [
+        "## 3. Reusing the same fitted model with different queries\n",
+        "\n",
+        "BM25 is a \"fit once, query many times\" workflow. The IDF and `avgdl` statistics are computed only during `fit`; calling `setQuery` again simply re-scores the documents with the existing statistics."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "xI8LuPg0VS20",
+        "outputId": "bf15eb79-c18c-48d6-84db-bcf4a26b0e90"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Query: vitamin C health benefits\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "|id |text                                                               |bm25_score        |terms_matched|\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "|1  |Apples are a great source of dietary fiber and vitamin C.          |2.8513563723478614|2            |\n",
+            "|7  |Vitamin C deficiency can lead to scurvy and immune system problems.|2.705465483484128 |2            |\n",
+            "|2  |Bananas are rich in potassium and natural sugars.                  |0.0               |0            |\n",
+            "|6  |The French Riviera is a warm coastal region in southern France.    |0.0               |0            |\n",
+            "|3  |Machine learning is a subset of artificial intelligence.           |0.0               |0            |\n",
+            "|8  |Neural networks are inspired by the human brain's structure.       |0.0               |0            |\n",
+            "|4  |Deep learning uses neural networks with many layers.               |0.0               |0            |\n",
+            "|9  |Potassium is an essential mineral for heart and muscle function.   |0.0               |0            |\n",
+            "|5  |Florence in Italy is one of the most beautiful cities in Europe.   |0.0               |0            |\n",
+            "|10 |Italy is home to some of the world's greatest Renaissance art.     |0.0               |0            |\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "\n",
+            "Query: neural networks artificial intelligence\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "|id |text                                                               |bm25_score        |terms_matched|\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "|3  |Machine learning is a subset of artificial intelligence.           |4.297975613824676 |2            |\n",
+            "|8  |Neural networks are inspired by the human brain's structure.       |3.0138782681751617|2            |\n",
+            "|4  |Deep learning uses neural networks with many layers.               |2.8513563723478614|2            |\n",
+            "|6  |The French Riviera is a warm coastal region in southern France.    |0.0               |0            |\n",
+            "|1  |Apples are a great source of dietary fiber and vitamin C.          |0.0               |0            |\n",
+            "|7  |Vitamin C deficiency can lead to scurvy and immune system problems.|0.0               |0            |\n",
+            "|2  |Bananas are rich in potassium and natural sugars.                  |0.0               |0            |\n",
+            "|9  |Potassium is an essential mineral for heart and muscle function.   |0.0               |0            |\n",
+            "|5  |Florence in Italy is one of the most beautiful cities in Europe.   |0.0               |0            |\n",
+            "|10 |Italy is home to some of the world's greatest Renaissance art.     |0.0               |0            |\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "\n",
+            "Query: Italy France Europe travel\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "|id |text                                                               |bm25_score        |terms_matched|\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "|5  |Florence in Italy is one of the most beautiful cities in Europe.   |3.533438718946651 |2            |\n",
+            "|6  |The French Riviera is a warm coastal region in southern France.    |1.917221596460438 |1            |\n",
+            "|10 |Italy is home to some of the world's greatest Renaissance art.     |1.5069391340875808|1            |\n",
+            "|1  |Apples are a great source of dietary fiber and vitamin C.          |0.0               |0            |\n",
+            "|7  |Vitamin C deficiency can lead to scurvy and immune system problems.|0.0               |0            |\n",
+            "|2  |Bananas are rich in potassium and natural sugars.                  |0.0               |0            |\n",
+            "|8  |Neural networks are inspired by the human brain's structure.       |0.0               |0            |\n",
+            "|3  |Machine learning is a subset of artificial intelligence.           |0.0               |0            |\n",
+            "|9  |Potassium is an essential mineral for heart and muscle function.   |0.0               |0            |\n",
+            "|4  |Deep learning uses neural networks with many layers.               |0.0               |0            |\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "loaded_bm25.setQuery(\"vitamin C health benefits\")\n",
+        "print(\"Query: vitamin C health benefits\")\n",
+        "ranked(infer_model, corpus).show(truncate=False)\n",
+        "\n",
+        "loaded_bm25.setQuery(\"neural networks artificial intelligence\")\n",
+        "print(\"Query: neural networks artificial intelligence\")\n",
+        "ranked(infer_model, corpus).show(truncate=False)\n",
+        "\n",
+        "loaded_bm25.setQuery(\"Italy France Europe travel\")\n",
+        "print(\"Query: Italy France Europe travel\")\n",
+        "ranked(infer_model, corpus).show(truncate=False)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UNOUwQU4VS20"
+      },
+      "source": [
+        "The same fitted `infer_model` produces a different ranking for each query, while reusing the identical IDF/`avgdl` statistics learned during the single `fit`."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "EH-_tXP8VS20"
+      },
+      "source": [
+        "## 4. Ranking with preprocessing\n",
+        "\n",
+        "BM25 plugs into a normal Spark NLP pipeline. Here we add a `Normalizer` (to strip punctuation and lowercase) before stop-word removal, so the tokens fed to BM25 are cleaner."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "PvtNs5NnVS20",
+        "outputId": "dbe06244-f321-4147-ef4c-7c6153479adc"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "|id |text                                                               |bm25_score        |terms_matched|\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "|1  |Apples are a great source of dietary fiber and vitamin C.          |2.834373904376761 |2            |\n",
+            "|7  |Vitamin C deficiency can lead to scurvy and immune system problems.|2.6686210444716867|2            |\n",
+            "|2  |Bananas are rich in potassium and natural sugars.                  |0.0               |0            |\n",
+            "|6  |The French Riviera is a warm coastal region in southern France.    |0.0               |0            |\n",
+            "|3  |Machine learning is a subset of artificial intelligence.           |0.0               |0            |\n",
+            "|8  |Neural networks are inspired by the human brain's structure.       |0.0               |0            |\n",
+            "|4  |Deep learning uses neural networks with many layers.               |0.0               |0            |\n",
+            "|9  |Potassium is an essential mineral for heart and muscle function.   |0.0               |0            |\n",
+            "|5  |Florence in Italy is one of the most beautiful cities in Europe.   |0.0               |0            |\n",
+            "|10 |Italy is home to some of the world's greatest Renaissance art.     |0.0               |0            |\n",
+            "+---+-------------------------------------------------------------------+------------------+-------------+\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "document_assembler = (\n",
+        "    DocumentAssembler()\n",
+        "    .setInputCol(\"text\")\n",
+        "    .setOutputCol(\"document\")\n",
+        ")\n",
+        "\n",
+        "tokenizer = (\n",
+        "    Tokenizer()\n",
+        "    .setInputCols([\"document\"])\n",
+        "    .setOutputCol(\"token\")\n",
+        ")\n",
+        "\n",
+        "normalizer = (\n",
+        "    Normalizer()\n",
+        "    .setInputCols([\"token\"])\n",
+        "    .setOutputCol(\"normalized\")\n",
+        "    .setLowercase(True)\n",
+        ")\n",
+        "\n",
+        "stop_words_cleaner = (\n",
+        "    StopWordsCleaner()\n",
+        "    .setInputCols([\"normalized\"])\n",
+        "    .setOutputCol(\"clean_token\")\n",
+        "    .setCaseSensitive(False)\n",
+        ")\n",
+        "\n",
+        "bm25 = (\n",
+        "    BM25Approach()\n",
+        "    .setInputCols([\"clean_token\"])\n",
+        "    .setOutputCol(\"bm25_rankings\")\n",
+        ")\n",
+        "\n",
+        "preprocess_pipeline = Pipeline(stages=[\n",
+        "    document_assembler,\n",
+        "    tokenizer,\n",
+        "    normalizer,\n",
+        "    stop_words_cleaner,\n",
+        "    bm25,\n",
+        "])\n",
+        "\n",
+        "preprocess_model = preprocess_pipeline.fit(corpus)\n",
+        "preprocess_model.stages[-1].setQuery(\"vitamin C health benefits fruits\")\n",
+        "ranked(preprocess_model, corpus).show(truncate=False)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "I_Dvv3k7VS20"
+      },
+      "source": [
+        "## Notes & limitations\n",
+        "\n",
+        "* **Purely lexical.** BM25 has no notion of synonyms or semantics, *car* and *automobile* are unrelated terms. For semantic ranking, see `DocumentSimilarityRankerApproach` (embedding + LSH based).\n",
+        "* **Vocabulary drift.** If the corpus grows significantly after the model is fit, the IDF map becomes stale and the model should be refit.\n",
+        "* **Annotation output.** Each document yields a single `bm25_rankings` annotation whose `result` is the score and whose `metadata` contains `bm25_score`, `num_query_terms_matched`, `query` and `doc_len`."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "colab": {
+      "provenance": []
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -61,6 +61,7 @@ sys.modules['com.johnsnowlabs.nlp.annotators.er'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.coref'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.cv'] = annotator
 sys.modules['com.johnsnowlabs.nlp.annotators.audio'] = annotator
+sys.modules['com.johnsnowlabs.nlp.annotators.similarity'] = annotator
 sys.modules['com.johnsnowlabs.ml.ai'] = annotator
 
 annotators = annotator

--- a/python/sparknlp/annotator/__init__.py
+++ b/python/sparknlp/annotator/__init__.py
@@ -51,6 +51,7 @@ from sparknlp.annotator.document_character_text_splitter import *
 from sparknlp.annotator.document_title_splitter import *
 from sparknlp.annotator.document_token_splitter import *
 from sparknlp.annotator.vector_db import *
+from sparknlp.annotator.similarity.bm25 import *
 
 if sys.version_info[0] == 2:
     raise ImportError(

--- a/python/sparknlp/annotator/similarity/bm25.py
+++ b/python/sparknlp/annotator/similarity/bm25.py
@@ -1,0 +1,298 @@
+#  Copyright 2017-2025 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Contains classes for the BM25 lexical document ranker."""
+
+from sparknlp.common import *
+from pyspark import keyword_only
+from pyspark.ml.param import TypeConverters, Params, Param
+
+
+class BM25Approach(AnnotatorApproach):
+    """Trains a BM25 (Okapi BM25) lexical ranker over a corpus of tokenized
+    documents.
+
+    BM25 is a bag-of-words retrieval function that ranks documents against a
+    query based on the query terms appearing in each document. Because a
+    document's score depends on corpus-level statistics (how many documents
+    contain a term, and the average document length), BM25 is implemented as a
+    two-phase Estimator/Model pair:
+
+    - ``BM25Approach`` (this class) scans the full corpus once during ``fit()``
+      and learns the document count ``N``, the document frequency ``df(t)`` of
+      every term, the average document length ``avgdl`` and the inverse document
+      frequency ``idf(t)`` of every term.
+    - :class:`BM25Model` reuses those statistics to score every document against
+      a user-provided query.
+
+    The input is a column of ``TOKEN`` annotations, so BM25 is normally placed
+    after a ``Tokenizer`` (optionally followed by a ``Normalizer`` and/or
+    ``StopWordsCleaner``).
+
+    ====================== ================
+    Input Annotation types Output Annotation type
+    ====================== ================
+    ``TOKEN``              ``BM25_RANKINGS``
+    ====================== ================
+
+    Parameters
+    ----------
+    k1
+        Term-frequency saturation parameter (typical range [1.0, 2.0]),
+        by default 1.2
+    b
+        Length-normalization parameter (range [0.0, 1.0]), by default 0.75
+    minDocFreq
+        Drop terms that appear in fewer than this many documents, by default 1
+    caseSensitive
+        Whether to treat tokens case-sensitively when computing statistics,
+        by default False
+
+    Examples
+    --------
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> document_assembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> tokenizer = Tokenizer() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("token")
+    >>> stop_words_cleaner = StopWordsCleaner() \\
+    ...     .setInputCols(["token"]) \\
+    ...     .setOutputCol("clean_token") \\
+    ...     .setCaseSensitive(False)
+    >>> bm25 = BM25Approach() \\
+    ...     .setInputCols(["clean_token"]) \\
+    ...     .setOutputCol("bm25_rankings") \\
+    ...     .setK1(1.2) \\
+    ...     .setB(0.75) \\
+    ...     .setMinDocFreq(1) \\
+    ...     .setCaseSensitive(False)
+    >>> pipeline = Pipeline(stages=[
+    ...     document_assembler, tokenizer, stop_words_cleaner, bm25])
+    >>> model = pipeline.fit(corpus)
+    >>> model.stages[-1].setQuery("vitamin C health benefits fruits")
+    >>> model.transform(corpus).selectExpr("explode(bm25_rankings) as r").show()
+    """
+
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
+
+    outputAnnotatorType = AnnotatorType.BM25_RANKINGS
+
+    k1 = Param(Params._dummy(),
+               "k1",
+               "BM25 term-frequency saturation parameter (typical range [1.0, 2.0])",
+               typeConverter=TypeConverters.toFloat)
+
+    b = Param(Params._dummy(),
+              "b",
+              "BM25 length-normalization parameter (range [0.0, 1.0])",
+              typeConverter=TypeConverters.toFloat)
+
+    minDocFreq = Param(Params._dummy(),
+                       "minDocFreq",
+                       "Drop terms that appear in fewer than this many documents",
+                       typeConverter=TypeConverters.toInt)
+
+    caseSensitive = Param(Params._dummy(),
+                          "caseSensitive",
+                          "Whether to treat tokens case-sensitively when computing statistics",
+                          typeConverter=TypeConverters.toBoolean)
+
+    def setK1(self, value):
+        """Sets the term-frequency saturation parameter k1, by default 1.2.
+
+        Parameters
+        ----------
+        value : float
+            Term-frequency saturation parameter (typical range [1.0, 2.0])
+        """
+        return self._set(k1=value)
+
+    def setB(self, value):
+        """Sets the length-normalization parameter b, by default 0.75.
+
+        Parameters
+        ----------
+        value : float
+            Length-normalization parameter (range [0.0, 1.0])
+        """
+        return self._set(b=value)
+
+    def setMinDocFreq(self, value):
+        """Sets the minimum document frequency for a term to be kept, by default 1.
+
+        Parameters
+        ----------
+        value : int
+            Drop terms that appear in fewer than this many documents
+        """
+        return self._set(minDocFreq=value)
+
+    def setCaseSensitive(self, value):
+        """Sets whether to treat tokens case-sensitively, by default False.
+
+        Parameters
+        ----------
+        value : bool
+            Whether to treat tokens case-sensitively when computing statistics
+        """
+        return self._set(caseSensitive=value)
+
+    @keyword_only
+    def __init__(self):
+        super(BM25Approach, self).__init__(
+            classname="com.johnsnowlabs.nlp.annotators.similarity.BM25Approach")
+        self._setDefault(
+            k1=1.2,
+            b=0.75,
+            minDocFreq=1,
+            caseSensitive=False
+        )
+
+    def _create_model(self, java_model):
+        return BM25Model(java_model=java_model)
+
+
+class BM25Model(AnnotatorModel):
+    """Fitted model produced by :class:`BM25Approach`.
+
+    It holds the corpus-level statistics (IDF map, average document length and
+    document count) and scores every document in a dataset against a query
+    using the Okapi BM25 ranking function. The query is provided at transform
+    time with ``setQuery(...)``, so the same fitted model can be reused for many
+    different queries ("fit once, query many times").
+
+    For every input document the model emits a single ``BM25_RANKINGS``
+    annotation whose ``result`` is the BM25 score and whose ``metadata``
+    contains ``bm25_score``, ``num_query_terms_matched``, ``query`` and
+    ``doc_len``.
+
+    ====================== ================
+    Input Annotation types Output Annotation type
+    ====================== ================
+    ``TOKEN``              ``BM25_RANKINGS``
+    ====================== ================
+
+    Parameters
+    ----------
+    query
+        The query to score every document against. Set this at query time.
+    k1
+        Term-frequency saturation parameter (carried over from the approach)
+    b
+        Length-normalization parameter (carried over from the approach)
+    caseSensitive
+        Whether tokens are treated case-sensitively (carried over from the approach)
+
+    Examples
+    --------
+    >>> from sparknlp.annotator import BM25Model
+    >>> loaded = BM25Model.load("/tmp/bm25_corpus_model")
+    >>> loaded.setQuery("neural networks deep learning")
+    """
+
+    name = "BM25Model"
+    inputAnnotatorTypes = [AnnotatorType.TOKEN]
+    outputAnnotatorType = AnnotatorType.BM25_RANKINGS
+
+    query = Param(Params._dummy(),
+                  "query",
+                  "The query to score every document against",
+                  typeConverter=TypeConverters.toString)
+
+    k1 = Param(Params._dummy(),
+               "k1",
+               "BM25 term-frequency saturation parameter (typical range [1.0, 2.0])",
+               typeConverter=TypeConverters.toFloat)
+
+    b = Param(Params._dummy(),
+              "b",
+              "BM25 length-normalization parameter (range [0.0, 1.0])",
+              typeConverter=TypeConverters.toFloat)
+
+    caseSensitive = Param(Params._dummy(),
+                          "caseSensitive",
+                          "Whether to treat tokens case-sensitively when scoring",
+                          typeConverter=TypeConverters.toBoolean)
+
+    avgDocLength = Param(Params._dummy(),
+                         "avgDocLength",
+                         "Average document length (in tokens) of the training corpus",
+                         typeConverter=TypeConverters.toFloat)
+
+    numDocuments = Param(Params._dummy(),
+                         "numDocuments",
+                         "Total number of documents in the training corpus",
+                         typeConverter=TypeConverters.toInt)
+
+    def setQuery(self, value):
+        """Sets the query that every document is scored against.
+
+        The same fitted model can be re-queried by calling ``setQuery`` again.
+
+        Parameters
+        ----------
+        value : str
+            The query string
+        """
+        return self._set(query=value)
+
+    def setK1(self, value):
+        """Sets the term-frequency saturation parameter k1.
+
+        Parameters
+        ----------
+        value : float
+            Term-frequency saturation parameter (typical range [1.0, 2.0])
+        """
+        return self._set(k1=value)
+
+    def setB(self, value):
+        """Sets the length-normalization parameter b.
+
+        Parameters
+        ----------
+        value : float
+            Length-normalization parameter (range [0.0, 1.0])
+        """
+        return self._set(b=value)
+
+    def setCaseSensitive(self, value):
+        """Sets whether to treat tokens case-sensitively when scoring.
+
+        Parameters
+        ----------
+        value : bool
+            Whether to treat tokens case-sensitively when scoring
+        """
+        return self._set(caseSensitive=value)
+
+    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.similarity.BM25Model",
+                 java_model=None):
+        super(BM25Model, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        # Mirror the Scala-side defaults so the Python params are populated even for a model
+        # constructed outside the fit()/load() paths. Learned statistics (idf, avgDocLength,
+        # numDocuments) are intentionally left unset; they only come from a fitted model.
+        self._setDefault(
+            query="",
+            k1=1.2,
+            b=0.75,
+            caseSensitive=False
+        )

--- a/python/sparknlp/annotator/similarity/bm25.py
+++ b/python/sparknlp/annotator/similarity/bm25.py
@@ -173,13 +173,28 @@ class BM25Model(AnnotatorModel):
     It holds the corpus-level statistics (IDF map, average document length and
     document count) and scores every document in a dataset against a query
     using the Okapi BM25 ranking function. The query is provided at transform
-    time with ``setQuery(...)``, so the same fitted model can be reused for many
-    different queries ("fit once, query many times").
+    time, so the same fitted model can be reused for many different queries
+    ("fit once, query many times"). Provide it either as a raw string with
+    ``setQuery(...)`` or — recommended when the corpus was analyzed by a
+    non-trivial pipeline — as already-analyzed tokens with
+    ``setQueryTokens(...)`` (see the analyzer-symmetry warning below).
 
     For every input document the model emits a single ``BM25_RANKINGS``
     annotation whose ``result`` is the BM25 score and whose ``metadata``
     contains ``bm25_score``, ``num_query_terms_matched``, ``query`` and
     ``doc_len``.
+
+    .. warning::
+        **Analyzer symmetry.** BM25 only scores a query term when it matches a
+        key in the learned IDF vocabulary, and those keys were produced by the
+        pipeline placed in front of ``BM25Approach`` (``Tokenizer``,
+        ``Normalizer``, a stemmer/lemmatizer, ...). A raw-string ``setQuery``
+        is only split on non-word characters and lowercased; if your corpus
+        pipeline *transforms* tokens (stemming, lemmatization, punctuation
+        stripping, ...), a raw query can silently fail to match. In that case
+        run the query through the **same** pipeline (e.g. with a
+        :class:`LightPipeline`) and pass the resulting tokens to
+        ``setQueryTokens``.
 
     ====================== ================
     Input Annotation types Output Annotation type
@@ -190,13 +205,21 @@ class BM25Model(AnnotatorModel):
     Parameters
     ----------
     query
-        The query to score every document against. Set this at query time.
+        The query to score every document against, as a raw string. The model
+        splits it on non-word characters; prefer ``queryTokens`` for non-trivial
+        pipelines (see the analyzer-symmetry warning above).
+    queryTokens
+        The query as a list of already-analyzed terms. When non-empty it
+        overrides ``query``. Obtain these by running the query through the same
+        pipeline used for the corpus, so query and documents match.
     k1
         Term-frequency saturation parameter (carried over from the approach)
     b
         Length-normalization parameter (carried over from the approach)
     caseSensitive
-        Whether tokens are treated case-sensitively (carried over from the approach)
+        Whether tokens are treated case-sensitively. Read-only: it is fixed when
+        the corpus statistics are computed and must not be changed on a fitted
+        model, so there is no ``setCaseSensitive`` here.
 
     Examples
     --------
@@ -214,6 +237,11 @@ class BM25Model(AnnotatorModel):
                   "The query to score every document against",
                   typeConverter=TypeConverters.toString)
 
+    queryTokens = Param(Params._dummy(),
+                        "queryTokens",
+                        "Pre-analyzed query terms; when non-empty they override the raw query string",
+                        typeConverter=TypeConverters.toListString)
+
     k1 = Param(Params._dummy(),
                "k1",
                "BM25 term-frequency saturation parameter (typical range [1.0, 2.0])",
@@ -226,7 +254,7 @@ class BM25Model(AnnotatorModel):
 
     caseSensitive = Param(Params._dummy(),
                           "caseSensitive",
-                          "Whether to treat tokens case-sensitively when scoring",
+                          "Whether to treat tokens case-sensitively when scoring (read-only; fixed at fit time)",
                           typeConverter=TypeConverters.toBoolean)
 
     avgDocLength = Param(Params._dummy(),
@@ -251,6 +279,21 @@ class BM25Model(AnnotatorModel):
         """
         return self._set(query=value)
 
+    def setQueryTokens(self, value):
+        """Sets the query as a list of already-analyzed terms.
+
+        When non-empty these override the raw ``query`` string. Obtain them by
+        running the query through the same pipeline used for the corpus (for
+        example with a :class:`LightPipeline`) so that the query and the
+        documents are analyzed identically.
+
+        Parameters
+        ----------
+        value : List[str]
+            Pre-analyzed query terms
+        """
+        return self._set(queryTokens=value)
+
     def setK1(self, value):
         """Sets the term-frequency saturation parameter k1.
 
@@ -271,16 +314,6 @@ class BM25Model(AnnotatorModel):
         """
         return self._set(b=value)
 
-    def setCaseSensitive(self, value):
-        """Sets whether to treat tokens case-sensitively when scoring.
-
-        Parameters
-        ----------
-        value : bool
-            Whether to treat tokens case-sensitively when scoring
-        """
-        return self._set(caseSensitive=value)
-
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.similarity.BM25Model",
                  java_model=None):
         super(BM25Model, self).__init__(
@@ -292,6 +325,7 @@ class BM25Model(AnnotatorModel):
         # numDocuments) are intentionally left unset; they only come from a fitted model.
         self._setDefault(
             query="",
+            queryTokens=[],
             k1=1.2,
             b=0.75,
             caseSensitive=False

--- a/python/sparknlp/annotator/similarity/bm25.py
+++ b/python/sparknlp/annotator/similarity/bm25.py
@@ -314,6 +314,27 @@ class BM25Model(AnnotatorModel):
         """
         return self._set(b=value)
 
+    def setCaseSensitive(self, value):
+        """``caseSensitive`` is read-only on a fitted ``BM25Model`` and cannot be set.
+
+        It is fixed when the corpus statistics are computed by :class:`BM25Approach` and is baked
+        into the IDF vocabulary keys. Changing it on a fitted model would desynchronize the
+        query/document terms from the stored vocabulary and silently corrupt every score, so set
+        it on :class:`BM25Approach` before ``fit()`` instead.
+
+        This method is defined only to override the setter that Spark NLP would otherwise generate
+        automatically for every parameter; calling it always raises.
+
+        Raises
+        ------
+        AttributeError
+            Always, because ``caseSensitive`` is read-only on the model.
+        """
+        raise AttributeError(
+            "caseSensitive is read-only on a fitted BM25Model: it is fixed when the corpus "
+            "statistics are computed by BM25Approach and baked into the IDF vocabulary. Set it on "
+            "BM25Approach before fit() instead.")
+
     def __init__(self, classname="com.johnsnowlabs.nlp.annotators.similarity.BM25Model",
                  java_model=None):
         super(BM25Model, self).__init__(

--- a/python/sparknlp/common/annotator_type.py
+++ b/python/sparknlp/common/annotator_type.py
@@ -36,3 +36,4 @@ class AnnotatorType(object):
     TABLE = "table"
     DUMMY = "dummy"
     DOC_SIMILARITY_RANKINGS = "doc_similarity_rankings"
+    BM25_RANKINGS = "bm25_rankings"

--- a/python/test/annotator/similarity/bm25_test.py
+++ b/python/test/annotator/similarity/bm25_test.py
@@ -136,3 +136,24 @@ class BM25TestSpec(unittest.TestCase):
 
         custom_model.setQuery("vitamin")
         self.assertTrue(all(r["bm25_score"] == 0.0 for r in self._ranked(custom_pipeline_model)))
+
+
+@pytest.mark.fast
+class BM25QueryTokensTestSpec(BM25TestSpec):
+    def runTest(self):
+        pipeline_model = self._fit()
+        bm25_model = pipeline_model.stages[-1]
+
+        # Pre-analyzed tokens are scored just like the equivalent raw query.
+        bm25_model.setQueryTokens(["vitamin", "c", "health", "benefits", "fruits"])
+        ranked = self._ranked(pipeline_model)
+        self.assertEqual({ranked[0]["id"], ranked[1]["id"]}, {1, 7})
+
+        # When both are set, queryTokens take precedence over the raw query string.
+        bm25_model.setQuery("neural networks deep learning")
+        bm25_model.setQueryTokens(["vitamin", "c"])
+        ranked = self._ranked(pipeline_model)
+        self.assertEqual({ranked[0]["id"], ranked[1]["id"]}, {1, 7})
+
+        # caseSensitive is fixed at fit time: the fitted model must not expose a setter for it.
+        self.assertFalse(hasattr(bm25_model, "setCaseSensitive"))

--- a/python/test/annotator/similarity/bm25_test.py
+++ b/python/test/annotator/similarity/bm25_test.py
@@ -140,6 +140,11 @@ class BM25TestSpec(unittest.TestCase):
 
 @pytest.mark.fast
 class BM25QueryTokensTestSpec(BM25TestSpec):
+    """Pre-analyzed queries (setQueryTokens) and the read-only caseSensitive lockdown.
+
+    Reuses the corpus and pipeline stages built by BM25TestSpec.setUp / _fit / _ranked.
+    """
+
     def runTest(self):
         pipeline_model = self._fit()
         bm25_model = pipeline_model.stages[-1]
@@ -155,5 +160,58 @@ class BM25QueryTokensTestSpec(BM25TestSpec):
         ranked = self._ranked(pipeline_model)
         self.assertEqual({ranked[0]["id"], ranked[1]["id"]}, {1, 7})
 
-        # caseSensitive is fixed at fit time: the fitted model must not expose a setter for it.
-        self.assertFalse(hasattr(bm25_model, "setCaseSensitive"))
+        # caseSensitive is fixed at fit time and baked into the IDF vocabulary: the getter still
+        # works (reflecting the value learned during fit), but the setter must refuse to mutate it.
+        self.assertFalse(bm25_model.getCaseSensitive())
+        with self.assertRaises(AttributeError):
+            bm25_model.setCaseSensitive(True)
+
+
+@pytest.mark.fast
+class BM25ExactScoreTestSpec(unittest.TestCase):
+    """Hand-computed BM25 verification mirroring the Scala BM25TestSpec, so the Python -> JVM
+    parameter round-trip is checked against exact numbers, not just ranking order."""
+
+    def setUp(self):
+        self.spark = SparkSessionForTest.spark
+        # A tiny corpus with no stop words, so tokens are fully predictable.
+        self.data = self.spark.createDataFrame(
+            [(1, "apple apple banana"), (2, "banana cherry"), (3, "cherry")], ["id", "text"])
+        self.document_assembler = DocumentAssembler() \
+            .setInputCol("text").setOutputCol("document")
+        self.tokenizer = Tokenizer().setInputCols(["document"]).setOutputCol("token")
+
+    def runTest(self):
+        import math
+
+        bm25 = BM25Approach().setInputCols(["token"]).setOutputCol("bm25_rankings")
+        model = Pipeline(stages=[self.document_assembler, self.tokenizer, bm25]).fit(self.data)
+        bm25_model = model.stages[-1]
+
+        # N = 3 documents, lengths 3 + 2 + 1 = 6 -> avgdl = 2.0
+        self.assertEqual(bm25_model.getNumDocuments(), 3)
+        self.assertAlmostEqual(bm25_model.getAvgDocLength(), 2.0, places=9)
+
+        bm25_model.setQuery("apple banana")
+        scored = {
+            row["id"]: (row["score"], row["matched"])
+            for row in (
+                model.transform(self.data)
+                .select(
+                    col("id"),
+                    col("bm25_rankings.metadata")[0]["bm25_score"].cast("double").alias("score"),
+                    col("bm25_rankings.metadata")[0]["num_query_terms_matched"].cast("int").alias("matched"))
+                .collect())
+        }
+
+        # Hand-computed BM25 for document 1 ("apple apple banana", len 3, avgdl 2, k1=1.2, b=0.75):
+        #   lengthNorm = 1.2 * (1 - 0.75 + 0.75 * 3/2) = 1.65
+        #   df(apple)=1, df(banana)=2 ; idf(t) = ln(1 + (N - df + 0.5) / (df + 0.5))
+        length_norm = 1.2 * (1.0 - 0.75 + 0.75 * 3.0 / 2.0)
+        expected_doc1 = (
+            math.log(1.0 + 2.5 / 1.5) * (2 * 2.2) / (2 + length_norm)
+            + math.log(1.6) * (1 * 2.2) / (1 + length_norm))
+        self.assertAlmostEqual(scored[1][0], expected_doc1, places=9)
+        self.assertEqual(scored[1][1], 2)       # both query terms matched in document 1
+        self.assertEqual(scored[3][0], 0.0)     # document 3 ("cherry") has neither query term
+        self.assertEqual(scored[3][1], 0)

--- a/python/test/annotator/similarity/bm25_test.py
+++ b/python/test/annotator/similarity/bm25_test.py
@@ -1,0 +1,138 @@
+#  Copyright 2017-2025 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import shutil
+import tempfile
+import unittest
+
+import pytest
+from pyspark.ml import Pipeline
+from pyspark.sql.functions import col, explode
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from test.util import SparkSessionForTest
+
+
+@pytest.mark.fast
+class BM25TestSpec(unittest.TestCase):
+    def setUp(self):
+        self.spark = SparkSessionForTest.spark
+        self.data = self.spark.createDataFrame([
+            (1, "Apples are a great source of dietary fiber and vitamin C."),
+            (2, "Bananas are rich in potassium and natural sugars."),
+            (3, "Machine learning is a subset of artificial intelligence."),
+            (4, "Deep learning uses neural networks with many layers."),
+            (5, "Florence in Italy is one of the most beautiful cities in Europe."),
+            (6, "The French Riviera is a warm coastal region in southern France."),
+            (7, "Vitamin C deficiency can lead to scurvy and immune system problems."),
+            (8, "Neural networks are inspired by the human brain's structure."),
+            (9, "Potassium is an essential mineral for heart and muscle function."),
+            (10, "Italy is home to some of the world's greatest Renaissance art."),
+        ], ["id", "text"])
+
+        self.document_assembler = DocumentAssembler() \
+            .setInputCol("text") \
+            .setOutputCol("document")
+        self.tokenizer = Tokenizer() \
+            .setInputCols(["document"]) \
+            .setOutputCol("token")
+        self.stop_words_cleaner = StopWordsCleaner() \
+            .setInputCols(["token"]) \
+            .setOutputCol("clean_token") \
+            .setCaseSensitive(False)
+
+    def _fit(self):
+        bm25 = BM25Approach() \
+            .setInputCols(["clean_token"]) \
+            .setOutputCol("bm25_rankings") \
+            .setK1(1.2) \
+            .setB(0.75) \
+            .setMinDocFreq(1) \
+            .setCaseSensitive(False)
+        pipeline = Pipeline(stages=[
+            self.document_assembler, self.tokenizer, self.stop_words_cleaner, bm25])
+        return pipeline.fit(self.data)
+
+    def _ranked(self, model):
+        result = model.transform(self.data)
+        return (
+            result
+            .select(col("id"), explode(col("bm25_rankings")).alias("ranking"))
+            .select(
+                col("id"),
+                col("ranking.metadata")["bm25_score"].cast("double").alias("bm25_score"),
+                col("ranking.metadata")["num_query_terms_matched"].cast("int").alias("terms_matched"))
+            .orderBy(col("bm25_score").desc())
+            .collect()
+        )
+
+    def runTest(self):
+        pipeline_model = self._fit()
+        bm25_model = pipeline_model.stages[-1]
+
+        # 1. Statistics learned during fit
+        self.assertEqual(bm25_model.getNumDocuments(), 10)
+        self.assertTrue(bm25_model.getAvgDocLength() > 0.0)
+
+        # 2. Ranking with a global query
+        bm25_model.setQuery("vitamin C health benefits fruits")
+        ranked = self._ranked(pipeline_model)
+        for row in ranked:
+            print(f"id={row['id']} score={row['bm25_score']} matched={row['terms_matched']}")
+        top_two = {ranked[0]["id"], ranked[1]["id"]}
+        self.assertEqual(top_two, {1, 7})
+        self.assertTrue(all(r["bm25_score"] >= 0.0 for r in ranked))
+
+        # 3. Reuse the same fitted model with a different query
+        bm25_model.setQuery("neural networks deep learning")
+        ai_ranked = self._ranked(pipeline_model)
+        self.assertIn(ai_ranked[0]["id"], {4, 8})
+
+        # 4. Save and load the fitted model, then reuse it
+        tmp_dir = tempfile.mkdtemp()
+        model_path = os.path.join(tmp_dir, "bm25_corpus_model")
+        try:
+            bm25_model.write().overwrite().save(model_path)
+            loaded = BM25Model.load(model_path)
+            self.assertEqual(loaded.getNumDocuments(), 10)
+
+            loaded.setQuery("Italy France Europe travel")
+            infer_pipeline = Pipeline(stages=[
+                self.document_assembler, self.tokenizer, self.stop_words_cleaner, loaded])
+            infer_model = infer_pipeline.fit(self.data)
+            travel_ranked = self._ranked(infer_model)
+            self.assertIn(travel_ranked[0]["id"], {5, 6, 10})
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+        # 5. Non-default tuning params must propagate from the approach to the fitted model, and
+        # minDocFreq must prune rare terms. "vitamin" appears in only 2 documents, so minDocFreq=3
+        # drops it; a query made solely of pruned terms then scores 0 for every document.
+        custom = (
+            BM25Approach()
+            .setInputCols(["clean_token"])
+            .setOutputCol("bm25_rankings")
+            .setK1(2.0)
+            .setB(0.5)
+            .setMinDocFreq(3)
+        )
+        custom_pipeline_model = Pipeline(stages=[
+            self.document_assembler, self.tokenizer, self.stop_words_cleaner, custom]).fit(self.data)
+        custom_model = custom_pipeline_model.stages[-1]
+        self.assertEqual(custom_model.getK1(), 2.0)
+        self.assertEqual(custom_model.getB(), 0.5)
+
+        custom_model.setQuery("vitamin")
+        self.assertTrue(all(r["bm25_score"] == 0.0 for r in self._ranked(custom_pipeline_model)))

--- a/src/main/scala/com/johnsnowlabs/nlp/AnnotatorType.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/AnnotatorType.scala
@@ -39,4 +39,5 @@ object AnnotatorType {
   val TABLE = "table"
   val DUMMY = "dummy"
   val DOC_SIMILARITY_RANKINGS = "doc_similarity_rankings"
+  val BM25_RANKINGS = "bm25_rankings"
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25Approach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25Approach.scala
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2017-2025 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.similarity
+
+import com.johnsnowlabs.nlp.AnnotatorType.{BM25_RANKINGS, TOKEN}
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorApproach, AnnotatorType}
+import org.apache.spark.ml.PipelineModel
+import org.apache.spark.ml.param.{BooleanParam, DoubleParam, IntParam, ParamValidators}
+import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
+import org.apache.spark.sql.{Dataset, Row}
+
+/** Trains a BM25 (Okapi BM25) lexical ranker over a corpus of tokenized documents.
+  *
+  * BM25 is a bag-of-words retrieval function that ranks documents against a query based on the
+  * query terms appearing in each document. Because the score of a document depends on
+  * corpus-level statistics (how many documents contain a term, and the average document length),
+  * BM25 has to be implemented as a two-phase Estimator/Model pair:
+  *
+  *   - [[BM25Approach]] (this class) scans the full corpus once during `fit()` and learns:
+  *     - the total document count `N`
+  *     - the document frequency `df(t)` of every vocabulary term
+  *     - the average document length `avgdl`
+  *     - the inverse document frequency `idf(t)` of every term
+  *   - [[BM25Model]] reuses those statistics at query time to score every document against a
+  *     user-provided query, emitting a `BM25_RANKINGS` annotation with the relevance score.
+  *
+  * The IDF uses the non-negative (Lucene / Elasticsearch) variant:
+  * {{{
+  *   idf(t) = ln(1 + (N - df(t) + 0.5) / (df(t) + 0.5))
+  * }}}
+  * and each document is scored as:
+  * {{{
+  *   score(D, Q) = sum over t in Q of
+  *     idf(t) * (tf(t, D) * (k1 + 1)) / (tf(t, D) + k1 * (1 - b + b * |D| / avgdl))
+  * }}}
+  *
+  * The input is a column of `TOKEN` annotations, so BM25 is normally placed after a [[Tokenizer]]
+  * (optionally followed by a [[Normalizer]] and/or [[StopWordsCleaner]]). For the produced model
+  * and usage examples see [[BM25Model]].
+  *
+  * ==Example==
+  * {{{
+  * import com.johnsnowlabs.nlp.base.DocumentAssembler
+  * import com.johnsnowlabs.nlp.annotators.{StopWordsCleaner, Tokenizer}
+  * import com.johnsnowlabs.nlp.annotators.similarity.BM25Approach
+  * import org.apache.spark.ml.Pipeline
+  *
+  * val documentAssembler = new DocumentAssembler()
+  *   .setInputCol("text")
+  *   .setOutputCol("document")
+  *
+  * val tokenizer = new Tokenizer()
+  *   .setInputCols("document")
+  *   .setOutputCol("token")
+  *
+  * val stopWords = new StopWordsCleaner()
+  *   .setInputCols("token")
+  *   .setOutputCol("clean_token")
+  *   .setCaseSensitive(false)
+  *
+  * val bm25 = new BM25Approach()
+  *   .setInputCols("clean_token")
+  *   .setOutputCol("bm25_rankings")
+  *   .setK1(1.2)
+  *   .setB(0.75)
+  *   .setMinDocFreq(1)
+  *   .setCaseSensitive(false)
+  *
+  * val pipeline = new Pipeline().setStages(
+  *   Array(documentAssembler, tokenizer, stopWords, bm25))
+  *
+  * val model = pipeline.fit(corpus)
+  * model.stages.last.asInstanceOf[BM25Model].setQuery("vitamin C health benefits fruits")
+  * model.transform(corpus).selectExpr("explode(bm25_rankings) as ranking").show(false)
+  * }}}
+  *
+  * @groupname anno Annotator types
+  * @groupdesc anno
+  *   Required input and expected output annotator types
+  * @groupname param Parameters
+  * @groupname setParam Parameter setters
+  * @groupname getParam Parameter getters
+  * @groupprio param  1
+  * @groupprio anno  2
+  * @groupprio setParam  4
+  * @groupprio getParam  5
+  */
+class BM25Approach(override val uid: String) extends AnnotatorApproach[BM25Model] {
+
+  def this() = this(Identifiable.randomUID("BM25Approach"))
+
+  override val description: String = "BM25 lexical document ranker"
+
+  /** Input annotator type: TOKEN
+    *
+    * @group anno
+    */
+  override val inputAnnotatorTypes: Array[AnnotatorType] = Array(TOKEN)
+
+  /** Output annotator type: BM25_RANKINGS
+    *
+    * @group anno
+    */
+  override val outputAnnotatorType: AnnotatorType = BM25_RANKINGS
+
+  /** Term-frequency saturation parameter `k1`. Higher values let the score keep growing with term
+    * frequency; lower values saturate faster. Typical range `[1.0, 2.0]` (Default: `1.2`).
+    *
+    * @group param
+    */
+  val k1 = new DoubleParam(
+    this,
+    "k1",
+    "BM25 term-frequency saturation parameter (typical range [1.0, 2.0])",
+    ParamValidators.gtEq(0.0))
+
+  /** @group setParam */
+  def setK1(value: Double): this.type = set(k1, value)
+
+  /** @group getParam */
+  def getK1: Double = $(k1)
+
+  /** Length-normalization parameter `b`. `0.0` disables document-length normalization, `1.0`
+    * applies it fully. Range `[0.0, 1.0]` (Default: `0.75`).
+    *
+    * @group param
+    */
+  val b = new DoubleParam(
+    this,
+    "b",
+    "BM25 length-normalization parameter (range [0.0, 1.0])",
+    ParamValidators.inRange(0.0, 1.0))
+
+  /** @group setParam */
+  def setB(value: Double): this.type = set(b, value)
+
+  /** @group getParam */
+  def getB: Double = $(b)
+
+  /** Minimum document frequency for a term to be kept in the vocabulary. Terms appearing in fewer
+    * than `minDocFreq` documents are dropped from the IDF map (Default: `1`).
+    *
+    * @group param
+    */
+  val minDocFreq = new IntParam(
+    this,
+    "minDocFreq",
+    "Drop terms that appear in fewer than this many documents",
+    ParamValidators.gtEq(1))
+
+  /** @group setParam */
+  def setMinDocFreq(value: Int): this.type = set(minDocFreq, value)
+
+  /** @group getParam */
+  def getMinDocFreq: Int = $(minDocFreq)
+
+  /** Whether to treat tokens case-sensitively. When `false` (Default), terms are lowercased
+    * before the corpus statistics are computed (and again when a query is scored).
+    *
+    * @group param
+    */
+  val caseSensitive = new BooleanParam(
+    this,
+    "caseSensitive",
+    "Whether to treat tokens case-sensitively when computing statistics")
+
+  /** @group setParam */
+  def setCaseSensitive(value: Boolean): this.type = set(caseSensitive, value)
+
+  /** @group getParam */
+  def getCaseSensitive: Boolean = $(caseSensitive)
+
+  setDefault(k1 -> 1.2, b -> 0.75, minDocFreq -> 1, caseSensitive -> false)
+
+  override def train(dataset: Dataset[_], recursivePipeline: Option[PipelineModel]): BM25Model = {
+
+    val inputCol = getInputCols.head
+    val isCaseSensitive = $(caseSensitive)
+
+    // Extract the normalized term list for every document from its TOKEN annotations. Empty
+    // documents are kept on purpose: BM25's corpus statistics (document count N and average
+    // document length) are defined over *all* documents, and a zero-length document naturally
+    // contributes nothing to the document frequencies.
+    val docTerms = dataset
+      .select(inputCol)
+      .rdd
+      .map { row =>
+        Option(row.getAs[Seq[Row]](0)).getOrElse(Seq.empty).map { annotationRow =>
+          val term = Annotation(annotationRow).result
+          if (isCaseSensitive) term else term.toLowerCase
+        }
+      }
+
+    // Cache: we scan the corpus twice (statistics, then document frequencies).
+    docTerms.persist()
+
+    try {
+      // Single pass for both the document count and the total token count.
+      val (numDocuments, totalLength) = docTerms.aggregate((0L, 0L))(
+        (acc, terms) => (acc._1 + 1L, acc._2 + terms.length),
+        (a, b) => (a._1 + b._1, a._2 + b._2))
+
+      require(
+        numDocuments > 0,
+        "BM25Approach received an empty corpus. Make sure the input token column is populated.")
+
+      val avgDocLength = totalLength.toDouble / numDocuments.toDouble
+
+      // Document frequency: count each distinct term once per document.
+      val docFreq = docTerms
+        .flatMap(_.distinct.map(term => (term, 1L)))
+        .reduceByKey(_ + _)
+        .filter { case (_, df) => df >= $(minDocFreq) }
+        .collectAsMap()
+
+      val n = numDocuments.toDouble
+      val idf = docFreq.map { case (term, df) =>
+        // Non-negative (Lucene/Elasticsearch) IDF variant.
+        term -> math.log(1.0 + (n - df + 0.5) / (df + 0.5))
+      }.toMap
+
+      new BM25Model()
+        .setIdf(idf)
+        .setAvgDocLength(avgDocLength)
+        .setNumDocuments(numDocuments)
+    } finally {
+      docTerms.unpersist()
+    }
+  }
+}
+
+/** This is the companion object of [[BM25Approach]]. Please refer to that class for the
+  * documentation.
+  */
+object BM25Approach extends DefaultParamsReadable[BM25Approach]

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25Approach.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25Approach.scala
@@ -48,9 +48,15 @@ import org.apache.spark.sql.{Dataset, Row}
   *     idf(t) * (tf(t, D) * (k1 + 1)) / (tf(t, D) + k1 * (1 - b + b * |D| / avgdl))
   * }}}
   *
-  * The input is a column of `TOKEN` annotations, so BM25 is normally placed after a [[Tokenizer]]
-  * (optionally followed by a [[Normalizer]] and/or [[StopWordsCleaner]]). For the produced model
+  * The input is a column of `TOKEN` annotations, so BM25 is normally placed after a
+  * [[com.johnsnowlabs.nlp.annotators.Tokenizer Tokenizer]] (optionally followed by a
+  * [[com.johnsnowlabs.nlp.annotators.Normalizer Normalizer]] and/or
+  * [[com.johnsnowlabs.nlp.annotators.StopWordsCleaner StopWordsCleaner]]). For the produced model
   * and usage examples see [[BM25Model]].
+  *
+  * The learned vocabulary (document frequencies and IDF) is collected to the driver during
+  * `fit()`. For corpora with a very large number of distinct terms, raise [[minDocFreq]] to prune
+  * rare terms and keep the driver-side vocabulary bounded.
   *
   * ==Example==
   * {{{

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25Model.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25Model.scala
@@ -26,7 +26,14 @@ import com.johnsnowlabs.nlp.{
   ParamsAndFeaturesReadable,
   ParamsAndFeaturesWritable
 }
-import org.apache.spark.ml.param.{BooleanParam, DoubleParam, LongParam, Param, ParamValidators}
+import org.apache.spark.ml.param.{
+  BooleanParam,
+  DoubleParam,
+  LongParam,
+  Param,
+  ParamValidators,
+  StringArrayParam
+}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.Dataset
 
@@ -34,10 +41,14 @@ import org.apache.spark.sql.Dataset
   * average document length and document count) and scores every document in a dataset against a
   * user-provided query using the Okapi BM25 ranking function.
   *
-  * The query is provided at transform time with `setQuery(...)`, so the same fitted model can be
-  * reused for many different queries ("fit once, query many times"). For every input document the
-  * model emits a single `BM25_RANKINGS` annotation whose `result` is the BM25 score and whose
-  * metadata contains:
+  * The query is provided at transform time, so the same fitted model can be reused for many
+  * different queries ("fit once, query many times"). Provide it either as a raw string with
+  * `setQuery(...)` (the model splits it on non-word characters) or — recommended when the corpus
+  * was analyzed by a non-trivial pipeline — as already-analyzed tokens with
+  * `setQueryTokens(...)`, so the query and the documents are tokenized/normalized identically
+  * (see the analyzer-symmetry note on the `query` parameter). For every input document the model
+  * emits a single `BM25_RANKINGS` annotation whose `result` is the BM25 score and whose metadata
+  * contains:
   *
   *   - `bm25_score` — the BM25 relevance score of the document for the current query
   *   - `num_query_terms_matched` — how many distinct query terms occur in the document
@@ -172,7 +183,11 @@ class BM25Model(override val uid: String)
   /** @group getParam */
   def getB: Double = $(b)
 
-  /** Whether tokens are treated case-sensitively (carried over from [[BM25Approach]]). The query
+  /** Whether tokens are treated case-sensitively. This is '''fixed when the corpus statistics are
+    * computed''' by [[BM25Approach]] and carried onto the model: the IDF vocabulary keys are
+    * stored with that exact case handling. Changing it on a fitted model would desynchronize the
+    * query/document terms from the stored vocabulary and silently corrupt the scores, so it is
+    * deliberately '''read-only''' here — there is no `setCaseSensitive` on the model. The query
     * is normalized with the same setting before scoring.
     *
     * @group param
@@ -180,16 +195,27 @@ class BM25Model(override val uid: String)
   val caseSensitive = new BooleanParam(
     this,
     "caseSensitive",
-    "Whether to treat tokens case-sensitively when scoring")
-
-  /** @group setParam */
-  def setCaseSensitive(value: Boolean): this.type = set(caseSensitive, value)
+    "Whether to treat tokens case-sensitively when scoring (read-only; fixed at fit time)")
 
   /** @group getParam */
   def getCaseSensitive: Boolean = $(caseSensitive)
 
-  /** The query that documents are scored against. Set this at query time; the same fitted model
-    * can be re-queried by calling `setQuery` again (Default: empty).
+  /** The query that documents are scored against, as a raw string. This is a '''convenience''':
+    * the model tokenizes it itself by splitting on non-word characters (`\W+`) and applying the
+    * model's case handling — it does '''not''' run the query through the same annotator pipeline
+    * used for the corpus.
+    *
+    * '''Analyzer-symmetry warning.''' BM25 only scores a query term when it matches a key in the
+    * learned IDF vocabulary, and those keys were produced by the pipeline placed in front of
+    * [[BM25Approach]] (e.g. [[com.johnsnowlabs.nlp.annotators.Tokenizer Tokenizer]],
+    * [[com.johnsnowlabs.nlp.annotators.Normalizer Normalizer]], a stemmer/lemmatizer, ...). If
+    * that pipeline ''transforms'' tokens (stemming, lemmatization, punctuation stripping, ...), a
+    * raw-string query analyzed only by `\W+` + lowercasing can fail to match and silently
+    * contribute nothing to the score. For anything beyond plain tokenization, analyze the query
+    * with the '''same''' pipeline and pass the resulting tokens via [[setQueryTokens]].
+    *
+    * Either `query` or `queryTokens` must be set before `transform`; when both are set,
+    * `queryTokens` takes precedence (Default: empty).
     *
     * @group param
     */
@@ -201,22 +227,48 @@ class BM25Model(override val uid: String)
   /** @group getParam */
   def getQuery: String = $(query)
 
+  /** The query as a list of '''already-analyzed''' terms. This is the recommended way to query
+    * when the corpus was built with a non-trivial pipeline: run the query string through the very
+    * same stages used for the documents (for example with a
+    * [[com.johnsnowlabs.nlp.LightPipeline LightPipeline]]) and pass the resulting tokens here, so
+    * the query and the documents are analyzed identically. When non-empty, `queryTokens`
+    * overrides [[query]]. The model still applies its (read-only) case handling to these tokens
+    * so they line up with the stored IDF keys (Default: empty).
+    *
+    * @group param
+    */
+  val queryTokens = new StringArrayParam(
+    this,
+    "queryTokens",
+    "Pre-analyzed query terms; when non-empty they override the raw query string")
+
+  /** @group setParam */
+  def setQueryTokens(value: Array[String]): this.type = set(queryTokens, value)
+
+  /** @group getParam */
+  def getQueryTokens: Array[String] = $(queryTokens)
+
   setDefault(
     inputCols -> Array(TOKEN),
     outputCol -> BM25_RANKINGS,
     k1 -> 1.2,
     b -> 0.75,
     caseSensitive -> false,
-    query -> "")
+    query -> "",
+    queryTokens -> Array.empty[String])
 
-  /** Splits a raw query string into normalized terms, applying the same case handling that was
-    * used when the corpus statistics were computed. The `(?U)` flag makes `\W` Unicode-aware so
-    * accented and other non-ASCII letters are kept as part of a term rather than used as
-    * delimiters.
+  /** Resolves the effective query terms, applying the same case handling that was used when the
+    * corpus statistics were computed so the terms line up with the stored IDF keys. Pre-analyzed
+    * [[queryTokens]] take precedence when set; otherwise the raw [[query]] string is split on
+    * non-word characters. The `(?U)` flag makes `\W` Unicode-aware so accented and other
+    * non-ASCII letters are kept as part of a term rather than used as delimiters.
     */
   private def queryTerms: Array[String] = {
-    val rawTerms = $(query).split("(?U)\\W+").filter(_.nonEmpty)
-    if ($(caseSensitive)) rawTerms else rawTerms.map(_.toLowerCase)
+    val rawTerms =
+      if ($(queryTokens).nonEmpty) $(queryTokens)
+      else $(query).split("(?U)\\W+")
+    val nonEmpty = rawTerms.filter(_.nonEmpty)
+    if ($(caseSensitive)) nonEmpty else nonEmpty.map(_.toLowerCase)
   }
 
   override def beforeAnnotate(dataset: Dataset[_]): Dataset[_] = {
@@ -225,8 +277,10 @@ class BM25Model(override val uid: String)
       "BM25Model is missing its learned statistics. Produce the model with BM25Approach.fit(...) " +
         "or load a previously fitted model before calling transform.")
     require(
-      $(query).trim.nonEmpty,
-      "BM25Model requires a query. Set one with setQuery(\"...\") before calling transform.")
+      $(query).trim.nonEmpty || $(queryTokens).exists(_.trim.nonEmpty),
+      "BM25Model requires a query. Set one with setQuery(\"...\") for a quick raw-string query, or " +
+        "setQueryTokens(Array(...)) with the query analyzed by the same pipeline as the corpus " +
+        "(recommended) before calling transform.")
     dataset
   }
 
@@ -267,6 +321,10 @@ class BM25Model(override val uid: String)
       }
     }
 
+    // Report whichever query representation was actually used for scoring.
+    val effectiveQuery =
+      if ($(queryTokens).nonEmpty) $(queryTokens).mkString(" ") else $(query)
+
     val begin = annotations.headOption.map(_.begin).getOrElse(0)
     val end = annotations.lastOption.map(_.end).getOrElse(0)
 
@@ -279,7 +337,7 @@ class BM25Model(override val uid: String)
         metadata = Map(
           "bm25_score" -> score.toString,
           "num_query_terms_matched" -> matched.toString,
-          "query" -> $(query),
+          "query" -> effectiveQuery,
           "doc_len" -> docLength.toString),
         embeddings = Array.emptyFloatArray))
   }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25Model.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25Model.scala
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2017-2025 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.similarity
+
+import com.johnsnowlabs.nlp.AnnotatorType.{BM25_RANKINGS, TOKEN}
+import com.johnsnowlabs.nlp.serialization.MapFeature
+import com.johnsnowlabs.nlp.{
+  Annotation,
+  AnnotatorModel,
+  AnnotatorType,
+  HasSimpleAnnotate,
+  ParamsAndFeaturesReadable,
+  ParamsAndFeaturesWritable
+}
+import org.apache.spark.ml.param.{BooleanParam, DoubleParam, LongParam, Param, ParamValidators}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.Dataset
+
+/** Fitted model produced by [[BM25Approach]]. It holds the corpus-level statistics (IDF map,
+  * average document length and document count) and scores every document in a dataset against a
+  * user-provided query using the Okapi BM25 ranking function.
+  *
+  * The query is provided at transform time with `setQuery(...)`, so the same fitted model can be
+  * reused for many different queries ("fit once, query many times"). For every input document the
+  * model emits a single `BM25_RANKINGS` annotation whose `result` is the BM25 score and whose
+  * metadata contains:
+  *
+  *   - `bm25_score` — the BM25 relevance score of the document for the current query
+  *   - `num_query_terms_matched` — how many distinct query terms occur in the document
+  *   - `query` — the query the document was scored against
+  *   - `doc_len` — the number of tokens in the document
+  *
+  * ==Example==
+  * {{{
+  * import com.johnsnowlabs.nlp.base.DocumentAssembler
+  * import com.johnsnowlabs.nlp.annotators.{StopWordsCleaner, Tokenizer}
+  * import com.johnsnowlabs.nlp.annotators.similarity.{BM25Approach, BM25Model}
+  * import org.apache.spark.ml.Pipeline
+  * import org.apache.spark.sql.functions.{col, explode}
+  *
+  * val documentAssembler = new DocumentAssembler().setInputCol("text").setOutputCol("document")
+  * val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token")
+  * val stopWords = new StopWordsCleaner().setInputCols("token").setOutputCol("clean_token")
+  * val bm25 = new BM25Approach().setInputCols("clean_token").setOutputCol("bm25_rankings")
+  *
+  * val model = new Pipeline()
+  *   .setStages(Array(documentAssembler, tokenizer, stopWords, bm25))
+  *   .fit(corpus)
+  *
+  * val bm25Model = model.stages.last.asInstanceOf[BM25Model]
+  * bm25Model.setQuery("vitamin C health benefits fruits")
+  *
+  * model.transform(corpus)
+  *   .select(explode(col("bm25_rankings")).alias("ranking"))
+  *   .select(col("ranking.metadata")("bm25_score").alias("bm25_score"))
+  *   .show(false)
+  * }}}
+  *
+  * @groupname anno Annotator types
+  * @groupdesc anno
+  *   Required input and expected output annotator types
+  * @groupname param Parameters
+  * @groupname setParam Parameter setters
+  * @groupname getParam Parameter getters
+  * @groupprio param  1
+  * @groupprio anno  2
+  * @groupprio setParam  4
+  * @groupprio getParam  5
+  */
+class BM25Model(override val uid: String)
+    extends AnnotatorModel[BM25Model]
+    with HasSimpleAnnotate[BM25Model]
+    with ParamsAndFeaturesWritable {
+
+  def this() = this(Identifiable.randomUID("BM25Model"))
+
+  /** Input annotator type: TOKEN
+    *
+    * @group anno
+    */
+  override val inputAnnotatorTypes: Array[AnnotatorType] = Array(TOKEN)
+
+  /** Output annotator type: BM25_RANKINGS
+    *
+    * @group anno
+    */
+  override val outputAnnotatorType: AnnotatorType = BM25_RANKINGS
+
+  /** Learned inverse document frequency for every vocabulary term.
+    *
+    * @group param
+    */
+  val idf: MapFeature[String, Double] = new MapFeature(this, "idf")
+
+  /** @group setParam */
+  def setIdf(value: Map[String, Double]): this.type = set(idf, value)
+
+  /** @group getParam */
+  def getIdf: Map[String, Double] = $$(idf)
+
+  /** Average document length (in tokens) of the training corpus.
+    *
+    * @group param
+    */
+  val avgDocLength = new DoubleParam(
+    this,
+    "avgDocLength",
+    "Average document length (in tokens) of the training corpus")
+
+  /** @group setParam */
+  def setAvgDocLength(value: Double): this.type = set(avgDocLength, value)
+
+  /** @group getParam */
+  def getAvgDocLength: Double = $(avgDocLength)
+
+  /** Total number of documents in the training corpus.
+    *
+    * @group param
+    */
+  val numDocuments =
+    new LongParam(this, "numDocuments", "Total number of documents in the training corpus")
+
+  /** @group setParam */
+  def setNumDocuments(value: Long): this.type = set(numDocuments, value)
+
+  /** @group getParam */
+  def getNumDocuments: Long = $(numDocuments)
+
+  /** Term-frequency saturation parameter `k1` (carried over from [[BM25Approach]]).
+    *
+    * @group param
+    */
+  val k1 = new DoubleParam(
+    this,
+    "k1",
+    "BM25 term-frequency saturation parameter (typical range [1.0, 2.0])",
+    ParamValidators.gtEq(0.0))
+
+  /** @group setParam */
+  def setK1(value: Double): this.type = set(k1, value)
+
+  /** @group getParam */
+  def getK1: Double = $(k1)
+
+  /** Length-normalization parameter `b` (carried over from [[BM25Approach]]).
+    *
+    * @group param
+    */
+  val b = new DoubleParam(
+    this,
+    "b",
+    "BM25 length-normalization parameter (range [0.0, 1.0])",
+    ParamValidators.inRange(0.0, 1.0))
+
+  /** @group setParam */
+  def setB(value: Double): this.type = set(b, value)
+
+  /** @group getParam */
+  def getB: Double = $(b)
+
+  /** Whether tokens are treated case-sensitively (carried over from [[BM25Approach]]). The query
+    * is normalized with the same setting before scoring.
+    *
+    * @group param
+    */
+  val caseSensitive = new BooleanParam(
+    this,
+    "caseSensitive",
+    "Whether to treat tokens case-sensitively when scoring")
+
+  /** @group setParam */
+  def setCaseSensitive(value: Boolean): this.type = set(caseSensitive, value)
+
+  /** @group getParam */
+  def getCaseSensitive: Boolean = $(caseSensitive)
+
+  /** The query that documents are scored against. Set this at query time; the same fitted model
+    * can be re-queried by calling `setQuery` again (Default: empty).
+    *
+    * @group param
+    */
+  val query = new Param[String](this, "query", "The query to score every document against")
+
+  /** @group setParam */
+  def setQuery(value: String): this.type = set(query, value)
+
+  /** @group getParam */
+  def getQuery: String = $(query)
+
+  setDefault(
+    inputCols -> Array(TOKEN),
+    outputCol -> BM25_RANKINGS,
+    k1 -> 1.2,
+    b -> 0.75,
+    caseSensitive -> false,
+    query -> "")
+
+  /** Splits a raw query string into normalized terms, applying the same case handling that was
+    * used when the corpus statistics were computed. The `(?U)` flag makes `\W` Unicode-aware so
+    * accented and other non-ASCII letters are kept as part of a term rather than used as
+    * delimiters.
+    */
+  private def queryTerms: Array[String] = {
+    val rawTerms = $(query).split("(?U)\\W+").filter(_.nonEmpty)
+    if ($(caseSensitive)) rawTerms else rawTerms.map(_.toLowerCase)
+  }
+
+  override def beforeAnnotate(dataset: Dataset[_]): Dataset[_] = {
+    require(
+      idf.isSet && isDefined(avgDocLength),
+      "BM25Model is missing its learned statistics. Produce the model with BM25Approach.fit(...) " +
+        "or load a previously fitted model before calling transform.")
+    require(
+      $(query).trim.nonEmpty,
+      "BM25Model requires a query. Set one with setQuery(\"...\") before calling transform.")
+    dataset
+  }
+
+  override def annotate(annotations: Seq[Annotation]): Seq[Annotation] = {
+    val isCaseSensitive = $(caseSensitive)
+    val docTerms = annotations.map { annotation =>
+      if (isCaseSensitive) annotation.result else annotation.result.toLowerCase
+    }
+
+    val docLength = docTerms.length
+    val termFrequencies = docTerms.groupBy(identity).map { case (term, occ) =>
+      term -> occ.length
+    }
+
+    val idfMap = $$(idf)
+    val avgdl = $(avgDocLength)
+    val k1Value = $(k1)
+    val bValue = $(b)
+
+    // Avoid division by zero on a degenerate (empty) corpus.
+    val safeAvgdl = if (avgdl > 0.0) avgdl else 1.0
+    val lengthNorm = k1Value * (1.0 - bValue + bValue * (docLength.toDouble / safeAvgdl))
+
+    val distinctQueryTerms = queryTerms.distinct
+
+    var score = 0.0
+    var matched = 0
+    distinctQueryTerms.foreach { term =>
+      val tf = termFrequencies.getOrElse(term, 0)
+      // Only count a query term as matched when it is both present in the document and part of
+      // the learned vocabulary, i.e. when it actually contributes to the score. Terms pruned by
+      // minDocFreq or never seen in the training corpus do not count.
+      if (tf > 0) {
+        idfMap.get(term).foreach { termIdf =>
+          matched += 1
+          score += termIdf * (tf * (k1Value + 1.0)) / (tf + lengthNorm)
+        }
+      }
+    }
+
+    val begin = annotations.headOption.map(_.begin).getOrElse(0)
+    val end = annotations.lastOption.map(_.end).getOrElse(0)
+
+    Seq(
+      Annotation(
+        annotatorType = outputAnnotatorType,
+        begin = begin,
+        end = end,
+        result = score.toString,
+        metadata = Map(
+          "bm25_score" -> score.toString,
+          "num_query_terms_matched" -> matched.toString,
+          "query" -> $(query),
+          "doc_len" -> docLength.toString),
+        embeddings = Array.emptyFloatArray))
+  }
+}
+
+trait ReadableBM25Model extends ParamsAndFeaturesReadable[BM25Model]
+
+/** This is the companion object of [[BM25Model]]. Please refer to that class for the
+  * documentation.
+  */
+object BM25Model extends ReadableBM25Model

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25TestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25TestSpec.scala
@@ -16,7 +16,8 @@
 
 package com.johnsnowlabs.nlp.annotators.similarity
 
-import com.johnsnowlabs.nlp.annotators.{StopWordsCleaner, Tokenizer}
+import com.johnsnowlabs.nlp.LightPipeline
+import com.johnsnowlabs.nlp.annotators.{Stemmer, StopWordsCleaner, Tokenizer}
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.tags.FastTest
@@ -273,5 +274,78 @@ class BM25TestSpec extends AnyFlatSpec {
     intercept[IllegalArgumentException](new BM25Approach().setB(2.0))
     intercept[IllegalArgumentException](new BM25Approach().setK1(-1.0))
     intercept[IllegalArgumentException](new BM25Approach().setMinDocFreq(0))
+  }
+
+  "BM25 with a token-transforming pipeline" should
+    "match an analyzed query that a raw-string query would miss" taggedAs FastTest in {
+      // The corpus is stemmed, so the IDF vocabulary only ever contains stems. A raw-string query
+      // is NOT stemmed by the model -- this is exactly the analyzer-asymmetry trap. Pre-analyzing
+      // the query with the same pipeline (setQueryTokens) is the cure.
+      val docs = Seq((1, "running runs"), (2, "jumping jumps")).toDF("id", "text")
+
+      val stemmer = new Stemmer().setInputCols("token").setOutputCol("stem")
+
+      // Analyze the query with exactly the stages used for the documents.
+      val analyzer = new Pipeline()
+        .setStages(Array(documentAssembler, tokenizer, stemmer))
+        .fit(docs)
+      val analyzedQuery = new LightPipeline(analyzer).annotate("running")("stem").toArray
+      // The stemmer actually transforms the surface form, which is what creates the asymmetry.
+      assert(analyzedQuery.nonEmpty && !analyzedQuery.contains("running"))
+
+      val bm25 = new BM25Approach().setInputCols("stem").setOutputCol("bm25_rankings")
+      val model = new Pipeline()
+        .setStages(Array(documentAssembler, tokenizer, stemmer, bm25))
+        .fit(docs)
+      val bm25Model = model.stages.last.asInstanceOf[BM25Model]
+
+      // The vocabulary is built from stems, so the surface form "running" is never a key, but the
+      // analyzed query terms are.
+      assert(analyzedQuery.forall(bm25Model.getIdf.contains))
+      assert(!bm25Model.getIdf.contains("running"))
+
+      def scoreOfDoc1(): Double =
+        model
+          .transform(docs)
+          .where(col("id") === 1)
+          .select(col("bm25_rankings.metadata")(0)("bm25_score").cast("double"))
+          .as[Double]
+          .head()
+
+      // Raw-string query bypasses the stemmer -> "running" misses the vocabulary -> 0.
+      bm25Model.setQuery("running")
+      assert(scoreOfDoc1() == 0.0)
+
+      // Pre-analyzed query (same pipeline) -> matches the stemmed vocabulary -> > 0. queryTokens
+      // also takes precedence over the still-set raw query.
+      bm25Model.setQueryTokens(analyzedQuery)
+      assert(scoreOfDoc1() > 0.0)
+    }
+
+  it should "score identically whether the query is a raw string or pre-analyzed tokens" taggedAs FastTest in {
+    val tiny =
+      Seq((1, "apple apple banana"), (2, "banana cherry"), (3, "cherry")).toDF("id", "text")
+    val bm25 = new BM25Approach().setInputCols("token").setOutputCol("bm25_rankings")
+    val model = new Pipeline()
+      .setStages(Array(documentAssembler, tokenizer, bm25))
+      .fit(tiny)
+    val bm25Model = model.stages.last.asInstanceOf[BM25Model]
+
+    def scores(): Map[Int, Double] =
+      model
+        .transform(tiny)
+        .select(
+          col("id"),
+          col("bm25_rankings.metadata")(0)("bm25_score").cast("double").alias("s"))
+        .as[(Int, Double)]
+        .collect()
+        .toMap
+
+    bm25Model.setQuery("apple banana")
+    val viaString = scores()
+    // The same terms supplied as pre-analyzed tokens must reproduce the scores exactly.
+    bm25Model.setQueryTokens(Array("apple", "banana"))
+    val viaTokens = scores()
+    viaString.foreach { case (id, s) => assert(math.abs(viaTokens(id) - s) < 1e-9) }
   }
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25TestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/similarity/BM25TestSpec.scala
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2017-2025 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.similarity
+
+import com.johnsnowlabs.nlp.annotators.{StopWordsCleaner, Tokenizer}
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.FastTest
+import org.apache.commons.io.FileUtils
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.functions.{col, explode}
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.nio.file.Files
+
+class BM25TestSpec extends AnyFlatSpec {
+
+  import ResourceHelper.spark.implicits._
+
+  private val corpus = Seq(
+    (1, "Apples are a great source of dietary fiber and vitamin C."),
+    (2, "Bananas are rich in potassium and natural sugars."),
+    (3, "Machine learning is a subset of artificial intelligence."),
+    (4, "Deep learning uses neural networks with many layers."),
+    (5, "Florence in Italy is one of the most beautiful cities in Europe."),
+    (6, "The French Riviera is a warm coastal region in southern France."),
+    (7, "Vitamin C deficiency can lead to scurvy and immune system problems."),
+    (8, "Neural networks are inspired by the human brain's structure."),
+    (9, "Potassium is an essential mineral for heart and muscle function."),
+    (10, "Italy is home to some of the world's greatest Renaissance art."))
+    .toDF("id", "text")
+
+  private val documentAssembler =
+    new DocumentAssembler().setInputCol("text").setOutputCol("document")
+
+  private val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token")
+
+  private val stopWordsCleaner = new StopWordsCleaner()
+    .setInputCols("token")
+    .setOutputCol("clean_token")
+    .setCaseSensitive(false)
+
+  private def fitPipeline(): PipelineModel = {
+    val bm25 = new BM25Approach()
+      .setInputCols("clean_token")
+      .setOutputCol("bm25_rankings")
+      .setK1(1.2)
+      .setB(0.75)
+      .setMinDocFreq(1)
+      .setCaseSensitive(false)
+
+    new Pipeline()
+      .setStages(Array(documentAssembler, tokenizer, stopWordsCleaner, bm25))
+      .fit(corpus)
+  }
+
+  /** Score the corpus and return rows of (id, bm25_score, terms_matched) ordered by score desc.
+    */
+  private def rankedResults(model: PipelineModel): Array[(Int, Double, Int)] = {
+    model
+      .transform(corpus)
+      .select(col("id"), explode(col("bm25_rankings")).alias("ranking"))
+      .select(
+        col("id"),
+        col("ranking.metadata")("bm25_score").cast("double").alias("bm25_score"),
+        col("ranking.metadata")("num_query_terms_matched").cast("int").alias("terms_matched"))
+      .orderBy(col("bm25_score").desc)
+      .as[(Int, Double, Int)]
+      .collect()
+  }
+
+  "BM25Approach" should "learn corpus statistics during fit" taggedAs FastTest in {
+    val pipelineModel = fitPipeline()
+    val bm25Model = pipelineModel.stages.last.asInstanceOf[BM25Model]
+
+    assert(bm25Model.getNumDocuments == 10L)
+    assert(bm25Model.getAvgDocLength > 0.0)
+    assert(bm25Model.getIdf.nonEmpty)
+    // All IDF weights are non-negative with the Lucene variant.
+    assert(bm25Model.getIdf.values.forall(_ >= 0.0))
+    // "vitamin" appears in two documents, so it must be in the vocabulary.
+    assert(bm25Model.getIdf.contains("vitamin"))
+  }
+
+  it should "rank documents by lexical relevance to the query" taggedAs FastTest in {
+    val pipelineModel = fitPipeline()
+    pipelineModel.stages.last
+      .asInstanceOf[BM25Model]
+      .setQuery("vitamin C health benefits fruits")
+
+    val ranked = rankedResults(pipelineModel)
+    ranked.foreach { case (id, score, matched) =>
+      println(s"id=$id score=$score terms_matched=$matched")
+    }
+
+    val topTwoIds = ranked.take(2).map(_._1).toSet
+    // Documents 1 and 7 are the only ones mentioning "vitamin"/"C".
+    assert(topTwoIds == Set(1, 7))
+
+    // Every score is non-negative and documents with no query term score exactly 0.
+    assert(ranked.forall(_._2 >= 0.0))
+    val unrelated = ranked.filter(_._1 == 3).head
+    assert(unrelated._2 == 0.0)
+    assert(unrelated._3 == 0)
+
+    // num_query_terms_matched is reported for the matching documents.
+    assert(ranked.filter(_._1 == 1).head._3 >= 1)
+  }
+
+  it should "reuse the same fitted statistics across different queries" taggedAs FastTest in {
+    val pipelineModel = fitPipeline()
+    val bm25Model = pipelineModel.stages.last.asInstanceOf[BM25Model]
+
+    bm25Model.setQuery("neural networks deep learning")
+    val aiTop = rankedResults(pipelineModel).head._1
+    assert(Set(4, 8).contains(aiTop))
+
+    bm25Model.setQuery("Italy France Europe travel")
+    val travelTop = rankedResults(pipelineModel).head._1
+    assert(Set(5, 6, 10).contains(travelTop))
+  }
+
+  it should "require a query before transform" taggedAs FastTest in {
+    val pipelineModel = fitPipeline()
+    // query defaults to empty -> transform must fail fast with a helpful message.
+    val thrown = intercept[IllegalArgumentException] {
+      pipelineModel.transform(corpus).collect()
+    }
+    assert(thrown.getMessage.contains("query"))
+  }
+
+  "BM25Model" should "be saved and loaded and produce identical rankings" taggedAs FastTest in {
+    val pipelineModel = fitPipeline()
+    val bm25Model = pipelineModel.stages.last.asInstanceOf[BM25Model]
+    bm25Model.setQuery("vitamin C health benefits fruits")
+    val before = rankedResults(pipelineModel)
+
+    val modelPath = Files.createTempDirectory("bm25_model").toFile
+    try {
+      bm25Model.write.overwrite().save(modelPath.getAbsolutePath)
+      val loaded = BM25Model.load(modelPath.getAbsolutePath)
+
+      assert(loaded.getNumDocuments == bm25Model.getNumDocuments)
+      assert(loaded.getAvgDocLength == bm25Model.getAvgDocLength)
+      assert(loaded.getIdf == bm25Model.getIdf)
+
+      loaded.setQuery("vitamin C health benefits fruits")
+      val inferPipeline = new Pipeline()
+        .setStages(Array(documentAssembler, tokenizer, stopWordsCleaner, loaded))
+        .fit(corpus)
+      val after = inferPipeline
+        .transform(corpus)
+        .select(
+          col("id"),
+          col("bm25_rankings.metadata")(0)("bm25_score").cast("double").alias("bm25_score"))
+        .as[(Int, Double)]
+        .collect()
+        .toMap
+
+      before.foreach { case (id, score, _) =>
+        assert(math.abs(after(id) - score) < 1e-9)
+      }
+    } finally {
+      FileUtils.deleteDirectory(modelPath)
+    }
+  }
+
+  "BM25" should "compute exact scores and statistics on a controlled corpus" taggedAs FastTest in {
+    // A tiny corpus with no stop words, so the tokens are fully predictable and the BM25
+    // statistics can be derived by hand.
+    val tiny =
+      Seq((1, "apple apple banana"), (2, "banana cherry"), (3, "cherry")).toDF("id", "text")
+
+    val bm25 = new BM25Approach()
+      .setInputCols("token")
+      .setOutputCol("bm25_rankings")
+
+    val model = new Pipeline()
+      .setStages(Array(documentAssembler, tokenizer, bm25))
+      .fit(tiny)
+    val bm25Model = model.stages.last.asInstanceOf[BM25Model]
+
+    // N = 3 documents, lengths 3 + 2 + 1 = 6 -> avgdl = 2.0
+    assert(bm25Model.getNumDocuments == 3L)
+    assert(bm25Model.getAvgDocLength == 2.0)
+
+    // df(apple)=1, df(banana)=2, df(cherry)=2 ; idf(t)=ln(1+(N-df+0.5)/(df+0.5))
+    assert(math.abs(bm25Model.getIdf("apple") - math.log(1.0 + 2.5 / 1.5)) < 1e-9)
+    assert(math.abs(bm25Model.getIdf("banana") - math.log(1.6)) < 1e-9)
+
+    bm25Model.setQuery("apple banana")
+    val scored = model
+      .transform(tiny)
+      .select(
+        col("id"),
+        col("bm25_rankings.metadata")(0)("bm25_score").cast("double").alias("score"),
+        col("bm25_rankings.metadata")(0)("num_query_terms_matched").cast("int").alias("matched"))
+      .as[(Int, Double, Int)]
+      .collect()
+      .map(r => r._1 -> (r._2, r._3))
+      .toMap
+
+    // Hand-computed BM25 for document 1 ("apple apple banana", len 3, avgdl 2, k1=1.2, b=0.75):
+    //   lengthNorm = 1.2 * (1 - 0.75 + 0.75 * 3/2) = 1.65
+    //   apple : idf=ln(2.6667) tf=2 -> idf * (2*2.2)/(2+1.65)
+    //   banana: idf=ln(1.6)    tf=1 -> idf * (1*2.2)/(1+1.65)
+    val lengthNorm = 1.2 * (1.0 - 0.75 + 0.75 * 3.0 / 2.0)
+    val expectedDoc1 =
+      math.log(1.0 + 2.5 / 1.5) * (2 * 2.2) / (2 + lengthNorm) +
+        math.log(1.6) * (1 * 2.2) / (1 + lengthNorm)
+    assert(math.abs(scored(1)._1 - expectedDoc1) < 1e-9)
+    assert(scored(1)._2 == 2) // both query terms matched in document 1
+    assert(scored(3)._1 == 0.0) // document 3 ("cherry") has neither query term
+    assert(scored(3)._2 == 0)
+  }
+
+  it should "honor non-default parameters and prune by minDocFreq" taggedAs FastTest in {
+    val tiny =
+      Seq((1, "apple apple banana"), (2, "banana cherry"), (3, "cherry")).toDF("id", "text")
+
+    val bm25 = new BM25Approach()
+      .setInputCols("token")
+      .setOutputCol("bm25_rankings")
+      .setK1(2.0)
+      .setB(0.5)
+      .setMinDocFreq(2)
+      .setCaseSensitive(true)
+
+    val model = new Pipeline()
+      .setStages(Array(documentAssembler, tokenizer, bm25))
+      .fit(tiny)
+    val bm25Model = model.stages.last.asInstanceOf[BM25Model]
+
+    // Non-default tuning params must be copied from the approach onto the fitted model.
+    assert(bm25Model.getK1 == 2.0)
+    assert(bm25Model.getB == 0.5)
+    assert(bm25Model.getCaseSensitive)
+
+    // minDocFreq=2 drops "apple" (df=1) but keeps "banana"/"cherry" (df=2).
+    assert(!bm25Model.getIdf.contains("apple"))
+    assert(bm25Model.getIdf.contains("banana"))
+
+    // "apple" is present in document 1 but pruned from the vocabulary, so it must NOT count as a
+    // matched term, and only "banana" contributes to the score.
+    bm25Model.setQuery("apple banana")
+    val doc1 = model
+      .transform(tiny)
+      .where(col("id") === 1)
+      .select(
+        col("bm25_rankings.metadata")(0)("bm25_score").cast("double").alias("score"),
+        col("bm25_rankings.metadata")(0)("num_query_terms_matched").cast("int").alias("matched"))
+      .as[(Double, Int)]
+      .head()
+    assert(doc1._2 == 1)
+    assert(doc1._1 > 0.0)
+  }
+
+  it should "reject out-of-range parameters" taggedAs FastTest in {
+    intercept[IllegalArgumentException](new BM25Approach().setB(2.0))
+    intercept[IllegalArgumentException](new BM25Approach().setK1(-1.0))
+    intercept[IllegalArgumentException](new BM25Approach().setMinDocFreq(0))
+  }
+}


### PR DESCRIPTION
## Description

Adds BM25 (Okapi BM25) lexical document retrieval as a two-phase Estimator/Model pair.

- `BM25Approach` (Estimator): scans the corpus once in `fit()` and learns document count N, per-term document frequency, average document length, and IDF (non-negative Lucene variant).
- `BM25Model` (Transformer): scores every document against a query set via `setQuery(...)` at transform time, emitting a `BM25_RANKINGS` annotation with `bm25_score` and `num_query_terms_matched` metadata. Fit once, query many times.
- Params: `k1`, `b`, `minDocFreq`, `caseSensitive` (range-validated).
- Adds the `BM25_RANKINGS` annotator type, Python wrapper, wiring, and an example notebook.

## Motivation and Context

Implements SPARKNLP-1145. BM25 cannot be a single annotator because scores depend on corpus-level statistics (document frequency, IDF, total document count, average document length) that only exist after the full corpus is seen. The Approach + Model split solves this and complements the semantic `DocumentSimilarityRanker` with a purely lexical option.

## How Has This Been Tested?

- Scala `BM25TestSpec` (offline FastTests): statistics learning, ranking, model reuse across queries, save/load, hand-computed exact-score verification, non-default params, `minDocFreq` pruning, and param-range rejection. All pass.
- Python `bm25_test.py` (fast): fit, query, reuse, save/load, param propagation. Passes with scores matching the Scala side.
- Notebook ran on google colab against the built jar.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.