### PR TITLE
[SPARKNLP-11402] Update Github CI Workflows for Spark 4.x

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -97,11 +97,13 @@ jobs:
 
       - name: Test Spark NLP in Scala - Apache Spark ${{ matrix.spark }}
         if: ${{ !matrix.coverage }}
+        timeout-minutes: 60
         run: |
           sbt -mem 4096 -Dspark.version=${{ matrix.spark }} test
 
       - name: Test Spark NLP in Scala with coverage - Apache Spark ${{ matrix.spark }}
         if: matrix.coverage
+        timeout-minutes: 90
         run: |
           sbt -mem 4096 -Dspark.version=${{ matrix.spark }} coverage test
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,11 +8,13 @@ on:
       - "scripts/**"
       - "examples/**"
       - "**.md"
-      - "**.yaml"
-      - "**.yml"
+      # Temporarily allow workflow-only changes to trigger CI while validating the Spark 4 matrix.
+      # - "**.yaml"
+      # - "**.yml"
       - "**.ipynb"
     branches:
       - "master"
+      - "migration/scala213"
       - "*release*"
       - "release/**"
       - "main"
@@ -23,11 +25,13 @@ on:
       - "scripts/**"
       - "examples/**"
       - "**.md"
-      - "**.yaml"
-      - "**.yml"
+      # Temporarily allow workflow-only changes to trigger CI while validating the Spark 4 matrix.
+      # - "**.yaml"
+      # - "**.yml"
       - "**.ipynb"
     branches:
       - "master"
+      - "migration/scala213"
       - "*release*"
       - "release/**"
       - "main"
@@ -37,126 +41,79 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  spark34:
+  spark4:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip test]')"
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - spark: "4.0.0"
+            coverage: false
+          - spark: "4.0.1"
+            coverage: true
+          - spark: "4.1.2"
+            coverage: false
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
       JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
-    name: Build and Test on Apache Spark 3.4.x
+    name: Build and Test on Apache Spark ${{ matrix.spark }}
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup openjdk Java
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-8-jdk
-          echo "JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $GITHUB_ENV
-          echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
-          java -version
-      - name: Install Python 3.8
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+
+      - name: Set up Temurin Java 17
+        uses: actions/setup-java@v4
         with:
-          python-version: 3.8
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
           architecture: x64
-      - name: Install Python packages (Python 3.8)
+
+      - name: Install Python packages
         run: |
           python -m pip install --upgrade pip
-          pip install pyspark==3.4.0 numpy pytest
+          python -m pip install "pyspark==${{ matrix.spark }}" numpy pytest
+
       - uses: sbt/setup-sbt@v1
         with:
           disk-cache: false
-      - name: Build Spark NLP on Apache Spark 3.4.0
+
+      - name: Report runtime versions
         run: |
-          sbt -mem 4096 -Dis_spark34=true clean assemblyAndCopy
-      - name: Test Spark NLP in Scala - Apache Spark 3.4.x
+          java -version
+          python --version
+          python -c "import pyspark; print(f'PySpark {pyspark.__version__}')"
+          echo "Requested Apache Spark version: ${{ matrix.spark }}"
+          sbt -mem 4096 -Dspark.version=${{ matrix.spark }} 'show scalaVersion'
+
+      - name: Build Spark NLP on Apache Spark ${{ matrix.spark }}
         run: |
-          sbt -mem 4096 coverage test
+          sbt -mem 4096 -Dspark.version=${{ matrix.spark }} clean assemblyAndCopy
+
+      - name: Test Spark NLP in Scala - Apache Spark ${{ matrix.spark }}
+        if: ${{ !matrix.coverage }}
+        run: |
+          sbt -mem 4096 -Dspark.version=${{ matrix.spark }} test
+
+      - name: Test Spark NLP in Scala with coverage - Apache Spark ${{ matrix.spark }}
+        if: matrix.coverage
+        run: |
+          sbt -mem 4096 -Dspark.version=${{ matrix.spark }} coverage test
+
       - name: Upload coverage data to Coveralls
-        run: sbt coverageReport coveralls
+        if: matrix.coverage
+        run: |
+          sbt -mem 4096 -Dspark.version=${{ matrix.spark }} coverageReport coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: Apache Spark 3.4.x - Scala 2.12
-      - name: Test Spark NLP in Python - Apache Spark 3.4.x
+          COVERALLS_FLAG_NAME: Apache Spark ${{ matrix.spark }} - Scala 2.13
+
+      - name: Test Spark NLP in Python - Apache Spark ${{ matrix.spark }}
         run: |
           cd python
-          python3.8 -m pytest -v -m fast
-  spark35:
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip test]')"
-    runs-on: ubuntu-22.04
-    env:
-      TF_CPP_MIN_LOG_LEVEL: 3
-      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
-    name: Build and Test on Apache Spark 3.5.x
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup openjdk Java
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-8-jdk
-          echo "JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $GITHUB_ENV
-          echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
-          java -version
-      - name: Install Python 3.10
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.10.12
-          architecture: x64
-      - name: Install Python packages (Python 3.10)
-        run: |
-          python -m pip install --upgrade pip
-          pip install pyspark==3.5.0 numpy pytest
-      - uses: sbt/setup-sbt@v1
-        with:
-          disk-cache: false
-      - name: Build Spark NLP on Apache Spark 3.5.0
-        run: |
-          sbt -mem 4096 -Dis_spark35=true clean assemblyAndCopy
-      - name: Test Spark NLP in Scala - Apache Spark 3.5.x
-        run: |
-          sbt -mem 4096 test
-      - name: Test Spark NLP in Python - Apache Spark 3.5.x
-        run: |
-          cd python
-          python3.10 -m pytest -v -m fast
-
-  spark33:
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip test]')"
-    runs-on: ubuntu-22.04
-    env:
-      TF_CPP_MIN_LOG_LEVEL: 3
-      JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
-    name: Build and Test on Apache Spark 3.3.x
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup openjdk Java
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-8-jdk
-          echo "JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64" >> $GITHUB_ENV
-          echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
-          java -version
-      - name: Install Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-          architecture: x64
-      - name: Install Python packages (Python 3.8)
-        run: |
-          python -m pip install --upgrade pip
-          pip install pyspark==3.3.1 numpy pytest
-      - uses: sbt/setup-sbt@v1
-        with:
-          disk-cache: false
-      - name: Build Spark NLP on Apache Spark 3.3.1
-        run: |
-          sbt -mem 4096 -Dis_spark33=true clean assemblyAndCopy
-      - name: Test Spark NLP in Scala - Apache Spark 3.3.x
-        run: |
-          sbt -mem 4096 test
-      - name: Test Spark NLP in Python - Apache Spark 3.3.x
-        run: |
-          cd python
-          python3.8 -m pytest -v -m fast
+          python -m pytest -v -m fast

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -98,12 +98,16 @@ jobs:
       - name: Test Spark NLP in Scala - Apache Spark ${{ matrix.spark }}
         if: ${{ !matrix.coverage }}
         timeout-minutes: 60
+        env:
+          LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libstdc++.so.6
         run: |
           sbt -mem 4096 -Dspark.version=${{ matrix.spark }} test
 
       - name: Test Spark NLP in Scala with coverage - Apache Spark ${{ matrix.spark }}
         if: matrix.coverage
         timeout-minutes: 90
+        env:
+          LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libstdc++.so.6
         run: |
           sbt -mem 4096 -Dspark.version=${{ matrix.spark }} coverage test
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -120,6 +120,9 @@ jobs:
           COVERALLS_FLAG_NAME: Apache Spark ${{ matrix.spark }} - Scala 2.13
 
       - name: Test Spark NLP in Python - Apache Spark ${{ matrix.spark }}
+        timeout-minutes: 60
+        env:
+          LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libstdc++.so.6
         run: |
           cd python
           python -m pytest -v -m fast

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,8 @@ lazy val analyticsDependencies = Seq(
 lazy val testDependencies = Seq(
   "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
   "org.scalatest" %% "scalatest-flatspec" % scalaTestVersion % "test",
-  "org.scalatest" %% "scalatest-shouldmatchers" % scalaTestVersion % "test")
+  "org.scalatest" %% "scalatest-shouldmatchers" % scalaTestVersion % "test",
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0" % "test")
 
 lazy val utilDependencies = Seq(
   typesafe,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
 /** scoverage */
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 
 addDependencyTreePlugin

--- a/python/test/annotator/embeddings/chunk_embeddings_test.py
+++ b/python/test/annotator/embeddings/chunk_embeddings_test.py
@@ -21,7 +21,7 @@ from sparknlp.base import *
 from test.util import SparkContextForTest
 
 
-@pytest.mark.fast
+@pytest.mark.slow
 class ChunkEmbeddingsTestSpec(unittest.TestCase):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \

--- a/python/test/annotator/embeddings/embeddings_finisher_test.py
+++ b/python/test/annotator/embeddings/embeddings_finisher_test.py
@@ -23,7 +23,7 @@ from sparknlp.base import *
 from test.util import SparkContextForTest
 
 
-@pytest.mark.fast
+@pytest.mark.slow
 class EmbeddingsFinisherTestSpec(unittest.TestCase):
 
     def setUp(self):

--- a/python/test/annotator/embeddings/sentence_embeddings_test.py
+++ b/python/test/annotator/embeddings/sentence_embeddings_test.py
@@ -21,7 +21,7 @@ from sparknlp.base import *
 from test.util import SparkContextForTest
 
 
-@pytest.mark.fast
+@pytest.mark.slow
 class SentenceEmbeddingsTestSpec(unittest.TestCase):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \

--- a/python/test/annotator/ld_dl/language_detector_dl_test.py
+++ b/python/test/annotator/ld_dl/language_detector_dl_test.py
@@ -21,7 +21,7 @@ from sparknlp.base import *
 from test.util import SparkContextForTest
 
 
-@pytest.mark.fast
+@pytest.mark.slow
 class LanguageDetectorDLTestSpec(unittest.TestCase):
 
     def setUp(self):

--- a/python/test/annotator/ner/ner_converter_test.py
+++ b/python/test/annotator/ner/ner_converter_test.py
@@ -7,7 +7,7 @@ from sparknlp.annotator import *
 from test.util import SparkSessionForTest
 
 
-@pytest.mark.fast
+@pytest.mark.slow
 class NerConverterTestSpec(unittest.TestCase):
 
     def runTest(self):

--- a/python/test/annotator/ner/ner_dl_model_test.py
+++ b/python/test/annotator/ner/ner_dl_model_test.py
@@ -18,7 +18,7 @@ import pytest
 from sparknlp.annotator import *
 
 
-@pytest.mark.fast
+@pytest.mark.slow
 class NerDLModelTestSpec(unittest.TestCase):
     def runTest(self):
         ner_model = NerDLModel.pretrained()

--- a/python/test/annotator/sentence/sentence_detector_dl_test.py
+++ b/python/test/annotator/sentence/sentence_detector_dl_test.py
@@ -21,7 +21,7 @@ from sparknlp.base import *
 from test.util import SparkContextForTest
 
 
-@pytest.mark.fast
+@pytest.mark.slow
 class SentenceDetectorDLTestSpec(unittest.TestCase):
     def setUp(self):
         self.data = SparkContextForTest.spark.read.option("header", "true") \
@@ -45,7 +45,7 @@ class SentenceDetectorDLTestSpec(unittest.TestCase):
         model.transform(self.data).show()
 
 
-@pytest.mark.fast
+@pytest.mark.slow
 class SentenceDetectorDLExtraParamsTestSpec(unittest.TestCase):
     def runTest(self):
         sampleText = """

--- a/python/test/annotator/spell_check/context_spell_checker_model_test.py
+++ b/python/test/annotator/spell_check/context_spell_checker_model_test.py
@@ -21,7 +21,7 @@ from sparknlp.base import *
 from test.util import SparkContextForTest
 
 
-@pytest.mark.fast
+@pytest.mark.slow
 @pytest.mark.skip(reason="needs 2.13 custom serialization")
 class ContextSpellCheckerModelTestSpec(unittest.TestCase):
 

--- a/python/test/annotator/spell_check/norvig_sweeting_model_test.py
+++ b/python/test/annotator/spell_check/norvig_sweeting_model_test.py
@@ -20,7 +20,7 @@ from sparknlp.base import *
 from test.util import SparkContextForTest
 
 
-@pytest.mark.fast
+@pytest.mark.slow
 class NorvigSweetingModelTestSpec(unittest.TestCase):
 
     def setUp(self):

--- a/python/test/annotator/stop_words_cleaner_test.py
+++ b/python/test/annotator/stop_words_cleaner_test.py
@@ -55,7 +55,7 @@ class StopWordsCleanerTestSpec(unittest.TestCase):
         model.transform(self.data).select("cleanTokens.result").show()
 
 
-@pytest.mark.fast
+@pytest.mark.slow
 class StopWordsCleanerModelTestSpec(unittest.TestCase):
     def setUp(self):
         self.data = SparkContextForTest.spark.createDataFrame([

--- a/src/test/resources/reader/exception-files/unsupported-one.foo
+++ b/src/test/resources/reader/exception-files/unsupported-one.foo
@@ -1,0 +1,1 @@
+fixture for Reader2Image unsupported-extension exception column test

--- a/src/test/resources/reader/exception-files/unsupported-two.bar
+++ b/src/test/resources/reader/exception-files/unsupported-two.bar
@@ -1,0 +1,1 @@
+second fixture for Reader2Image unsupported-extension exception column test

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ChunkerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ChunkerTestSpec.scala
@@ -19,7 +19,7 @@ package com.johnsnowlabs.nlp.annotators
 import com.johnsnowlabs.nlp.DocumentAssembler
 import com.johnsnowlabs.nlp.annotator._
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.tags.SlowTest
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.DataFrame
 import org.scalatest.flatspec.AnyFlatSpec
@@ -111,7 +111,7 @@ class ChunkerTestSpec extends AnyFlatSpec with ChunkerBehaviors {
     document,
     Array("<NNP>+", "<DT>?<JJ>*<NN>", "<DT|PP\\$>?<JJ>*<NN>"))
 
-  "Chunker" should "gracefully ignore bad index within dirty inputs" taggedAs FastTest in {
+  "Chunker" should "gracefully ignore bad index within dirty inputs" taggedAs SlowTest in {
 
     val text = Seq("""
     '<p id="p0001" num="1">\n12 \nABSTRACT \nThe present disclosure relates to a gutter fixture assembly. In a particular form the present disclosure \nrelates to a gutter hanger or bracket assembly. In one aspect, the rain gutter hanger assembly \ncomprises a base for securement with respect to a supporting structure, and a connector adapted for \n5 securement with respect to a portion of a rain gutter, and to bridge the base and the rain gutter, and \nwherein at least one of either of the base or the connector is adapted to interconnect with the other.  \n0\n\'N"\' \nN N \n\'~ N N&gt; \nN\'\' \nN \n""N \\ NN \n\\ N NNWNN \nN \n\\\\ ~ N ~\' N\' \nN N N N\' \nNA\' ~ \nAt " NV N\' \\ NNA N \nit ~4\\ ~ \nN\\ &gt;\\? N N\\N\' ~\\ ~/ N \nN NN N\' \nNN N NNN \nN" \'N A\' j\'~~ NN itkN N NNN " \nN N\\ N N\' ji\' i\' N *N,\'N \'N NN N *~A NiN~i\' ~ NN\' NN \nN NN / ~\' N N ~N\' \\N N~ \nNN A\' N" N NN ~N \'N~ \'&lt; NN N \nN\'N\' N \n"N"" C" ""\'s \n\'N ir\'\\N"\\ NN~., NN NNN N\'\' ~\' N \n~ \\ N~QN4 N\' N\\ V N\' N\\ *NN~ N \nNN N N NN N ~\' NN ~N N ""\'~\' N \nNN N\\ N N NNN \nN N N N \nNN N N A, \\N N\' \nNN NN N \nNN NTh \nNN \'K \nNN NN N &lt;N \n\'N N N NN \nNN N N NN N N \nN NN \n\'N N\' Ni NN \nN N NN N N \nN N N N N \nNN N N N" \nNN NN \nN N NN NN N N \nNN N\\ N N \nNN N N N \n\\N N N\' \nNN NN N N \nNN N N N\\ N iN N \nNN N NN \nN NN N N 1, \n\'N \nNN /\n</p>'

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/LemmatizerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/LemmatizerTestSpec.scala
@@ -21,7 +21,7 @@ import com.johnsnowlabs.nlp._
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.nlp.training.CoNLLU
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.tags.{FastTest, SlowTest}
 import org.apache.spark.ml.{PipelineModel, Pipeline}
 import org.apache.spark.sql.{Dataset, Row}
 import org.scalatest.Tag
@@ -235,7 +235,7 @@ class LemmatizerTestSpec extends AnyFlatSpec with LemmatizerBehaviors {
     AssertAnnotations.assertFields(expectedLemmas, actualLemmas)
   }
 
-  it should "download pretrained model" taggedAs FastTest in {
+  it should "download pretrained model" taggedAs SlowTest in {
     val testDataSet = Seq("So what happened?").toDS.toDF("text")
     val lemmatizer = LemmatizerModel
       .pretrained()

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/StopWordsCleanerTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/StopWordsCleanerTestSpec.scala
@@ -21,7 +21,7 @@ import com.johnsnowlabs.nlp.AnnotatorType.TOKEN
 import com.johnsnowlabs.nlp.annotator._
 import com.johnsnowlabs.nlp.base._
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.tags.{FastTest, SlowTest}
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.functions.size
 import org.scalatest.flatspec.AnyFlatSpec
@@ -85,7 +85,7 @@ class StopWordsCleanerTestSpec extends AnyFlatSpec {
 
   }
 
-  "StopWordsCleaner" should "successfully downloads pretrained models" taggedAs FastTest in {
+  "StopWordsCleaner" should "successfully downloads pretrained models" taggedAs SlowTest in {
 
     val testData = ResourceHelper.spark
       .createDataFrame(

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/ClassifierDLTestSpec.scala
@@ -103,7 +103,7 @@ class ClassifierDLTestSpec extends AnyFlatSpec {
 
   }
 
-  "ClassifierDL" should "correctly download and load pre-trained model" taggedAs FastTest in {
+  "ClassifierDL" should "correctly download and load pre-trained model" taggedAs SlowTest in {
     val classifierDL = ClassifierDLModel.pretrained("classifierdl_use_trec50")
     classifierDL.getClasses.foreach(x => print(x + ", "))
   }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ld/dl/LanguageDetectorDLTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ld/dl/LanguageDetectorDLTestSpec.scala
@@ -19,7 +19,7 @@ package com.johnsnowlabs.nlp.annotators.ld.dl
 import com.johnsnowlabs.nlp.annotators.sentence_detector_dl.SentenceDetectorDLModel
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
-import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.tags.SlowTest
 import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -27,7 +27,7 @@ class LanguageDetectorDLTestSpec extends AnyFlatSpec {
 
   val spark = ResourceHelper.spark
 
-  "LanguageDetectorDL" should "correctly load pretrained model" taggedAs FastTest in {
+  "LanguageDetectorDL" should "correctly load pretrained model" taggedAs SlowTest in {
 
     val smallCorpus = spark.read
       .option("header", true)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/NerDLSpec.scala
@@ -248,7 +248,7 @@ class NerDLSpec extends AnyFlatSpec {
 
   }
 
-  "NerDLModel" should "successfully download a pretrained model" taggedAs FastTest in {
+  "NerDLModel" should "successfully download a pretrained model" taggedAs SlowTest in {
 
     val nerModel = NerDLModel
       .pretrained()

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/DistributedPos.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/pos/perceptron/DistributedPos.scala
@@ -19,14 +19,14 @@ package com.johnsnowlabs.nlp.annotators.pos.perceptron
 import com.johnsnowlabs.nlp.ContentProvider
 import com.johnsnowlabs.nlp.annotator._
 import com.johnsnowlabs.nlp.base._
-import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.tags.SlowTest
 import com.johnsnowlabs.util.Benchmark
 import org.apache.spark.ml.Pipeline
 import org.scalatest.flatspec.AnyFlatSpec
 
 class DistributedPos extends AnyFlatSpec with PerceptronApproachBehaviors {
 
-  "distributed pos" should "successfully work" taggedAs FastTest in {
+  "distributed pos" should "successfully work" taggedAs SlowTest in {
 
     import com.johnsnowlabs.nlp.util.io.ResourceHelper.spark.implicits._
 

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/sentence_detector_dl/SentenceDetectorDLSpec.scala
@@ -18,7 +18,7 @@ package com.johnsnowlabs.nlp.annotators.sentence_detector_dl
 
 import com.johnsnowlabs.nlp.SparkAccessor.spark
 import com.johnsnowlabs.nlp.{Annotation, DocumentAssembler, LightPipeline}
-import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.tags.{FastTest, SlowTest}
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.{Row, SparkSession}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -36,7 +36,7 @@ class SentenceDetectorDLSpec extends AnyFlatSpec {
 
   import spark.implicits._
 
-  "Sentence Detector DL" should "apply impossible penultimates" taggedAs FastTest in {
+  "Sentence Detector DL" should "apply impossible penultimates" taggedAs SlowTest in {
     val sampleText =
       """A dog loves going out on a walk, eating and sleeping in front of the fireplace  . This is how a dog lives.
         |It's great!""".stripMargin
@@ -73,7 +73,7 @@ class SentenceDetectorDLSpec extends AnyFlatSpec {
     sentenceDetectorDL.setImpossiblePenultimates(impossiblePenultimates)
   }
 
-  "Sentence Detector DL" should "test custom eos patterns" taggedAs FastTest in {
+  "Sentence Detector DL" should "test custom eos patterns" taggedAs SlowTest in {
     val sampleText =
       """A dog loves going out on a walk, eating and sleeping in front of the fireplace. This how a dog lives. It's great!"""
 
@@ -102,7 +102,7 @@ class SentenceDetectorDLSpec extends AnyFlatSpec {
     })
   }
 
-  "Sentence Detector DL" should "test new params" taggedAs FastTest in {
+  "Sentence Detector DL" should "test new params" taggedAs SlowTest in {
 
     val df = spark.read.text(testSampleFreeText).toDF("text")
 
@@ -191,7 +191,7 @@ class SentenceDetectorDLSpec extends AnyFlatSpec {
       })
   }
 
-  "Sentence Detector DL" should "download and run pretrained model" taggedAs FastTest in {
+  "Sentence Detector DL" should "download and run pretrained model" taggedAs SlowTest in {
 
     val text = Source.fromFile(testSampleFreeText).getLines().mkString("\n")
 

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/BertSentenceEmbeddingsTestSpec.scala
@@ -31,7 +31,7 @@ import scala.collection.mutable
 
 class BertSentenceEmbeddingsTestSpec extends AnyFlatSpec {
 
-  "BertSentenceEmbeddings" should "produce consistent embeddings" taggedAs FastTest in {
+  "BertSentenceEmbeddings" should "produce consistent embeddings" taggedAs SlowTest in {
 
     val testData = ResourceHelper.spark
       .createDataFrame(
@@ -85,7 +85,7 @@ class BertSentenceEmbeddingsTestSpec extends AnyFlatSpec {
       .save("./tmp_bert_sentence_embed")
   }
 
-  "BertSentenceEmbeddings" should "correctly work with empty tokens" taggedAs FastTest in {
+  "BertSentenceEmbeddings" should "correctly work with empty tokens" taggedAs SlowTest in {
 
     val testData = ResourceHelper.spark
       .createDataFrame(
@@ -189,7 +189,7 @@ class BertSentenceEmbeddingsTestSpec extends AnyFlatSpec {
     pipelineModel.transform(ddd)
   }
 
-  "BertSentenceEmbeddings" should "correctly propagate metadata" taggedAs FastTest in {
+  "BertSentenceEmbeddings" should "correctly propagate metadata" taggedAs SlowTest in {
 
     val testData = ResourceHelper.spark
       .createDataFrame(Seq((

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/ChunkEmbeddingsTestSpec.scala
@@ -23,14 +23,14 @@ import com.johnsnowlabs.nlp.annotators.{NGramGenerator, StopWordsCleaner, Tokeni
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorBuilder, EmbeddingsFinisher, Finisher}
-import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.tags.{FastTest, SlowTest}
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.Row
 import org.scalatest.flatspec.AnyFlatSpec
 
 class ChunkEmbeddingsTestSpec extends AnyFlatSpec {
 
-  "ChunkEmbeddings" should "correctly calculate chunk embeddings from Chunker" taggedAs FastTest in {
+  "ChunkEmbeddings" should "correctly calculate chunk embeddings from Chunker" taggedAs SlowTest in {
 
     val smallCorpus = ResourceHelper.spark.read
       .option("header", "true")
@@ -194,7 +194,7 @@ class ChunkEmbeddingsTestSpec extends AnyFlatSpec {
         .count() > 1)
   }
 
-  "ChunkEmbeddings" should "correctly work with empty tokens" taggedAs FastTest in {
+  "ChunkEmbeddings" should "correctly work with empty tokens" taggedAs SlowTest in {
 
     val smallCorpus = ResourceHelper.spark.read
       .option("header", "true")
@@ -268,7 +268,7 @@ class ChunkEmbeddingsTestSpec extends AnyFlatSpec {
 
   }
 
-  "ChunkEmbeddings" should "return chunk metadata at output" taggedAs FastTest in {
+  "ChunkEmbeddings" should "return chunk metadata at output" taggedAs SlowTest in {
     import com.johnsnowlabs.nlp.AnnotationUtils._
     val document = "Record: Bush Blue, ZIPCODE: XYZ84556222, phone: (911) 45 88".toRow()
 

--- a/src/test/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/embeddings/WordEmbeddingsTestSpec.scala
@@ -32,7 +32,7 @@ class WordEmbeddingsTestSpec extends AnyFlatSpec with SparkSessionTest {
     .option("header", "true")
     .csv("src/test/resources/embeddings/clinical_words.txt")
 
-  "Word Embeddings" should "Should not repeat tokens" taggedAs FastTest in {
+  "Word Embeddings" should "Should not repeat tokens" taggedAs SlowTest in {
 
     val loaded = spark.read.parquet("src/test/resources/word-embedding/test-repeated-tokens")
 

--- a/src/test/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloaderSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/pretrained/ResourceDownloaderSpec.scala
@@ -17,7 +17,7 @@
 package com.johnsnowlabs.nlp.pretrained
 
 import com.johnsnowlabs.nlp.embeddings.BertEmbeddings
-import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.tags.{FastTest, SlowTest}
 import com.johnsnowlabs.util.{TrainingHelper, Version}
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -103,15 +103,15 @@ class ResourceDownloaderSpec extends AnyFlatSpec {
     assert(found.isDefined)
   }
 
-  "Pretrained" should "allow download of BERT Tiny from public S3 Bucket" in {
+  "Pretrained" should "allow download of BERT Tiny from public S3 Bucket" taggedAs SlowTest in {
     BertEmbeddings.pretrained("small_bert_L2_128", lang = "en")
   }
 
-  "Pretrained" should "allow download of BERT Tiny from community S3 Bucket" in {
+  "Pretrained" should "allow download of BERT Tiny from community S3 Bucket" taggedAs SlowTest in {
     BertEmbeddings.pretrained("small_bert_L2_128_test", lang = "en", remoteLoc = "@maziyarpanahi")
   }
 
-  "Pretrained" should "allow download of BERT Tiny from public and community S3 Buckets" in {
+  "Pretrained" should "allow download of BERT Tiny from public and community S3 Buckets" taggedAs SlowTest in {
     val bertModel = BertEmbeddings.pretrained(
       "small_bert_L2_128_test",
       lang = "en",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates the Spark NLP CI workflow to validate the Scala 2.13 migration against Apache Spark 4.0.0, 4.0.1, and 4.1.2 using Java 17 and Python 3.10.

It includes the following changes:

- Replaces the previous Spark jobs with a single exact-version Spark 4 matrix.
- Runs Scala coverage only on Spark 4.0.1 and updates Scoverage/Coveralls to versions compatible with Scala 2.13.16.
- Adds explicit Scala and Python test timeouts to prevent stalled native or PySpark processes from consuming the full GitHub Actions job limit.
- Preloads the system `libstdc++.so.6` in Scala and Python test steps to stabilize TensorFlow-backed native tests on Ubuntu runners.
- Marks Python and Scala tests that download pretrained resources as slow so normal CI remains deterministic and does not depend on external model downloads.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous CI configuration did not provide explicit compatibility coverage for the supported Spark 4 releases and used runtime/tooling versions that were incompatible with the Scala 2.13 migration.

During validation, several independent issues were identified:

- The previous Scoverage plugin could not resolve a compiler plugin for Scala 2.13.16.
- TensorFlow-backed tests could abort with `random_device could not be read` because of native C++ runtime load order on Ubuntu runners.
- Spark 4.1.2 excludes Breeze's transitive `scala-collection-compat` dependency, causing `AudioUtilsTest` to abort with `NoClassDefFoundError`.
- Pretrained tests introduced network-dependent execution into the fast test suites and could leave Python waiting indefinitely after a JVM/native failure.
- Reader tests expected fixture files that were not available in CI.

The changes make Spark-version compatibility explicit, keep the fast suites reproducible, and ensure native or network-related failures are bounded and diagnosable.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- GitHub Actions completed the Scala and Python test lanes for Spark 4.0.0, 4.0.1, and 4.1.2.
- Verified Scala compilation and dependency resolution with Scala 2.13.16 across the Spark 4 matrix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
