### PR TITLE
[Spark 4.x] [Sparknlp-674] implement a new annotator to allow summarization

### DIFF
--- a/docs/en/annotator_entries/Summarization.md
+++ b/docs/en/annotator_entries/Summarization.md
@@ -26,6 +26,10 @@ configures the shared delegate in place — use one instance per concurrent call
 **Note:** With the `llm` method the document text is embedded into the prompt, so a document
 containing instructions can influence its own summary (prompt injection). The built-in system
 prompt reduces but does not eliminate this.
+
+**Note:** `transform` caches the input row ids and the computed summaries to keep the returned
+DataFrame consistent. These caches cannot be released through this API; they are freed when the
+SparkSession ends or via `spark.catalog.clearCache()` (which clears all cached data).
 {%- endcapture -%}
 
 {%- capture model_input_anno -%}
@@ -114,7 +118,9 @@ Three summarization methods are supported, each with an automatically selected d
 Documents longer than the model context are handled automatically
 (`setLongDocumentStrategy("auto" | "truncate" | "hierarchical")`): the document is split at
 sentence boundaries into overlapping chunks, each chunk is summarized, and the intermediate
-summaries are combined and summarized again.
+summaries are combined and summarized again. `auto` and `hierarchical` currently behave
+identically (a document that fits is summarized in a single pass either way); only `truncate`
+differs, cutting the document to the context budget.
 
 The public API exposes summarization concepts rather than model concepts:
 

--- a/docs/en/annotator_entries/Summarization.md
+++ b/docs/en/annotator_entries/Summarization.md
@@ -1,0 +1,225 @@
+{%- capture title -%}
+Summarization
+{%- endcapture -%}
+
+{%- capture model_description -%}
+Fitted model produced by `Summarization`. It orchestrates the resolved summarization delegate at
+the DataFrame level: prompt building, long document chunking, delegate inference, output cleanup,
+and transparency metadata.
+
+The summarization `method` is bound at fit time. A `SummarizationModel` only holds the delegate
+of the method it was fitted with (`llm`, `encoder_decoder`, or `extractive`). Task parameters
+that shape the output (summary length, style, focus, long document strategy, MMR/position
+weights, generation settings) can be changed freely on the fitted model. Saving the model
+persists the underlying delegate weights, so fitted pipelines reload without network access.
+
+This is the instantiated model of the `Summarization` estimator. To build one, fit a
+`Summarization` stage (see the documentation of that class).
+
+**Note:** As a DataFrame level orchestrator, this annotator is not supported in `LightPipeline`.
+{%- endcapture -%}
+
+{%- capture model_input_anno -%}
+DOCUMENT
+{%- endcapture -%}
+
+{%- capture model_output_anno -%}
+DOCUMENT
+{%- endcapture -%}
+
+{%- capture model_python_example -%}
+>>> import sparknlp
+>>> from sparknlp.base import *
+>>> from sparknlp.annotator import *
+>>> from pyspark.ml import Pipeline
+>>> documentAssembler = DocumentAssembler() \
+...     .setInputCol("text") \
+...     .setOutputCol("document")
+>>> summarizer = Summarization() \
+...     .setInputCols(["document"]) \
+...     .setOutputCol("summary") \
+...     .setMethod("extractive") \
+...     .setMaxSummaryLength(60)
+>>> pipeline = Pipeline().setStages([documentAssembler, summarizer])
+>>> data = spark.createDataFrame([["<a long document ...>"]]).toDF("text")
+>>> model = pipeline.fit(data)
+>>> # the fitted stage is a SummarizationModel; its parameters can still be tuned
+>>> result = model.transform(data)
+>>> result.select("summary.result").show(truncate=False)
+{%- endcapture -%}
+
+{%- capture model_scala_example -%}
+import com.johnsnowlabs.nlp.base._
+import com.johnsnowlabs.nlp.annotator._
+import org.apache.spark.ml.Pipeline
+import spark.implicits._
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val summarizer = new Summarization()
+  .setInputCols("document")
+  .setOutputCol("summary")
+  .setMethod("extractive")
+  .setMaxSummaryLength(60)
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, summarizer))
+
+val data = Seq("<a long document ...>").toDF("text")
+val model = pipeline.fit(data)
+val result = model.transform(data)
+result.select("summary.result").show(false)
+{%- endcapture -%}
+
+{%- capture model_api_link -%}
+[SummarizationModel](/api/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel)
+{%- endcapture -%}
+
+{%- capture model_python_api_link -%}
+[SummarizationModel](/api/python/reference/autosummary/sparknlp/annotator/seq2seq/summarization/index.html#sparknlp.annotator.seq2seq.summarization.SummarizationModel)
+{%- endcapture -%}
+
+{%- capture model_source_link -%}
+[SummarizationModel](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala)
+{%- endcapture -%}
+
+{%- capture approach_description -%}
+High level, task oriented document summarization. `Summarization` is a zero configuration
+estimator: state *what* you want (summary length, style, focus) and the annotator decides *how*
+to produce it (model selection, prompting, generation settings, and long document handling). No
+prompt writing or model choice is required, because `fit()` resolves and downloads a sensible default
+model for the chosen method.
+
+Three summarization methods are supported, each with an automatically selected default model:
+
+* `llm` (default): an instruction tuned GGUF LLM run with llama.cpp (via `AutoGGUFModel`). The
+  annotator owns the summarization prompt, the system prompt, safe generation defaults, and
+  reasoning mode suppression. Default model: `qwen3_4b_q8_0_gguf`.
+* `encoder_decoder`: a specialized abstractive summarization model (`BartTransformer`, DistilBART
+  fine tuned on XSum). Default model: `distilbart_xsum_12_6`.
+* `extractive`: selects the most central sentences from the original document using sentence
+  embeddings, position augmented centrality, and MMR redundancy control (a PacSum style ranker).
+  The output contains only text taken from the source. Default model: `all_mpnet_base_v2`.
+
+Documents longer than the model context are handled automatically
+(`setLongDocumentStrategy("auto" | "truncate" | "hierarchical")`): the document is split at
+sentence boundaries into overlapping chunks, each chunk is summarized, and the intermediate
+summaries are combined and summarized again.
+
+The public API exposes summarization concepts rather than model concepts:
+
+```scala
+summarizer
+  .setMethod("llm")
+  .setMaxSummaryLength(250)
+  .setMinSummaryLength(50)
+  .setSummaryStyle("concise")        // concise | detailed | bullets (llm)
+  .setFocus("main findings")          // free text focus hint (llm)
+  .setLongDocumentStrategy("auto")
+```
+
+Advanced parameters (`setModel`, `setNumBeams`, `setTemperature`, `setTopP`, `setChunkSize`,
+`setChunkOverlap`, `setMmrLambda`, `setPositionBias`, `setGpuLayers`) are optional; most users
+never need them. Parameters that do not apply to the selected method are ignored with a logged
+warning. On CPU only clusters, set `setGpuLayers(0)` for the `llm` method.
+
+Regardless of method, the output is a single `DOCUMENT` annotation whose metadata reports the
+selected `method`, `model`, `engine`, estimated original/summary token counts, number of chunks,
+and the long document strategy used.
+
+For extended examples of usage, see the
+[example notebook](https://github.com/JohnSnowLabs/spark-nlp/tree/master/examples/python/annotation/text/english/text-summarization/Summarization_Annotator.ipynb).
+{%- endcapture -%}
+
+{%- capture approach_input_anno -%}
+DOCUMENT
+{%- endcapture -%}
+
+{%- capture approach_output_anno -%}
+DOCUMENT
+{%- endcapture -%}
+
+{%- capture approach_python_example -%}
+>>> import sparknlp
+>>> from sparknlp.base import *
+>>> from sparknlp.annotator import *
+>>> from pyspark.ml import Pipeline
+>>> documentAssembler = DocumentAssembler() \
+...     .setInputCol("text") \
+...     .setOutputCol("document")
+>>> # zero configuration: the default method (llm) and its default model are resolved at fit()
+>>> summarizer = Summarization() \
+...     .setInputCols(["document"]) \
+...     .setOutputCol("summary") \
+...     .setMethod("encoder_decoder") \
+...     .setMaxSummaryLength(80)
+>>> pipeline = Pipeline().setStages([documentAssembler, summarizer])
+>>> data = spark.createDataFrame([[
+...     "Spark NLP is an open source text processing library for Python, Java and Scala. "
+...     "It provides production grade, scalable, and trainable versions of the latest research "
+...     "in natural language processing."]]).toDF("text")
+>>> result = pipeline.fit(data).transform(data)
+>>> result.select("summary.result").show(truncate=False)
+>>> result.select("summary.metadata").show(truncate=False)
+{%- endcapture -%}
+
+{%- capture approach_scala_example -%}
+import com.johnsnowlabs.nlp.base._
+import com.johnsnowlabs.nlp.annotator._
+import org.apache.spark.ml.Pipeline
+import spark.implicits._
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val summarizer = new Summarization()
+  .setInputCols("document")
+  .setOutputCol("summary")
+  .setMethod("encoder_decoder")
+  .setMaxSummaryLength(80)
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, summarizer))
+
+val data = Seq(
+  "Spark NLP is an open source text processing library for Python, Java and Scala. " +
+    "It provides production grade, scalable, and trainable versions of the latest research " +
+    "in natural language processing.").toDF("text")
+
+val result = pipeline.fit(data).transform(data)
+result.select("summary.result").show(false)
+result.select("summary.metadata").show(false)
+{%- endcapture -%}
+
+{%- capture approach_api_link -%}
+[Summarization](/api/com/johnsnowlabs/nlp/annotators/seq2seq/Summarization)
+{%- endcapture -%}
+
+{%- capture approach_python_api_link -%}
+[Summarization](/api/python/reference/autosummary/sparknlp/annotator/seq2seq/summarization/index.html#sparknlp.annotator.seq2seq.summarization.Summarization)
+{%- endcapture -%}
+
+{%- capture approach_source_link -%}
+[Summarization](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/Summarization.scala)
+{%- endcapture -%}
+
+{% include templates/approach_model_template.md
+title=title
+model_description=model_description
+model_input_anno=model_input_anno
+model_output_anno=model_output_anno
+model_python_example=model_python_example
+model_scala_example=model_scala_example
+model_api_link=model_api_link
+model_python_api_link=model_python_api_link
+model_source_link=model_source_link
+approach_description=approach_description
+approach_input_anno=approach_input_anno
+approach_output_anno=approach_output_anno
+approach_python_example=approach_python_example
+approach_scala_example=approach_scala_example
+approach_api_link=approach_api_link
+approach_python_api_link=approach_python_api_link
+approach_source_link=approach_source_link
+%}

--- a/docs/en/annotator_entries/Summarization.md
+++ b/docs/en/annotator_entries/Summarization.md
@@ -17,6 +17,15 @@ This is the instantiated model of the `Summarization` estimator. To build one, f
 `Summarization` stage (see the documentation of that class).
 
 **Note:** As a DataFrame level orchestrator, this annotator is not supported in `LightPipeline`.
+
+**Note:** The `encoder_decoder` method pins inference to a single Spark partition (the BART
+backend is not thread-safe); the `llm` and `extractive` methods keep the input partitioning. A
+single fitted model instance is not safe for concurrent `transform` calls, since `transform`
+configures the shared delegate in place — use one instance per concurrent caller.
+
+**Note:** With the `llm` method the document text is embedded into the prompt, so a document
+containing instructions can influence its own summary (prompt injection). The built-in system
+prompt reduces but does not eliminate this.
 {%- endcapture -%}
 
 {%- capture model_input_anno -%}

--- a/docs/en/annotators.md
+++ b/docs/en/annotators.md
@@ -106,6 +106,7 @@ There are two types of Annotators:
 {% include templates/anno_table_entry.md path="" name="SentimentDetector" summary="Rule based sentiment detector, which calculates a score based on predefined keywords."%}
 {% include templates/anno_table_entry.md path="" name="Stemmer" summary="Returns hard-stems out of words with the objective of retrieving the meaningful part of the word."%}
 {% include templates/anno_table_entry.md path="" name="StopWordsCleaner" summary="This annotator takes a sequence of strings (e.g. the output of a Tokenizer, Normalizer, Lemmatizer, and Stemmer) and drops all the stop words from the input sequences."%}
+{% include templates/anno_table_entry.md path="" name="Summarization" summary="Task oriented, zero configuration document summarization with a choice of llm, encoder_decoder, or extractive methods and automatic long document handling."%}
 {% include templates/anno_table_entry.md path="" name="SymmetricDelete Spellchecker" summary="Symmetric Delete spelling correction algorithm."%}
 {% include templates/anno_table_entry.md path="" name="TextMatcher" summary="Matches exact phrases (by token) provided in a file against a Document."%}
 {% include templates/anno_table_entry.md path="" name="Token2Chunk" summary="Converts `TOKEN` type Annotations to `CHUNK` type."%}

--- a/docs/en/tasks/summarization.md
+++ b/docs/en/tasks/summarization.md
@@ -29,7 +29,68 @@ The choice of model for summarization depends on whether the goal is extractive 
 
 Explore the available summarization models at [Spark NLP Models](https://sparknlp.org/models) to find the one that best suits your summarization needs.
 
+## Zero configuration with the `Summarization` annotator
+
+If you would rather not choose a model or write prompts, the high level
+[`Summarization`](/docs/en/annotator_entries/Summarization) annotator picks and loads a sensible
+default model for you and owns prompting, generation settings, and long document handling. Select
+one of three methods (`llm`, `encoder_decoder`, or `extractive`) and control the result with
+task level parameters such as `setMaxSummaryLength`, `setSummaryStyle`, and `setFocus`.
+
+<div class="tabs-box" markdown="1">
+{% include programmingLanguageSelectScalaPython.html %}
+```python
+from sparknlp.base import DocumentAssembler
+from sparknlp.annotator import Summarization
+from pyspark.ml import Pipeline
+
+documentAssembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+# encoder_decoder resolves DistilBART automatically; use "extractive" for a CPU only,
+# source faithful summary, or "llm" (default) for an instruction tuned generative summary.
+summarizer = Summarization() \
+    .setInputCols(["document"]) \
+    .setOutputCol("summary") \
+    .setMethod("encoder_decoder") \
+    .setMaxSummaryLength(80)
+
+pipeline = Pipeline(stages=[documentAssembler, summarizer])
+data = spark.createDataFrame([[passage]]).toDF("text")
+result = pipeline.fit(data).transform(data)
+result.select("summary.result", "summary.metadata").show(truncate=False)
+```
+```scala
+import com.johnsnowlabs.nlp.base._
+import com.johnsnowlabs.nlp.annotator._
+import org.apache.spark.ml.Pipeline
+
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val summarizer = new Summarization()
+  .setInputCols("document")
+  .setOutputCol("summary")
+  .setMethod("encoder_decoder")
+  .setMaxSummaryLength(80)
+
+val pipeline = new Pipeline().setStages(Array(documentAssembler, summarizer))
+val data = Seq(passage).toDF("text")
+val result = pipeline.fit(data).transform(data)
+result.select("summary.result", "summary.metadata").show(false)
+```
+</div>
+
+See the [`Summarization` annotator reference](/docs/en/annotator_entries/Summarization) and the
+[end to end notebook](https://github.com/JohnSnowLabs/spark-nlp/tree/master/examples/python/annotation/text/english/text-summarization/Summarization_Annotator.ipynb)
+for the full parameter set, long document strategies, and per method examples.
+
 ## How to use
+
+The example below uses [`BartTransformer`](/docs/en/transformers#barttransformer) directly, which
+gives you full control over a specific model when you do not want the automatic defaults.
 
 <div class="tabs-box" markdown="1">
 {% include programmingLanguageSelectScalaPython.html %}

--- a/examples/python/annotation/text/english/text-summarization/Summarization_Annotator.ipynb
+++ b/examples/python/annotation/text/english/text-summarization/Summarization_Annotator.ipynb
@@ -1,0 +1,563 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "q0T-CZdmbRti"
+   },
+   "source": [
+    "![JohnSnowLabs](https://sparknlp.org/assets/images/logo.png)\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-summarization/Summarization_Annotator.ipynb)\n",
+    "\n",
+    "# Document Summarization with the `Summarization` Annotator\n",
+    "\n",
+    "`Summarization` is a high level, **task oriented** annotator: you say *what* you want (how long, what style, what to focus on) and it decides *how* to produce it, selecting and downloading a model, building prompts, setting safe generation defaults, and handling documents that are longer than the model context.\n",
+    "\n",
+    "It supports three methods, each with an automatically selected default model:\n",
+    "\n",
+    "| Method | What it does | Default model | Best for |\n",
+    "|--------|--------------|---------------|----------|\n",
+    "| `llm` (default) | Instruction tuned LLM (llama.cpp) generates a summary | `qwen3_4b_q8_0_gguf` | Highest quality, controllable via style/focus; GPU recommended |\n",
+    "| `encoder_decoder` | Purpose built abstractive model (DistilBART) | `distilbart_xsum_12_6` | Fast fluent abstractive summaries |\n",
+    "| `extractive` | Selects the most central original sentences (PacSum style centrality + MMR) | `all_mpnet_base_v2` | CPU only, high throughput, source faithful (no hallucination) |\n",
+    "\n",
+    "Every method takes `DOCUMENT` in and returns `DOCUMENT` out, with rich metadata describing what happened. This notebook walks through all of it end to end."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jxOlyo-gbRtl"
+   },
+   "source": [
+    "## 1. Setup\n",
+    "\n",
+    "Install and start Spark NLP on Google Colab, using the setup script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "hnNOv1CvbRtm"
+   },
+   "outputs": [],
+   "source": [
+    "# Only run this cell if you are on Google Colab\n",
+    "! wget -q http://setup.johnsnowlabs.com/colab.sh -O - | bash\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "WBgiV6y_bRtn"
+   },
+   "outputs": [],
+   "source": [
+    "import sparknlp\n",
+    "from sparknlp.base import DocumentAssembler\n",
+    "from sparknlp.annotator import Summarization, SummarizationModel\n",
+    "from pyspark.ml import Pipeline, PipelineModel\n",
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "# For the LLM method a GPU is recommended. On a CPU-only machine keep gpu=False and set\n",
+    "# .setGpuLayers(0) on the llm summarizer (shown later).\n",
+    "spark = sparknlp.start()\n",
+    "\n",
+    "print('Spark NLP version:', sparknlp.version())\n",
+    "print('Apache Spark version:', spark.version)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2c9q68grbRto"
+   },
+   "source": [
+    "## 2. Quickstart\n",
+    "\n",
+    "A minimal pipeline is a `DocumentAssembler` feeding a `Summarization` stage. The `method` is chosen at build time; the default (or an explicit) model is resolved and downloaded when you call `fit()`.\n",
+    "\n",
+    "We start with the **extractive** method because it is CPU friendly and downloads only a small sentence embeddings model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "DUGdliiibRto",
+    "outputId": "7d1e5469-2038-4bc0-98cc-0822d15d26b8"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+\n",
+      "|result                                                                                                                                                                                                                                                                                                                                  |\n",
+      "+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+\n",
+      "|[Renewable energy capacity grew at a record pace last year, driven mainly by solar and wind. Global installations rose by nearly 50 percent compared with the previous year, according to the International Energy Agency. China accounted for the largest share of new capacity, followed by the European Union and the United States.]|\n",
+      "+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "document_assembler = DocumentAssembler() \\\n",
+    "    .setInputCol('text') \\\n",
+    "    .setOutputCol('document')\n",
+    "\n",
+    "summarizer = Summarization() \\\n",
+    "    .setInputCols(['document']) \\\n",
+    "    .setOutputCol('summary') \\\n",
+    "    .setMethod('extractive') \\\n",
+    "    .setMaxSummaryLength(60)\n",
+    "\n",
+    "pipeline = Pipeline(stages=[\n",
+    "    document_assembler,\n",
+    "    summarizer\n",
+    "])\n",
+    "\n",
+    "article = (\n",
+    "    'Renewable energy capacity grew at a record pace last year, driven mainly by solar and wind. '\n",
+    "    'Global installations rose by nearly 50 percent compared with the previous year, according to '\n",
+    "    'the International Energy Agency. China accounted for the largest share of new capacity, followed '\n",
+    "    'by the European Union and the United States. Falling equipment costs and supportive government '\n",
+    "    'policies were the main drivers of the expansion. Analysts caution, however, that grid '\n",
+    "    'infrastructure and permitting delays could slow deployment in the coming years. The agency '\n",
+    "    'expects renewables to overtake coal as the largest source of electricity generation before the '\n",
+    "    'end of the decade if current trends continue.'\n",
+    ")\n",
+    "\n",
+    "data = spark.createDataFrame([[article]]).toDF('text')\n",
+    "model = pipeline.fit(data)\n",
+    "result = model.transform(data)\n",
+    "\n",
+    "result.select('summary.result').show(truncate=False)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qpPywIE-bRtp"
+   },
+   "source": [
+    "### The output is a `DOCUMENT` with transparency metadata\n",
+    "\n",
+    "Every summary annotation carries metadata describing exactly what the annotator did: which method and model ran, the inference engine, estimated token counts, how many chunks were used, and (for extractive) how many sentences were selected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "DB209vlnesed",
+    "outputId": "1e9329eb-e523-4a02-b6a5-f3e91161b9ff"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SUMMARY\n",
+      "Renewable energy capacity grew at a record pace last year, driven mainly by solar and wind. Global\n",
+      "installations rose by nearly 50 percent compared with the previous year, according to the\n",
+      "International Energy Agency. China accounted for the largest share of new capacity, followed by the\n",
+      "European Union and the United States.\n",
+      "\n",
+      "METADATA\n",
+      "+--------------------+-----------------+\n",
+      "|key                 |value            |\n",
+      "+--------------------+-----------------+\n",
+      "|engine              |onnx             |\n",
+      "|longDocumentStrategy|native           |\n",
+      "|method              |extractive       |\n",
+      "|model               |all_mpnet_base_v2|\n",
+      "|originalTokensEst   |173              |\n",
+      "|sentence            |0                |\n",
+      "|sentencesSelected   |3                |\n",
+      "|sentencesTotal      |6                |\n",
+      "|summaryTokensEst    |81               |\n",
+      "+--------------------+-----------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import textwrap\n",
+    "\n",
+    "summary_row = result.select(F.explode('summary').alias('s')).select('s.result', 's.metadata').first()\n",
+    "\n",
+    "print(\"SUMMARY\")\n",
+    "print(textwrap.fill(summary_row['result'], width=100))\n",
+    "print()\n",
+    "\n",
+    "print(\"METADATA\")\n",
+    "metadata_df = spark.createDataFrame(\n",
+    "    sorted(summary_row['metadata'].items()), ['key', 'value']\n",
+    ")\n",
+    "metadata_df.show(truncate=False)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "S3g3nxTBbRtr"
+   },
+   "source": [
+    "## 3. Comparing the three methods on the same document\n",
+    "\n",
+    "The same task level API works across methods; only `setMethod` (and the model it resolves) changes. Below we run **extractive** and **encoder_decoder** on the same article and compare.\n",
+    "\n",
+    "> The **llm** method downloads a ~4 GB GGUF model and prefers a GPU. It is shown in section 5 with CPU safe settings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "id": "RQKxsLe1T63c"
+   },
+   "outputs": [],
+   "source": [
+    "def summarize(method, text, **params):\n",
+    "    s = Summarization().setInputCols(['document']).setOutputCol('summary').setMethod(method)\n",
+    "    for k, v in params.items():\n",
+    "        getattr(s, 'set' + k[0].upper() + k[1:])(v)\n",
+    "    p = Pipeline(stages=[document_assembler, s])\n",
+    "    df = spark.createDataFrame([[text]]).toDF('text')\n",
+    "    out = p.fit(df).transform(df)\n",
+    "    row = out.select('summary.result', 'summary.metadata').first()\n",
+    "    return row[0][0], row[1][0]\n",
+    "\n",
+    "ext_summary, ext_meta = summarize('extractive', article, maxSummaryLength=60)\n",
+    "enc_summary, enc_meta = summarize('encoder_decoder', article, maxSummaryLength=60)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "ShSCMQQObRtr",
+    "outputId": "1ac1a03a-7322-4867-a593-1fdfbc4b29e9"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EXTRACTIVE  (method=extractive, model=all_mpnet_base_v2)\n",
+      "Renewable energy capacity grew at a record pace last year, driven mainly by solar and wind. Global installations rose by nearly 50 percent compared with the previous year, according to the International Energy Agency. China accounted for the largest share of new capacity, followed by the European Union and the United States.\n",
+      "\n",
+      "ENCODER_DECODER  (method=encoder_decoder, model=distilbart_xsum_12_6)\n",
+      "Global installations of solar and the International Energy Agency (IEA) has reported a report on global installations of renewable energy.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('EXTRACTIVE  (method=%s, model=%s)' % (ext_meta['method'], ext_meta['model']))\n",
+    "print(ext_summary)\n",
+    "print()\n",
+    "print('ENCODER_DECODER  (method=%s, model=%s)' % (enc_meta['method'], enc_meta['model']))\n",
+    "print(enc_summary)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0Fqznm84bRts"
+   },
+   "source": [
+    "Notice the difference: **extractive** returns sentences copied verbatim from the source (safe, no hallucination), while **encoder_decoder** rephrases the content into new, fluent sentences (abstractive)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ReSYV9UHbRtt"
+   },
+   "source": [
+    "## 4. Long documents are handled automatically\n",
+    "\n",
+    "When a document is longer than the model's context window, `Summarization` splits it at sentence boundaries into overlapping chunks, summarizes each chunk, and then combines and re summarizes the intermediate summaries (hierarchical map/reduce). You never split documents yourself.\n",
+    "\n",
+    "`setLongDocumentStrategy` accepts:\n",
+    "* `auto` (default): summarize directly when it fits, otherwise fall back to hierarchical.\n",
+    "* `hierarchical`: always chunk, summarize, and reduce.\n",
+    "* `truncate`: cut to the context limit and summarize once.\n",
+    "\n",
+    "`setChunkSize` (approximate tokens) and `setChunkOverlap` (sentences shared between chunks) give finer control. The `numChunks` metadata field tells you how many chunks were used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "wYWScALabRtt",
+    "outputId": "fe86cf28-72ff-4dae-df11-4fea4c46e881"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of chunks used: 4\n",
+      "Strategy: hierarchical\n",
+      "\n",
+      "Global installations of renewable energy capacity grew at a record pace last year, according to a report from the International Energy Agency.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Build a long document by concatenating several paragraphs.\n",
+    "long_document = ' '.join([article] * 8)   # ~2,600 words\n",
+    "\n",
+    "long_summarizer = Summarization() \\\n",
+    "    .setInputCols(['document']) \\\n",
+    "    .setOutputCol('summary') \\\n",
+    "    .setMethod('encoder_decoder') \\\n",
+    "    .setMaxSummaryLength(90) \\\n",
+    "    .setLongDocumentStrategy('hierarchical') \\\n",
+    "    .setChunkSize(400) \\\n",
+    "    .setChunkOverlap(1)\n",
+    "\n",
+    "long_pipeline = Pipeline(stages=[document_assembler, long_summarizer])\n",
+    "long_df = spark.createDataFrame([[long_document]]).toDF('text')\n",
+    "long_out = long_pipeline.fit(long_df).transform(long_df)\n",
+    "\n",
+    "row = long_out.select('summary.result', 'summary.metadata').first()\n",
+    "print('Number of chunks used:', row[1][0]['numChunks'])\n",
+    "print('Strategy:', row[1][0]['longDocumentStrategy'])\n",
+    "print()\n",
+    "print(row[0][0])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Vqg9ybOZbRtt"
+   },
+   "source": [
+    "## 5. The LLM method (instruction tuned, most controllable)\n",
+    "\n",
+    "The `llm` method runs an instruction tuned GGUF model through llama.cpp. The annotator owns the prompt, the system prompt, and reasoning suppression, so you only provide task settings. Style and focus are honored through the prompt.\n",
+    "\n",
+    "**On CPU:** call `setGpuLayers(0)`. **On GPU:** use the Spark NLP GPU package and leave `gpuLayers` at its default (99). The default model is ~4 GB and will download on first `fit()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "PHnreEbhbRtt",
+    "outputId": "ded936f0-1e1a-4922-c331-1775514e8908"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "engine: llamacpp | model: qwen3_4b_q8_0_gguf\n",
+      "\n",
+      "- Record growth in renewable energy capacity driven by solar and wind.  \n",
+      "- China, EU, and US led new installations.  \n",
+      "- Falling costs and policies fueled expansion.  \n",
+      "- Grid infrastructure and delays pose deployment risks.  \n",
+      "- Renewables expected to surpass coal by 2030.\n"
+     ]
+    }
+   ],
+   "source": [
+    "llm_summarizer = Summarization() \\\n",
+    "    .setInputCols(['document']) \\\n",
+    "    .setOutputCol('summary') \\\n",
+    "    .setMethod('llm') \\\n",
+    "    .setMaxSummaryLength(70) \\\n",
+    "    .setSummaryStyle('bullets') \\\n",
+    "    .setFocus('the main drivers and the main risk') \\\n",
+    "    .setGpuLayers(0)          # set to 99 (default) on a GPU cluster\n",
+    "\n",
+    "llm_pipeline = Pipeline(stages=[document_assembler, llm_summarizer])\n",
+    "llm_out = llm_pipeline.fit(data).transform(data)\n",
+    "\n",
+    "row = llm_out.select('summary.result', 'summary.metadata').first()\n",
+    "print('engine:', row[1][0]['engine'], '| model:', row[1][0]['model'])\n",
+    "print()\n",
+    "print(row[0][0])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "THxDq3x1bRtt"
+   },
+   "source": [
+    "## 6. Real world batch: summarizing many documents at once\n",
+    "\n",
+    "Because `Summarization` is a normal Spark NLP stage, a fitted model summarizes an entire DataFrame in one distributed pass, one summary per input row. This is the typical production pattern: a table of articles, tickets, filings, or abstracts in, a table of summaries out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "FrHH_0tebRtu",
+    "outputId": "129ac785-ea8a-4023-e6d3-0f4cfb540b2f"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+--------+----------------------------------------------------------------------------------------------------+------------------+\n",
+      "|category|                                                                                             summary|sentences_selected|\n",
+      "+--------+----------------------------------------------------------------------------------------------------+------------------+\n",
+      "|  energy|Renewable energy capacity grew at a record pace last year, driven mainly by solar and wind. Globa...|                 2|\n",
+      "|  health|A large clinical study reported that a new once-daily pill reduced the risk of stroke in high-ris...|                 1|\n",
+      "|    tech|The company unveiled its next-generation processor, which it says delivers a forty percent improv...|                 2|\n",
+      "+--------+----------------------------------------------------------------------------------------------------+------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "documents = [\n",
+    "    ('energy', article),\n",
+    "    ('health', (\n",
+    "        'A large clinical study reported that a new once-daily pill reduced the risk of stroke in '\n",
+    "        'high-risk patients by about a third compared with the standard treatment. The trial '\n",
+    "        'followed more than fifteen thousand participants across twelve countries for four years. '\n",
+    "        'Side effects were generally mild, though a small number of patients discontinued the drug '\n",
+    "        'because of dizziness. Regulators are expected to review the results later this year, and '\n",
+    "        'the manufacturer said it would seek approval in several major markets.')),\n",
+    "    ('tech', (\n",
+    "        'The company unveiled its next-generation processor, which it says delivers a forty percent '\n",
+    "        'improvement in performance per watt over the previous generation. The chip is built on a '\n",
+    "        'newer manufacturing process and adds dedicated hardware for on-device machine learning. '\n",
+    "        'Analysts said the efficiency gains could help the company win back customers in the laptop '\n",
+    "        'market, where battery life has become a key selling point. Shipments are scheduled to begin '\n",
+    "        'next quarter.')),\n",
+    "]\n",
+    "\n",
+    "batch_df = spark.createDataFrame(documents, ['category', 'text'])\n",
+    "\n",
+    "batch_summarizer = Summarization() \\\n",
+    "    .setInputCols(['document']) \\\n",
+    "    .setOutputCol('summary') \\\n",
+    "    .setMethod('extractive') \\\n",
+    "    .setMaxSummaryLength(40)\n",
+    "\n",
+    "batch_model = Pipeline(stages=[document_assembler, batch_summarizer]).fit(batch_df)\n",
+    "batch_result = batch_model.transform(batch_df)\n",
+    "\n",
+    "batch_result.select(\n",
+    "    'category',\n",
+    "    F.col('summary.result').getItem(0).alias('summary'),\n",
+    "    F.col('summary.metadata').getItem(0)['sentencesSelected'].alias('sentences_selected'),\n",
+    ").show(truncate=100)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Lp176-zPbRtu"
+   },
+   "source": [
+    "## 7. Save and reload a fitted pipeline\n",
+    "\n",
+    "Saving a fitted `Summarization` pipeline persists the underlying model weights, so it reloads and runs **offline**, no re download and no network access required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "ah8GPj2ObRtv",
+    "outputId": "f7ca75e6-d2ce-4626-87f3-e90e471f0d70"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+--------+----------------------------------------------------------------------------------------------------+\n",
+      "|category|                                                                                             summary|\n",
+      "+--------+----------------------------------------------------------------------------------------------------+\n",
+      "|  energy|Renewable energy capacity grew at a record pace last year, driven mainly by solar and wind. Globa...|\n",
+      "|  health|A large clinical study reported that a new once-daily pill reduced the risk of stroke in high-ris...|\n",
+      "|    tech|The company unveiled its next-generation processor, which it says delivers a forty percent improv...|\n",
+      "+--------+----------------------------------------------------------------------------------------------------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "path = '/tmp/summarization_pipeline'\n",
+    "batch_model.write().overwrite().save(path)\n",
+    "\n",
+    "reloaded = PipelineModel.load(path)\n",
+    "reloaded.transform(batch_df).select(\n",
+    "    'category', F.col('summary.result').getItem(0).alias('summary')\n",
+    ").show(truncate=100)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0EMTT3xKbRtv"
+   },
+   "source": [
+    "## Choosing a method\n",
+    "\n",
+    "| If you need... | Use |\n",
+    "|----------------|-----|\n",
+    "| No hallucination, exact source sentences, CPU only, high throughput | `extractive` |\n",
+    "| Fluent rephrased summaries, fast, no GPU required | `encoder_decoder` |\n",
+    "| The highest quality and control via style/focus, GPU available | `llm` |\n",
+    "\n",
+    "### Notes\n",
+    "* Parameters that do not apply to the chosen method are ignored with a logged warning (e.g. `setNumBeams` on `llm`, `setMmrLambda` on `encoder_decoder`).\n",
+    "* `setMinSummaryLength` must be `<= setMaxSummaryLength` (validated at `fit()`).\n",
+    "* This annotator runs at the DataFrame level and is **not** supported in `LightPipeline`.\n",
+    "* For a custom model, pass `setModel('<name-from-models-hub>')` matching the selected method's engine."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/python/sparknlp/annotator/seq2seq/__init__.py
+++ b/python/sparknlp/annotator/seq2seq/__init__.py
@@ -33,3 +33,4 @@ from sparknlp.annotator.seq2seq.cohere_transformer import *
 from sparknlp.annotator.seq2seq.olmo_transformer import *
 from sparknlp.annotator.seq2seq.phi4_transformer import *
 from sparknlp.annotator.seq2seq.auto_gguf_reranker import *
+from sparknlp.annotator.seq2seq.summarization import *

--- a/python/sparknlp/annotator/seq2seq/summarization.py
+++ b/python/sparknlp/annotator/seq2seq/summarization.py
@@ -364,3 +364,10 @@ class SummarizationModel(AnnotatorModel, _SummarizationParams):
             Resolved pretrained model name
         """
         return self.getOrDefault(self.resolvedModel)
+
+    def close(self):
+        """Frees the llama.cpp native resources held by the ``llm`` delegate.
+
+        No-op for the ``encoder_decoder`` and ``extractive`` methods.
+        """
+        return self._java_obj.close()

--- a/python/sparknlp/annotator/seq2seq/summarization.py
+++ b/python/sparknlp/annotator/seq2seq/summarization.py
@@ -1,0 +1,366 @@
+#  Copyright 2017-2026 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Contains classes for the Summarization annotator."""
+
+from sparknlp.common import *
+
+
+class _SummarizationParams:
+    """Task-level parameters shared by :class:`.Summarization` and
+    :class:`.SummarizationModel`."""
+
+    method = Param(Params._dummy(), "method",
+                   "Summarization method: llm, encoder_decoder or extractive",
+                   typeConverter=TypeConverters.toString)
+
+    model = Param(Params._dummy(), "model",
+                  "Pretrained model name overriding the method default",
+                  typeConverter=TypeConverters.toString)
+
+    maxSummaryLength = Param(Params._dummy(), "maxSummaryLength",
+                             "Target maximum summary length (approximate words)",
+                             typeConverter=TypeConverters.toInt)
+
+    minSummaryLength = Param(Params._dummy(), "minSummaryLength",
+                             "Minimum summary length (approximate words)",
+                             typeConverter=TypeConverters.toInt)
+
+    summaryStyle = Param(Params._dummy(), "summaryStyle",
+                         "Summary style: concise, detailed or bullets",
+                         typeConverter=TypeConverters.toString)
+
+    focus = Param(Params._dummy(), "focus",
+                  "Focus hint for the summary (llm method only)",
+                  typeConverter=TypeConverters.toString)
+
+    longDocumentStrategy = Param(Params._dummy(), "longDocumentStrategy",
+                                 "Long document strategy: auto, truncate or hierarchical",
+                                 typeConverter=TypeConverters.toString)
+
+    numBeams = Param(Params._dummy(), "numBeams",
+                     "Number of beams (encoder_decoder method only)",
+                     typeConverter=TypeConverters.toInt)
+
+    temperature = Param(Params._dummy(), "temperature",
+                        "Generation temperature",
+                        typeConverter=TypeConverters.toFloat)
+
+    topP = Param(Params._dummy(), "topP",
+                 "Top-p (nucleus) sampling",
+                 typeConverter=TypeConverters.toFloat)
+
+    chunkSize = Param(Params._dummy(), "chunkSize",
+                      "Chunk size in approximate tokens (0 = auto)",
+                      typeConverter=TypeConverters.toInt)
+
+    chunkOverlap = Param(Params._dummy(), "chunkOverlap",
+                         "Sentence overlap between consecutive chunks",
+                         typeConverter=TypeConverters.toInt)
+
+    mmrLambda = Param(Params._dummy(), "mmrLambda",
+                      "MMR relevance/redundancy trade-off (extractive only)",
+                      typeConverter=TypeConverters.toFloat)
+
+    positionBias = Param(Params._dummy(), "positionBias",
+                         "Lead-position prior weight (extractive only)",
+                         typeConverter=TypeConverters.toFloat)
+
+    gpuLayers = Param(Params._dummy(), "gpuLayers",
+                      "GPU layers for the llm method (0 = CPU only)",
+                      typeConverter=TypeConverters.toInt)
+
+    def setMethod(self, value):
+        """Sets the summarization method: ``llm``, ``encoder_decoder`` or ``extractive``.
+
+        Parameters
+        ----------
+        value : str
+            Summarization method
+        """
+        return self._set(method=value)
+
+    def setModel(self, value):
+        """Sets a pretrained model name overriding the method's default model.
+
+        Parameters
+        ----------
+        value : str
+            Pretrained model name
+        """
+        return self._set(model=value)
+
+    def setMaxSummaryLength(self, value):
+        """Sets the target maximum summary length in approximate words.
+
+        Parameters
+        ----------
+        value : int
+            Maximum summary length
+        """
+        return self._set(maxSummaryLength=value)
+
+    def setMinSummaryLength(self, value):
+        """Sets the minimum summary length in approximate words (generative methods only).
+
+        Parameters
+        ----------
+        value : int
+            Minimum summary length
+        """
+        return self._set(minSummaryLength=value)
+
+    def setSummaryStyle(self, value):
+        """Sets the summary style: ``concise``, ``detailed`` or ``bullets`` (llm only).
+
+        Parameters
+        ----------
+        value : str
+            Summary style
+        """
+        return self._set(summaryStyle=value)
+
+    def setFocus(self, value):
+        """Sets a free-text focus hint for the summary (llm only).
+
+        Parameters
+        ----------
+        value : str
+            Focus hint, e.g. "main findings"
+        """
+        return self._set(focus=value)
+
+    def setLongDocumentStrategy(self, value):
+        """Sets the long-document strategy: ``auto``, ``truncate`` or ``hierarchical``.
+
+        Parameters
+        ----------
+        value : str
+            Long-document strategy
+        """
+        return self._set(longDocumentStrategy=value)
+
+    def setNumBeams(self, value):
+        """Sets the number of beams for beam search (encoder_decoder only).
+
+        Parameters
+        ----------
+        value : int
+            Number of beams
+        """
+        return self._set(numBeams=value)
+
+    def setTemperature(self, value):
+        """Sets the generation temperature (llm only).
+
+        Parameters
+        ----------
+        value : float
+            Temperature
+        """
+        return self._set(temperature=value)
+
+    def setTopP(self, value):
+        """Sets top-p (nucleus) sampling (llm only).
+
+        Parameters
+        ----------
+        value : float
+            Top-p value
+        """
+        return self._set(topP=value)
+
+    def setChunkSize(self, value):
+        """Sets the chunk size in approximate tokens for hierarchical summarization
+        (0 = derive automatically).
+
+        Parameters
+        ----------
+        value : int
+            Chunk size in tokens
+        """
+        return self._set(chunkSize=value)
+
+    def setChunkOverlap(self, value):
+        """Sets the number of sentences repeated between consecutive chunks.
+
+        Parameters
+        ----------
+        value : int
+            Sentence overlap
+        """
+        return self._set(chunkOverlap=value)
+
+    def setMmrLambda(self, value):
+        """Sets the MMR relevance/redundancy trade-off (extractive only).
+
+        Parameters
+        ----------
+        value : float
+            Lambda in [0, 1]; higher = more relevance-driven
+        """
+        return self._set(mmrLambda=value)
+
+    def setPositionBias(self, value):
+        """Sets the lead-position prior weight (extractive only).
+
+        Parameters
+        ----------
+        value : float
+            Position bias weight
+        """
+        return self._set(positionBias=value)
+
+    def setGpuLayers(self, value):
+        """Sets the number of model layers offloaded to the GPU for the llm
+        method (0 = CPU only; default 99 = offload all).
+
+        Parameters
+        ----------
+        value : int
+            Number of GPU layers
+        """
+        return self._set(gpuLayers=value)
+
+
+class Summarization(AnnotatorApproach, _SummarizationParams):
+    """High-level, task-oriented document summarization.
+
+    ``Summarization`` is a zero-configuration estimator: state what you want
+    (summary length, style, focus) and the annotator decides how to produce it
+    (model selection, prompting, generation settings, long-document handling).
+    No prompt writing or model choice is required:
+
+    >>> summarizer = Summarization() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("summary")
+
+    ``fit()`` downloads the default (or user-overridden) pretrained model and
+    returns a :class:`.SummarizationModel`.
+
+    Three methods are supported, each with an automatically selected default
+    model:
+
+    - ``llm`` (default): an instruction-tuned GGUF LLM run with llama.cpp; the
+      annotator owns the summarization prompt, system prompt, safe generation
+      defaults and reasoning-mode suppression.
+    - ``encoder_decoder``: a specialized abstractive summarization model
+      (DistilBART fine-tuned on XSum).
+    - ``extractive``: selects the most central sentences from the original
+      document using sentence embeddings, position-augmented centrality and
+      MMR redundancy control.
+
+    Documents longer than the model context are chunked at sentence boundaries,
+    summarized per chunk, and the intermediate summaries are combined and
+    summarized again (see ``setLongDocumentStrategy``).
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT``           ``DOCUMENT``
+    ====================== ======================
+
+    Examples
+    --------
+    >>> import sparknlp
+    >>> from sparknlp.base import *
+    >>> from sparknlp.annotator import *
+    >>> from pyspark.ml import Pipeline
+    >>> documentAssembler = DocumentAssembler() \\
+    ...     .setInputCol("text") \\
+    ...     .setOutputCol("document")
+    >>> summarizer = Summarization() \\
+    ...     .setInputCols(["document"]) \\
+    ...     .setOutputCol("summary") \\
+    ...     .setMethod("extractive") \\
+    ...     .setMaxSummaryLength(100)
+    >>> pipeline = Pipeline().setStages([documentAssembler, summarizer])
+    >>> data = spark.createDataFrame([["Long document text ..."]]).toDF("text")
+    >>> result = pipeline.fit(data).transform(data)
+    >>> result.select("summary.result").show(truncate=False)
+    """
+
+    name = "Summarization"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
+
+    outputAnnotatorType = AnnotatorType.DOCUMENT
+
+    @keyword_only
+    def __init__(self):
+        super(Summarization, self).__init__(
+            classname="com.johnsnowlabs.nlp.annotators.seq2seq.Summarization")
+        self._setDefault(
+            method="llm",
+            model="",
+            maxSummaryLength=250,
+            minSummaryLength=20,
+            summaryStyle="concise",
+            focus="",
+            longDocumentStrategy="auto",
+            numBeams=4,
+            temperature=0.2,
+            topP=0.9,
+            chunkSize=0,
+            chunkOverlap=1,
+            mmrLambda=0.7,
+            positionBias=0.3,
+            gpuLayers=99)
+
+    def _create_model(self, java_model):
+        return SummarizationModel(java_model=java_model)
+
+
+class SummarizationModel(AnnotatorModel, _SummarizationParams):
+    """Fitted model produced by :class:`.Summarization`.
+
+    Orchestrates the resolved summarization delegate: prompt building,
+    long-document chunking, delegate inference, output cleanup and
+    transparency metadata (method, model, engine, token estimates, chunk
+    count) on each output annotation.
+
+    Saving this model persists the delegate (model weights included), so
+    fitted pipelines reload without network access.
+
+    ====================== ======================
+    Input Annotation types Output Annotation type
+    ====================== ======================
+    ``DOCUMENT``           ``DOCUMENT``
+    ====================== ======================
+    """
+
+    name = "SummarizationModel"
+
+    inputAnnotatorTypes = [AnnotatorType.DOCUMENT]
+
+    outputAnnotatorType = AnnotatorType.DOCUMENT
+
+    resolvedModel = Param(Params._dummy(), "resolvedModel",
+                          "Pretrained model name resolved at fit time",
+                          typeConverter=TypeConverters.toString)
+
+    def __init__(self, classname="com.johnsnowlabs.nlp.annotators.seq2seq.SummarizationModel",
+                 java_model=None):
+        super(SummarizationModel, self).__init__(
+            classname=classname,
+            java_model=java_model)
+
+    def getResolvedModel(self):
+        """Gets the pretrained model name resolved at fit time.
+
+        Returns
+        -------
+        str
+            Resolved pretrained model name
+        """
+        return self.getOrDefault(self.resolvedModel)

--- a/python/sparknlp/annotator/seq2seq/summarization.py
+++ b/python/sparknlp/annotator/seq2seq/summarization.py
@@ -52,6 +52,10 @@ class _SummarizationParams:
                      "Number of beams (encoder_decoder method only)",
                      typeConverter=TypeConverters.toInt)
 
+    noRepeatNgramSize = Param(Params._dummy(), "noRepeatNgramSize",
+                              "Forbid repeating this n-gram size (encoder_decoder method only, 0 = disabled)",
+                              typeConverter=TypeConverters.toInt)
+
     temperature = Param(Params._dummy(), "temperature",
                         "Generation temperature",
                         typeConverter=TypeConverters.toFloat)
@@ -143,6 +147,10 @@ class _SummarizationParams:
     def setLongDocumentStrategy(self, value):
         """Sets the long-document strategy: ``auto``, ``truncate`` or ``hierarchical``.
 
+        ``auto`` and ``hierarchical`` currently behave identically (a document
+        that fits is summarized in a single pass either way); only ``truncate``
+        differs, cutting the document to the context budget.
+
         Parameters
         ----------
         value : str
@@ -159,6 +167,17 @@ class _SummarizationParams:
             Number of beams
         """
         return self._set(numBeams=value)
+
+    def setNoRepeatNgramSize(self, value):
+        """Sets the n-gram size that may not repeat in the generated summary
+        (encoder_decoder only, 0 = disabled).
+
+        Parameters
+        ----------
+        value : int
+            Forbidden n-gram size
+        """
+        return self._set(noRepeatNgramSize=value)
 
     def setTemperature(self, value):
         """Sets the generation temperature (llm only).
@@ -309,6 +328,7 @@ class Summarization(AnnotatorApproach, _SummarizationParams):
             focus="",
             longDocumentStrategy="auto",
             numBeams=4,
+            noRepeatNgramSize=3,
             temperature=0.2,
             topP=0.9,
             chunkSize=0,

--- a/python/test/annotator/seq2seq/summarization_test.py
+++ b/python/test/annotator/seq2seq/summarization_test.py
@@ -38,6 +38,7 @@ class SummarizationParamsTestSpec(unittest.TestCase):
         self.assertEqual(summ.getOrDefault(summ.summaryStyle), "concise")
         self.assertEqual(summ.getOrDefault(summ.longDocumentStrategy), "auto")
         self.assertEqual(summ.getOrDefault(summ.numBeams), 4)
+        self.assertEqual(summ.getOrDefault(summ.noRepeatNgramSize), 3)
         self.assertAlmostEqual(summ.getOrDefault(summ.mmrLambda), 0.7, places=5)
         self.assertEqual(summ.getOrDefault(summ.gpuLayers), 99)
 
@@ -57,6 +58,7 @@ class SummarizationParamsTestSpec(unittest.TestCase):
                 .setFocus("main findings")
                 .setLongDocumentStrategy("truncate")
                 .setNumBeams(3)
+                .setNoRepeatNgramSize(2)
                 .setTemperature(0.5)
                 .setTopP(0.8)
                 .setChunkSize(512)
@@ -73,6 +75,7 @@ class SummarizationParamsTestSpec(unittest.TestCase):
         self.assertEqual(summ.getOrDefault(summ.focus), "main findings")
         self.assertEqual(summ.getOrDefault(summ.longDocumentStrategy), "truncate")
         self.assertEqual(summ.getOrDefault(summ.numBeams), 3)
+        self.assertEqual(summ.getOrDefault(summ.noRepeatNgramSize), 2)
         self.assertAlmostEqual(summ.getOrDefault(summ.temperature), 0.5, places=5)
         self.assertAlmostEqual(summ.getOrDefault(summ.topP), 0.8, places=5)
         self.assertEqual(summ.getOrDefault(summ.chunkSize), 512)

--- a/python/test/annotator/seq2seq/summarization_test.py
+++ b/python/test/annotator/seq2seq/summarization_test.py
@@ -99,3 +99,5 @@ class SummarizationModelParamsTestSpec(unittest.TestCase):
         self.assertEqual(model.getOrDefault(model.maxSummaryLength), 33)
         # lazyAnnotator param must exist (CanBeLazy), otherwise fit()/binding breaks
         self.assertIn("lazyAnnotator", [p.name for p in model.params])
+        # close() must exist and be a no-op passthrough for a non-llm delegate
+        self.assertTrue(hasattr(model, "close"))

--- a/python/test/annotator/seq2seq/summarization_test.py
+++ b/python/test/annotator/seq2seq/summarization_test.py
@@ -1,0 +1,101 @@
+#  Copyright 2017-2026 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import unittest
+
+import pytest
+
+from sparknlp.annotator import *
+from sparknlp.base import *
+from sparknlp.common import AnnotatorType
+from test.util import SparkContextForTest
+
+
+@pytest.mark.fast
+class SummarizationParamsTestSpec(unittest.TestCase):
+    """Pure param-plumbing checks for the Python Summarization wrapper (no model download)."""
+
+    def setUp(self):
+        self.spark = SparkContextForTest.spark
+
+    def runTest(self):
+        summ = Summarization()
+
+        # defaults
+        self.assertEqual(summ.getOrDefault(summ.method), "llm")
+        self.assertEqual(summ.getOrDefault(summ.maxSummaryLength), 250)
+        self.assertEqual(summ.getOrDefault(summ.minSummaryLength), 20)
+        self.assertEqual(summ.getOrDefault(summ.summaryStyle), "concise")
+        self.assertEqual(summ.getOrDefault(summ.longDocumentStrategy), "auto")
+        self.assertEqual(summ.getOrDefault(summ.numBeams), 4)
+        self.assertAlmostEqual(summ.getOrDefault(summ.mmrLambda), 0.7, places=5)
+        self.assertEqual(summ.getOrDefault(summ.gpuLayers), 99)
+
+        # annotator type contract
+        self.assertEqual(Summarization.inputAnnotatorTypes, [AnnotatorType.DOCUMENT])
+        self.assertEqual(Summarization.outputAnnotatorType, AnnotatorType.DOCUMENT)
+
+        # setters round-trip
+        summ = (Summarization()
+                .setInputCols(["document"])
+                .setOutputCol("summary")
+                .setMethod("extractive")
+                .setModel("custom_model")
+                .setMaxSummaryLength(42)
+                .setMinSummaryLength(5)
+                .setSummaryStyle("bullets")
+                .setFocus("main findings")
+                .setLongDocumentStrategy("truncate")
+                .setNumBeams(3)
+                .setTemperature(0.5)
+                .setTopP(0.8)
+                .setChunkSize(512)
+                .setChunkOverlap(2)
+                .setMmrLambda(0.6)
+                .setPositionBias(0.4)
+                .setGpuLayers(0))
+
+        self.assertEqual(summ.getOrDefault(summ.method), "extractive")
+        self.assertEqual(summ.getOrDefault(summ.model), "custom_model")
+        self.assertEqual(summ.getOrDefault(summ.maxSummaryLength), 42)
+        self.assertEqual(summ.getOrDefault(summ.minSummaryLength), 5)
+        self.assertEqual(summ.getOrDefault(summ.summaryStyle), "bullets")
+        self.assertEqual(summ.getOrDefault(summ.focus), "main findings")
+        self.assertEqual(summ.getOrDefault(summ.longDocumentStrategy), "truncate")
+        self.assertEqual(summ.getOrDefault(summ.numBeams), 3)
+        self.assertAlmostEqual(summ.getOrDefault(summ.temperature), 0.5, places=5)
+        self.assertAlmostEqual(summ.getOrDefault(summ.topP), 0.8, places=5)
+        self.assertEqual(summ.getOrDefault(summ.chunkSize), 512)
+        self.assertEqual(summ.getOrDefault(summ.chunkOverlap), 2)
+        self.assertAlmostEqual(summ.getOrDefault(summ.positionBias), 0.4, places=5)
+        self.assertEqual(summ.getOrDefault(summ.gpuLayers), 0)
+
+        # Summarization is an estimator; its model type is SummarizationModel
+        self.assertTrue(hasattr(summ, "fit"))
+        java_model = summ._java_obj  # binding exists on the JVM side
+        self.assertTrue(java_model is not None)
+
+
+@pytest.mark.fast
+class SummarizationModelParamsTestSpec(unittest.TestCase):
+    def setUp(self):
+        self.spark = SparkContextForTest.spark
+
+    def runTest(self):
+        model = SummarizationModel()
+        self.assertEqual(SummarizationModel.inputAnnotatorTypes, [AnnotatorType.DOCUMENT])
+        self.assertEqual(SummarizationModel.outputAnnotatorType, AnnotatorType.DOCUMENT)
+        model.setMaxSummaryLength(33)
+        self.assertEqual(model.getOrDefault(model.maxSummaryLength), 33)
+        # lazyAnnotator param must exist (CanBeLazy), otherwise fit()/binding breaks
+        self.assertIn("lazyAnnotator", [p.name for p in model.params])

--- a/src/main/scala/com/johnsnowlabs/ml/ai/util/Generation/Generate.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/util/Generation/Generate.scala
@@ -233,6 +233,7 @@ trait Generate {
         // Process the logits by defined logit processors
         val nextTokenScoresProcessed =
           logitProcessor.process(expandedInputs, nextTokenScores, currentLength)
+        nextTokenScores = nextTokenScoresProcessed
 
         // Process the logits by defined logit warpers
         if (doSample) {

--- a/src/main/scala/com/johnsnowlabs/ml/ai/util/Generation/Generate.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/util/Generation/Generate.scala
@@ -118,8 +118,8 @@ trait Generate {
         noRepeatNgramSize = noRepeatNgramSize,
         vocabSize = vocabSize))
 
-//    logitProcessorList.addProcess(
-//      new MinLengthLogitProcessor(eosTokenId, minOutputLength, vocabSize))
+    logitProcessorList.addProcess(
+      new MinLengthLogitProcessor(eosTokenId, minOutputLength, vocabSize))
 
     logitProcessorList.addProcess(new TemperatureLogitWarper(temperature))
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotator.scala
@@ -819,6 +819,14 @@ package object annotator {
   type AutoGGUFModel = com.johnsnowlabs.nlp.annotators.seq2seq.AutoGGUFModel
   object AutoGGUFModel extends ReadablePretrainedAutoGGUFModel with ReadAutoGGUFModel
 
+  type Summarization = com.johnsnowlabs.nlp.annotators.seq2seq.Summarization
+  object Summarization extends DefaultParamsReadable[Summarization]
+
+  type SummarizationModel = com.johnsnowlabs.nlp.annotators.seq2seq.SummarizationModel
+  object SummarizationModel
+      extends ParamsAndFeaturesReadable[SummarizationModel]
+      with ReadSummarizationDelegate
+
   type MxbaiEmbeddings =
     com.johnsnowlabs.nlp.embeddings.MxbaiEmbeddings
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/ExtractiveSummarizationRanker.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/ExtractiveSummarizationRanker.scala
@@ -80,12 +80,6 @@ private[seq2seq] object ExtractiveSummarizationRanker {
     }
     if (current.nonEmpty) chunks += current.mkString(" ")
 
-    // Guard: if overlap seeding produced a trailing chunk that is a strict subset of the
-    // previous chunk (all-overlap chunk), drop it.
-    if (chunks.length > 1 && chunks.last.nonEmpty && chunks(chunks.length - 2).endsWith(
-        chunks.last))
-      chunks.remove(chunks.length - 1)
-
     chunks.toArray
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/ExtractiveSummarizationRanker.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/ExtractiveSummarizationRanker.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.nlp.annotators.seq2seq
+
+import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.DefaultPragmaticMethod
+
+/** Pure (Spark-free) building blocks for the [[Summarization]] annotator.
+  *
+  * Contains:
+  *   - a rule-based sentence splitter (reusing the pragmatic sentence detector engine),
+  *   - a sentence packer that groups sentences into character-budgeted chunks with overlap (used
+  *     for hierarchical long-document summarization),
+  *   - a PacSum-style position-augmented centrality ranker with MMR selection (used by the
+  *     `extractive` method).
+  *
+  * All functions are deterministic and side-effect free so they can be used inside Spark UDFs and
+  * unit-tested without a SparkSession.
+  */
+private[seq2seq] object ExtractiveSummarizationRanker {
+
+  /** Splits text into sentences using the rule-based pragmatic method (no model download). */
+  def splitSentences(text: String): Array[String] = {
+    if (text == null || text.trim.isEmpty) return Array.empty[String]
+    val method = new DefaultPragmaticMethod(useAbbreviations = true, detectLists = false)
+    val bounds = method.extractBounds(text)
+    val sentences = bounds.map(_.content.trim).filter(_.nonEmpty)
+    if (sentences.isEmpty) Array(text.trim) else sentences
+  }
+
+  /** Packs sentences into chunks whose length stays under `budgetChars`, with `overlapSentences`
+    * sentences repeated between consecutive chunks for context continuity.
+    *
+    * A single sentence longer than the budget is hard-truncated to the budget.
+    */
+  def packChunks(
+      sentences: Array[String],
+      budgetChars: Int,
+      overlapSentences: Int): Array[String] = {
+    require(budgetChars > 0, "budgetChars must be > 0")
+    if (sentences.isEmpty) return Array.empty[String]
+
+    val chunks = scala.collection.mutable.ArrayBuffer.empty[String]
+    val current = scala.collection.mutable.ArrayBuffer.empty[String]
+    var currentLen = 0
+
+    def flush(): Unit = {
+      if (current.nonEmpty) {
+        chunks += current.mkString(" ")
+        val overlap = current.takeRight(math.max(0, overlapSentences)).toArray
+        current.clear()
+        currentLen = 0
+        // seed next chunk with the overlap sentences (never let overlap alone exceed budget)
+        overlap.foreach { s =>
+          if (currentLen + s.length + 1 <= budgetChars / 2) {
+            current += s
+            currentLen += s.length + 1
+          }
+        }
+      }
+    }
+
+    sentences.foreach { raw =>
+      val s = if (raw.length > budgetChars) raw.substring(0, budgetChars) else raw
+      if (currentLen + s.length + 1 > budgetChars && current.nonEmpty) flush()
+      current += s
+      currentLen += s.length + 1
+    }
+    if (current.nonEmpty) chunks += current.mkString(" ")
+
+    // Guard: if overlap seeding produced a trailing chunk that is a strict subset of the
+    // previous chunk (all-overlap chunk), drop it.
+    if (chunks.length > 1 && chunks.last.nonEmpty && chunks(chunks.length - 2).endsWith(
+        chunks.last))
+      chunks.remove(chunks.length - 1)
+
+    chunks.toArray
+  }
+
+  private def dot(a: Array[Float], b: Array[Float]): Double = {
+    var s = 0.0
+    var i = 0
+    val n = math.min(a.length, b.length)
+    while (i < n) { s += a(i).toDouble * b(i).toDouble; i += 1 }
+    s
+  }
+
+  private def norm(a: Array[Float]): Double = math.sqrt(dot(a, a))
+
+  /** Cosine similarity; 0.0 when either vector is degenerate. */
+  def cosine(a: Array[Float], b: Array[Float]): Double = {
+    val na = norm(a)
+    val nb = norm(b)
+    if (na == 0.0 || nb == 0.0) 0.0 else dot(a, b) / (na * nb)
+  }
+
+  /** PacSum-style position-augmented asymmetric degree centrality.
+    *
+    * `score(i) = sum_{j>i} sim(i,j) * wForward + sum_{j<i} sim(i,j) * wBackward + positionBias /
+    * (1 + i)`
+    *
+    * Forward edges (similarity to *later* sentences) dominate, giving earlier sentences that
+    * introduce recurring content higher centrality; the explicit position prior encodes the lead
+    * bias that strong extractive baselines rely on.
+    */
+  def centralityScores(
+      embeddings: Array[Array[Float]],
+      wForward: Double = 1.0,
+      wBackward: Double = 0.3,
+      positionBias: Double = 0.3): Array[Double] = {
+    val n = embeddings.length
+    val scores = new Array[Double](n)
+    if (n == 0) return scores
+    if (n == 1) return Array(1.0 + positionBias)
+
+    // precompute pairwise cosine (upper triangle)
+    var i = 0
+    while (i < n) {
+      var j = i + 1
+      while (j < n) {
+        val sim = math.max(0.0, cosine(embeddings(i), embeddings(j)))
+        scores(i) += sim * wForward // i sees a later sentence j
+        scores(j) += sim * wBackward // j sees an earlier sentence i
+        j += 1
+      }
+      i += 1
+    }
+    // normalize centrality to [0,1] before adding the position prior so the prior's scale
+    // is comparable across documents of different lengths
+    val max = scores.max
+    i = 0
+    while (i < n) {
+      val centrality = if (max > 0.0) scores(i) / max else 0.0
+      scores(i) = centrality + positionBias / (1.0 + i)
+      i += 1
+    }
+    scores
+  }
+
+  /** Greedy MMR selection under a word budget.
+    *
+    * Picks `argmax_i lambda * score(i) - (1 - lambda) * maxSim(i, selected)` until adding the
+    * next sentence would exceed `budgetWords` (at least one sentence is always selected).
+    *
+    * @return
+    *   selected sentence indices in original document order
+    */
+  def mmrSelect(
+      embeddings: Array[Array[Float]],
+      scores: Array[Double],
+      wordCounts: Array[Int],
+      budgetWords: Int,
+      lambda: Double): Array[Int] = {
+    val n = embeddings.length
+    if (n == 0) return Array.empty[Int]
+
+    val selected = scala.collection.mutable.ArrayBuffer.empty[Int]
+    val remaining = scala.collection.mutable.LinkedHashSet(0 until n: _*)
+    var usedWords = 0
+
+    while (remaining.nonEmpty) {
+      var bestIdx = -1
+      var bestVal = Double.MinValue
+      remaining.foreach { i =>
+        val redundancy =
+          if (selected.isEmpty) 0.0
+          else selected.map(j => math.max(0.0, cosine(embeddings(i), embeddings(j)))).max
+        val value = lambda * scores(i) - (1.0 - lambda) * redundancy
+        if (value > bestVal) {
+          bestVal = value
+          bestIdx = i
+        }
+      }
+      if (bestIdx < 0) return selected.sorted.toArray
+
+      val cost = math.max(1, wordCounts(bestIdx))
+      if (selected.nonEmpty && usedWords + cost > budgetWords) {
+        // budget exhausted
+        return selected.sorted.toArray
+      }
+      selected += bestIdx
+      usedWords += cost
+      remaining -= bestIdx
+      if (usedWords >= budgetWords) return selected.sorted.toArray
+    }
+    selected.sorted.toArray
+  }
+
+  def countWords(s: String): Int =
+    if (s == null || s.trim.isEmpty) 0 else s.trim.split("\\s+").length
+}

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/Summarization.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/Summarization.scala
@@ -129,7 +129,9 @@ trait SummarizationParams extends Params {
 
   /** Strategy for documents longer than the model context: `auto`, `truncate` or `hierarchical`
     * (Default: `auto`). `auto` summarizes directly when the document fits and falls back to
-    * hierarchical chunk-then-combine summarization when it does not.
+    * hierarchical chunk-then-combine summarization when it does not. Since `hierarchical` also
+    * summarizes a fitting document in a single pass, `auto` and `hierarchical` currently behave
+    * identically; only `truncate` differs (it cuts the document to the context budget).
     * @group param
     */
   val longDocumentStrategy = new Param[String](

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/Summarization.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/Summarization.scala
@@ -1,0 +1,470 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.nlp.annotators.seq2seq
+
+import com.johnsnowlabs.nlp.AnnotatorApproach
+import com.johnsnowlabs.nlp.AnnotatorType.DOCUMENT
+import com.johnsnowlabs.nlp.embeddings.MPNetEmbeddings
+import org.apache.spark.ml.PipelineModel
+import org.apache.spark.ml.param.{FloatParam, IntParam, Param, Params}
+import org.apache.spark.ml.util.{DefaultParamsReadable, Identifiable}
+import org.apache.spark.sql.Dataset
+import org.slf4j.LoggerFactory
+
+/** Task-level parameters shared between the [[Summarization]] estimator and the fitted
+  * [[SummarizationModel]].
+  */
+trait SummarizationParams extends Params {
+
+  /** Summarization method: `llm`, `encoder_decoder` or `extractive` (Default: `llm`).
+    *
+    *   - `llm`: an instruction-tuned GGUF LLM (via AutoGGUFModel / llama.cpp) prompted for
+    *     summarization.
+    *   - `encoder_decoder`: a specialized abstractive summarization model (DistilBART).
+    *   - `extractive`: selects the most central sentences of the original document
+    *     (embedding-based centrality with position prior and MMR redundancy control).
+    *
+    * @group param
+    */
+  val method =
+    new Param[String](this, "method", "Summarization method: llm, encoder_decoder or extractive")
+
+  /** @group setParam */
+  def setMethod(value: String): this.type = {
+    require(
+      Summarization.supportedMethods.contains(value),
+      s"Method '$value' is not supported. Choose one of: ${Summarization.supportedMethods.mkString(", ")}")
+    set(method, value)
+  }
+
+  /** @group getParam */
+  def getMethod: String = $(method)
+
+  /** Optional pretrained model name overriding the method's default model (Default: `""` = use
+    * the method's default).
+    *
+    * @group param
+    */
+  val model =
+    new Param[String](this, "model", "Pretrained model name overriding the method default")
+
+  /** @group setParam */
+  def setModel(value: String): this.type = set(model, value)
+
+  /** @group getParam */
+  def getModel: String = $(model)
+
+  /** Target maximum summary length in words/tokens, approximate (Default: `250`).
+    * @group param
+    */
+  val maxSummaryLength =
+    new IntParam(this, "maxSummaryLength", "Target maximum summary length (approximate words)")
+
+  /** @group setParam */
+  def setMaxSummaryLength(value: Int): this.type = {
+    require(value > 0, "maxSummaryLength must be > 0")
+    set(maxSummaryLength, value)
+  }
+
+  /** @group getParam */
+  def getMaxSummaryLength: Int = $(maxSummaryLength)
+
+  /** Minimum summary length in words/tokens, generative methods only (Default: `20`).
+    * @group param
+    */
+  val minSummaryLength =
+    new IntParam(this, "minSummaryLength", "Minimum summary length (approximate words)")
+
+  /** @group setParam */
+  def setMinSummaryLength(value: Int): this.type = {
+    require(value >= 0, "minSummaryLength must be >= 0")
+    set(minSummaryLength, value)
+  }
+
+  /** @group getParam */
+  def getMinSummaryLength: Int = $(minSummaryLength)
+
+  /** Summary style used to build the LLM prompt: `concise`, `detailed` or `bullets` (Default:
+    * `concise`). Only applies to the `llm` method.
+    * @group param
+    */
+  val summaryStyle =
+    new Param[String](this, "summaryStyle", "Summary style: concise, detailed or bullets")
+
+  /** @group setParam */
+  def setSummaryStyle(value: String): this.type = {
+    require(
+      Summarization.supportedStyles.contains(value),
+      s"Style '$value' is not supported. Choose one of: ${Summarization.supportedStyles.mkString(", ")}")
+    set(summaryStyle, value)
+  }
+
+  /** @group getParam */
+  def getSummaryStyle: String = $(summaryStyle)
+
+  /** Optional free-text focus hint included in the LLM prompt, e.g. "main findings" (Default:
+    * `""`). Only applies to the `llm` method.
+    * @group param
+    */
+  val focus = new Param[String](this, "focus", "Focus hint for the summary (llm method only)")
+
+  /** @group setParam */
+  def setFocus(value: String): this.type = set(focus, value)
+
+  /** @group getParam */
+  def getFocus: String = $(focus)
+
+  /** Strategy for documents longer than the model context: `auto`, `truncate` or `hierarchical`
+    * (Default: `auto`). `auto` summarizes directly when the document fits and falls back to
+    * hierarchical chunk-then-combine summarization when it does not.
+    * @group param
+    */
+  val longDocumentStrategy = new Param[String](
+    this,
+    "longDocumentStrategy",
+    "Long document strategy: auto, truncate or hierarchical")
+
+  /** @group setParam */
+  def setLongDocumentStrategy(value: String): this.type = {
+    require(
+      Summarization.supportedStrategies.contains(value),
+      s"Strategy '$value' is not supported. Choose one of: ${Summarization.supportedStrategies
+          .mkString(", ")}")
+    set(longDocumentStrategy, value)
+  }
+
+  /** @group getParam */
+  def getLongDocumentStrategy: String = $(longDocumentStrategy)
+
+  /** Number of beams for beam search (Default: `4`). Only applies to the `encoder_decoder`
+    * method.
+    * @group param
+    */
+  val numBeams = new IntParam(this, "numBeams", "Number of beams (encoder_decoder method only)")
+
+  /** @group setParam */
+  def setNumBeams(value: Int): this.type = {
+    require(value > 0, "numBeams must be > 0")
+    set(numBeams, value)
+  }
+
+  /** @group getParam */
+  def getNumBeams: Int = $(numBeams)
+
+  /** Generation temperature (Default: `0.2`). Applies to the `llm` method.
+    * @group param
+    */
+  val temperature = new FloatParam(this, "temperature", "Generation temperature")
+
+  /** @group setParam */
+  def setTemperature(value: Float): this.type = {
+    require(value >= 0, "temperature must be >= 0")
+    set(temperature, value)
+  }
+
+  /** @group getParam */
+  def getTemperature: Float = $(temperature)
+
+  /** Top-p (nucleus) sampling (Default: `0.9`). Applies to the `llm` method.
+    * @group param
+    */
+  val topP = new FloatParam(this, "topP", "Top-p (nucleus) sampling")
+
+  /** @group setParam */
+  def setTopP(value: Float): this.type = {
+    require(value > 0 && value <= 1, "topP must be in (0, 1]")
+    set(topP, value)
+  }
+
+  /** @group getParam */
+  def getTopP: Float = $(topP)
+
+  /** Chunk size in approximate tokens used for hierarchical summarization (Default: `0` = derive
+    * automatically from the model's context limit).
+    * @group param
+    */
+  val chunkSize =
+    new IntParam(this, "chunkSize", "Chunk size in approximate tokens (0 = auto)")
+
+  /** @group setParam */
+  def setChunkSize(value: Int): this.type = {
+    require(value >= 0, "chunkSize must be >= 0")
+    set(chunkSize, value)
+  }
+
+  /** @group getParam */
+  def getChunkSize: Int = $(chunkSize)
+
+  /** Number of sentences repeated between consecutive chunks (Default: `1`).
+    * @group param
+    */
+  val chunkOverlap =
+    new IntParam(this, "chunkOverlap", "Sentence overlap between consecutive chunks")
+
+  /** @group setParam */
+  def setChunkOverlap(value: Int): this.type = {
+    require(value >= 0, "chunkOverlap must be >= 0")
+    set(chunkOverlap, value)
+  }
+
+  /** @group getParam */
+  def getChunkOverlap: Int = $(chunkOverlap)
+
+  /** MMR trade-off between relevance and redundancy in extractive selection, higher = more
+    * relevance-driven (Default: `0.7`). Only applies to the `extractive` method.
+    * @group param
+    */
+  val mmrLambda =
+    new FloatParam(this, "mmrLambda", "MMR relevance/redundancy trade-off (extractive only)")
+
+  /** @group setParam */
+  def setMmrLambda(value: Float): this.type = {
+    require(value >= 0 && value <= 1, "mmrLambda must be in [0, 1]")
+    set(mmrLambda, value)
+  }
+
+  /** @group getParam */
+  def getMmrLambda: Float = $(mmrLambda)
+
+  /** Weight of the lead-position prior in extractive sentence ranking (Default: `0.3`). Only
+    * applies to the `extractive` method.
+    * @group param
+    */
+  val positionBias =
+    new FloatParam(this, "positionBias", "Lead-position prior weight (extractive only)")
+
+  /** @group setParam */
+  def setPositionBias(value: Float): this.type = {
+    require(value >= 0, "positionBias must be >= 0")
+    set(positionBias, value)
+  }
+
+  /** @group getParam */
+  def getPositionBias: Float = $(positionBias)
+
+  /** Number of model layers offloaded to the GPU for the `llm` method (Default: `99` = offload
+    * all). Set to `0` on CPU-only clusters. Ignored by the other methods.
+    * @group param
+    */
+  val gpuLayers =
+    new IntParam(this, "gpuLayers", "GPU layers for the llm method (0 = CPU only)")
+
+  /** @group setParam */
+  def setGpuLayers(value: Int): this.type = {
+    require(value >= 0, "gpuLayers must be >= 0")
+    set(gpuLayers, value)
+  }
+
+  /** @group getParam */
+  def getGpuLayers: Int = $(gpuLayers)
+
+  setDefault(
+    method -> "llm",
+    model -> "",
+    maxSummaryLength -> 250,
+    minSummaryLength -> 20,
+    summaryStyle -> "concise",
+    focus -> "",
+    longDocumentStrategy -> "auto",
+    numBeams -> 4,
+    temperature -> 0.2f,
+    topP -> 0.9f,
+    chunkSize -> 0,
+    chunkOverlap -> 1,
+    mmrLambda -> 0.7f,
+    positionBias -> 0.3f,
+    gpuLayers -> 99)
+}
+
+/** High-level, task-oriented document summarization.
+  *
+  * `Summarization` is a zero-configuration estimator: users state what they want (summary length,
+  * style, focus) and the annotator decides how to produce it (model selection, prompting,
+  * generation settings, long-document handling). No prompt writing or model choice is required:
+  *
+  * {{{
+  * val summarizer = new Summarization()
+  *   .setInputCols("document")
+  *   .setOutputCol("summary")
+  *
+  * val model = pipeline.fit(data) // default model resolves and downloads here
+  * }}}
+  *
+  * Three methods are supported, each with an automatically selected default model:
+  *
+  *   - `llm` (default): an instruction-tuned GGUF LLM run with llama.cpp ([[AutoGGUFModel]]); the
+  *     annotator owns the summarization prompt, system prompt, safe generation defaults and
+  *     reasoning-mode suppression.
+  *   - `encoder_decoder`: a specialized abstractive summarization model ([[BartTransformer]],
+  *     DistilBART fine-tuned on XSum).
+  *   - `extractive`: selects the most central sentences from the original document using sentence
+  *     embeddings, position-augmented centrality and MMR redundancy control; the output contains
+  *     only text from the source document.
+  *
+  * Documents longer than the model context are handled automatically (see
+  * [[SummarizationParams.longDocumentStrategy]]): the document is split at sentence boundaries
+  * into overlapping chunks, each chunk is summarized, and the intermediate summaries are combined
+  * and summarized again.
+  *
+  * `fit()` downloads the default (or user-overridden) pretrained model and returns a
+  * [[SummarizationModel]]; saved fitted pipelines embed the resolved model and load offline.
+  *
+  * ==Example==
+  * {{{
+  * import com.johnsnowlabs.nlp.base.DocumentAssembler
+  * import com.johnsnowlabs.nlp.annotators.seq2seq.Summarization
+  * import org.apache.spark.ml.Pipeline
+  *
+  * val documentAssembler = new DocumentAssembler().setInputCol("text").setOutputCol("document")
+  *
+  * val summarizer = new Summarization()
+  *   .setInputCols("document")
+  *   .setOutputCol("summary")
+  *   .setMethod("extractive")
+  *   .setMaxSummaryLength(100)
+  *
+  * val pipeline = new Pipeline().setStages(Array(documentAssembler, summarizer))
+  * val result = pipeline.fit(data).transform(data)
+  * result.select("summary.result").show(false)
+  * }}}
+  *
+  * @param uid
+  *   required uid for storing annotator to disk
+  * @groupname anno Annotator types
+  * @groupdesc anno
+  *   Required input and expected output annotator types
+  * @groupname Ungrouped Members
+  * @groupname param Parameters
+  * @groupname setParam Parameter setters
+  * @groupname getParam Parameter getters
+  * @groupprio param 1
+  * @groupprio anno 2
+  * @groupprio Ungrouped 3
+  * @groupprio setParam 4
+  * @groupprio getParam 5
+  */
+class Summarization(override val uid: String)
+    extends AnnotatorApproach[SummarizationModel]
+    with SummarizationParams {
+
+  def this() = this(Identifiable.randomUID("SUMMARIZATION"))
+
+  override val description: String =
+    "High-level task-oriented document summarization (llm, encoder_decoder or extractive)"
+
+  /** Input Annotator Type: DOCUMENT
+    * @group anno
+    */
+  override val inputAnnotatorTypes: Array[String] = Array(DOCUMENT)
+
+  /** Output Annotator Type: DOCUMENT
+    * @group anno
+    */
+  override val outputAnnotatorType: String = DOCUMENT
+
+  private val logger = LoggerFactory.getLogger("Summarization")
+
+  private def warnIgnored(): Unit = {
+    val m = $(method)
+    if (m != "llm") {
+      if (isSet(focus) && $(focus).nonEmpty)
+        logger.warn(s"Parameter 'focus' only applies to method 'llm' and is ignored for '$m'")
+      if (isSet(summaryStyle))
+        logger.warn(
+          s"Parameter 'summaryStyle' only applies to method 'llm' and is ignored for '$m'")
+      if (isSet(temperature))
+        logger.warn(
+          s"Parameter 'temperature' only applies to method 'llm' and is ignored for '$m'")
+      if (isSet(topP))
+        logger.warn(s"Parameter 'topP' only applies to method 'llm' and is ignored for '$m'")
+    }
+    if (m != "encoder_decoder" && isSet(numBeams))
+      logger.warn(
+        s"Parameter 'numBeams' only applies to method 'encoder_decoder' and is ignored for '$m'")
+    if (m != "extractive") {
+      if (isSet(mmrLambda))
+        logger.warn(
+          s"Parameter 'mmrLambda' only applies to method 'extractive' and is ignored for '$m'")
+      if (isSet(positionBias))
+        logger.warn(
+          s"Parameter 'positionBias' only applies to method 'extractive' and is ignored for '$m'")
+    } else if (isSet(minSummaryLength)) {
+      logger.warn(
+        "Parameter 'minSummaryLength' does not apply to method 'extractive' " +
+          "(maxSummaryLength is the sentence-selection budget) and is ignored")
+    }
+  }
+
+  /** Resolves the summarization method to a configured [[SummarizationModel]], downloading the
+    * default pretrained delegate when no explicit model name was set.
+    */
+  override def train(
+      dataset: Dataset[_],
+      recursivePipeline: Option[PipelineModel]): SummarizationModel = {
+    require(
+      $(minSummaryLength) <= $(maxSummaryLength),
+      s"minSummaryLength (${$(minSummaryLength)}) must be <= maxSummaryLength " +
+        s"(${$(maxSummaryLength)})")
+    warnIgnored()
+
+    val summarizationModel = new SummarizationModel()
+    val requested = $(model)
+
+    $(method) match {
+      case "llm" =>
+        val name = if (requested.nonEmpty) requested else Summarization.defaultLlmModel
+        logger.info(s"Summarization: resolving llm delegate '$name'")
+        val delegate = AutoGGUFModel.pretrained(name)
+        summarizationModel
+          .setLlmDelegate(delegate)
+          .setResolvedModel(name)
+
+      case "encoder_decoder" =>
+        val name =
+          if (requested.nonEmpty) requested else Summarization.defaultEncoderDecoderModel
+        logger.info(s"Summarization: resolving encoder_decoder delegate '$name'")
+        val delegate = BartTransformer.pretrained(name)
+        summarizationModel
+          .setSeq2SeqDelegate(delegate)
+          .setResolvedModel(name)
+
+      case "extractive" =>
+        val name = if (requested.nonEmpty) requested else Summarization.defaultEmbeddingsModel
+        logger.info(s"Summarization: resolving extractive embeddings delegate '$name'")
+        val delegate = MPNetEmbeddings.pretrained(name)
+        summarizationModel
+          .setEmbeddingsDelegate(delegate)
+          .setResolvedModel(name)
+    }
+
+    summarizationModel
+  }
+}
+
+/** This is the companion object of [[Summarization]]. Please refer to that class for the
+  * documentation.
+  */
+object Summarization extends DefaultParamsReadable[Summarization] {
+
+  val supportedMethods: Array[String] = Array("llm", "encoder_decoder", "extractive")
+  val supportedStyles: Array[String] = Array("concise", "detailed", "bullets")
+  val supportedStrategies: Array[String] = Array("auto", "truncate", "hierarchical")
+
+  /** Default pretrained model per method. */
+  val defaultLlmModel: String = "qwen3_4b_q8_0_gguf"
+  val defaultEncoderDecoderModel: String = "distilbart_xsum_12_6"
+  val defaultEmbeddingsModel: String = "all_mpnet_base_v2"
+}

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/Summarization.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/Summarization.scala
@@ -375,7 +375,7 @@ class Summarization(override val uid: String)
     */
   override val outputAnnotatorType: String = DOCUMENT
 
-  private val logger = LoggerFactory.getLogger("Summarization")
+  private val logger = LoggerFactory.getLogger(classOf[Summarization])
 
   private def warnIgnored(): Unit = {
     val m = $(method)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/Summarization.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/Summarization.scala
@@ -164,6 +164,24 @@ trait SummarizationParams extends Params {
   /** @group getParam */
   def getNumBeams: Int = $(numBeams)
 
+  /** Size of n-grams that may not repeat in the generated summary (Default: `3`). Only applies to
+    * the `encoder_decoder` method; `0` disables the constraint.
+    * @group param
+    */
+  val noRepeatNgramSize = new IntParam(
+    this,
+    "noRepeatNgramSize",
+    "Forbid repeating this n-gram size (encoder_decoder method only, 0 = disabled)")
+
+  /** @group setParam */
+  def setNoRepeatNgramSize(value: Int): this.type = {
+    require(value >= 0, "noRepeatNgramSize must be >= 0")
+    set(noRepeatNgramSize, value)
+  }
+
+  /** @group getParam */
+  def getNoRepeatNgramSize: Int = $(noRepeatNgramSize)
+
   /** Generation temperature (Default: `0.2`). Applies to the `llm` method.
     * @group param
     */
@@ -280,6 +298,7 @@ trait SummarizationParams extends Params {
     focus -> "",
     longDocumentStrategy -> "auto",
     numBeams -> 4,
+    noRepeatNgramSize -> 3,
     temperature -> 0.2f,
     topP -> 0.9f,
     chunkSize -> 0,
@@ -394,6 +413,10 @@ class Summarization(override val uid: String)
     if (m != "encoder_decoder" && isSet(numBeams))
       logger.warn(
         s"Parameter 'numBeams' only applies to method 'encoder_decoder' and is ignored for '$m'")
+    if (m != "encoder_decoder" && isSet(noRepeatNgramSize))
+      logger.warn(
+        "Parameter 'noRepeatNgramSize' only applies to method 'encoder_decoder' " +
+          s"and is ignored for '$m'")
     if (m != "extractive") {
       if (isSet(mmrLambda))
         logger.warn(

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala
@@ -371,9 +371,11 @@ class SummarizationModel(override val uid: String)
       var stripped = raw.replaceAll("(?s)<think>.*?</think>", "")
       val openIdx = stripped.indexOf("<think>")
       if (openIdx >= 0) stripped = stripped.substring(0, openIdx)
-      if (isLlm)
-        stripped.replaceAll("(?im)^\\s*(summary|here is (a|the) summary)\\s*:?\\s*", "").trim
-      else stripped.trim
+      if (isLlm) {
+        val withoutLabel =
+          stripped.replaceAll("(?im)^\\s*(summary|here is (a|the) summary)\\s*:?\\s*", "").trim
+        SummarizationModel.unwrapJsonStringLiteral(withoutLabel)
+      } else stripped.trim
     }
 
     val joinPairsUdf = udf { pairs: Seq[Row] =>
@@ -713,4 +715,19 @@ object SummarizationModel
     with ReadSummarizationDelegate {
 
   private[seq2seq] val delegateDir = "summarization_delegate"
+
+  /** Some instruction-tuned models occasionally emit the summary as a JSON-string literal
+    * (wrapped in double quotes, with `\n` written out as a literal backslash-n) instead of raw
+    * text. Unwrap that shape back into plain text; text that isn't wrapped is returned unchanged.
+    */
+  private[seq2seq] def unwrapJsonStringLiteral(text: String): String = {
+    if (text.length >= 2 && text.head == '"' && text.last == '"') {
+      text
+        .substring(1, text.length - 1)
+        .replace("\\n", "\n")
+        .replace("\\\"", "\"")
+        .replace("\\\\", "\\")
+        .trim
+    } else text
+  }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala
@@ -47,8 +47,16 @@ import org.slf4j.LoggerFactory
   *     explanatory error; fit a new [[Summarization]] stage instead. All other task parameters
   *     (lengths, style, focus, strategy, ...) can be changed freely after fit.
   *   - As a DataFrame-level orchestrator this annotator is not supported in LightPipeline.
-  *   - Generative transforms cache the input row ids and the computed summaries for the lifetime
-  *     of the returned DataFrame (inference intermediates are released eagerly).
+  *   - `transform` configures the shared delegate (input/output columns, generation settings) in
+  *     place, so a single model instance is not safe for concurrent `transform` calls; use one
+  *     instance per concurrent caller.
+  *   - Transforms cache the input row ids and the computed summaries for the lifetime of the
+  *     returned DataFrame (generative inference intermediates are released eagerly). The
+  *     encoder_decoder method pins inference to a single partition (the BART backend is not
+  *     thread-safe); the llm and extractive methods keep the input partitioning.
+  *   - For the `llm` method the document text is embedded into the prompt, so a document
+  *     containing instructions can influence its own summary (prompt injection); the system
+  *     prompt reduces but does not eliminate this.
   *
   * @param uid
   *   required uid for storing annotator to disk
@@ -82,7 +90,7 @@ class SummarizationModel(override val uid: String)
     */
   override val outputAnnotatorType: String = DOCUMENT
 
-  private val logger = LoggerFactory.getLogger("SummarizationModel")
+  private val logger = LoggerFactory.getLogger(classOf[SummarizationModel])
 
   /** Name of the pretrained model resolved at fit time (for transparency metadata).
     * @group param
@@ -166,6 +174,7 @@ class SummarizationModel(override val uid: String)
   private val pairsCol = s"__${uid}_pairs"
   private val sentCol = s"__${uid}_sentences"
   private val embCol = s"__${uid}_sentEmbeddings"
+  private val singleDocCol = s"__${uid}_singleDoc"
   private val resultCol = s"__${uid}_resultAnns"
 
   private def internalColumns: Seq[String] = Seq(
@@ -185,6 +194,7 @@ class SummarizationModel(override val uid: String)
     pairsCol,
     sentCol,
     embCol,
+    singleDocCol,
     resultCol)
 
   private def documentColMetadata: Metadata = {
@@ -311,8 +321,12 @@ class SummarizationModel(override val uid: String)
       val src =
         if (isReduce) "the following partial summaries of a longer document"
         else "the following text"
+      // task params are mutable on the fitted model, so minWords can exceed maxWords here even
+      // though the estimator rejects that at fit; clamp to keep the prompt coherent
+      val effMin = math.max(0, math.min(minWords, maxWords))
       val lengthClause =
-        if (minWords > 0) s"The summary must be between $minWords and $maxWords words."
+        if (effMin > 0 && effMin < maxWords)
+          s"The summary must be between $effMin and $maxWords words."
         else s"The summary must be at most $maxWords words."
       s"$style$focusHint $lengthClause Summarize $src:\n\n$text\n\nSummary:"
     }
@@ -371,12 +385,14 @@ class SummarizationModel(override val uid: String)
     val withId = df.withColumn(rowIdCol, monotonically_increasing_id()).persist()
     withId.count() // pin row ids
 
-    // one work row per input DOCUMENT annotation
+    // one work row per input DOCUMENT annotation; posexplode (not posexplode_outer) so a row
+    // whose input annotation array is empty/null produces no work row and, via the closing left
+    // join, an empty output array (empty in -> empty out, matching the extractive path)
     var pending: DataFrame = withId
-      .select(col(rowIdCol), posexplode_outer(col(getInputCols.head)).as(Seq(annIdxCol, "__ann")))
+      .select(col(rowIdCol), posexplode(col(getInputCols.head)).as(Seq(annIdxCol, "__ann")))
       .select(
         col(rowIdCol),
-        coalesce(col(annIdxCol), lit(0)).as(annIdxCol),
+        col(annIdxCol),
         coalesce(col("__ann.result"), lit("")).as(textCol),
         coalesce(col("__ann.metadata"), typedLit(Map.empty[String, String])).as(srcMetaCol))
       .withColumn(origLenCol, length(col(textCol)))
@@ -407,14 +423,16 @@ class SummarizationModel(override val uid: String)
         // The encoder-decoder (BART) backend keeps mutable per-instance decoder tensors that are
         // not thread-safe; running it across several Spark partitions lets concurrent tasks share
         // one broadcast model and corrupt each other's decode state (TF shape mismatches). Pin the
-        // generative delegate stage to a single partition so inference is single-threaded. Lane
-        // level parallelism (one method per JVM) still keeps the machine busy.
-        val prompted = exploded
+        // BART delegate stage to a single partition so inference is single-threaded. The llm
+        // (llama.cpp) delegate has no such constraint, so it keeps the input partitioning and its
+        // cluster parallelism. Lane-level parallelism (one method per JVM) still keeps the machine
+        // busy in the pinned case.
+        val promptedBase = exploded
           .withColumn(
             delegateInCol,
             mkDocUdf(promptUdf(col(chunkTextCol), lit(round > 0)))
               .as(delegateInCol, documentColMetadata))
-          .coalesce(1)
+        val prompted = if (isLlm) promptedBase else promptedBase.coalesce(1)
 
         val summarized = delegate
           .transform(prompted)
@@ -426,7 +444,8 @@ class SummarizationModel(override val uid: String)
         val perAnnotation = summarized
           .groupBy(col(rowIdCol), col(annIdxCol))
           .agg(
-            sort_array(collect_list(struct(col(chunkIdxCol), col(summaryTextCol)))).as(pairsCol),
+            // joinPairsUdf re-sorts by chunk index, so no sort_array is needed here
+            collect_list(struct(col(chunkIdxCol), col(summaryTextCol))).as(pairsCol),
             first(col(srcMetaCol)).as(srcMetaCol),
             first(col(origLenCol)).as(origLenCol),
             first(col(totalChunksCol)).as(totalChunksCol),
@@ -529,17 +548,6 @@ class SummarizationModel(override val uid: String)
   // ------------------------------------------------------------------------------------------
 
   private def transformExtractive(df: DataFrame): DataFrame = {
-    val embeddings = getEmbeddingsDelegate
-      .setInputCols(sentCol)
-      .setOutputCol(embCol)
-
-    val sentenceDetector = new SentenceDetector()
-      .setInputCols(getInputCols.head)
-      .setOutputCol(sentCol)
-
-    val withSentences = sentenceDetector.transform(df)
-    val withEmbeddings = embeddings.transform(withSentences)
-
     val budgetWords = $(maxSummaryLength)
     val lambda = $(mmrLambda).toDouble
     val posBias = $(positionBias).toDouble
@@ -548,58 +556,106 @@ class SummarizationModel(override val uid: String)
     val engine = engineName
     val cpt = charsPerToken
 
+    val withId = df.withColumn(rowIdCol, monotonically_increasing_id()).persist()
+    withId.count() // pin row ids for the closing join
+
+    // Rebuild each input annotation as its own single-DOCUMENT row before sentence detection.
+    // Sentence detectors reset character offsets per document, so several DOCUMENT annotations in
+    // one row (e.g. from MultiDocumentAssembler, where every document begins at offset 0) would
+    // otherwise overlap and a begin/end containment match could pull one document's sentences
+    // into another's summary. Scoping ranking to one document per row removes that ambiguity.
+    val mkSingleDocUdf = udf { (text: String, meta: Map[String, String]) =>
+      val t = Option(text).getOrElse("")
+      Seq(
+        Annotation(DOCUMENT, 0, math.max(0, t.length - 1), t, Option(meta).getOrElse(Map.empty)))
+    }
+
+    val exploded = withId
+      .select(col(rowIdCol), posexplode(col(getInputCols.head)).as(Seq(annIdxCol, "__ann")))
+      .withColumn(textCol, coalesce(col("__ann.result"), lit("")))
+      .withColumn(
+        srcMetaCol,
+        coalesce(col("__ann.metadata"), typedLit(Map.empty[String, String])))
+      .withColumn(
+        singleDocCol,
+        mkSingleDocUdf(col(textCol), col(srcMetaCol)).as(singleDocCol, documentColMetadata))
+      .drop("__ann")
+
+    val sentenceDetector = new SentenceDetector()
+      .setInputCols(singleDocCol)
+      .setOutputCol(sentCol)
+    val embeddings = getEmbeddingsDelegate
+      .setInputCols(sentCol)
+      .setOutputCol(embCol)
+
+    val withSentences = sentenceDetector.transform(exploded)
+    val withEmbeddings = embeddings.transform(withSentences)
+
+    // Rank the sentences of exactly one document (this row) into a single summary annotation.
+    // Sentence and embedding annotations are aligned 1:1 by index within the row.
     val rankUdf = udf { (docAnns: Seq[Row], sentAnns: Seq[Row], embAnns: Seq[Row]) =>
-      val docs = Option(docAnns).getOrElse(Seq.empty).map(Annotation(_))
-      val sents = Option(sentAnns).getOrElse(Seq.empty).map(Annotation(_))
-      val embs = Option(embAnns).getOrElse(Seq.empty).map(Annotation(_))
+      val doc = Option(docAnns).getOrElse(Seq.empty).map(Annotation(_)).headOption
+      val sents = Option(sentAnns).getOrElse(Seq.empty).map(Annotation(_)).toArray
+      val embs = Option(embAnns).getOrElse(Seq.empty).map(Annotation(_)).toArray
 
-      docs.map { doc =>
-        // sentences (and aligned embeddings) belonging to this document annotation
-        val indexed = sents.zipWithIndex.filter { case (s, _) =>
-          s.begin >= doc.begin && s.end <= doc.end
-        }
-        val sentTexts = indexed.map(_._1.result).toArray
-        val sentEmbs = indexed.map { case (_, i) =>
-          if (i < embs.length) embs(i).embeddings else Array.emptyFloatArray
-        }.toArray
+      val docText = doc.map(_.result).getOrElse("")
+      val docMeta = doc.map(_.metadata).getOrElse(Map.empty[String, String])
+      val sentTexts = sents.map(_.result)
+      val sentEmbs = sentTexts.indices.map { i =>
+        if (i < embs.length) embs(i).embeddings else Array.emptyFloatArray
+      }.toArray
 
-        if (sentTexts.isEmpty || doc.result.trim.isEmpty) {
-          Annotation(
-            DOCUMENT,
-            0,
-            0,
-            "",
-            Map("method" -> methodName, "model" -> modelName, "engine" -> engine))
-        } else {
-          val scores =
-            ExtractiveSummarizationRanker.centralityScores(sentEmbs, positionBias = posBias)
-          val wordCounts = sentTexts.map(ExtractiveSummarizationRanker.countWords)
-          val selected = ExtractiveSummarizationRanker.mmrSelect(
-            sentEmbs,
-            scores,
-            wordCounts,
-            budgetWords,
-            lambda)
-          val summary = selected.map(sentTexts(_)).mkString(" ")
-          // source metadata first so this stage's keys win on collision
-          val metadata = doc.metadata ++ Map(
-            "method" -> methodName,
-            "model" -> modelName,
-            "engine" -> engine,
-            "longDocumentStrategy" -> "native",
-            "sentencesSelected" -> selected.length.toString,
-            "sentencesTotal" -> sentTexts.length.toString,
-            "originalTokensEst" -> (doc.result.length / cpt).toString,
-            "summaryTokensEst" -> (summary.length / cpt).toString)
-          Annotation(DOCUMENT, 0, math.max(0, summary.length - 1), summary, metadata)
-        }
+      // source metadata first so this stage's keys win on collision (e.g. chained summarizers)
+      val baseMeta = docMeta ++ Map(
+        "method" -> methodName,
+        "model" -> modelName,
+        "engine" -> engine,
+        "longDocumentStrategy" -> "native")
+
+      if (sentTexts.isEmpty || docText.trim.isEmpty) {
+        Annotation(DOCUMENT, 0, 0, "", baseMeta)
+      } else {
+        val scores =
+          ExtractiveSummarizationRanker.centralityScores(sentEmbs, positionBias = posBias)
+        val wordCounts = sentTexts.map(ExtractiveSummarizationRanker.countWords)
+        val selected = ExtractiveSummarizationRanker.mmrSelect(
+          sentEmbs,
+          scores,
+          wordCounts,
+          budgetWords,
+          lambda)
+        val summary = selected.map(sentTexts(_)).mkString(" ")
+        val metadata = baseMeta ++ Map(
+          "sentencesSelected" -> selected.length.toString,
+          "sentencesTotal" -> sentTexts.length.toString,
+          "originalTokensEst" -> (docText.length / cpt).toString,
+          "summaryTokensEst" -> (summary.length / cpt).toString)
+        Annotation(DOCUMENT, 0, math.max(0, summary.length - 1), summary, metadata)
       }
     }
 
-    withEmbeddings
+    val ranked = withEmbeddings
+      .withColumn(resultCol, rankUdf(col(singleDocCol), col(sentCol), col(embCol)))
+
+    // annotation structs contain a map field and are not orderable, so ordering by annotation
+    // index must happen inside a UDF rather than via sort_array
+    val sortAnnotationsUdf = udf { pairs: Seq[Row] =>
+      pairs
+        .sortBy(_.getInt(0))
+        .map(r => Annotation(r.getStruct(1)))
+    }
+
+    val resultPerRow = ranked
+      .groupBy(col(rowIdCol))
+      .agg(collect_list(struct(col(annIdxCol), col(resultCol))).as(pairsCol))
+      .withColumn(resultCol, sortAnnotationsUdf(col(pairsCol)))
+      .select(col(rowIdCol), col(resultCol))
+
+    withId
+      .join(resultPerRow, Seq(rowIdCol), "left")
       .withColumn(
         getOutputCol,
-        wrapColumnMetadata(rankUdf(col(getInputCols.head), col(sentCol), col(embCol))))
+        wrapColumnMetadata(coalesce(col(resultCol), typedLit(Seq.empty[Annotation]))))
       .drop(internalColumns: _*)
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala
@@ -24,7 +24,7 @@ import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructType}
-import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import org.slf4j.LoggerFactory
 
 /** Fitted model produced by [[Summarization]].
@@ -363,10 +363,10 @@ class SummarizationModel(override val uid: String)
       else text
     }
 
-    val extractSummaryUdf = udf { anns: Seq[Row] =>
+    val extractSummaryUdf = udf { anns: Seq[Annotation] =>
       val raw =
         if (anns == null || anns.isEmpty) ""
-        else Annotation(anns.head).result
+        else anns.head.result
       // remove complete <think>...</think> blocks first, then any dangling unclosed <think>
       // (Qwen and similar reasoning models can emit an opening tag whose closing tag was cut
       // off by the generation budget; strip from the opening tag to the end of the output)
@@ -380,9 +380,8 @@ class SummarizationModel(override val uid: String)
       } else stripped.trim
     }
 
-    val joinPairsUdf = udf { pairs: Seq[Row] =>
+    val joinPairsUdf = udf { pairs: Seq[(Int, String)] =>
       pairs
-        .map(r => (r.getInt(0), r.getString(1)))
         .sortBy(_._1)
         .map(_._2)
         .filter(_.nonEmpty)
@@ -521,10 +520,8 @@ class SummarizationModel(override val uid: String)
 
     // annotation structs contain a map field and are not orderable, so ordering by annotation
     // index must happen inside a UDF rather than via sort_array
-    val sortAnnotationsUdf = udf { pairs: Seq[Row] =>
-      pairs
-        .sortBy(_.getInt(0))
-        .map(r => Annotation(r.getStruct(1)))
+    val sortAnnotationsUdf = udf { pairs: Seq[(Int, Annotation)] =>
+      pairs.sortBy(_._1).map(_._2)
     }
 
     val resultPerRow = summaries
@@ -600,17 +597,18 @@ class SummarizationModel(override val uid: String)
 
     // Rank the sentences of exactly one document (this row) into a single summary annotation.
     // Sentence and embedding annotations are aligned 1:1 by index within the row.
-    val rankUdf = udf { (docAnns: Seq[Row], sentAnns: Seq[Row], embAnns: Seq[Row]) =>
-      val doc = Option(docAnns).getOrElse(Seq.empty).map(Annotation(_)).headOption
-      val sents = Option(sentAnns).getOrElse(Seq.empty).map(Annotation(_)).toArray
-      val embs = Option(embAnns).getOrElse(Seq.empty).map(Annotation(_)).toArray
+    val rankUdf = udf {
+      (docAnns: Seq[Annotation], sentAnns: Seq[Annotation], embAnns: Seq[Annotation]) =>
+        val doc = Option(docAnns).getOrElse(Seq.empty).headOption
+        val sents = Option(sentAnns).getOrElse(Seq.empty).toArray
+        val embs = Option(embAnns).getOrElse(Seq.empty).toArray
 
-      val docText = doc.map(_.result).getOrElse("")
-      val docMeta = doc.map(_.metadata).getOrElse(Map.empty[String, String])
-      val sentTexts = sents.map(_.result)
-      val sentEmbs = sentTexts.indices.map { i =>
-        if (i < embs.length) embs(i).embeddings else Array.emptyFloatArray
-      }.toArray
+        val docText = doc.map(_.result).getOrElse("")
+        val docMeta = doc.map(_.metadata).getOrElse(Map.empty[String, String])
+        val sentTexts = sents.map(_.result)
+        val sentEmbs = sentTexts.indices.map { i =>
+          if (i < embs.length) embs(i).embeddings else Array.emptyFloatArray
+        }.toArray
 
       // source metadata first so this stage's keys win on collision (e.g. chained summarizers)
       val baseMeta = docMeta ++ Map(
@@ -646,10 +644,8 @@ class SummarizationModel(override val uid: String)
 
     // annotation structs contain a map field and are not orderable, so ordering by annotation
     // index must happen inside a UDF rather than via sort_array
-    val sortAnnotationsUdf = udf { pairs: Seq[Row] =>
-      pairs
-        .sortBy(_.getInt(0))
-        .map(r => Annotation(r.getStruct(1)))
+    val sortAnnotationsUdf = udf { pairs: Seq[(Int, Annotation)] =>
+      pairs.sortBy(_._1).map(_._2)
     }
 
     val resultPerRow = ranked

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala
@@ -51,9 +51,11 @@ import org.slf4j.LoggerFactory
   *     place, so a single model instance is not safe for concurrent `transform` calls; use one
   *     instance per concurrent caller.
   *   - Transforms cache the input row ids and the computed summaries for the lifetime of the
-  *     returned DataFrame (generative inference intermediates are released eagerly). The
-  *     encoder_decoder method pins inference to a single partition (the BART backend is not
-  *     thread-safe); the llm and extractive methods keep the input partitioning.
+  *     returned DataFrame (generative inference intermediates are released eagerly). These caches
+  *     back the returned DataFrame and cannot be unpersisted through this API; they are freed
+  *     when the SparkSession ends or via `spark.catalog.clearCache()` (which clears all cached
+  *     data). The encoder_decoder method pins inference to a single partition (the BART backend
+  *     is not thread-safe); the llm and extractive methods keep the input partitioning.
   *   - For the `llm` method the document text is embedded into the prompt, so a document
   *     containing instructions can influence its own summary (prompt injection); the system
   *     prompt reduces but does not eliminate this.
@@ -719,15 +721,37 @@ object SummarizationModel
   /** Some instruction-tuned models occasionally emit the summary as a JSON-string literal
     * (wrapped in double quotes, with `\n` written out as a literal backslash-n) instead of raw
     * text. Unwrap that shape back into plain text; text that isn't wrapped is returned unchanged.
+    *
+    * Quotes alone are not proof of the JSON shape (a summary may legitimately open and close with
+    * a quotation mark), so unwrapping additionally requires at least one JSON escape sequence
+    * inside the quotes.
     */
   private[seq2seq] def unwrapJsonStringLiteral(text: String): String = {
-    if (text.length >= 2 && text.head == '"' && text.last == '"') {
-      text
-        .substring(1, text.length - 1)
-        .replace("\\n", "\n")
-        .replace("\\\"", "\"")
-        .replace("\\\\", "\\")
-        .trim
-    } else text
+    val looksWrapped = text.length >= 2 && text.head == '"' && text.last == '"'
+    if (!looksWrapped) return text
+    val inner = text.substring(1, text.length - 1)
+    val hasEscapes =
+      inner.contains("\\n") || inner.contains("\\\"") || inner.contains("\\t")
+    if (!hasEscapes) return text
+
+    // decode in a single pass so an escaped backslash cannot recombine with the character
+    // after it (sequential replace() calls would turn the literal \\n into a newline)
+    val sb = new StringBuilder(inner.length)
+    var i = 0
+    while (i < inner.length) {
+      if (inner(i) == '\\' && i + 1 < inner.length) {
+        inner(i + 1) match {
+          case 'n' => sb.append('\n'); i += 2
+          case 't' => sb.append('\t'); i += 2
+          case '"' => sb.append('"'); i += 2
+          case '\\' => sb.append('\\'); i += 2
+          case _ => sb.append(inner(i)); i += 1
+        }
+      } else {
+        sb.append(inner(i))
+        i += 1
+      }
+    }
+    sb.toString.trim
   }
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala
@@ -1,0 +1,657 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.nlp.annotators.seq2seq
+
+import com.johnsnowlabs.nlp.AnnotatorType.DOCUMENT
+import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
+import com.johnsnowlabs.nlp.embeddings.MPNetEmbeddings
+import com.johnsnowlabs.nlp.{Annotation, CanBeLazy, ParamsAndFeaturesReadable, RawAnnotator}
+import org.apache.hadoop.fs.Path
+import org.apache.spark.ml.param.{Param, ParamMap}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructType}
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
+import org.slf4j.LoggerFactory
+
+/** Fitted model produced by [[Summarization]].
+  *
+  * Orchestrates the resolved summarization delegate at the DataFrame level: prompt building,
+  * long-document chunking (hierarchical map/reduce summarization), delegate inference, output
+  * cleanup and transparency metadata. The delegate is one of:
+  *
+  *   - [[AutoGGUFModel]] for method `llm`,
+  *   - [[BartTransformer]] for method `encoder_decoder`,
+  *   - [[MPNetEmbeddings]] (+ rule-based sentence detection and a PacSum-style ranker) for method
+  *     `extractive`.
+  *
+  * Saving this model persists the delegate (model weights included) under the model path, so
+  * fitted pipelines reload without network access.
+  *
+  * Notes:
+  *   - The summarization `method` is bound at fit time: this model only holds the delegate of the
+  *     method it was fitted with. Changing `method` on a fitted model fails at transform with an
+  *     explanatory error; fit a new [[Summarization]] stage instead. All other task parameters
+  *     (lengths, style, focus, strategy, ...) can be changed freely after fit.
+  *   - As a DataFrame-level orchestrator this annotator is not supported in LightPipeline.
+  *   - Generative transforms cache the input row ids and the computed summaries for the lifetime
+  *     of the returned DataFrame (inference intermediates are released eagerly).
+  *
+  * @param uid
+  *   required uid for storing annotator to disk
+  * @groupname anno Annotator types
+  * @groupdesc anno
+  *   Required input and expected output annotator types
+  * @groupname Ungrouped Members
+  * @groupname param Parameters
+  * @groupname setParam Parameter setters
+  * @groupname getParam Parameter getters
+  * @groupprio param 1
+  * @groupprio anno 2
+  * @groupprio Ungrouped 3
+  * @groupprio setParam 4
+  * @groupprio getParam 5
+  */
+class SummarizationModel(override val uid: String)
+    extends RawAnnotator[SummarizationModel]
+    with CanBeLazy
+    with SummarizationParams {
+
+  def this() = this(Identifiable.randomUID("SUMMARIZATION_MODEL"))
+
+  /** Input Annotator Type: DOCUMENT
+    * @group anno
+    */
+  override val inputAnnotatorTypes: Array[String] = Array(DOCUMENT)
+
+  /** Output Annotator Type: DOCUMENT
+    * @group anno
+    */
+  override val outputAnnotatorType: String = DOCUMENT
+
+  private val logger = LoggerFactory.getLogger("SummarizationModel")
+
+  /** Name of the pretrained model resolved at fit time (for transparency metadata).
+    * @group param
+    */
+  val resolvedModel =
+    new Param[String](this, "resolvedModel", "Pretrained model name resolved at fit time")
+
+  /** @group setParam */
+  def setResolvedModel(value: String): this.type = set(resolvedModel, value)
+
+  /** @group getParam */
+  def getResolvedModel: String = get(resolvedModel).getOrElse("")
+
+  setDefault(resolvedModel -> "")
+
+  // ------------------------------------------------------------------------------------------
+  // Delegates (not Spark params; serialized via onWrite / companion reader)
+  // ------------------------------------------------------------------------------------------
+
+  private var _llmDelegate: Option[AutoGGUFModel] = None
+  private var _seq2SeqDelegate: Option[BartTransformer] = None
+  private var _embeddingsDelegate: Option[MPNetEmbeddings] = None
+
+  /** @group setParam */
+  def setLlmDelegate(value: AutoGGUFModel): this.type = {
+    _llmDelegate = Some(value)
+    this
+  }
+
+  /** @group setParam */
+  def setSeq2SeqDelegate(value: BartTransformer): this.type = {
+    _seq2SeqDelegate = Some(value)
+    this
+  }
+
+  /** @group setParam */
+  def setEmbeddingsDelegate(value: MPNetEmbeddings): this.type = {
+    _embeddingsDelegate = Some(value)
+    this
+  }
+
+  /** @group getParam */
+  def getLlmDelegate: AutoGGUFModel =
+    _llmDelegate.getOrElse(
+      throw new IllegalStateException(
+        "No LLM delegate set. Fit a Summarization stage with method 'llm' first."))
+
+  /** @group getParam */
+  def getSeq2SeqDelegate: BartTransformer =
+    _seq2SeqDelegate.getOrElse(
+      throw new IllegalStateException(
+        "No encoder_decoder delegate set. Fit a Summarization stage with method " +
+          "'encoder_decoder' first."))
+
+  /** @group getParam */
+  def getEmbeddingsDelegate: MPNetEmbeddings =
+    _embeddingsDelegate.getOrElse(
+      throw new IllegalStateException(
+        "No embeddings delegate set. Fit a Summarization stage with method 'extractive' first."))
+
+  /** Closes the llama.cpp backend if the llm delegate is loaded, freeing native resources. */
+  def close(): Unit = _llmDelegate.foreach(_.close())
+
+  // ------------------------------------------------------------------------------------------
+  // Internal column names
+  // ------------------------------------------------------------------------------------------
+
+  private val rowIdCol = s"__${uid}_rowId"
+  private val annIdxCol = s"__${uid}_annIdx"
+  private val textCol = s"__${uid}_text"
+  private val srcMetaCol = s"__${uid}_srcMeta"
+  private val origLenCol = s"__${uid}_origLen"
+  private val chunksCol = s"__${uid}_chunks"
+  private val nChunksCol = s"__${uid}_nChunks"
+  private val totalChunksCol = s"__${uid}_totalChunks"
+  private val chunkIdxCol = s"__${uid}_chunkIdx"
+  private val chunkTextCol = s"__${uid}_chunkText"
+  private val delegateInCol = s"__${uid}_delegateIn"
+  private val delegateOutCol = s"__${uid}_delegateOut"
+  private val summaryTextCol = s"__${uid}_summaryText"
+  private val pairsCol = s"__${uid}_pairs"
+  private val sentCol = s"__${uid}_sentences"
+  private val embCol = s"__${uid}_sentEmbeddings"
+  private val resultCol = s"__${uid}_resultAnns"
+
+  private def internalColumns: Seq[String] = Seq(
+    rowIdCol,
+    annIdxCol,
+    textCol,
+    srcMetaCol,
+    origLenCol,
+    chunksCol,
+    nChunksCol,
+    totalChunksCol,
+    chunkIdxCol,
+    chunkTextCol,
+    delegateInCol,
+    delegateOutCol,
+    summaryTextCol,
+    pairsCol,
+    sentCol,
+    embCol,
+    resultCol)
+
+  private def documentColMetadata: Metadata = {
+    val metadataBuilder: MetadataBuilder = new MetadataBuilder()
+    metadataBuilder.putString("annotatorType", DOCUMENT)
+    metadataBuilder.build
+  }
+
+  // ------------------------------------------------------------------------------------------
+  // Budgets and prompts (driver-side; UDFs only capture local immutable values)
+  // ------------------------------------------------------------------------------------------
+
+  /** Approximate chars-per-token factor used for context estimates. */
+  private val charsPerToken = 4
+
+  private def promptOverheadTokens: Int = 150
+
+  /** Effective per-pass input budget in characters for the generative delegate. */
+  private def budgetChars: Int = {
+    val tokens =
+      if ($(chunkSize) > 0) $(chunkSize)
+      else
+        $(method) match {
+          case "llm" =>
+            // keep prompt + generation inside the context window
+            val ctx = math.max(getLlmDelegate.getNCtx, 4096)
+            math.max(256, (ctx * 0.6).toInt - promptOverheadTokens - $(maxSummaryLength))
+          case _ =>
+            // stay safely inside the delegate's encoder length (TF-exported BART graphs are
+            // traced for maxInputLength positions, default 512; exceeding it is a graph error)
+            val delegate = getSeq2SeqDelegate
+            val maxIn = delegate.getOrDefault(delegate.maxInputLength)
+            math.max(128, maxIn - 64)
+        }
+    tokens * charsPerToken
+  }
+
+  private def systemPromptText: String =
+    "/no_think\n" +
+      "You are a professional text summarization engine. " +
+      "Write only the requested summary of the user's text. " +
+      "Do not include reasoning, explanations, analysis, notes, markdown headers, labels, " +
+      "or <think> tags. Never refuse; always produce a summary."
+
+  private def styleClause: String = $(summaryStyle) match {
+    case "detailed" => "Write a detailed summary covering all major points."
+    case "bullets" => "Write the summary as short bullet points, one key point per line."
+    case _ => "Write a concise summary."
+  }
+
+  private def focusClause: String =
+    if ($(focus).nonEmpty) s" Focus on: ${$(focus)}." else ""
+
+  private def engineName: String = $(method) match {
+    case "llm" => "llamacpp"
+    case "encoder_decoder" => getSeq2SeqDelegate.getEngine
+    case "extractive" => getEmbeddingsDelegate.getEngine
+  }
+
+  private def configureLlm(): AutoGGUFModel = {
+    val delegate = getLlmDelegate
+    if (delegate.getNCtx < 4096) delegate.setNCtx(4096)
+    delegate
+      .setInputCols(delegateInCol)
+      .setOutputCol(delegateOutCol)
+      .setUseChatTemplate(true)
+      .setSystemPrompt(systemPromptText)
+      .setTemperature($(temperature))
+      .setTopP($(topP))
+      .setNPredict(math.max(64, $(maxSummaryLength) * 2))
+      .setNGpuLayers($(gpuLayers))
+      .setReasoningBudget(0)
+      .setRemoveThinkingTag("think")
+  }
+
+  private def configureSeq2Seq(): BartTransformer = {
+    getSeq2SeqDelegate
+      .setInputCols(delegateInCol)
+      .setOutputCol(delegateOutCol)
+      .setMaxOutputLength($(maxSummaryLength))
+      .setMinOutputLength(math.max(0, math.min($(minSummaryLength), $(maxSummaryLength) - 1)))
+      .setBeamSize($(numBeams))
+      .setDoSample(false)
+  }
+
+  // ------------------------------------------------------------------------------------------
+  // Transform
+  // ------------------------------------------------------------------------------------------
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    require(
+      validate(dataset.schema),
+      s"Wrong or missing inputCols annotators in $uid. Received inputCols: " +
+        s"${getInputCols.mkString(",")}. Make sure such annotators exist in your pipeline " +
+        s"and have the annotator type: ${inputAnnotatorTypes.mkString(", ")}")
+
+    $(method) match {
+      case "extractive" => transformExtractive(dataset.toDF())
+      case "llm" | "encoder_decoder" => transformGenerative(dataset.toDF())
+      case other => throw new IllegalArgumentException(s"Unsupported method '$other'")
+    }
+  }
+
+  // ------------------------------------------------------------------------------------------
+  // Generative path (llm / encoder_decoder)
+  // ------------------------------------------------------------------------------------------
+
+  private def transformGenerative(df: DataFrame): DataFrame = {
+    val isLlm = $(method) == "llm"
+    val delegate = if (isLlm) configureLlm() else configureSeq2Seq()
+    val strategy = $(longDocumentStrategy)
+    val budget = budgetChars
+    val overlap = $(chunkOverlap)
+    val maxRounds = if (strategy == "truncate") 1 else 3
+
+    // local copies for UDF closures (avoid serializing the model into tasks)
+    val style = styleClause
+    val focusHint = focusClause
+    val maxWords = $(maxSummaryLength)
+
+    val minWords = $(minSummaryLength)
+
+    def buildPromptLocal(text: String, isReduce: Boolean): String = {
+      val src =
+        if (isReduce) "the following partial summaries of a longer document"
+        else "the following text"
+      val lengthClause =
+        if (minWords > 0) s"The summary must be between $minWords and $maxWords words."
+        else s"The summary must be at most $maxWords words."
+      s"$style$focusHint $lengthClause Summarize $src:\n\n$text\n\nSummary:"
+    }
+
+    val chunkFn = (budgetC: Int, strat: String, lastRound: Boolean, overlapS: Int) =>
+      udf { text: String =>
+        val t = Option(text).getOrElse("")
+        if (t.length <= budgetC) Seq(t)
+        else
+          strat match {
+            case "truncate" => Seq(t.substring(0, budgetC))
+            case _ if lastRound => Seq(t.substring(0, budgetC))
+            case _ =>
+              val sentences = ExtractiveSummarizationRanker.splitSentences(t)
+              ExtractiveSummarizationRanker.packChunks(sentences, budgetC, overlapS).toSeq
+          }
+      }
+
+    val mkDocUdf = udf { text: String =>
+      val t = Option(text).getOrElse("")
+      if (t.trim.isEmpty) Seq.empty[Annotation]
+      else Seq(Annotation(DOCUMENT, 0, t.length - 1, t, Map.empty[String, String]))
+    }
+
+    val promptUdf = udf { (t: String, reduceRound: Boolean) =>
+      val text = Option(t).getOrElse("")
+      if (text.trim.isEmpty) ""
+      else if (isLlm) buildPromptLocal(text, reduceRound)
+      else text
+    }
+
+    val extractSummaryUdf = udf { anns: Seq[Row] =>
+      val raw =
+        if (anns == null || anns.isEmpty) ""
+        else Annotation(anns.head).result
+      // remove complete <think>...</think> blocks first, then any dangling unclosed <think>
+      // (Qwen and similar reasoning models can emit an opening tag whose closing tag was cut
+      // off by the generation budget; strip from the opening tag to the end of the output)
+      var stripped = raw.replaceAll("(?s)<think>.*?</think>", "")
+      val openIdx = stripped.indexOf("<think>")
+      if (openIdx >= 0) stripped = stripped.substring(0, openIdx)
+      if (isLlm)
+        stripped.replaceAll("(?im)^\\s*(summary|here is (a|the) summary)\\s*:?\\s*", "").trim
+      else stripped.trim
+    }
+
+    val joinPairsUdf = udf { pairs: Seq[Row] =>
+      pairs
+        .map(r => (r.getInt(0), r.getString(1)))
+        .sortBy(_._1)
+        .map(_._2)
+        .filter(_.nonEmpty)
+        .mkString(" ")
+    }
+
+    val withId = df.withColumn(rowIdCol, monotonically_increasing_id()).persist()
+    withId.count() // pin row ids
+
+    // one work row per input DOCUMENT annotation
+    var pending: DataFrame = withId
+      .select(col(rowIdCol), posexplode_outer(col(getInputCols.head)).as(Seq(annIdxCol, "__ann")))
+      .select(
+        col(rowIdCol),
+        coalesce(col(annIdxCol), lit(0)).as(annIdxCol),
+        coalesce(col("__ann.result"), lit("")).as(textCol),
+        coalesce(col("__ann.metadata"), typedLit(Map.empty[String, String])).as(srcMetaCol))
+      .withColumn(origLenCol, length(col(textCol)))
+      .withColumn(totalChunksCol, lit(0))
+
+    var done: Option[DataFrame] = None
+    var round = 0
+    // intermediate per-round caches; released once the final result is materialized
+    val roundCaches = scala.collection.mutable.ArrayBuffer.empty[DataFrame]
+
+    try {
+      while (round < maxRounds && pending != null) {
+        val lastRound = round == maxRounds - 1
+
+        val chunked = pending
+          .withColumn(chunksCol, chunkFn(budget, strategy, lastRound, overlap)(col(textCol)))
+          .withColumn(nChunksCol, size(col(chunksCol)))
+
+        val exploded = chunked.select(
+          col(rowIdCol),
+          col(annIdxCol),
+          col(srcMetaCol),
+          col(origLenCol),
+          col(totalChunksCol),
+          col(nChunksCol),
+          posexplode_outer(col(chunksCol)).as(Seq(chunkIdxCol, chunkTextCol)))
+
+        // The encoder-decoder (BART) backend keeps mutable per-instance decoder tensors that are
+        // not thread-safe; running it across several Spark partitions lets concurrent tasks share
+        // one broadcast model and corrupt each other's decode state (TF shape mismatches). Pin the
+        // generative delegate stage to a single partition so inference is single-threaded. Lane
+        // level parallelism (one method per JVM) still keeps the machine busy.
+        val prompted = exploded
+          .withColumn(
+            delegateInCol,
+            mkDocUdf(promptUdf(col(chunkTextCol), lit(round > 0)))
+              .as(delegateInCol, documentColMetadata))
+          .coalesce(1)
+
+        val summarized = delegate
+          .transform(prompted)
+          .withColumn(summaryTextCol, extractSummaryUdf(col(delegateOutCol)))
+          .persist()
+        summarized.count() // materialize: avoid re-running inference on branch reuse
+        roundCaches += summarized
+
+        val perAnnotation = summarized
+          .groupBy(col(rowIdCol), col(annIdxCol))
+          .agg(
+            sort_array(collect_list(struct(col(chunkIdxCol), col(summaryTextCol)))).as(pairsCol),
+            first(col(srcMetaCol)).as(srcMetaCol),
+            first(col(origLenCol)).as(origLenCol),
+            first(col(totalChunksCol)).as(totalChunksCol),
+            first(col(nChunksCol)).as(nChunksCol))
+          .withColumn(summaryTextCol, joinPairsUdf(col(pairsCol)))
+          .withColumn(
+            totalChunksCol,
+            when(col(totalChunksCol) === 0, col(nChunksCol)).otherwise(col(totalChunksCol)))
+          .drop(pairsCol)
+
+        val finishedThisRound = perAnnotation
+          .filter(col(nChunksCol) === 1)
+          .select(rowIdCol, annIdxCol, summaryTextCol, srcMetaCol, origLenCol, totalChunksCol)
+
+        done = done match {
+          case Some(d) => Some(d.union(finishedThisRound))
+          case None => Some(finishedThisRound)
+        }
+
+        val stillPending = perAnnotation.filter(col(nChunksCol) > 1)
+        // early exit: when nothing needs another reduce round (the common single-chunk case),
+        // do not schedule further delegate passes over empty frames
+        val hasPending = round + 1 < maxRounds && !stillPending.isEmpty
+        pending =
+          if (hasPending)
+            stillPending.select(
+              col(rowIdCol),
+              col(annIdxCol),
+              col(summaryTextCol).as(textCol),
+              col(srcMetaCol),
+              col(origLenCol),
+              col(totalChunksCol))
+          else null
+
+        round += 1
+      }
+    } catch {
+      case t: Throwable =>
+        (roundCaches :+ withId).foreach(f => scala.util.Try(f.unpersist()))
+        throw t
+    }
+
+    val summaries = done.get
+
+    // build final DOCUMENT annotations and group them back per original row
+    val methodName = $(method)
+    val modelName = getResolvedModel
+    val engine = engineName
+    val strategyName = strategy
+    val cpt = charsPerToken
+
+    val mkResultUdf = udf {
+      (summary: String, srcMeta: Map[String, String], origLen: Int, chunks: Int) =>
+        val text = Option(summary).getOrElse("")
+        // source metadata first so this stage's keys win on collision (e.g. chained summarizers)
+        val metadata = Option(srcMeta).getOrElse(Map.empty[String, String]) ++ Map(
+          "method" -> methodName,
+          "model" -> modelName,
+          "engine" -> engine,
+          "longDocumentStrategy" -> strategyName,
+          "numChunks" -> math.max(chunks, 1).toString,
+          "originalTokensEst" -> (origLen / cpt).toString,
+          "summaryTokensEst" -> (text.length / cpt).toString)
+        Annotation(DOCUMENT, 0, math.max(0, text.length - 1), text, metadata)
+    }
+
+    // annotation structs contain a map field and are not orderable, so ordering by annotation
+    // index must happen inside a UDF rather than via sort_array
+    val sortAnnotationsUdf = udf { pairs: Seq[Row] =>
+      pairs
+        .sortBy(_.getInt(0))
+        .map(r => Annotation(r.getStruct(1)))
+    }
+
+    val resultPerRow = summaries
+      .withColumn(
+        resultCol,
+        mkResultUdf(col(summaryTextCol), col(srcMetaCol), col(origLenCol), col(totalChunksCol)))
+      .groupBy(col(rowIdCol))
+      .agg(collect_list(struct(col(annIdxCol), col(resultCol))).as(pairsCol))
+      .withColumn(resultCol, sortAnnotationsUdf(col(pairsCol)))
+      .select(col(rowIdCol), col(resultCol))
+      .persist()
+    resultPerRow.count() // materialize so the per-round inference caches can be released
+
+    // the summaries are now safely cached in resultPerRow; free the inference intermediates
+    roundCaches.foreach(f => scala.util.Try(f.unpersist()))
+
+    val joined = withId
+      .join(resultPerRow, Seq(rowIdCol), "left")
+      .withColumn(
+        getOutputCol,
+        wrapColumnMetadata(coalesce(col(resultCol), typedLit(Seq.empty[Annotation]))))
+
+    joined.drop(internalColumns: _*)
+  }
+
+  // ------------------------------------------------------------------------------------------
+  // Extractive path
+  // ------------------------------------------------------------------------------------------
+
+  private def transformExtractive(df: DataFrame): DataFrame = {
+    val embeddings = getEmbeddingsDelegate
+      .setInputCols(sentCol)
+      .setOutputCol(embCol)
+
+    val sentenceDetector = new SentenceDetector()
+      .setInputCols(getInputCols.head)
+      .setOutputCol(sentCol)
+
+    val withSentences = sentenceDetector.transform(df)
+    val withEmbeddings = embeddings.transform(withSentences)
+
+    val budgetWords = $(maxSummaryLength)
+    val lambda = $(mmrLambda).toDouble
+    val posBias = $(positionBias).toDouble
+    val methodName = $(method)
+    val modelName = getResolvedModel
+    val engine = engineName
+    val cpt = charsPerToken
+
+    val rankUdf = udf { (docAnns: Seq[Row], sentAnns: Seq[Row], embAnns: Seq[Row]) =>
+      val docs = Option(docAnns).getOrElse(Seq.empty).map(Annotation(_))
+      val sents = Option(sentAnns).getOrElse(Seq.empty).map(Annotation(_))
+      val embs = Option(embAnns).getOrElse(Seq.empty).map(Annotation(_))
+
+      docs.map { doc =>
+        // sentences (and aligned embeddings) belonging to this document annotation
+        val indexed = sents.zipWithIndex.filter { case (s, _) =>
+          s.begin >= doc.begin && s.end <= doc.end
+        }
+        val sentTexts = indexed.map(_._1.result).toArray
+        val sentEmbs = indexed.map { case (_, i) =>
+          if (i < embs.length) embs(i).embeddings else Array.emptyFloatArray
+        }.toArray
+
+        if (sentTexts.isEmpty || doc.result.trim.isEmpty) {
+          Annotation(
+            DOCUMENT,
+            0,
+            0,
+            "",
+            Map("method" -> methodName, "model" -> modelName, "engine" -> engine))
+        } else {
+          val scores =
+            ExtractiveSummarizationRanker.centralityScores(sentEmbs, positionBias = posBias)
+          val wordCounts = sentTexts.map(ExtractiveSummarizationRanker.countWords)
+          val selected = ExtractiveSummarizationRanker.mmrSelect(
+            sentEmbs,
+            scores,
+            wordCounts,
+            budgetWords,
+            lambda)
+          val summary = selected.map(sentTexts(_)).mkString(" ")
+          // source metadata first so this stage's keys win on collision
+          val metadata = doc.metadata ++ Map(
+            "method" -> methodName,
+            "model" -> modelName,
+            "engine" -> engine,
+            "longDocumentStrategy" -> "native",
+            "sentencesSelected" -> selected.length.toString,
+            "sentencesTotal" -> sentTexts.length.toString,
+            "originalTokensEst" -> (doc.result.length / cpt).toString,
+            "summaryTokensEst" -> (summary.length / cpt).toString)
+          Annotation(DOCUMENT, 0, math.max(0, summary.length - 1), summary, metadata)
+        }
+      }
+    }
+
+    withEmbeddings
+      .withColumn(
+        getOutputCol,
+        wrapColumnMetadata(rankUdf(col(getInputCols.head), col(sentCol), col(embCol))))
+      .drop(internalColumns: _*)
+  }
+
+  // ------------------------------------------------------------------------------------------
+  // Persistence
+  // ------------------------------------------------------------------------------------------
+
+  override def onWrite(path: String, spark: SparkSession): Unit = {
+    super.onWrite(path, spark)
+    val delegatePath = new Path(path, SummarizationModel.delegateDir).toString
+    $(method) match {
+      case "llm" => getLlmDelegate.write.save(delegatePath)
+      case "encoder_decoder" => getSeq2SeqDelegate.write.save(delegatePath)
+      case "extractive" => getEmbeddingsDelegate.write.save(delegatePath)
+    }
+  }
+
+  override def copy(extra: ParamMap): SummarizationModel = {
+    val copied = super.copy(extra)
+    _llmDelegate.foreach(copied.setLlmDelegate)
+    _seq2SeqDelegate.foreach(copied.setSeq2SeqDelegate)
+    _embeddingsDelegate.foreach(copied.setEmbeddingsDelegate)
+    copied
+  }
+
+  override protected def extraValidate(structType: StructType): Boolean = true
+}
+
+trait ReadSummarizationDelegate {
+  this: ParamsAndFeaturesReadable[SummarizationModel] =>
+
+  def readDelegate(instance: SummarizationModel, path: String, spark: SparkSession): Unit = {
+    val delegatePath = new Path(path, SummarizationModel.delegateDir).toString
+    instance.getMethod match {
+      case "llm" =>
+        instance.setLlmDelegate(AutoGGUFModel.load(delegatePath))
+      case "encoder_decoder" =>
+        instance.setSeq2SeqDelegate(BartTransformer.load(delegatePath))
+      case "extractive" =>
+        instance.setEmbeddingsDelegate(MPNetEmbeddings.load(delegatePath))
+    }
+  }
+
+  addReader(readDelegate)
+}
+
+/** This is the companion object of [[SummarizationModel]]. Please refer to that class for the
+  * documentation.
+  */
+object SummarizationModel
+    extends ParamsAndFeaturesReadable[SummarizationModel]
+    with ReadSummarizationDelegate {
+
+  private[seq2seq] val delegateDir = "summarization_delegate"
+}

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationModel.scala
@@ -264,6 +264,8 @@ class SummarizationModel(override val uid: String)
       .setSystemPrompt(systemPromptText)
       .setTemperature($(temperature))
       .setTopP($(topP))
+      .setRepeatPenalty(1.1f)
+      .setRepeatLastN(64)
       .setNPredict(math.max(64, $(maxSummaryLength) * 2))
       .setNGpuLayers($(gpuLayers))
       .setReasoningBudget(0)
@@ -278,6 +280,7 @@ class SummarizationModel(override val uid: String)
       .setMinOutputLength(math.max(0, math.min($(minSummaryLength), $(maxSummaryLength) - 1)))
       .setBeamSize($(numBeams))
       .setDoSample(false)
+      .setNoRepeatNgramSize($(noRepeatNgramSize))
   }
 
   // ------------------------------------------------------------------------------------------

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationE2EBase.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationE2EBase.scala
@@ -16,9 +16,12 @@
 package com.johnsnowlabs.nlp.annotators.seq2seq
 
 import com.johnsnowlabs.nlp.Annotation
+import com.johnsnowlabs.nlp.AnnotatorType.DOCUMENT
 import com.johnsnowlabs.nlp.base.DocumentAssembler
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.functions.{col, udf}
+import org.apache.spark.sql.types.{Metadata, MetadataBuilder}
 import org.apache.spark.sql.{DataFrame, Row}
 
 /** Shared fixtures/helpers for the split per-method Summarization end-to-end specs. Each concrete
@@ -75,6 +78,27 @@ trait SummarizationE2EBase {
       "through at least midday tomorrow."
 
   protected def df(texts: String*): DataFrame = texts.toDF("text")
+
+  /** Column-metadata marking a hand-built column as DOCUMENT annotations. */
+  protected val docColMetadata: Metadata =
+    new MetadataBuilder().putString("annotatorType", DOCUMENT).build()
+
+  /** Builds a DataFrame with a ready-made `document` column from raw annotation texts. Each
+    * argument is one row's list of DOCUMENT annotations; every annotation starts at offset 0 (so
+    * annotations within a row share/overlap character ranges) and an empty list yields a row with
+    * a genuinely empty annotation array. Used to exercise multi-document and empty-input paths
+    * without a DocumentAssembler (which always emits exactly one non-empty-array annotation).
+    */
+  protected def documentsDF(rows: Seq[String]*): DataFrame = {
+    val toDocs = udf { texts: Seq[String] =>
+      texts.map(t =>
+        Annotation(DOCUMENT, 0, math.max(0, t.length - 1), t, Map.empty[String, String]))
+    }
+    rows.toSeq
+      .map(_.toSeq)
+      .toDF("texts")
+      .withColumn("document", toDocs(col("texts")).as("document", docColMetadata))
+  }
 
   protected def documentAssembler: DocumentAssembler =
     new DocumentAssembler().setInputCol("text").setOutputCol("document")

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationE2EBase.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationE2EBase.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.nlp.annotators.seq2seq
+
+import com.johnsnowlabs.nlp.Annotation
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.{DataFrame, Row}
+
+/** Shared fixtures/helpers for the split per-method Summarization end-to-end specs. Each concrete
+  * spec exercises exactly one method (and therefore one pretrained model), so the specs can run
+  * as independent JVM processes in parallel without racing on the shared model download cache.
+  *
+  * The long documents are generated in-memory from distinct, self-contained paragraphs so the
+  * suite carries no external corpora. This is sufficient because the long-document assertions
+  * (chunk counts, hierarchical rounds, verbatim-subset selection, save/load) are content
+  * agnostic: they only require documents that exceed the model context and split into several
+  * sentences.
+  */
+trait SummarizationE2EBase {
+
+  import ResourceHelper.spark.implicits._
+
+  /** Repeats a paragraph until the text is at least `minChars` long. */
+  private def longDoc(paragraph: String, minChars: Int): String = {
+    val sb = new StringBuilder
+    while (sb.length < minChars) sb.append(paragraph).append(' ')
+    sb.toString.trim
+  }
+
+  private val economyParagraph =
+    "The national statistics office reported that industrial output rose modestly last quarter. " +
+      "Manufacturers cited stronger export demand and easing supply constraints as the main " +
+      "drivers. Economists cautioned that rising energy costs could weigh on margins in the " +
+      "months ahead. Consumer spending held steady while household savings edged lower. Analysts " +
+      "expect the central bank to keep interest rates unchanged at its next meeting."
+
+  private val climateParagraph =
+    "Average surface temperatures have continued to climb across most measured regions. " +
+      "Researchers link the trend to sustained greenhouse gas emissions from energy and " +
+      "transport. Coastal areas reported shifting precipitation patterns and more frequent " +
+      "flooding. Agricultural yields are projected to decline in several affected regions. Local " +
+      "governments have begun funding adaptation and resilience programmes."
+
+  private val biologyParagraph =
+    "The survey documented considerable variation among the sampled populations. Individuals with " +
+      "traits suited to the local environment tended to leave more descendants. Over successive " +
+      "generations these advantageous characteristics became more common. Isolated groups " +
+      "gradually diverged as conditions differed between habitats. The authors argue that small " +
+      "inherited differences accumulate into pronounced change over long periods."
+
+  // long, self-contained documents (no external corpora); sized to exceed the model context
+  protected lazy val swiftDoc: String = longDoc(economyParagraph, 6000)
+  protected lazy val wikiDoc: String = longDoc(climateParagraph, 12000)
+  protected lazy val darwinDoc: String = longDoc(biologyParagraph, 24000)
+
+  protected val shortDoc: String =
+    "PG&E stated it scheduled the blackouts in response to forecasts for high winds " +
+      "amid dry conditions. The aim is to reduce the risk of wildfires. Nearly 800 thousand " +
+      "customers were scheduled to be affected by the shutoffs which were expected to last " +
+      "through at least midday tomorrow."
+
+  protected def df(texts: String*): DataFrame = texts.toDF("text")
+
+  protected def documentAssembler: DocumentAssembler =
+    new DocumentAssembler().setInputCol("text").setOutputCol("document")
+
+  protected def fit(summarizer: Summarization, data: DataFrame): PipelineModel =
+    new Pipeline().setStages(Array(documentAssembler, summarizer)).fit(data)
+
+  protected def summarizationStage(fitted: PipelineModel): SummarizationModel =
+    fitted.stages.collectFirst { case m: SummarizationModel => m }.get
+
+  protected def annotations(result: DataFrame): Seq[Annotation] =
+    result
+      .select("summary")
+      .collect()
+      .flatMap(row => Option(row.getSeq[Row](0)).getOrElse(Seq.empty).map(Annotation(_)))
+      .toSeq
+
+  protected def words(s: String): Int = ExtractiveSummarizationRanker.countWords(s)
+
+  protected def assertCoreMetadata(ann: Annotation, method: String): Unit = {
+    assert(ann.metadata("method") == method, s"metadata.method must be $method")
+    assert(ann.metadata("model").nonEmpty, "metadata.model must be present")
+    assert(ann.metadata("engine").nonEmpty, "metadata.engine must be present")
+    assert(ann.metadata.contains("originalTokensEst"), "originalTokensEst missing")
+    assert(ann.metadata.contains("summaryTokensEst"), "summaryTokensEst missing")
+  }
+
+  protected def summarizer(method: String): Summarization =
+    new Summarization().setInputCols("document").setOutputCol("summary").setMethod(method)
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationEncoderDecoderE2ESpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationEncoderDecoderE2ESpec.scala
@@ -139,4 +139,32 @@ class SummarizationEncoderDecoderE2ESpec extends AnyFlatSpec with SummarizationE
     assert(ann.result.nonEmpty)
     assert(ann.metadata("numChunks").toInt > 1)
   }
+
+  // Gap #10 — a genuinely empty input annotation array must yield an empty output array, while a
+  // real document in the same batch is still summarized (empty in -> empty out).
+  it should "return an empty summary array for an empty input annotation array" taggedAs SlowTest in {
+    val model =
+      summarizationStage(fit(summarizer("encoder_decoder").setMaxSummaryLength(30), df(shortDoc)))
+    val data = documentsDF(Seq.empty[String], Seq(shortDoc)) // row 0 empty, row 1 one document
+    val sizes = model
+      .transform(data)
+      .select("summary")
+      .collect()
+      .map(r => Option(r.getSeq[org.apache.spark.sql.Row](0)).getOrElse(Seq.empty).length)
+    assert(sizes.toSeq == Seq(0, 1), s"expected [0, 1] summaries per row, got ${sizes.toSeq}")
+  }
+
+  // Gap #11 — hierarchical chunking with a positive sentence overlap must run end-to-end and
+  // still produce a summary (exercises packChunks overlap seeding in the generative path).
+  it should "chunk long documents with sentence overlap between chunks" taggedAs SlowTest in {
+    val summ = summarizer("encoder_decoder")
+      .setMaxSummaryLength(40)
+      .setChunkSize(150)
+      .setChunkOverlap(2)
+      .setLongDocumentStrategy("hierarchical")
+    val fitted = fit(summ, df(wikiDoc))
+    val ann = annotations(fitted.transform(df(wikiDoc))).head
+    assert(ann.result.nonEmpty, "overlapped-chunk summary must not be empty")
+    assert(ann.metadata("numChunks").toInt > 1, "document must be chunked")
+  }
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationEncoderDecoderE2ESpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationEncoderDecoderE2ESpec.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.nlp.annotators.seq2seq
+
+import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
+import com.johnsnowlabs.tags.SlowTest
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.scalatest.flatspec.AnyFlatSpec
+
+/** Exhaustive encoder-decoder validation (model: distilbart_xsum_12_6). Runs independently of the
+  * other method specs so the three lanes can execute in parallel.
+  */
+class SummarizationEncoderDecoderE2ESpec extends AnyFlatSpec with SummarizationE2EBase {
+
+  "Summarization encoder_decoder (e2e)" should "summarize real documents, chunking long ones" taggedAs SlowTest in {
+    val data = df(shortDoc, swiftDoc, wikiDoc)
+    val fitted = fit(summarizer("encoder_decoder").setMaxSummaryLength(80), data)
+
+    val anns = annotations(fitted.transform(data))
+    assert(anns.length == 3)
+    anns.foreach { ann =>
+      assert(ann.result.nonEmpty, "summary must not be empty")
+      assertCoreMetadata(ann, "encoder_decoder")
+    }
+    val byLen = anns.sortBy(_.metadata("originalTokensEst").toInt)
+    assert(byLen.head.metadata("numChunks").toInt == 1, "short doc must not be chunked")
+    assert(byLen(1).metadata("numChunks").toInt > 1, "swift doc must be chunked")
+    assert(byLen(2).metadata("numChunks").toInt > 1, "wiki doc must be chunked")
+
+    val model = summarizationStage(fitted)
+
+    model.setNumBeams(1)
+    assert(annotations(fitted.transform(df(shortDoc))).head.result.nonEmpty, "greedy must work")
+    model.setNumBeams(4)
+
+    model.setMaxSummaryLength(30)
+    model.setMinSummaryLength(5)
+    assert(annotations(fitted.transform(df(shortDoc))).head.result.nonEmpty)
+    model.setMaxSummaryLength(80)
+    model.setMinSummaryLength(20)
+
+    model.setLongDocumentStrategy("truncate")
+    val truncated = annotations(fitted.transform(df(wikiDoc))).head
+    assert(truncated.metadata("numChunks").toInt == 1, "truncate must not chunk")
+    assert(truncated.metadata("longDocumentStrategy") == "truncate")
+    model.setLongDocumentStrategy("auto")
+
+    model.setChunkSize(200)
+    model.setChunkOverlap(0)
+    val fineChunked = annotations(fitted.transform(df(swiftDoc))).head
+    assert(
+      fineChunked.metadata("numChunks").toInt > anns(1).metadata("numChunks").toInt,
+      "smaller chunkSize must produce more chunks")
+    model.setChunkSize(0)
+    model.setChunkOverlap(1)
+  }
+
+  it should "round-trip through save/load and still transform" taggedAs SlowTest in {
+    val data = df(shortDoc)
+    val fitted = fit(summarizer("encoder_decoder").setMaxSummaryLength(40), data)
+    val path = s"file:///tmp/summarization_e2e_encdec_${System.currentTimeMillis()}"
+    fitted.write.overwrite().save(path)
+    val ann = annotations(PipelineModel.load(path).transform(data)).head
+    assert(ann.result.nonEmpty)
+    assert(ann.metadata("method") == "encoder_decoder")
+  }
+
+  // Gap #1 — the generative path explodes/regroups per DOCUMENT annotation and sorts them back
+  // by index (the struct-with-map ordering path). Verify a multi-annotation row round-trips.
+  it should "align one summary per DOCUMENT annotation in a multi-annotation row" taggedAs SlowTest in {
+    val doc = documentAssembler
+    val sentences = new SentenceDetector()
+      .setInputCols("document")
+      .setOutputCol("sentences")
+      .setExplodeSentences(false)
+    val summ = summarizer("encoder_decoder").setInputCols("sentences").setMaxSummaryLength(20)
+    val data = df(shortDoc)
+    val fitted = new Pipeline().setStages(Array(doc, sentences, summ)).fit(data)
+    val anns = annotations(fitted.transform(data))
+    assert(anns.length >= 2, s"expected a summary per sentence, got ${anns.length}")
+    anns.foreach(a => assert(a.metadata("method") == "encoder_decoder"))
+  }
+
+  // Gap #2 — force the hierarchical reduce to run several rounds: many small chunks whose
+  // combined intermediate summaries still exceed the budget, recursing until they fit.
+  it should "summarize across multiple hierarchical reduce rounds" taggedAs SlowTest in {
+    val multiRoundDoc = ((shortDoc + " ") * 6).trim
+    val summ = summarizer("encoder_decoder")
+      .setMaxSummaryLength(40)
+      .setChunkSize(100)
+      .setLongDocumentStrategy("hierarchical")
+    val fitted = fit(summ, df(multiRoundDoc))
+    val ann = annotations(fitted.transform(df(multiRoundDoc))).head
+    assert(ann.result.nonEmpty, "multi-round summary must not be empty")
+    assert(ann.metadata("numChunks").toInt > 1, "document must be chunked")
+    assert(ann.metadata("longDocumentStrategy") == "hierarchical")
+  }
+
+  // Gap #6 — empty / whitespace inputs must not crash and must still yield one row each.
+  it should "handle empty and whitespace inputs" taggedAs SlowTest in {
+    val data = df("", "   ", shortDoc)
+    val fitted = fit(summarizer("encoder_decoder").setMaxSummaryLength(30), data)
+    val anns = annotations(fitted.transform(data))
+    assert(anns.length == 3)
+    assert(anns.count(_.result.nonEmpty) >= 1, "the non-empty document must be summarized")
+  }
+
+  // Gap #8 — a smaller maxSummaryLength must actually bound the generated output.
+  it should "let maxSummaryLength bound the output length" taggedAs SlowTest in {
+    val fitted = fit(summarizer("encoder_decoder").setMaxSummaryLength(120), df(shortDoc))
+    val model = summarizationStage(fitted)
+    model.setMaxSummaryLength(120)
+    val long = annotations(fitted.transform(df(shortDoc))).head.result
+    model.setMaxSummaryLength(12)
+    val short = annotations(fitted.transform(df(shortDoc))).head.result
+    assert(words(short) <= words(long), "smaller budget must not produce a longer summary")
+    assert(words(short) <= 20, "a 12-token budget must produce a short summary")
+  }
+
+  // Gap #9 — regression guard for the coalesce(1) fix: many input partitions must not
+  // reintroduce the BART concurrency shape crash.
+  it should "stay correct when the input is spread across many partitions" taggedAs SlowTest in {
+    val data = df(swiftDoc).repartition(8)
+    val fitted = fit(summarizer("encoder_decoder").setMaxSummaryLength(50), data)
+    val ann = annotations(fitted.transform(data)).head
+    assert(ann.result.nonEmpty)
+    assert(ann.metadata("numChunks").toInt > 1)
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationExtractiveE2ESpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationExtractiveE2ESpec.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.nlp.annotators.seq2seq
+
+import com.johnsnowlabs.nlp.LightPipeline
+import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
+import com.johnsnowlabs.tags.SlowTest
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.scalatest.flatspec.AnyFlatSpec
+
+/** Exhaustive extractive-method validation (model: all_mpnet_base_v2). Runs independently of the
+  * other method specs so the three lanes can execute in parallel.
+  */
+class SummarizationExtractiveE2ESpec extends AnyFlatSpec with SummarizationE2EBase {
+
+  "Summarization extractive (e2e)" should "handle real documents of every size with correct metadata" taggedAs SlowTest in {
+    val data = df(shortDoc, swiftDoc, wikiDoc, darwinDoc)
+    val fitted = fit(summarizer("extractive").setMaxSummaryLength(80), data)
+
+    val anns = annotations(fitted.transform(data))
+    assert(anns.length == 4)
+    anns.foreach { ann =>
+      assert(ann.result.nonEmpty, "summary must not be empty")
+      assertCoreMetadata(ann, "extractive")
+      assert(ann.metadata("sentencesSelected").toInt >= 1)
+      assert(
+        ann.metadata("sentencesSelected").toInt <= ann.metadata("sentencesTotal").toInt,
+        "selected must be <= total")
+      assert(words(ann.result) <= 80 + 60, s"budget exceeded: ${words(ann.result)} words")
+    }
+
+    // extractive summaries must be verbatim subsets of the source
+    val darwinSummary = anns.last.result
+    ExtractiveSummarizationRanker.splitSentences(darwinSummary).foreach { s =>
+      val needle = s.take(60).trim.replaceAll("\\s+", " ")
+      assert(
+        darwinDoc.replaceAll("\\s+", " ").contains(needle),
+        s"extractive sentence not found verbatim in source: '$needle...'")
+    }
+
+    val model = summarizationStage(fitted)
+
+    model.setMmrLambda(0.0f)
+    assert(annotations(fitted.transform(df(wikiDoc))).head.result.nonEmpty)
+    model.setMmrLambda(1.0f)
+    assert(annotations(fitted.transform(df(wikiDoc))).head.result.nonEmpty)
+    model.setMmrLambda(0.7f)
+
+    model.setPositionBias(5.0f)
+    val leadBiased = annotations(fitted.transform(df(wikiDoc))).head.result
+    val firstSentence = ExtractiveSummarizationRanker.splitSentences(wikiDoc).head
+    assert(
+      leadBiased.replaceAll("\\s+", " ").contains(firstSentence.take(50).replaceAll("\\s+", " ")),
+      "strong positionBias must select the lead sentence")
+    model.setPositionBias(0.3f)
+
+    model.setMaxSummaryLength(30)
+    val tiny = annotations(fitted.transform(df(wikiDoc))).head
+    model.setMaxSummaryLength(200)
+    val large = annotations(fitted.transform(df(wikiDoc))).head
+    assert(
+      words(tiny.result) < words(large.result),
+      "smaller budget must produce shorter summary")
+  }
+
+  it should "handle empty and whitespace documents without failing" taggedAs SlowTest in {
+    val data = df("", "   ", shortDoc)
+    val fitted = fit(summarizer("extractive"), data)
+    val anns = annotations(fitted.transform(data))
+    assert(anns.length == 3)
+    assert(anns.last.result.nonEmpty, "non-empty doc must still be summarized")
+  }
+
+  it should "round-trip through save/load with identical output" taggedAs SlowTest in {
+    val data = df(swiftDoc)
+    val fitted = fit(summarizer("extractive").setMaxSummaryLength(60), data)
+    val before = annotations(fitted.transform(data)).head.result
+
+    val path = s"file:///tmp/summarization_e2e_extractive_${System.currentTimeMillis()}"
+    fitted.write.overwrite().save(path)
+    val after = annotations(PipelineModel.load(path).transform(data)).head.result
+    assert(before == after, "extractive summarization must be deterministic across save/load")
+  }
+
+  it should "accept an explicit model override" taggedAs SlowTest in {
+    val data = df(shortDoc)
+    val fitted = fit(summarizer("extractive").setModel("all_mpnet_base_v2"), data)
+    assert(annotations(fitted.transform(data)).head.metadata("model") == "all_mpnet_base_v2")
+  }
+
+  // Gap #1 — a single row can hold several DOCUMENT annotations (e.g. from SentenceDetector);
+  // each must get its own summary. Exercises the per-document mapping in the extractive UDF.
+  it should "emit one summary per DOCUMENT annotation when a row holds several" taggedAs SlowTest in {
+    val doc = documentAssembler
+    val sentences = new SentenceDetector()
+      .setInputCols("document")
+      .setOutputCol("sentences")
+      .setExplodeSentences(false)
+    val summ = summarizer("extractive").setInputCols("sentences").setMaxSummaryLength(20)
+    val data = df(shortDoc)
+    val fitted = new Pipeline().setStages(Array(doc, sentences, summ)).fit(data)
+    val anns = annotations(fitted.transform(data))
+    assert(anns.length >= 2, s"expected one summary per sentence-document, got ${anns.length}")
+    anns.foreach(a => assert(a.metadata("method") == "extractive"))
+  }
+
+  // Gap #7 — offsets must be consistent for multibyte/emoji text.
+  it should "produce valid offsets for unicode and emoji text" taggedAs SlowTest in {
+    val uni =
+      ("日本語の要約テスト。これはユニコード対応の確認です。Café déjà vu, naive facade. 🎉🚀 " * 4).trim
+    val fitted = fit(summarizer("extractive").setMaxSummaryLength(40), df(uni))
+    val ann = annotations(fitted.transform(df(uni))).head
+    assert(ann.result.nonEmpty)
+    assert(ann.begin == 0)
+    assert(ann.end == math.max(0, ann.result.length - 1), "end offset must match result length")
+  }
+
+  // Gap #3/#4 — model params must survive save/load, and the delegate must deserialize from disk
+  // (close the in-memory copy first so the loaded model cannot reuse it).
+  it should "preserve params and reload the delegate from disk" taggedAs SlowTest in {
+    val summ =
+      summarizer("extractive").setMaxSummaryLength(44).setMmrLambda(0.6f).setPositionBias(0.8f)
+    val fitted = fit(summ, df(shortDoc))
+    val path = s"file:///tmp/summ_model_params_${System.currentTimeMillis()}"
+    fitted.write.overwrite().save(path)
+    summarizationStage(fitted).close() // extractive: no-op, but proves independence
+
+    val loaded = PipelineModel.load(path)
+    val lm = loaded.stages.collectFirst { case m: SummarizationModel => m }.get
+    assert(lm.getMaxSummaryLength == 44)
+    assert(lm.getMmrLambda == 0.6f)
+    assert(lm.getPositionBias == 0.8f)
+    assert(lm.getMethod == "extractive")
+    assert(annotations(loaded.transform(df(shortDoc))).head.result.nonEmpty)
+  }
+
+  // Gap #5 — DataFrame-only contract: LightPipeline must not fabricate a summary.
+  it should "not fabricate a summary under LightPipeline" taggedAs SlowTest in {
+    val fitted = fit(summarizer("extractive").setMaxSummaryLength(20), df(shortDoc))
+    val light = new LightPipeline(fitted)
+    scala.util.Try(light.annotate(shortDoc)) match {
+      case scala.util.Success(m) =>
+        val s = m.getOrElse("summary", Seq.empty)
+        assert(
+          s.isEmpty || s.forall(_.isEmpty),
+          "LightPipeline is unsupported and must not return a real summary")
+      case scala.util.Failure(_) => succeed
+    }
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationExtractiveE2ESpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationExtractiveE2ESpec.scala
@@ -19,6 +19,7 @@ import com.johnsnowlabs.nlp.LightPipeline
 import com.johnsnowlabs.nlp.annotators.sbd.pragmatic.SentenceDetector
 import com.johnsnowlabs.tags.SlowTest
 import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.Row
 import org.scalatest.flatspec.AnyFlatSpec
 
 /** Exhaustive extractive-method validation (model: all_mpnet_base_v2). Runs independently of the
@@ -145,6 +146,56 @@ class SummarizationExtractiveE2ESpec extends AnyFlatSpec with SummarizationE2EBa
     assert(lm.getPositionBias == 0.8f)
     assert(lm.getMethod == "extractive")
     assert(annotations(loaded.transform(df(shortDoc))).head.result.nonEmpty)
+  }
+
+  // Gap #10 — several DOCUMENT annotations in one row that share character offsets (all begin at
+  // 0) must not bleed sentences into each other's summary. Guards the per-document isolation of
+  // the extractive path.
+  it should "not mix sentences across DOCUMENT annotations that share offsets" taggedAs SlowTest in {
+    val climate =
+      "Average surface temperatures keep climbing across every measured region on the planet. " +
+        "Coastal areas report shifting precipitation patterns and far more frequent flooding. " +
+        "Agricultural yields are projected to fall sharply in several of the affected regions. " +
+        "Governments have started funding adaptation and coastal resilience programmes."
+    val finance =
+      "The central bank held its benchmark interest rate unchanged at the latest meeting. " +
+        "Analysts expect consumer inflation to ease gradually over the coming few quarters."
+
+    val model =
+      summarizationStage(fit(summarizer("extractive").setMaxSummaryLength(40), df(shortDoc)))
+    val data = documentsDF(Seq(climate, finance)) // one row, two overlapping-offset documents
+    val anns = annotations(model.transform(data))
+    assert(anns.length == 2, s"expected one summary per document, got ${anns.length}")
+
+    val norm = (s: String) => s.replaceAll("\\s+", " ").trim
+    val climateNorm = norm(climate)
+    val financeNorm = norm(finance)
+
+    // annotations come back ordered by annotation index: 0 = climate, 1 = finance
+    ExtractiveSummarizationRanker.splitSentences(anns.head.result).foreach { s =>
+      assert(
+        climateNorm.contains(norm(s)),
+        s"first document's summary must contain only its own sentences: '${norm(s)}'")
+    }
+    ExtractiveSummarizationRanker.splitSentences(anns(1).result).foreach { s =>
+      assert(
+        financeNorm.contains(norm(s)),
+        s"second document's summary must contain only its own sentences: '${norm(s)}'")
+    }
+  }
+
+  // Gap #11 — a genuinely empty input annotation array must yield an empty output array (empty in
+  // -> empty out), while a real document in the same batch is still summarized.
+  it should "return an empty summary array for an empty input annotation array" taggedAs SlowTest in {
+    val model =
+      summarizationStage(fit(summarizer("extractive").setMaxSummaryLength(30), df(shortDoc)))
+    val data = documentsDF(Seq.empty[String], Seq(shortDoc)) // row 0 empty, row 1 one document
+    val sizes = model
+      .transform(data)
+      .select("summary")
+      .collect()
+      .map(r => Option(r.getSeq[Row](0)).getOrElse(Seq.empty).length)
+    assert(sizes.toSeq == Seq(0, 1), s"expected [0, 1] summaries per row, got ${sizes.toSeq}")
   }
 
   // Gap #5 — DataFrame-only contract: LightPipeline must not fabricate a summary.

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationLlmE2ESpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationLlmE2ESpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.nlp.annotators.seq2seq
+
+import com.johnsnowlabs.tags.SlowTest
+import org.apache.spark.ml.PipelineModel
+import org.scalatest.flatspec.AnyFlatSpec
+
+/** Exhaustive LLM-method validation (model: qwen3_4b_q8_0_gguf, CPU via gpuLayers=0). Runs
+  * independently of the other method specs so the three lanes can execute in parallel.
+  */
+class SummarizationLlmE2ESpec extends AnyFlatSpec with SummarizationE2EBase {
+
+  private def llm: Summarization = summarizer("llm").setGpuLayers(0)
+
+  "Summarization llm (e2e)" should "summarize with every prompt-shaping parameter" taggedAs SlowTest in {
+    val data = df(shortDoc)
+    val fitted = fit(llm.setMaxSummaryLength(80), data)
+
+    val concise = annotations(fitted.transform(data)).head
+    assert(concise.result.nonEmpty, "summary must not be empty")
+    assertCoreMetadata(concise, "llm")
+    assert(concise.metadata("engine") == "llamacpp")
+    assert(!concise.result.contains("<think>"), "think tags must be stripped")
+    assert(words(concise.result) <= 80 * 3, s"summary too long: ${words(concise.result)} words")
+
+    val model = summarizationStage(fitted)
+
+    model.setSummaryStyle("bullets")
+    assert(annotations(fitted.transform(data)).head.result.nonEmpty)
+    model.setSummaryStyle("detailed")
+    assert(annotations(fitted.transform(data)).head.result.nonEmpty)
+    model.setSummaryStyle("concise")
+
+    model.setFocus("number of affected customers")
+    assert(annotations(fitted.transform(data)).head.result.nonEmpty)
+    model.setFocus("")
+
+    model.setTemperature(0.7f)
+    model.setTopP(0.95f)
+    assert(annotations(fitted.transform(data)).head.result.nonEmpty)
+    model.setTemperature(0.2f)
+    model.setTopP(0.9f)
+
+    model.setMaxSummaryLength(40)
+    assert(annotations(fitted.transform(data)).head.result.nonEmpty)
+    model.setMaxSummaryLength(80)
+  }
+
+  it should "handle a real long document hierarchically and via truncate" taggedAs SlowTest in {
+    val data = df(swiftDoc)
+    val fitted = fit(llm.setMaxSummaryLength(100).setChunkSize(1200), data)
+
+    val hier = annotations(fitted.transform(data)).head
+    assert(hier.result.nonEmpty, "hierarchical summary must not be empty")
+    assert(hier.metadata("numChunks").toInt > 1, "document must have been chunked")
+    assert(!hier.result.contains("<think>"))
+
+    val model = summarizationStage(fitted)
+    model.setLongDocumentStrategy("truncate")
+    val trunc = annotations(fitted.transform(data)).head
+    assert(trunc.result.nonEmpty)
+    assert(trunc.metadata("numChunks").toInt == 1, "truncate must not chunk")
+    model.setLongDocumentStrategy("auto")
+  }
+
+  it should "round-trip through save/load and still transform" taggedAs SlowTest in {
+    val data = df(shortDoc)
+    val fitted = fit(llm.setMaxSummaryLength(50), data)
+    val path = s"file:///tmp/summarization_e2e_llm_${System.currentTimeMillis()}"
+    fitted.write.overwrite().save(path)
+    val ann = annotations(PipelineModel.load(path).transform(data)).head
+    assert(ann.result.nonEmpty)
+    assert(ann.metadata("method") == "llm")
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationLlmE2ESpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationLlmE2ESpec.scala
@@ -86,4 +86,16 @@ class SummarizationLlmE2ESpec extends AnyFlatSpec with SummarizationE2EBase {
     assert(ann.result.nonEmpty)
     assert(ann.metadata("method") == "llm")
   }
+
+  // Gap #12 — task params are mutable on the fitted model, so minSummaryLength can be pushed
+  // above maxSummaryLength after fit (the estimator only rejects it at fit time). The prompt
+  // builder must clamp instead of emitting an incoherent "between 400 and 60 words" instruction.
+  it should "tolerate minSummaryLength greater than maxSummaryLength on the fitted model" taggedAs SlowTest in {
+    val fitted = fit(llm.setMaxSummaryLength(60), df(shortDoc))
+    val model = summarizationStage(fitted)
+    model.setMinSummaryLength(400) // exceeds max; must be clamped in the prompt, not crash
+    val ann = annotations(fitted.transform(df(shortDoc))).head
+    assert(ann.result.nonEmpty, "summary must still be produced when min > max")
+    model.setMinSummaryLength(20)
+  }
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationTestSpec.scala
@@ -101,6 +101,19 @@ class SummarizationTestSpec extends AnyFlatSpec {
     }
   }
 
+  it should "unwrap a JSON-string-literal shaped llm response" taggedAs FastTest in {
+    val wrapped = "\"- First point.  \\n- Second point.  \\n- Third point.\""
+    val unwrapped = SummarizationModel.unwrapJsonStringLiteral(wrapped)
+    assert(unwrapped == "- First point.  \n- Second point.  \n- Third point.")
+    assert(!unwrapped.contains("\\n"), "literal backslash-n must become a real newline")
+    assert(!unwrapped.startsWith("\""), "wrapping quote must be stripped")
+  }
+
+  it should "leave plain (non-wrapped) llm responses unchanged" taggedAs FastTest in {
+    val plain = "- First point.\n- Second point."
+    assert(SummarizationModel.unwrapJsonStringLiteral(plain) == plain)
+  }
+
   it should "rank lead and central sentences higher" taggedAs FastTest in {
     // sentence 0 and 1 similar (recurring topic), sentence 2 orthogonal
     val embs = Array(Array(1.0f, 0.1f, 0.0f), Array(0.9f, 0.2f, 0.0f), Array(0.0f, 0.0f, 1.0f))

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationTestSpec.scala
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.nlp.annotators.seq2seq
+
+import com.johnsnowlabs.nlp.Annotation
+import com.johnsnowlabs.nlp.annotators.Tokenizer
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.{FastTest, SlowTest}
+import org.apache.spark.ml.{Pipeline, PipelineModel}
+import org.apache.spark.sql.{DataFrame, Row}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class SummarizationTestSpec extends AnyFlatSpec {
+
+  import ResourceHelper.spark.implicits._
+
+  private val shortText =
+    "PG&E stated it scheduled the blackouts in response to forecasts for high winds " +
+      "amid dry conditions. The aim is to reduce the risk of wildfires. Nearly 800 thousand " +
+      "customers were scheduled to be affected by the shutoffs which were expected to last " +
+      "through at least midday tomorrow."
+
+  private val longText = {
+    val paragraph =
+      "The research team analyzed climate data from over two hundred weather stations. " +
+        "Temperatures rose steadily across all measured regions during the last decade. " +
+        "Precipitation patterns shifted significantly in coastal areas. " +
+        "The models predict further changes if emissions continue at current rates. " +
+        "Agricultural yields are expected to decline in affected regions. " +
+        "Local governments have begun implementing adaptation strategies. "
+    paragraph * 40 // ~15k chars, forces chunking for encoder_decoder budgets
+  }
+
+  private def collectAnnotations(df: DataFrame, colName: String): Seq[Annotation] =
+    df.select(colName)
+      .collect()
+      .flatMap(row => Option(row.getSeq[Row](0)).getOrElse(Seq.empty).map(Annotation(_)))
+      .toSeq
+
+  private def pipelineFor(summarizer: Summarization): Pipeline = {
+    val documentAssembler =
+      new DocumentAssembler().setInputCol("text").setOutputCol("document")
+    new Pipeline().setStages(Array(documentAssembler, summarizer))
+  }
+
+  // ------------------------------------------------------------------------------------------
+  // FastTest: pure logic
+  // ------------------------------------------------------------------------------------------
+
+  "ExtractiveSummarizationRanker" should "split and pack sentences within budget" taggedAs FastTest in {
+    val sentences = ExtractiveSummarizationRanker.splitSentences(
+      "First sentence here. Second sentence follows. Third one ends it.")
+    assert(sentences.length == 3)
+
+    val chunks = ExtractiveSummarizationRanker.packChunks(sentences, budgetChars = 45, 1)
+    assert(chunks.length > 1)
+    assert(chunks.forall(_.length <= 45 + 25)) // overlap seeding tolerance
+  }
+
+  it should "produce single chunk when text fits" taggedAs FastTest in {
+    val sentences = Array("Short one.", "Another short.")
+    val chunks = ExtractiveSummarizationRanker.packChunks(sentences, budgetChars = 1000, 1)
+    assert(chunks.length == 1)
+  }
+
+  it should "rank lead and central sentences higher" taggedAs FastTest in {
+    // sentence 0 and 1 similar (recurring topic), sentence 2 orthogonal
+    val embs = Array(Array(1.0f, 0.1f, 0.0f), Array(0.9f, 0.2f, 0.0f), Array(0.0f, 0.0f, 1.0f))
+    val scores = ExtractiveSummarizationRanker.centralityScores(embs)
+    assert(scores(0) > scores(2), "lead + central sentence must outrank isolated late sentence")
+  }
+
+  it should "respect the word budget and avoid redundant picks in MMR" taggedAs FastTest in {
+    val embs = Array(
+      Array(1.0f, 0.0f),
+      Array(1.0f, 0.0f), // duplicate of 0
+      Array(0.0f, 1.0f))
+    val scores = Array(1.0, 0.99, 0.5)
+    val wordCounts = Array(5, 5, 5)
+    // with a redundancy-leaning lambda the duplicate must lose to the diverse sentence
+    val selected =
+      ExtractiveSummarizationRanker.mmrSelect(embs, scores, wordCounts, budgetWords = 10, 0.5)
+    assert(selected.length == 2)
+    assert(selected.contains(0))
+    assert(selected.contains(2), "MMR should prefer the diverse sentence over the duplicate")
+    // with a purely relevance-driven lambda the duplicate wins instead
+    val relevanceOnly =
+      ExtractiveSummarizationRanker.mmrSelect(embs, scores, wordCounts, budgetWords = 10, 1.0)
+    assert(relevanceOnly.sameElements(Array(0, 1)))
+  }
+
+  it should "always select at least one sentence" taggedAs FastTest in {
+    val embs = Array(Array(1.0f, 0.0f))
+    val selected =
+      ExtractiveSummarizationRanker.mmrSelect(embs, Array(1.0), Array(50), budgetWords = 10, 0.7)
+    assert(selected.length == 1)
+  }
+
+  "Summarization" should "validate parameter values" taggedAs FastTest in {
+    val summarizer = new Summarization()
+    assertThrows[IllegalArgumentException](summarizer.setMethod("magic"))
+    assertThrows[IllegalArgumentException](summarizer.setSummaryStyle("epic"))
+    assertThrows[IllegalArgumentException](summarizer.setLongDocumentStrategy("never"))
+    assertThrows[IllegalArgumentException](summarizer.setMaxSummaryLength(0))
+    assertThrows[IllegalArgumentException](summarizer.setMmrLambda(1.5f))
+    summarizer.setMethod("extractive").setSummaryStyle("bullets")
+    assert(summarizer.getMethod == "extractive")
+  }
+
+  // ------------------------------------------------------------------------------------------
+  // SlowTest: end-to-end per method (downloads pretrained models)
+  // ------------------------------------------------------------------------------------------
+
+  "Summarization extractive" should "summarize and report metadata" taggedAs SlowTest in {
+    val data = Seq(shortText, longText).toDF("text")
+
+    val summarizer = new Summarization()
+      .setInputCols("document")
+      .setOutputCol("summary")
+      .setMethod("extractive")
+      .setMaxSummaryLength(60)
+
+    val model = pipelineFor(summarizer).fit(data)
+    val result = model.transform(data)
+    val annotations = collectAnnotations(result, "summary")
+
+    assert(annotations.length == 2)
+    annotations.foreach { ann =>
+      assert(ann.result.nonEmpty, "summary must not be empty")
+      assert(ann.metadata("method") == "extractive")
+      assert(ann.metadata("model").nonEmpty)
+      assert(ann.metadata("sentencesSelected").toInt >= 1)
+      // extractive summaries only contain source sentences
+      assert(ExtractiveSummarizationRanker.countWords(ann.result) <= 60 + 40)
+    }
+  }
+
+  it should "round-trip through PipelineModel save/load" taggedAs SlowTest in {
+    val data = Seq(shortText).toDF("text")
+    val summarizer = new Summarization()
+      .setInputCols("document")
+      .setOutputCol("summary")
+      .setMethod("extractive")
+      .setMaxSummaryLength(40)
+
+    val fitted = pipelineFor(summarizer).fit(data)
+    val path = s"file:///tmp/summarization_extractive_pipeline_${System.currentTimeMillis()}"
+    fitted.write.overwrite().save(path)
+
+    val loaded = PipelineModel.load(path)
+    val annotations = collectAnnotations(loaded.transform(data), "summary")
+    assert(annotations.head.result.nonEmpty)
+    assert(annotations.head.metadata("method") == "extractive")
+  }
+
+  "Summarization encoder_decoder" should "summarize short and long documents" taggedAs SlowTest in {
+    val data = Seq(shortText, longText).toDF("text")
+
+    val summarizer = new Summarization()
+      .setInputCols("document")
+      .setOutputCol("summary")
+      .setMethod("encoder_decoder")
+      .setMaxSummaryLength(60)
+
+    val model = pipelineFor(summarizer).fit(data)
+    val result = model.transform(data)
+    val annotations = collectAnnotations(result, "summary")
+
+    assert(annotations.length == 2)
+    annotations.foreach { ann =>
+      assert(ann.result.nonEmpty, "summary must not be empty")
+      assert(ann.metadata("method") == "encoder_decoder")
+    }
+    // the long document must have used more than one chunk
+    val longMeta = annotations.map(_.metadata).maxBy(_("originalTokensEst").toInt)
+    assert(longMeta("numChunks").toInt > 1, "long document should be chunked")
+  }
+
+  it should "round-trip through PipelineModel save/load" taggedAs SlowTest in {
+    val data = Seq(shortText).toDF("text")
+    val summarizer = new Summarization()
+      .setInputCols("document")
+      .setOutputCol("summary")
+      .setMethod("encoder_decoder")
+      .setMaxSummaryLength(40)
+
+    val fitted = pipelineFor(summarizer).fit(data)
+    val path = s"file:///tmp/summarization_encdec_pipeline_${System.currentTimeMillis()}"
+    fitted.write.overwrite().save(path)
+
+    val loaded = PipelineModel.load(path)
+    val annotations = collectAnnotations(loaded.transform(data), "summary")
+    assert(annotations.head.result.nonEmpty)
+  }
+
+  "Summarization llm" should "summarize with the default GGUF model" taggedAs SlowTest in {
+    val data = Seq(shortText).toDF("text")
+
+    val summarizer = new Summarization()
+      .setInputCols("document")
+      .setOutputCol("summary")
+      .setMethod("llm")
+      .setMaxSummaryLength(80)
+      .setSummaryStyle("concise")
+
+    val model = pipelineFor(summarizer).fit(data)
+    val result = model.transform(data)
+    val annotations = collectAnnotations(result, "summary")
+
+    assert(annotations.nonEmpty)
+    val ann = annotations.head
+    assert(ann.result.nonEmpty, "summary must not be empty")
+    assert(!ann.result.contains("<think>"), "reasoning tags must be stripped")
+    assert(ann.metadata("method") == "llm")
+    assert(ann.metadata("engine") == "llamacpp")
+  }
+
+  // ------------------------------------------------------------------------------------------
+  // FastTest: serialization + schema contract (no model download)
+  // ------------------------------------------------------------------------------------------
+
+  "Summarization estimator" should "round-trip every parameter through save/load" taggedAs FastTest in {
+    ResourceHelper.spark // ensure an active local SparkSession for the ML writer
+    val s = new Summarization()
+      .setInputCols("document")
+      .setOutputCol("summary")
+      .setMethod("extractive")
+      .setModel("custom_model")
+      .setMaxSummaryLength(123)
+      .setMinSummaryLength(7)
+      .setSummaryStyle("bullets")
+      .setFocus("main findings")
+      .setLongDocumentStrategy("truncate")
+      .setNumBeams(6)
+      .setTemperature(0.4f)
+      .setTopP(0.85f)
+      .setChunkSize(999)
+      .setChunkOverlap(3)
+      .setMmrLambda(0.55f)
+      .setPositionBias(0.9f)
+      .setGpuLayers(0)
+    val path = s"file:///tmp/summ_estimator_params_${System.currentTimeMillis()}"
+    s.write.overwrite().save(path)
+    val loaded = Summarization.load(path)
+    assert(loaded.getMethod == "extractive")
+    assert(loaded.getModel == "custom_model")
+    assert(loaded.getMaxSummaryLength == 123)
+    assert(loaded.getMinSummaryLength == 7)
+    assert(loaded.getSummaryStyle == "bullets")
+    assert(loaded.getFocus == "main findings")
+    assert(loaded.getLongDocumentStrategy == "truncate")
+    assert(loaded.getNumBeams == 6)
+    assert(loaded.getTemperature == 0.4f)
+    assert(loaded.getTopP == 0.85f)
+    assert(loaded.getChunkSize == 999)
+    assert(loaded.getChunkOverlap == 3)
+    assert(loaded.getMmrLambda == 0.55f)
+    assert(loaded.getPositionBias == 0.9f)
+    assert(loaded.getGpuLayers == 0)
+  }
+
+  it should "fail fast at fit when minSummaryLength exceeds maxSummaryLength" taggedAs FastTest in {
+    val documentAssembler =
+      new DocumentAssembler().setInputCol("text").setOutputCol("document")
+    val data = documentAssembler.transform(Seq("some text").toDF("text"))
+    val summarizer = new Summarization()
+      .setInputCols("document")
+      .setOutputCol("summary")
+      .setMethod("extractive")
+      .setMinSummaryLength(300)
+      .setMaxSummaryLength(100)
+    // the require fires before any model resolution/download
+    assertThrows[IllegalArgumentException](summarizer.fit(data))
+  }
+
+  it should "reject inputs that are not DOCUMENT annotations" taggedAs FastTest in {
+    val documentAssembler =
+      new DocumentAssembler().setInputCol("text").setOutputCol("document")
+    val tokenizer = new Tokenizer().setInputCols("document").setOutputCol("token")
+    val base = documentAssembler.transform(Seq("hello world foo bar").toDF("text"))
+    val tokenized = tokenizer.fit(base).transform(base)
+
+    val model = new SummarizationModel()
+      .setInputCols("token")
+      .setOutputCol("summary")
+      .setMethod("extractive")
+    // validate() runs before any delegate is touched, so this needs no model
+    assertThrows[IllegalArgumentException](model.transform(tokenized))
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationTestSpec.scala
@@ -114,6 +114,21 @@ class SummarizationTestSpec extends AnyFlatSpec {
     assert(SummarizationModel.unwrapJsonStringLiteral(plain) == plain)
   }
 
+  it should "keep quotes on a summary that merely starts and ends with a quotation mark" taggedAs FastTest in {
+    // quoted speech, not a JSON-string literal: no escape sequences inside the quotes
+    val quoted = "\"We will reduce the risk of wildfires,\" the utility said."
+    assert(SummarizationModel.unwrapJsonStringLiteral(quoted) == quoted)
+    val fullyQuoted = "\"The utility scheduled blackouts to reduce wildfire risk.\""
+    assert(SummarizationModel.unwrapJsonStringLiteral(fullyQuoted) == fullyQuoted)
+  }
+
+  it should "not turn an escaped backslash followed by n into a newline" taggedAs FastTest in {
+    // the JSON escape \\n denotes a literal backslash followed by the letter n
+    val wrapped = "\"path C:\\\\new stays literal.\\nSecond line.\""
+    val unwrapped = SummarizationModel.unwrapJsonStringLiteral(wrapped)
+    assert(unwrapped == "path C:\\new stays literal.\nSecond line.")
+  }
+
   it should "rank lead and central sentences higher" taggedAs FastTest in {
     // sentence 0 and 1 similar (recurring topic), sentence 2 orthogonal
     val embs = Array(Array(1.0f, 0.1f, 0.0f), Array(0.9f, 0.2f, 0.0f), Array(0.0f, 0.0f, 1.0f))

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/seq2seq/SummarizationTestSpec.scala
@@ -77,6 +77,30 @@ class SummarizationTestSpec extends AnyFlatSpec {
     assert(chunks.length == 1)
   }
 
+  it should "carry overlap sentences between consecutive chunks" taggedAs FastTest in {
+    val sentences = Array("Alpha one.", "Bravo two.", "Charlie three.", "Delta four.")
+    val chunks = ExtractiveSummarizationRanker.packChunks(sentences, budgetChars = 22, 1)
+    assert(chunks.length >= 2)
+    // the second chunk is seeded with the last sentence of the first (overlap continuity)
+    assert(
+      chunks(1).startsWith("Bravo two."),
+      s"expected overlap 'Bravo two.' to seed the second chunk, got '${chunks(1)}'")
+  }
+
+  it should "not emit a trailing chunk that only repeats the previous overlap" taggedAs FastTest in {
+    val sentences = (1 to 12).map(i => s"Sentence number $i ends here.").toArray
+    for (budget <- Seq(20, 30, 45, 60); overlap <- Seq(1, 2)) {
+      val chunks = ExtractiveSummarizationRanker.packChunks(sentences, budget, overlap)
+      chunks.sliding(2).foreach {
+        case Array(prev, next) =>
+          assert(
+            !prev.endsWith(next),
+            s"trailing all-overlap chunk not dropped (budget=$budget, overlap=$overlap)")
+        case _ => // single-chunk window, nothing to compare
+      }
+    }
+  }
+
   it should "rank lead and central sentences higher" taggedAs FastTest in {
     // sentence 0 and 1 similar (recurring topic), sentence 2 orthogonal
     val embs = Array(Array(1.0f, 0.1f, 0.0f), Array(0.9f, 0.2f, 0.0f), Array(0.0f, 0.0f, 1.0f))


### PR DESCRIPTION
Spark 4.x / Scala 2.13 / Java 17 port of #14794.

Ported the Summarization commits onto migration/scala213 and fixed
one real Spark 4 issue:

SummarizationModel.scala has its own custom udf(...) calls typed as Seq[Row]. Spark 4 can't build an encoder for that type and throws scala.MatchError: UnboundRowEncoder. The existing Spark4 fix in AnnotatorModel.scala doesn't cover this because Summarization doesn't use the standard annotate path. Changed those UDFs to use Seq[Annotation], Seq[(Int, Annotation)], and Seq[(Int, String)] instead, which Spark's normal case class encoder handles fine on both Spark 3.x and 4.x.

Tested on a Databricks Spark 4.1.0 / Scala 2.13 / JDK17 cluster: unit spec 15/15, and all three E2E suites (llm, encoder_decoder, extractive) pass against real models.