### PR TITLE
[Spark 4.x] [SPARKNLP-1407] Add Spark 4 build profiles

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,15 +47,21 @@ jobs:
       matrix:
         include:
           - spark: "4.0.0"
+            profile: spark400
+            variant: cpu
             coverage: false
           - spark: "4.0.1"
+            profile: spark4
+            variant: cpu
             coverage: true
           - spark: "4.1.2"
+            profile: spark4
+            variant: cpu
             coverage: false
     env:
       TF_CPP_MIN_LOG_LEVEL: 3
       JAVA_OPTS: "-Xmx4096m -XX:+UseG1GC"
-    name: Build and Test on Apache Spark ${{ matrix.spark }}
+    name: Build and Test ${{ matrix.profile }}/${{ matrix.variant }} on Apache Spark ${{ matrix.spark }}
 
     steps:
       - uses: actions/checkout@v4
@@ -87,11 +93,24 @@ jobs:
           python --version
           python -c "import pyspark; print(f'PySpark {pyspark.__version__}')"
           echo "Requested Apache Spark version: ${{ matrix.spark }}"
-          sbt -mem 4096 -Dspark.version=${{ matrix.spark }} 'show scalaVersion'
+          sbt -mem 4096 \
+            -Dspark.build.profile=${{ matrix.profile }} \
+            -Dspark.build.variant=${{ matrix.variant }} \
+            -Dspark.version=${{ matrix.spark }} \
+            'show selectedSparkBuildProfile' \
+            'show selectedSparkBuildVariant' \
+            'show selectedSparkVersion' \
+            'show selectedSparkArtifact' \
+            'show scalaVersion' \
+            'show projectID'
 
       - name: Build Spark NLP on Apache Spark ${{ matrix.spark }}
         run: |
-          sbt -mem 4096 -Dspark.version=${{ matrix.spark }} clean assemblyAndCopy
+          sbt -mem 4096 \
+            -Dspark.build.profile=${{ matrix.profile }} \
+            -Dspark.build.variant=${{ matrix.variant }} \
+            -Dspark.version=${{ matrix.spark }} \
+            clean assemblyAndCopy
 
       - name: Test Spark NLP in Scala - Apache Spark ${{ matrix.spark }}
         if: ${{ !matrix.coverage }}
@@ -99,7 +118,11 @@ jobs:
         env:
           LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libstdc++.so.6
         run: |
-          sbt -mem 4096 -Dspark.version=${{ matrix.spark }} test
+          sbt -mem 4096 \
+            -Dspark.build.profile=${{ matrix.profile }} \
+            -Dspark.build.variant=${{ matrix.variant }} \
+            -Dspark.version=${{ matrix.spark }} \
+            test
 
       - name: Test Spark NLP in Scala with coverage - Apache Spark ${{ matrix.spark }}
         if: matrix.coverage
@@ -107,12 +130,20 @@ jobs:
         env:
           LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libstdc++.so.6
         run: |
-          sbt -mem 4096 -Dspark.version=${{ matrix.spark }} coverage test
+          sbt -mem 4096 \
+            -Dspark.build.profile=${{ matrix.profile }} \
+            -Dspark.build.variant=${{ matrix.variant }} \
+            -Dspark.version=${{ matrix.spark }} \
+            coverage test
 
       - name: Upload coverage data to Coveralls
         if: matrix.coverage
         run: |
-          sbt -mem 4096 -Dspark.version=${{ matrix.spark }} coverageReport coveralls
+          sbt -mem 4096 \
+            -Dspark.build.profile=${{ matrix.profile }} \
+            -Dspark.build.variant=${{ matrix.variant }} \
+            -Dspark.version=${{ matrix.spark }} \
+            coverageReport coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: Apache Spark ${{ matrix.spark }} - Scala 2.13

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,22 @@ import Dependencies.*
 import M2Resolvers.m2Resolvers
 import sbtassembly.MergeStrategy
 
-name := getPackageName(is_silicon, is_gpu, is_aarch64)
+lazy val selectedSparkBuildProfile =
+  settingKey[String]("Selected Spark build profile").withRank(KeyRanks.Invisible)
+lazy val selectedSparkBuildVariant =
+  settingKey[String]("Selected Spark build variant").withRank(KeyRanks.Invisible)
+lazy val selectedSparkVersion =
+  settingKey[String]("Selected Spark compile or validation version").withRank(KeyRanks.Invisible)
+lazy val selectedSparkArtifact =
+  settingKey[String]("Selected Spark NLP artifact base name").withRank(KeyRanks.Invisible)
+
+selectedSparkBuildProfile := sparkBuildProfile.id
+selectedSparkBuildVariant := sparkBuildVariant.id
+selectedSparkVersion := sparkVer
+selectedSparkArtifact := sparkArtifactBaseName
+
+name := sparkArtifactBaseName
+moduleName := sparkArtifactBaseName
 
 organization := "com.johnsnowlabs.nlp"
 
@@ -90,34 +105,23 @@ lazy val utilDependencies = Seq(
 lazy val typedDependencyParserDependencies = Seq(junit)
 
 val tensorflowDependencies: Seq[sbt.ModuleID] =
-  if (is_gpu.equals("true"))
-    Seq(tensorflowGPU)
-  else if (is_silicon.equals("true"))
-    Seq(tensorflowM1)
-  else if (is_aarch64.equals("true"))
-    Seq(tensorflowLinuxAarch64)
-  else
-    Seq(tensorflowCPU)
+  sparkBuildVariant.id match {
+    case "gpu" => Seq(tensorflowGPU)
+    case "silicon" => Seq(tensorflowM1)
+    case "aarch64" => Seq(tensorflowLinuxAarch64)
+    case "cpu" => Seq(tensorflowCPU)
+  }
 
 val onnxDependencies: Seq[sbt.ModuleID] =
-  if (is_gpu.equals("true"))
-    Seq(onnxGPU)
-  else if (is_silicon.equals("true"))
-    Seq(onnxCPU)
-  else if (is_aarch64.equals("true"))
-    Seq(onnxCPU)
-  else
-    Seq(onnxCPU)
+  if (sparkBuildVariant.isGpu) Seq(onnxGPU) else Seq(onnxCPU)
 
 val llamaCppDependencies =
-  if (is_gpu.equals("true"))
-    Seq(llamaCppGPU)
-  else if (is_silicon.equals("true"))
-    Seq(llamaCppSilicon)
-  else if (is_aarch64.equals("true"))
-    Seq(llamaCppAarch64)
-  else
-    Seq(llamaCppCPU)
+  sparkBuildVariant.id match {
+    case "gpu" => Seq(llamaCppGPU)
+    case "silicon" => Seq(llamaCppSilicon)
+    case "aarch64" => Seq(llamaCppAarch64)
+    case "cpu" => Seq(llamaCppCPU)
+  }
 
 val openVinoDependencies: Seq[sbt.ModuleID] = Seq(openVinoCPU)
 
@@ -148,7 +152,7 @@ lazy val root = (project in file("."))
         typedDependencyParserDependencies,
     // TODO potentially improve this?
     mavenProps := {
-      sys.props("javacpp.platform.extension") = if (is_gpu.equals("true")) "-gpu" else ""
+      sys.props("javacpp.platform.extension") = if (sparkBuildVariant.isGpu) "-gpu" else ""
     })
 
 (assembly / assemblyShadeRules) := Seq(

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -5,7 +5,7 @@ seotitle: Spark NLP - Installation
 title: Spark NLP - Installation
 permalink: /docs/en/install
 key: docs-install
-modify_date: "2024-07-04"
+modify_date: "2026-07-16"
 show_nav: true
 sidebar:
     nav: sparknlp
@@ -45,23 +45,21 @@ Spark NLP {{ site.sparknlp_version }} is built with ONNX 1.17.0 and TensorFlow 2
 
 </div><div class="h3-box" markdown="1">
 
-### Scala 2.13
+### Spark 4 and Scala 2.13
 
-**NOTE**: PySpark from PyPI is based on Scala 2.12 by default, and you can use our Scala 2.12 version. If you need to start a Scala 2.13 instance, you can set the `SPARK_HOME` environment variable to a Spark Scala 2.13 installation, or install PySpark from the official Spark archives.
+Spark 4 uses Scala 2.13. Spark 4.0.0 has a dedicated artifact because its Spark ML `Param[T]` ABI is not binary-compatible with Spark 4.0.1 and later validated Spark 4 releases.
 
 ```bash
-# Load Spark NLP with Spark Shell
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp_2.13:{{ site.sparknlp_version }}
+# Spark 4.0.0 only
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-spark400_2.13:{{ site.sparknlp_version }}
 
-# Load Spark NLP with PySpark
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.13:{{ site.sparknlp_version }}
-
-# Load Spark NLP with Spark Submit
+# Spark 4.0.1 and later validated Spark 4 versions
 spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.13:{{ site.sparknlp_version }}
-
-# Load Spark NLP as external JAR after compiling and building Spark NLP by `sbt assembly`
-spark-shell --jars spark-nlp-assembly-{{ site.sparknlp_version }}.jar
 ```
+
+The same naming rule applies to GPU, Apple Silicon, and Linux AArch64 artifacts, for example `spark-nlp-gpu-spark400_2.13` for Spark 4.0.0 and `spark-nlp-gpu_2.13` for the forward Spark 4 lane.
+
+Spark 3.x with Scala 2.13 and Spark 4.x with Scala 2.12 are not supported.
 
 ## Python
 
@@ -107,6 +105,18 @@ import sparknlp
 spark = sparknlp.start()
 ```
 
+The same Python wheel supports the declared Spark 3 and Spark 4 runtime lanes. `sparknlp.start()` detects the installed PySpark version and selects the Maven artifact automatically:
+
+| Installed PySpark | Selected artifact |
+|---|---|
+| Spark 3.x | `spark-nlp_2.12` |
+| Spark 4.0.0 | `spark-nlp-spark400_2.13` |
+| Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2 | `spark-nlp_2.13` |
+
+The selected hardware option is applied to the same lane. For example, `sparknlp.start(gpu=True)` selects the corresponding `spark-nlp-gpu` artifact. Only one of `gpu`, `apple_silicon`, or `aarch64` may be enabled.
+
+Migration note: the release line that introduces this mapping removes the experimental `scala213` argument from `sparknlp.start()`. Do not pass a Scala selector; install the supported PySpark runtime and let Spark NLP resolve the matching artifact.
+
 If you need to manually start SparkSession because you have other configurations and `sparknlp.start()` is not including them,
 you can manually start the SparkSession with:
 
@@ -121,6 +131,8 @@ spark = SparkSession.builder \
     .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:{{ site.sparknlp_version }}") \
     .getOrCreate()
 ```
+
+The manual example above is for Spark 3.x. For Spark 4.0.0 use `spark-nlp-spark400_2.13`; for Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2 use `spark-nlp_2.13`.
 
 If using local jars, you can use `spark.jars` instead for comma-delimited jar files. For cluster setups, of course,
 you'll have to put the jars in a reachable location for all driver and executor nodes.
@@ -179,14 +191,14 @@ result = pipeline.annotate('The Mona Lisa is a 16th century oil painting created
 
 ## Scala and Java
 
-To use Spark NLP you need the following requirements:
+Select the Java and Scala line that matches the Spark runtime:
 
-- Java 8 and 11
-- Apache Spark 3.5.x, 3.4.x, 3.3.x, 3.2.x, 3.1.x, 3.0.x
+- Spark 3.x: Scala 2.12 and the existing Java 8/11 support baseline
+- Spark 4.x: Scala 2.13 and Java 17
 
 #### Maven
 
-**spark-nlp** on Apache Spark 3.0.x, 3.1.x, 3.2.x, 3.3.x, and 3.4.x
+**spark-nlp** on Apache Spark 3.x
 
 The `spark-nlp` has been published to
 the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp).
@@ -237,7 +249,7 @@ the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/s
 
 #### SBT
 
-**spark-nlp** on Apache Spark 3.0.x, 3.1.x, 3.2.x, 3.3.x, and 3.4.x
+**spark-nlp** on Apache Spark 3.x
 
 ```scala
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp
@@ -269,24 +281,32 @@ Maven Central: [https://mvnrepository.com/artifact/com.johnsnowlabs.nlp](https:/
 
 If you are interested, there is a simple SBT project for Spark NLP to guide you on how to use it in your projects [Spark NLP SBT Starter](https://github.com/maziyarpanahi/spark-nlp-starter)
 
-### Scala 2.13 Support
+### Spark 4 / Scala 2.13 Support
 
-**NOTE**: PyPi installed Pyspark only runs on Scala 2.12, so the following section will not apply for it. If you need to start a Scala 2.13 instance, you can set the `SPARK_HOME` environment variable to a Spark Scala 2.13 installation, or install PySpark from the official Spark archives.
+Spark 4 is supported with Scala 2.13 only. Spark 3.x remains on Scala 2.12 and is not supported with Scala 2.13 in this release line.
 
-If you are using `DependencyParserModel` or `TextMatcherModel` in your pipelines and wish to import from the Scala 2.12 version to 2.13, then you will need to export them manually. For this, please see the example notebook [Converting Spark NLP Scala 2.12 models to Scala 2.13](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/scala213/converting_models_from_212.ipynb).
+Spark 4.0.0 requires a dedicated artifact because its Spark ML parameter ABI differs from Spark 4.0.1 and later validated Spark 4 releases.
 
-`spark-nlp` with Scala 2.13 support has been published to [Maven Central](https://central.sonatype.com/artifact/com.johnsnowlabs.nlp/spark-nlp_2.13). You can use these coordinates to set up your Spark instance with config `--packages` or download the jar directly. For example:
+When migrating pipelines that contain `DependencyParserModel` or `TextMatcherModel` from Spark 3/Scala 2.12 to Spark 4/Scala 2.13, export those models manually. See [Converting Spark NLP Scala 2.12 models to Scala 2.13](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/scala213/converting_models_from_212.ipynb).
 
-```sh
-# Load Spark NLP with Spark Submit
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:6.4.1
+| Spark runtime | CPU artifact | GPU artifact |
+|---|---|---|
+| Spark 4.0.0 | `spark-nlp-spark400_2.13` | `spark-nlp-gpu-spark400_2.13` |
+| Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2 | `spark-nlp_2.13` | `spark-nlp-gpu_2.13` |
+
+The same profile suffix applies to `spark-nlp-silicon` and `spark-nlp-aarch64`.
+
+**Spark 4.0.0 Maven dependency:**
+
+```xml
+<dependency>
+    <groupId>com.johnsnowlabs.nlp</groupId>
+    <artifactId>spark-nlp-spark400_2.13</artifactId>
+    <version>{{ site.sparknlp_version }}</version>
+</dependency>
 ```
 
-See our [cheat sheet](#spark-nlp-cheatsheet) for more examples.
-
-To use spark-nlp Scala 2.13 as a dependency, change the `2.12` string in our dependencies to `2.13`.
-
-**spark-nlp:**
+**Validated forward Spark 4 Maven dependency (4.0.1, 4.1.0, 4.1.1, and 4.1.2):**
 
 ```xml
 <dependency>
@@ -296,61 +316,7 @@ To use spark-nlp Scala 2.13 as a dependency, change the `2.12` string in our dep
 </dependency>
 ```
 
-**spark-nlp-gpu:**
-
-```xml
-<dependency>
-    <groupId>com.johnsnowlabs.nlp</groupId>
-    <artifactId>spark-nlp-gpu_2.13</artifactId>
-    <version>{{ site.sparknlp_version }}</version>
-</dependency>
-```
-
-**spark-nlp-silicon:**
-
-```xml
-<dependency>
-    <groupId>com.johnsnowlabs.nlp</groupId>
-    <artifactId>spark-nlp-silicon_2.13</artifactId>
-    <version>{{ site.sparknlp_version }}</version>
-</dependency>
-```
-
-**spark-nlp-aarch64:**
-
-```xml
-<dependency>
-    <groupId>com.johnsnowlabs.nlp</groupId>
-    <artifactId>spark-nlp-aarch64_2.13</artifactId>
-    <version>{{ site.sparknlp_version }}</version>
-</dependency>
-```
-
-If you are running an sbt project in Scala 2.13, then you you don't require any changes, as the sbt syntax handles it automatically:
-
-**spark-nlp:**
-
-```scala
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp" % "{{ site.sparknlp_version }}"
-```
-
-**spark-nlp-gpu:**
-
-```scala
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-gpu" % "{{ site.sparknlp_version }}"
-```
-
-**spark-nlp-silicon:**
-
-```scala
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-silicon" % "{{ site.sparknlp_version }}"
-```
-
-**spark-nlp-aarch64:**
-
-```scala
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-aarch64" % "{{ site.sparknlp_version }}"
-```
+In Python, prefer `sparknlp.start()` so the installed PySpark version selects the correct lane automatically.
 
 </div><div class="h3-box" markdown="1">
 
@@ -1193,7 +1159,14 @@ gcloud dataproc clusters create ${CLUSTER_NAME} \
 
 ## Apache Spark Support
 
-Spark NLP *{{ site.sparknlp_version }}* has been built on top of Apache Spark 3.4 while fully supports Apache Spark 3.0.x, 3.1.x, 3.2.x, 3.3.x, 3.4.x, and 3.5.x
+Spark NLP supports Spark 3.x with Scala 2.12 and the following Spark 4/Scala 2.13 lanes:
+
+| Spark runtime | Scala | Java | Maven artifact |
+|---|---:|---:|---|
+| Spark 4.0.0 | 2.13 | 17 | `spark-nlp-spark400_2.13` |
+| Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2 | 2.13 | 17 | `spark-nlp_2.13` |
+
+Spark 3.x with Scala 2.13 and Spark 4.x with Scala 2.12 are not supported. The table below records historical Spark NLP 4.x and 5.x compatibility.
 
 {:.table-model-big}
 
@@ -1212,7 +1185,9 @@ Spark NLP *{{ site.sparknlp_version }}* has been built on top of Apache Spark 3.
 
 Find out more about `Spark NLP` versions from our [release notes](https://github.com/JohnSnowLabs/spark-nlp/releases).
 
-## Scala and Python Support
+## Historical Scala and Python Support
+
+The current Spark 3 line uses Scala 2.12 and the Spark 4 line uses Scala 2.13. Supported Python versions follow the selected Apache Spark runtime. The table below records historical Spark NLP 4.x and 5.x compatibility.
 
 {:.table-model-big}
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,97 +3,87 @@ import sbt._
 object Dependencies {
 
   /** ------- Spark version start ------- */
+  final case class SparkBuildProfile(
+      id: String,
+      compileBaseline: String,
+      artifactSuffix: String,
+      supportedVersions: Seq[String])
+
+  final case class SparkBuildVariant(id: String, artifactBaseName: String) {
+    def isGpu: Boolean = id == "gpu"
+  }
+
   val spark400Ver = "4.0.0"
   val spark401Ver = "4.0.1"
   val spark410Ver = "4.1.0"
   val spark411Ver = "4.1.1"
   val spark412Ver = "4.1.2"
 
-  val spark4Versions: Seq[String] = Seq(
-    spark400Ver,
-    spark401Ver,
-    spark410Ver,
-    spark411Ver,
-    spark412Ver)
+  val spark400Profile = SparkBuildProfile(
+    id = "spark400",
+    compileBaseline = spark400Ver,
+    artifactSuffix = "-spark400",
+    supportedVersions = Seq(spark400Ver))
 
-  /* Default Spark 4 baseline. Use -Dspark.version=<version> for a specific Spark 4.x lane. */
-  val spark4DefaultVer = spark401Ver
+  val spark4Profile = SparkBuildProfile(
+    id = "spark4",
+    compileBaseline = spark401Ver,
+    artifactSuffix = "",
+    supportedVersions = Seq(spark401Ver, spark410Ver, spark411Ver, spark412Ver))
 
-  /* required for different hardware */
-  val is_gpu: String = System.getProperty("is_gpu", "false")
-  val is_opt: String = System.getProperty("is_opt", "false")
-  val is_silicon: String = System.getProperty("is_silicon", "false")
-  val is_aarch64: String = System.getProperty("is_aarch64", "false")
+  val sparkBuildProfiles: Map[String, SparkBuildProfile] =
+    Seq(spark400Profile, spark4Profile).map(profile => profile.id -> profile).toMap
 
-  /* only used for unit tests and compatibility lanes */
-  val is_spark400: String = System.getProperty("is_spark400", "false")
-  val is_spark401: String = System.getProperty("is_spark401", "false")
-  val is_spark410: String = System.getProperty("is_spark410", "false")
-  val is_spark411: String = System.getProperty("is_spark411", "false")
-  val is_spark412: String = System.getProperty("is_spark412", "false")
+  val sparkBuildProfileId: String =
+    System.getProperty("spark.build.profile", spark4Profile.id).trim.toLowerCase
+
+  val sparkBuildProfile: SparkBuildProfile = sparkBuildProfiles.getOrElse(
+    sparkBuildProfileId,
+    throw new IllegalArgumentException(
+      s"Unsupported Spark build profile '$sparkBuildProfileId'. " +
+        s"Supported profiles: ${sparkBuildProfiles.keys.toSeq.sorted.mkString(", ")}"))
+
+  val cpuVariant = SparkBuildVariant("cpu", "spark-nlp")
+  val gpuVariant = SparkBuildVariant("gpu", "spark-nlp-gpu")
+  val siliconVariant = SparkBuildVariant("silicon", "spark-nlp-silicon")
+  val aarch64Variant = SparkBuildVariant("aarch64", "spark-nlp-aarch64")
+
+  val sparkBuildVariants: Map[String, SparkBuildVariant] =
+    Seq(cpuVariant, gpuVariant, siliconVariant, aarch64Variant)
+      .map(variant => variant.id -> variant)
+      .toMap
+
+  val sparkBuildVariantId: String =
+    System.getProperty("spark.build.variant", cpuVariant.id).trim.toLowerCase
+
+  val sparkBuildVariant: SparkBuildVariant = sparkBuildVariants.getOrElse(
+    sparkBuildVariantId,
+    throw new IllegalArgumentException(
+      s"Unsupported Spark build variant '$sparkBuildVariantId'. " +
+        s"Supported variants: ${sparkBuildVariants.keys.toSeq.sorted.mkString(", ")}"))
 
   private val sparkVersionOverride = System.getProperty("spark.version", "").trim
 
-  private val sparkProfiles = Seq(
-    "-Dis_spark400=true" -> spark400Ver,
-    "-Dis_spark401=true" -> spark401Ver,
-    "-Dis_spark410=true" -> spark410Ver,
-    "-Dis_spark411=true" -> spark411Ver,
-    "-Dis_spark412=true" -> spark412Ver)
-
-  private val selectedSparkProfiles = sparkProfiles
-    .zip(
-      Seq(
-        is_spark400,
-        is_spark401,
-        is_spark410,
-        is_spark411,
-        is_spark412))
-    .collect { case ((profile, version), "true") => profile -> version }
+  val sparkVer: String =
+    if (sparkVersionOverride.nonEmpty) sparkVersionOverride
+    else sparkBuildProfile.compileBaseline
 
   require(
-    selectedSparkProfiles.size <= 1,
-    s"Select at most one Spark 4 profile: ${sparkProfiles.map(_._1).mkString(", ")}")
+    sparkBuildProfile.supportedVersions.contains(sparkVer),
+    s"Spark version '$sparkVer' is not supported by build profile '${sparkBuildProfile.id}'. " +
+      s"Supported versions: ${sparkBuildProfile.supportedVersions.mkString(", ")}")
 
-  require(
-    sparkVersionOverride.isEmpty || selectedSparkProfiles.isEmpty,
-    "Use either -Dspark.version=<Spark 4.x version> or a Spark profile flag, not both")
+  val sparkArtifactBaseName: String =
+    sparkBuildVariant.artifactBaseName + sparkBuildProfile.artifactSuffix
 
-  val sparkVer: String = getSparkVersion(sparkVersionOverride, selectedSparkProfiles)
+  val isPublishBaseline: Boolean = sparkVer == sparkBuildProfile.compileBaseline
 
   /** ------- Spark version end ------- */
-
-  /** Package attributes */
-  def getPackageName(is_silicon: String, is_gpu: String, is_aarch64: String): String = {
-    if (is_gpu.equals("true")) {
-      "spark-nlp-gpu"
-    } else if (is_silicon.equals("true")) {
-      "spark-nlp-silicon"
-    } else if (is_aarch64.equals("true")) {
-      "spark-nlp-aarch64"
-    } else {
-      "spark-nlp"
-    }
-  }
-
-  def getSparkVersion(
-      sparkVersionOverride: String,
-      selectedSparkProfiles: Seq[(String, String)]): String = {
-    val selectedVersion =
-      if (sparkVersionOverride.nonEmpty) sparkVersionOverride
-      else selectedSparkProfiles.headOption.map(_._2).getOrElse(spark4DefaultVer)
-
-    require(
-      spark4Versions.contains(selectedVersion),
-      s"Unsupported Spark version '$selectedVersion'. Supported Spark 4 versions: ${spark4Versions.mkString(", ")}")
-
-    selectedVersion
-  }
 
   /** ------- Scala version start ------- */
   lazy val scalaVer: String = "2.13.16"
 
-  lazy val supportedScalaVersions: Seq[String] = List(scalaVer)
+  lazy val supportedScalaVersions: Seq[String] = Seq(scalaVer)
 
   val scalaTestVersion = "3.2.19"
 

--- a/publish.sbt
+++ b/publish.sbt
@@ -18,6 +18,16 @@ ThisBuild / credentials += Credentials(Path.userHome / ".sbt" / "sonatype_centra
 ThisBuild / pomIncludeRepository := { _ => false }
 ThisBuild / publishMavenStyle := true
 
+publish / skip := {
+  if (!Dependencies.isPublishBaseline) {
+    throw new MessageOnlyException(
+      s"Publishing profile '${Dependencies.sparkBuildProfile.id}' is only allowed with its " +
+        s"Spark ${Dependencies.sparkBuildProfile.compileBaseline} compile baseline. " +
+        s"Selected Spark version: ${Dependencies.sparkVer}.")
+  }
+  false
+}
+
 // new setting for the Central Portal
 ThisBuild / publishTo := {
   val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"

--- a/python/docs/getting_started/index.rst
+++ b/python/docs/getting_started/index.rst
@@ -43,6 +43,12 @@ This cheat sheet can be used as a quick reference on how to set up your environm
     # Load Spark NLP with Spark Submit
     spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:|release|
 
+    # Spark 4.0.0 / Scala 2.13
+    spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-spark400_2.13:|release|
+
+    # Spark 4.0.1 and later validated Spark 4 versions / Scala 2.13
+    spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.13:|release|
+
     # Load Spark NLP as external JAR after compiling and building Spark NLP by `sbt assembly`
     spark-shell --jar spark-nlp-assembly-|release|
 
@@ -51,15 +57,15 @@ This cheat sheet can be used as a quick reference on how to set up your environm
 Requirements
 ************
 
-Spark NLP is built on top of Apache Spark `3.x`. For using Spark NLP you need:
+Spark NLP supports explicit Spark/Scala runtime lanes:
 
-* Java 8
-* Apache Spark (from ``2.3.x`` to ``3.3.x``)
-* Python ``3.8.x`` if you are using PySpark ``3.x``
+* Spark 3.x with Scala 2.12
+* Spark 4.0.0 with Scala 2.13 through the dedicated ``spark400`` artifact
+* Spark 4.0.1, 4.1.0, 4.1.1, and 4.1.2 with Scala 2.13 through the default ``_2.13`` artifact
 
-    * **NOTE**: Since Spark version 3.2, Python 3.6 is deprecated. If you are using this
-      python version, consider sticking to lower versions of Spark.
-    * For Python ``3.6.x`` and ``3.7.x`` we recommend PySpark ``2.3.x`` or ``2.4.x``
+Spark 3.x with Scala 2.13 and Spark 4.x with Scala 2.12 are not supported. Use a
+Java and Python version supported by the selected Apache Spark runtime; Spark 4
+validation uses Java 17.
 
 It is recommended to have basic knowledge of the framework and a working environment before using Spark NLP.
 Please refer to `Spark documentation <https://spark.apache.org/docs/latest/api/python/index.html>`_ to get started with Spark.
@@ -68,12 +74,14 @@ Please refer to `Spark documentation <https://spark.apache.org/docs/latest/api/p
 Installation
 ************
 
-First, let's make sure the installed java version is Java 8 (Oracle or OpenJDK):
+First, make sure the installed Java version matches the selected Spark runtime.
+Use the existing Java 8/11 support baseline for Spark 3.x and Java 17 for Spark 4.x:
 
 .. code-block:: bash
 
     java -version
-    # openjdk version "1.8.0_292"
+    # Spark 3.x: Java 8/11 baseline
+    # Spark 4.x: Java 17
 
 Using Conda
 ===========
@@ -124,6 +132,20 @@ A Spark session for Spark NLP can be created (or retrieved) by using :func:`spar
     import sparknlp
     spark = sparknlp.start()
 
+The same Python wheel supports the declared Spark 3 and Spark 4 lanes.
+``sparknlp.start()`` detects the installed PySpark version and resolves:
+
+* Spark 3.x to ``spark-nlp_2.12``
+* Spark 4.0.0 to ``spark-nlp-spark400_2.13``
+* Spark 4.0.1, 4.1.0, 4.1.1, and 4.1.2 to ``spark-nlp_2.13``
+
+The ``gpu``, ``apple_silicon``, and ``aarch64`` options select the corresponding
+hardware artifact in the same runtime lane. Only one hardware option may be enabled.
+
+The release line that introduces this mapping removes the experimental
+``scala213`` argument. Install a supported PySpark version and allow
+``sparknlp.start()`` to select Scala and the Maven lane automatically.
+
 If you need to manually start SparkSession because you have other configurations and ``sparknlp.start()`` is not including them,
 you can manually start the SparkSession with:
 
@@ -139,3 +161,7 @@ you can manually start the SparkSession with:
         .config("spark.driver.maxResultSize", "0") \
         .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:|release|") \
         .getOrCreate()
+
+The manual example above is for Spark 3.x. Use
+``spark-nlp-spark400_2.13`` for Spark 4.0.0 or ``spark-nlp_2.13`` for
+Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2.

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -16,12 +16,14 @@ import subprocess
 import sys
 import threading
 
+from pyspark import __version__ as pyspark_version
 from pyspark.conf import SparkConf
 from pyspark.context import SparkContext
 from pyspark.java_gateway import launch_gateway
 from pyspark.sql import SparkSession
 
 from sparknlp import annotator
+from sparknlp._maven import resolve_spark_nlp_coordinate
 # Must be declared here one by one or else PretrainedPipeline will fail with AttributeError
 from sparknlp.base import DocumentAssembler, MultiDocumentAssembler, Finisher, EmbeddingsFinisher, TokenAssembler, \
     Doc2Chunk, AudioAssembler, GraphFinisher, ImageAssembler, TableAssembler, MultiColumnAssembler
@@ -81,8 +83,7 @@ def start(gpu=False,
           params=None,
           real_time_output=False,
           output_level=1,
-          skip_sparknlp_maven=False,
-          scala213=False):
+          skip_sparknlp_maven=False):
     """Starts a PySpark instance with default parameters for Spark NLP.
 
     The default parameters would result in the equivalent of:
@@ -96,7 +97,7 @@ def start(gpu=False,
             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer") \\
             .config("spark.kryoserializer.buffer.max", "2000M") \\
             .config("spark.driver.maxResultSize", "0") \\
-            .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:|release|") \\
+            .config("spark.jars.packages", "<resolved Spark NLP Maven coordinate>") \\
             .getOrCreate()
 
     Parameters
@@ -131,13 +132,12 @@ def start(gpu=False,
     skip_sparknlp_maven : bool, optional
         Whether to avoid adding the default Spark NLP Maven package. Use this
         when providing a custom Spark NLP jar with ``spark.jars``.
-    scala213 : bool, optional
-        Whether to use Scala 2.13 build of Spark NLP, by default False (Scala 2.12)
 
     Notes
     -----
-    Since Spark version 3.2, Python 3.6 is deprecated. If you are using this
-    python version, consider sticking to lower versions of Spark.
+    The Maven artifact is selected from the installed PySpark version. Spark 3.x
+    uses Scala 2.12. Spark 4.0.0 uses the dedicated ``spark400`` Scala 2.13
+    artifact. Spark 4.0.1, 4.1.0, 4.1.1, and 4.1.2 use the default Scala 2.13 artifact.
 
     Returns
     -------
@@ -169,6 +169,16 @@ def start(gpu=False,
 
     skip_sparknlp_maven = is_skip_sparknlp_maven_enabled()
 
+    spark_jars_packages = ""
+    if not skip_sparknlp_maven:
+        spark_jars_packages = resolve_spark_nlp_coordinate(
+            pyspark_version,
+            maven_version,
+            gpu=gpu,
+            apple_silicon=apple_silicon,
+            aarch64=aarch64,
+        )
+
     driver_cores = "*"
     for key, value in params.items():
         if key == "spark.driver.cores":
@@ -182,14 +192,6 @@ def start(gpu=False,
             self.master, self.app_name = "local[{}]".format(driver_cores), "Spark NLP"
             self.serializer, self.serializer_max_buffer = "org.apache.spark.serializer.KryoSerializer", "2000M"
             self.driver_max_result_size = "0"
-            # Spark NLP on CPU or GPU
-            scala_version = "2.13" if scala213 else "2.12"
-            self.maven_spark3 = f"com.johnsnowlabs.nlp:spark-nlp_{scala_version}:{maven_version}"
-            self.maven_gpu_spark3 = f"com.johnsnowlabs.nlp:spark-nlp-gpu_{scala_version}:{maven_version}"
-            # Spark NLP on Apple Silicon
-            self.maven_silicon = f"com.johnsnowlabs.nlp:spark-nlp-silicon_{scala_version}:{current_version}"
-            # Spark NLP on Linux Aarch64
-            self.maven_aarch64 = f"com.johnsnowlabs.nlp:spark-nlp-aarch64_{scala_version}:{current_version}"
 
     def start_without_realtime_output():
         builder = SparkSession.builder \
@@ -199,15 +201,6 @@ def start(gpu=False,
             .config("spark.serializer", spark_nlp_config.serializer) \
             .config("spark.kryoserializer.buffer.max", spark_nlp_config.serializer_max_buffer) \
             .config("spark.driver.maxResultSize", spark_nlp_config.driver_max_result_size)
-
-        if apple_silicon:
-            spark_jars_packages = spark_nlp_config.maven_silicon
-        elif aarch64:
-            spark_jars_packages = spark_nlp_config.maven_aarch64
-        elif gpu:
-            spark_jars_packages = spark_nlp_config.maven_gpu_spark3
-        else:
-            spark_jars_packages = spark_nlp_config.maven_spark3
 
         if cache_folder != '':
             builder.config("spark.jsl.settings.pretrained.cache_folder", cache_folder)
@@ -244,15 +237,6 @@ def start(gpu=False,
                 spark_conf.set("spark.serializer", spark_nlp_config.serializer)
                 spark_conf.set("spark.kryoserializer.buffer.max", spark_nlp_config.serializer_max_buffer)
                 spark_conf.set("spark.driver.maxResultSize", spark_nlp_config.driver_max_result_size)
-
-                if apple_silicon:
-                    spark_jars_packages = spark_nlp_config.maven_silicon
-                elif aarch64:
-                    spark_jars_packages = spark_nlp_config.maven_aarch64
-                elif gpu:
-                    spark_jars_packages = spark_nlp_config.maven_gpu_spark3
-                else:
-                    spark_jars_packages = spark_nlp_config.maven_spark3
 
                 if cache_folder != '':
                     spark_conf.set("spark.jsl.settings.pretrained.cache_folder", cache_folder)

--- a/python/sparknlp/_maven.py
+++ b/python/sparknlp/_maven.py
@@ -1,0 +1,86 @@
+#  Copyright 2017-2026 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import re
+
+
+SUPPORTED_FORWARD_SPARK4_VERSIONS = frozenset(
+    {"4.0.1", "4.1.0", "4.1.1", "4.1.2"}
+)
+
+_VARIANT_ARTIFACTS = {
+    "cpu": "spark-nlp",
+    "gpu": "spark-nlp-gpu",
+    "silicon": "spark-nlp-silicon",
+    "aarch64": "spark-nlp-aarch64",
+}
+
+_RELEASE_VERSION_PATTERN = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def resolve_spark_nlp_coordinate(
+    pyspark_version,
+    spark_nlp_version,
+    gpu=False,
+    apple_silicon=False,
+    aarch64=False,
+):
+    """Resolve the Spark NLP Maven coordinate for a supported PySpark runtime."""
+    selected_variants = [
+        name
+        for name, enabled in (
+            ("gpu", gpu),
+            ("silicon", apple_silicon),
+            ("aarch64", aarch64),
+        )
+        if enabled
+    ]
+    if len(selected_variants) > 1:
+        raise ValueError(
+            "Only one Spark NLP hardware variant can be enabled: "
+            "gpu, apple_silicon, or aarch64."
+        )
+
+    normalized_version = str(pyspark_version)
+    version_match = _RELEASE_VERSION_PATTERN.fullmatch(normalized_version)
+    if version_match is None:
+        raise _unsupported_pyspark_version(normalized_version)
+
+    spark_major = int(version_match.group(1))
+    if spark_major == 3:
+        scala_binary_version = "2.12"
+        profile_suffix = ""
+    elif normalized_version == "4.0.0":
+        scala_binary_version = "2.13"
+        profile_suffix = "-spark400"
+    elif normalized_version in SUPPORTED_FORWARD_SPARK4_VERSIONS:
+        scala_binary_version = "2.13"
+        profile_suffix = ""
+    else:
+        raise _unsupported_pyspark_version(normalized_version)
+
+    variant = selected_variants[0] if selected_variants else "cpu"
+    artifact = f"{_VARIANT_ARTIFACTS[variant]}{profile_suffix}_{scala_binary_version}"
+    return f"com.johnsnowlabs.nlp:{artifact}:{spark_nlp_version}"
+
+
+def _unsupported_pyspark_version(pyspark_version):
+    supported_spark4_versions = ", ".join(
+        ["4.0.0"] + sorted(SUPPORTED_FORWARD_SPARK4_VERSIONS)
+    )
+    return ValueError(
+        f"Unsupported PySpark version '{pyspark_version}'. "
+        "Spark NLP supports Spark 3.x with Scala 2.12 and the validated "
+        f"Spark 4 versions {supported_spark4_versions} with Scala 2.13."
+    )

--- a/python/test/maven_coordinate_resolver_test.py
+++ b/python/test/maven_coordinate_resolver_test.py
@@ -1,0 +1,337 @@
+#  Copyright 2017-2026 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+import sparknlp
+
+
+class FakeHadoopConfiguration:
+    def set(self, key, value):
+        pass
+
+
+class FakeJsc:
+    def hadoopConfiguration(self):
+        return FakeHadoopConfiguration()
+
+
+class FakeSparkContext:
+    def __init__(self, gateway=None):
+        self.gateway = gateway
+        self._jsc = FakeJsc()
+
+
+class FakeSparkSessionInstance:
+    def __init__(self, spark_context=None):
+        self.sparkContext = spark_context or FakeSparkContext()
+
+
+class FakeBuilder:
+    def __init__(self):
+        self.settings = {}
+
+    def appName(self, value):
+        self.settings["spark.app.name"] = value
+        return self
+
+    def master(self, value):
+        self.settings["spark.master"] = value
+        return self
+
+    def config(self, key, value):
+        self.settings[key] = value
+        return self
+
+    def getOrCreate(self):
+        return FakeSparkSessionInstance()
+
+
+class FakeSparkSession:
+    _instantiatedSession = None
+    builder = FakeBuilder()
+
+    def __new__(cls, spark_context=None):
+        return FakeSparkSessionInstance(spark_context)
+
+
+class FakeSparkConf:
+    latest = None
+
+    def __init__(self):
+        self.settings = {}
+        type(self).latest = self
+
+    def setAppName(self, value):
+        self.settings["spark.app.name"] = value
+        return self
+
+    def setMaster(self, value):
+        self.settings["spark.master"] = value
+        return self
+
+    def set(self, key, value):
+        self.settings[key] = value
+        return self
+
+
+class FakeThread:
+    def __init__(self, target):
+        self.target = target
+
+    def start(self):
+        pass
+
+    def join(self):
+        pass
+
+
+def resolve_coordinate(*args, **kwargs):
+    from sparknlp._maven import resolve_spark_nlp_coordinate
+
+    return resolve_spark_nlp_coordinate(*args, **kwargs)
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "spark_version,expected_artifact",
+    [
+        ("3.0.0", "spark-nlp_2.12"),
+        ("3.5.6", "spark-nlp_2.12"),
+        ("4.0.0", "spark-nlp-spark400_2.13"),
+        ("4.0.1", "spark-nlp_2.13"),
+        ("4.1.0", "spark-nlp_2.13"),
+        ("4.1.1", "spark-nlp_2.13"),
+        ("4.1.2", "spark-nlp_2.13"),
+    ],
+)
+def test_resolves_cpu_artifact_from_pyspark_version(spark_version, expected_artifact):
+    coordinate = resolve_coordinate(spark_version, "6.4.1")
+
+    assert coordinate == f"com.johnsnowlabs.nlp:{expected_artifact}:6.4.1"
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "variant_flags,expected_base_artifact",
+    [
+        ({}, "spark-nlp"),
+        ({"gpu": True}, "spark-nlp-gpu"),
+        ({"apple_silicon": True}, "spark-nlp-silicon"),
+        ({"aarch64": True}, "spark-nlp-aarch64"),
+    ],
+)
+def test_resolves_all_spark3_hardware_variants(variant_flags, expected_base_artifact):
+    coordinate = resolve_coordinate("3.5.8", "6.4.1", **variant_flags)
+
+    assert coordinate == f"com.johnsnowlabs.nlp:{expected_base_artifact}_2.12:6.4.1"
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "variant_flags,expected_base_artifact",
+    [
+        ({}, "spark-nlp"),
+        ({"gpu": True}, "spark-nlp-gpu"),
+        ({"apple_silicon": True}, "spark-nlp-silicon"),
+        ({"aarch64": True}, "spark-nlp-aarch64"),
+    ],
+)
+def test_resolves_all_spark400_hardware_variants(variant_flags, expected_base_artifact):
+    coordinate = resolve_coordinate("4.0.0", "6.4.1", **variant_flags)
+
+    assert coordinate == (
+        f"com.johnsnowlabs.nlp:{expected_base_artifact}-spark400_2.13:6.4.1"
+    )
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "variant_flags,expected_base_artifact",
+    [
+        ({}, "spark-nlp"),
+        ({"gpu": True}, "spark-nlp-gpu"),
+        ({"apple_silicon": True}, "spark-nlp-silicon"),
+        ({"aarch64": True}, "spark-nlp-aarch64"),
+    ],
+)
+def test_resolves_all_forward_spark4_hardware_variants(
+    variant_flags, expected_base_artifact
+):
+    coordinate = resolve_coordinate("4.1.2", "6.4.1", **variant_flags)
+
+    assert coordinate == f"com.johnsnowlabs.nlp:{expected_base_artifact}_2.13:6.4.1"
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "spark_version",
+    ["2.4.8", "4.0.2", "4.2.0", "5.0.0", "4.0.0.dev1", "invalid"],
+)
+def test_rejects_unsupported_or_unvalidated_pyspark_versions(spark_version):
+    with pytest.raises(ValueError, match="Unsupported PySpark version"):
+        resolve_coordinate(spark_version, "6.4.1")
+
+
+@pytest.mark.fast
+def test_normalizes_version_like_objects_before_comparison():
+    class VersionLike:
+        def __str__(self):
+            return "4.0.0"
+
+    assert resolve_coordinate(VersionLike(), "6.4.1") == (
+        "com.johnsnowlabs.nlp:spark-nlp-spark400_2.13:6.4.1"
+    )
+
+
+@pytest.mark.fast
+def test_start_does_not_expose_manual_scala_selector():
+    assert "scala213" not in inspect.signature(sparknlp.start).parameters
+
+
+@pytest.mark.fast
+def test_start_uses_resolver_coordinate_for_standard_session(monkeypatch):
+    coordinate = "com.johnsnowlabs.nlp:spark-nlp-spark400_2.13:6.4.1"
+    calls = []
+
+    def fake_resolver(*args, **kwargs):
+        calls.append((args, kwargs))
+        return coordinate
+
+    FakeSparkSession.builder = FakeBuilder()
+    monkeypatch.setattr(sparknlp, "pyspark_version", "4.0.0")
+    monkeypatch.setattr(sparknlp, "resolve_spark_nlp_coordinate", fake_resolver)
+    monkeypatch.setattr(sparknlp, "SparkSession", FakeSparkSession)
+
+    sparknlp.start()
+
+    assert calls == [
+        (
+            ("4.0.0", "6.4.1"),
+            {
+                "gpu": False,
+                "apple_silicon": False,
+                "aarch64": False,
+            },
+        )
+    ]
+    assert FakeSparkSession.builder.settings["spark.jars.packages"] == coordinate
+
+
+@pytest.mark.fast
+def test_start_uses_resolver_coordinate_for_realtime_session(monkeypatch):
+    coordinate = "com.johnsnowlabs.nlp:spark-nlp-gpu_2.13:6.4.1"
+    calls = []
+
+    def fake_resolver(*args, **kwargs):
+        calls.append((args, kwargs))
+        return coordinate
+
+    process = SimpleNamespace(
+        stdout=SimpleNamespace(readline=lambda: b""),
+        stderr=SimpleNamespace(readline=lambda: b""),
+    )
+    gateway = SimpleNamespace(proc=process)
+
+    monkeypatch.setattr(sparknlp, "pyspark_version", "4.1.2")
+    monkeypatch.setattr(sparknlp, "resolve_spark_nlp_coordinate", fake_resolver)
+    monkeypatch.setattr(sparknlp, "SparkConf", FakeSparkConf)
+    monkeypatch.setattr(sparknlp, "SparkContext", FakeSparkContext)
+    monkeypatch.setattr(sparknlp, "SparkSession", FakeSparkSession)
+    monkeypatch.setattr(sparknlp, "launch_gateway", lambda **kwargs: gateway)
+    monkeypatch.setattr(sparknlp.threading, "Thread", FakeThread)
+
+    session = sparknlp.start(gpu=True, real_time_output=True)
+
+    assert calls == [
+        (
+            ("4.1.2", "6.4.1"),
+            {
+                "gpu": True,
+                "apple_silicon": False,
+                "aarch64": False,
+            },
+        )
+    ]
+    assert isinstance(session, FakeSparkSessionInstance)
+    assert FakeSparkConf.latest is not None
+    assert FakeSparkConf.latest.settings["spark.jars.packages"] == coordinate
+
+
+@pytest.mark.fast
+def test_skip_maven_bypasses_runtime_resolution(monkeypatch):
+    def unexpected_resolver(*args, **kwargs):
+        raise AssertionError("Resolver must not run when Maven injection is disabled")
+
+    FakeSparkSession.builder = FakeBuilder()
+    monkeypatch.setattr(sparknlp, "resolve_spark_nlp_coordinate", unexpected_resolver)
+    monkeypatch.setattr(sparknlp, "SparkSession", FakeSparkSession)
+
+    sparknlp.start(
+        params={"spark.jars": "/tmp/sparknlp.jar"},
+        skip_sparknlp_maven=True,
+    )
+
+    assert "spark.jars.packages" not in FakeSparkSession.builder.settings
+    assert FakeSparkSession.builder.settings["spark.jars"] == "/tmp/sparknlp.jar"
+
+
+@pytest.mark.fast
+def test_skip_maven_param_bypasses_runtime_resolution(monkeypatch):
+    def unexpected_resolver(*args, **kwargs):
+        raise AssertionError("Resolver must not run when Maven injection is disabled")
+
+    FakeSparkSession.builder = FakeBuilder()
+    monkeypatch.setattr(sparknlp, "resolve_spark_nlp_coordinate", unexpected_resolver)
+    monkeypatch.setattr(sparknlp, "SparkSession", FakeSparkSession)
+
+    sparknlp.start(
+        params={
+            "spark.jars": "/tmp/sparknlp.jar",
+            "skip_sparknlp_maven": "true",
+        }
+    )
+
+    assert "spark.jars.packages" not in FakeSparkSession.builder.settings
+    assert FakeSparkSession.builder.settings["spark.jars"] == "/tmp/sparknlp.jar"
+    assert "skip_sparknlp_maven" not in FakeSparkSession.builder.settings
+
+
+@pytest.mark.fast
+def test_start_merges_resolved_coordinate_with_caller_packages(monkeypatch):
+    coordinate = "com.johnsnowlabs.nlp:spark-nlp_2.13:6.4.1"
+    caller_package = "org.example:extra-package_2.13:1.0.0"
+
+    FakeSparkSession.builder = FakeBuilder()
+    monkeypatch.setattr(sparknlp, "pyspark_version", "4.0.1")
+    monkeypatch.setattr(
+        sparknlp,
+        "resolve_spark_nlp_coordinate",
+        lambda *args, **kwargs: coordinate,
+    )
+    monkeypatch.setattr(sparknlp, "SparkSession", FakeSparkSession)
+
+    sparknlp.start(params={"spark.jars.packages": caller_package})
+
+    assert FakeSparkSession.builder.settings["spark.jars.packages"] == (
+        coordinate + "," + caller_package
+    )
+
+
+@pytest.mark.fast
+def test_rejects_conflicting_hardware_variants():
+    with pytest.raises(ValueError, match="Only one Spark NLP hardware variant"):
+        resolve_coordinate("4.0.1", "6.4.1", gpu=True, apple_silicon=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds explicit Spark 4 build profiles and updates `sparknlp.start()` to select the matching Spark NLP Maven artifact from the installed PySpark version.

The build now supports:

- `spark400`: compiled against Spark 4.0.0 and published with the dedicated `-spark400_2.13` artifact suffix.
- `spark4`: compiled against Spark 4.0.1 and published with the default `_2.13` suffix for Spark 4.0.1, 4.1.0, 4.1.1, and 4.1.2.
- CPU, GPU, Apple Silicon, and Linux AArch64 variants for both Spark 4 profiles.
- Profile-aware artifact names and publishing safeguards that only allow each profile to be published from its compile baseline.
- Configured CI to build and test Spark 4.0.0, 4.0.1, and 4.1.2 with the corresponding profiles.

The Python API uses the same compatibility matrix automatically:

- Spark 3.x resolves to the existing Scala 2.12 artifacts.
- Spark 4.0.0 resolves to the dedicated `spark400` Scala 2.13 artifacts.
- Spark 4.0.1, 4.1.0, 4.1.1, and 4.1.2 resolve to the default Scala 2.13 artifacts.

This removes the manual `scala213` selector while preserving local/custom JAR workflows through `skip_sparknlp_maven`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Spark 4.0.0 and Spark 4.0.1 use incompatible Spark ML `Param[T]` constructor ABIs. A single Spark 4 JAR cannot safely support both runtimes, so Spark NLP needs separate build and publication lanes while keeping the source and release process aligned.

At the same time, Spark NLP should continue publishing one Python wheel without requiring users to understand Scala binary versions or select an internal build profile. Resolving the Maven coordinate from the installed PySpark version keeps the Python API simple, preserves Spark 3 compatibility, and prevents a Spark runtime from loading an incompatible Spark NLP artifact.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
- Validated the `spark400` and `spark4` profile configuration for CPU, GPU, Apple Silicon, and Linux AArch64 artifact names.
- Built the Spark 4.0.0 and Spark 4.0.1 CPU assemblies with their respective build profiles.
- Verified basic Spark NLP execution with the Spark 4.0.0 assembly on Spark 4.0.0.
- Verified the Spark 4.0.1 assembly on Spark 4.0.1 and Spark 4.1.0.
- Added focused tests for Maven coordinate resolution, unsupported versions, conflicting hardware options, local Maven bypass, custom package merging, and both standard and real-time startup paths.
- End-to-end Maven resolution through `sparknlp.start()` will be validated with the release candidate after the corresponding CPU artifacts are published to Maven.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
