### PR TITLE
AutoGGUFVisionModel: batch image decoding across parallel slots

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFVisionModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFVisionModel.scala
@@ -239,23 +239,22 @@ class AutoGGUFVisionModel(override val uid: String)
               .toArray)
       }
 
-      val textAndMeta: Array[(String, Map[String, String])] = prompts
-        .zip(base64EncodedImages)
-        .map { case (prompt, base64Image) =>
-          try {
-            val results = LlamaExtensions.completeImage(
-              model,
-              getInferenceParameters,
-              getSystemPrompt,
-              prompt,
-              base64Image)
-            val resultsCleaned = processCompletions(Array(results)).head
-            (resultsCleaned, Map.empty[String, String])
-          } catch {
-            case e: LlamaException =>
-              logger.error("Error in llama.cpp image batch completion", e)
-              ("", Map("llamacpp_exception" -> e.getMessage))
-          }
+      val textAndMeta: Array[(String, Map[String, String])] =
+        try {
+          // Decode the whole batch in ONE request so images run across the parallel slots configured
+          // above (setParallel(getBatchSize)), instead of one completeImage() call per image (which
+          // decodes single-stream and leaves the parallel slots idle).
+          val results = LlamaExtensions.multiCompleteImage(
+            model,
+            getInferenceParameters,
+            getSystemPrompt,
+            prompts,
+            base64EncodedImages)
+          processCompletions(results).map(cleaned => (cleaned, Map.empty[String, String]))
+        } catch {
+          case e: LlamaException =>
+            logger.error("Error in llama.cpp image batch completion", e)
+            Array.fill(prompts.length)(("", Map("llamacpp_exception" -> e.getMessage)))
         }
 
       val result: Seq[Seq[Annotation]] =

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFVisionModelTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFVisionModelTestSpec.scala
@@ -104,6 +104,76 @@ class AutoGGUFVisionModelTestSpec extends AnyFlatSpec {
     }
   }
 
+  it should "batch image inference and be faster than serial on GPU" taggedAs SlowTest in {
+    // batchAnnotate decodes a batch in one multiCompleteImage call across the parallel slots
+    // (setParallel = batchSize); serial (batchSize=1) decodes one image at a time. On GPU the
+    // batch should be faster. cachePrompt=false keeps the serial-vs-batch A/B cache-symmetric.
+    val gpuLayers = 99
+
+    def buildModel(bs: Int): AutoGGUFVisionModel =
+      AutoGGUFVisionModel
+        .pretrained()
+        .setInputCols("caption_document", "image_assembler")
+        .setOutputCol("completions")
+        .setBatchSize(bs)
+        .setNGpuLayers(gpuLayers)
+        // nCtx is the TOTAL context split across the parallel slots (= batchSize), so scale it to
+        // keep ~2048 tokens/slot (enough for the image tokens + caption) regardless of batch size.
+        .setNCtx(2048 * bs)
+        .setNPredict(nPredict)
+        .setCachePrompt(false)
+        .setTemperature(0.05f)
+        .setTopK(40)
+        .setTopP(0.95f)
+
+    val nImages = expectedWords.size
+
+    def runTimed(bs: Int): (Long, Array[(String, Annotation)]) = {
+      val fitted = new Pipeline()
+        .setStages(Array(documentAssembler, imageAssembler, buildModel(bs)))
+        .fit(data)
+      // warm-up transform loads the model session; time the second transform
+      fitted.transform(data.repartition(1)).select("completions").collect()
+      val t0 = System.nanoTime()
+      val rows =
+        fitted.transform(data.repartition(1)).select("image_assembler", "completions").collect()
+      val elapsedMs = (System.nanoTime() - t0) / 1000000L
+      val captions = rows.map { row =>
+        val image = AnnotationImage(row.getAs[mutable.WrappedArray[Row]](0).head)
+        val annotation = Annotation(row.getAs[mutable.WrappedArray[Row]](1).head)
+        (image.origin.split("/").last, annotation)
+      }
+      (elapsedMs, captions)
+    }
+
+    val (serialMs, serialCaptions) = runTimed(1)
+    val (batchMs, batchCaptions) = runTimed(nImages)
+    val speedup = serialMs.toDouble / math.max(batchMs, 1L)
+    println(
+      s"[VISION BATCH PERF] images=$nImages | serial(bs=1)=${serialMs}ms " +
+        s"batch(bs=$nImages)=${batchMs}ms speedup=${"%.2f".format(speedup)}x")
+
+    // Correctness (always): both configurations caption every image correctly, one per input.
+    Seq(("serial", serialCaptions), ("batch", batchCaptions)).foreach { case (label, captions) =>
+      assert(
+        captions.length == nImages,
+        s"[$label] produced ${captions.length} captions, expected $nImages")
+      captions.foreach { case (fileName, completion) =>
+        val expected = expectedWords(fileName)
+        assert(
+          completion.result.toLowerCase().contains(expected.toLowerCase()),
+          s"[$label] expected '$expected' in caption for $fileName, got: ${completion.result}")
+      }
+    }
+
+    // Speed (GPU only): batching overlaps decode across the parallel slots.
+    if (gpuLayers > 0)
+      assert(
+        batchMs < serialMs,
+        s"expected batch (bs=$nImages) faster than serial (bs=1) on GPU: " +
+          s"serial=${serialMs}ms batch=${batchMs}ms")
+  }
+
   it should "be serializable" taggedAs SlowTest in {
     val pipelineModel = pipeline.fit(data)
     val savePath = "./tmp_autogguf_vision_model"


### PR DESCRIPTION
## What
`AutoGGUFVisionModel.batchAnnotate` decoded a batch with **one `completeImage()` call per image** (serial, single-stream) — leaving the parallel slots from `setParallel(getBatchSize)` idle. This submits the whole batch in **one** `LlamaExtensions.multiCompleteImage()` call so images decode across those slots. ~16-line change, error handling + `processCompletions` preserved.

## Depends on
⛔ **jsl-llama.cpp#8** (adds `LlamaExtensions.multiCompleteImage`) must be merged + released — this won't compile against the current `jsl-llamacpp` 2.0.3. Draft until then; bump `llamaCppVersion` when the release lands.

## Verified (locally, before opening)
Built spark-nlp under **JDK 8** against a `jsl-llamacpp-gpu` jar patched with `multiCompleteImage`, on a T4:
```
slow:testOnly *AutoGGUFVisionModelTestSpec -- -z "caption the images correctly"
- should caption the images correctly   ✅   (Qwen2.5-VL-3B on CUDA, batchSize=2, 10 images, all captions correct)
Tests: succeeded 5, failed 1
```
(The 1 failure is `should be able to remove thinking tags` — missing `SmolVLM-256M` model file in the local env, unrelated to this change; fails identically on master.)

## Speedup
The parallel-decode win is engine-layer and measured in jsl-llama.cpp#8 (regime-dependent; ~1.8× full-res OCR, more for decode-heavy/small). This PR is the wiring that lets the annotator actually use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)