### PR TITLE
[SPARKNLP-1407] Handle Spark-specific Maven coordinate resolution

### DIFF
--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -5,7 +5,7 @@ seotitle: Spark NLP - Installation
 title: Spark NLP - Installation
 permalink: /docs/en/install
 key: docs-install
-modify_date: "2024-07-04"
+modify_date: "2026-07-16"
 show_nav: true
 sidebar:
     nav: sparknlp
@@ -45,23 +45,21 @@ Spark NLP {{ site.sparknlp_version }} is built with ONNX 1.17.0 and TensorFlow 2
 
 </div><div class="h3-box" markdown="1">
 
-### Scala 2.13
+### Spark 4 and Scala 2.13
 
-**NOTE**: PySpark from PyPI is based on Scala 2.12 by default, and you can use our Scala 2.12 version. If you need to start a Scala 2.13 instance, you can set the `SPARK_HOME` environment variable to a Spark Scala 2.13 installation, or install PySpark from the official Spark archives.
+Spark 4 uses Scala 2.13. Spark 4.0.0 has a dedicated artifact because its Spark ML `Param[T]` ABI is not binary-compatible with Spark 4.0.1 and later validated Spark 4 releases.
 
 ```bash
-# Load Spark NLP with Spark Shell
-spark-shell --packages com.johnsnowlabs.nlp:spark-nlp_2.13:{{ site.sparknlp_version }}
+# Spark 4.0.0 only
+spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-spark400_2.13:{{ site.sparknlp_version }}
 
-# Load Spark NLP with PySpark
-pyspark --packages com.johnsnowlabs.nlp:spark-nlp_2.13:{{ site.sparknlp_version }}
-
-# Load Spark NLP with Spark Submit
+# Spark 4.0.1 and later validated Spark 4 versions
 spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.13:{{ site.sparknlp_version }}
-
-# Load Spark NLP as external JAR after compiling and building Spark NLP by `sbt assembly`
-spark-shell --jars spark-nlp-assembly-{{ site.sparknlp_version }}.jar
 ```
+
+The same naming rule applies to GPU, Apple Silicon, and Linux AArch64 artifacts, for example `spark-nlp-gpu-spark400_2.13` for Spark 4.0.0 and `spark-nlp-gpu_2.13` for the forward Spark 4 lane.
+
+Spark 3.x with Scala 2.13 and Spark 4.x with Scala 2.12 are not supported.
 
 ## Python
 
@@ -107,6 +105,18 @@ import sparknlp
 spark = sparknlp.start()
 ```
 
+The same Python wheel supports the declared Spark 3 and Spark 4 runtime lanes. `sparknlp.start()` detects the installed PySpark version and selects the Maven artifact automatically:
+
+| Installed PySpark | Selected artifact |
+|---|---|
+| Spark 3.x | `spark-nlp_2.12` |
+| Spark 4.0.0 | `spark-nlp-spark400_2.13` |
+| Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2 | `spark-nlp_2.13` |
+
+The selected hardware option is applied to the same lane. For example, `sparknlp.start(gpu=True)` selects the corresponding `spark-nlp-gpu` artifact. Only one of `gpu`, `apple_silicon`, or `aarch64` may be enabled.
+
+Migration note: the release line that introduces this mapping removes the experimental `scala213` argument from `sparknlp.start()`. Do not pass a Scala selector; install the supported PySpark runtime and let Spark NLP resolve the matching artifact.
+
 If you need to manually start SparkSession because you have other configurations and `sparknlp.start()` is not including them,
 you can manually start the SparkSession with:
 
@@ -121,6 +131,8 @@ spark = SparkSession.builder \
     .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:{{ site.sparknlp_version }}") \
     .getOrCreate()
 ```
+
+The manual example above is for Spark 3.x. For Spark 4.0.0 use `spark-nlp-spark400_2.13`; for Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2 use `spark-nlp_2.13`.
 
 If using local jars, you can use `spark.jars` instead for comma-delimited jar files. For cluster setups, of course,
 you'll have to put the jars in a reachable location for all driver and executor nodes.
@@ -179,14 +191,14 @@ result = pipeline.annotate('The Mona Lisa is a 16th century oil painting created
 
 ## Scala and Java
 
-To use Spark NLP you need the following requirements:
+Select the Java and Scala line that matches the Spark runtime:
 
-- Java 8 and 11
-- Apache Spark 3.5.x, 3.4.x, 3.3.x, 3.2.x, 3.1.x, 3.0.x
+- Spark 3.x: Scala 2.12 and the existing Java 8/11 support baseline
+- Spark 4.x: Scala 2.13 and Java 17
 
 #### Maven
 
-**spark-nlp** on Apache Spark 3.0.x, 3.1.x, 3.2.x, 3.3.x, and 3.4.x
+**spark-nlp** on Apache Spark 3.x
 
 The `spark-nlp` has been published to
 the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp).
@@ -237,7 +249,7 @@ the [Maven Repository](https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/s
 
 #### SBT
 
-**spark-nlp** on Apache Spark 3.0.x, 3.1.x, 3.2.x, 3.3.x, and 3.4.x
+**spark-nlp** on Apache Spark 3.x
 
 ```scala
 // https://mvnrepository.com/artifact/com.johnsnowlabs.nlp/spark-nlp
@@ -269,24 +281,32 @@ Maven Central: [https://mvnrepository.com/artifact/com.johnsnowlabs.nlp](https:/
 
 If you are interested, there is a simple SBT project for Spark NLP to guide you on how to use it in your projects [Spark NLP SBT Starter](https://github.com/maziyarpanahi/spark-nlp-starter)
 
-### Scala 2.13 Support
+### Spark 4 / Scala 2.13 Support
 
-**NOTE**: PyPi installed Pyspark only runs on Scala 2.12, so the following section will not apply for it. If you need to start a Scala 2.13 instance, you can set the `SPARK_HOME` environment variable to a Spark Scala 2.13 installation, or install PySpark from the official Spark archives.
+Spark 4 is supported with Scala 2.13 only. Spark 3.x remains on Scala 2.12 and is not supported with Scala 2.13 in this release line.
 
-If you are using `DependencyParserModel` or `TextMatcherModel` in your pipelines and wish to import from the Scala 2.12 version to 2.13, then you will need to export them manually. For this, please see the example notebook [Converting Spark NLP Scala 2.12 models to Scala 2.13](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/scala213/converting_models_from_212.ipynb).
+Spark 4.0.0 requires a dedicated artifact because its Spark ML parameter ABI differs from Spark 4.0.1 and later validated Spark 4 releases.
 
-`spark-nlp` with Scala 2.13 support has been published to [Maven Central](https://central.sonatype.com/artifact/com.johnsnowlabs.nlp/spark-nlp_2.13). You can use these coordinates to set up your Spark instance with config `--packages` or download the jar directly. For example:
+When migrating pipelines that contain `DependencyParserModel` or `TextMatcherModel` from Spark 3/Scala 2.12 to Spark 4/Scala 2.13, export those models manually. See [Converting Spark NLP Scala 2.12 models to Scala 2.13](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/scala213/converting_models_from_212.ipynb).
 
-```sh
-# Load Spark NLP with Spark Submit
-spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:6.4.2
+| Spark runtime | CPU artifact | GPU artifact |
+|---|---|---|
+| Spark 4.0.0 | `spark-nlp-spark400_2.13` | `spark-nlp-gpu-spark400_2.13` |
+| Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2 | `spark-nlp_2.13` | `spark-nlp-gpu_2.13` |
+
+The same profile suffix applies to `spark-nlp-silicon` and `spark-nlp-aarch64`.
+
+**Spark 4.0.0 Maven dependency:**
+
+```xml
+<dependency>
+    <groupId>com.johnsnowlabs.nlp</groupId>
+    <artifactId>spark-nlp-spark400_2.13</artifactId>
+    <version>{{ site.sparknlp_version }}</version>
+</dependency>
 ```
 
-See our [cheat sheet](#spark-nlp-cheatsheet) for more examples.
-
-To use spark-nlp Scala 2.13 as a dependency, change the `2.12` string in our dependencies to `2.13`.
-
-**spark-nlp:**
+**Validated forward Spark 4 Maven dependency (4.0.1, 4.1.0, 4.1.1, and 4.1.2):**
 
 ```xml
 <dependency>
@@ -296,61 +316,7 @@ To use spark-nlp Scala 2.13 as a dependency, change the `2.12` string in our dep
 </dependency>
 ```
 
-**spark-nlp-gpu:**
-
-```xml
-<dependency>
-    <groupId>com.johnsnowlabs.nlp</groupId>
-    <artifactId>spark-nlp-gpu_2.13</artifactId>
-    <version>{{ site.sparknlp_version }}</version>
-</dependency>
-```
-
-**spark-nlp-silicon:**
-
-```xml
-<dependency>
-    <groupId>com.johnsnowlabs.nlp</groupId>
-    <artifactId>spark-nlp-silicon_2.13</artifactId>
-    <version>{{ site.sparknlp_version }}</version>
-</dependency>
-```
-
-**spark-nlp-aarch64:**
-
-```xml
-<dependency>
-    <groupId>com.johnsnowlabs.nlp</groupId>
-    <artifactId>spark-nlp-aarch64_2.13</artifactId>
-    <version>{{ site.sparknlp_version }}</version>
-</dependency>
-```
-
-If you are running an sbt project in Scala 2.13, then you you don't require any changes, as the sbt syntax handles it automatically:
-
-**spark-nlp:**
-
-```scala
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp" % "{{ site.sparknlp_version }}"
-```
-
-**spark-nlp-gpu:**
-
-```scala
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-gpu" % "{{ site.sparknlp_version }}"
-```
-
-**spark-nlp-silicon:**
-
-```scala
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-silicon" % "{{ site.sparknlp_version }}"
-```
-
-**spark-nlp-aarch64:**
-
-```scala
-libraryDependencies += "com.johnsnowlabs.nlp" %% "spark-nlp-aarch64" % "{{ site.sparknlp_version }}"
-```
+In Python, prefer `sparknlp.start()` so the installed PySpark version selects the correct lane automatically.
 
 </div><div class="h3-box" markdown="1">
 
@@ -1193,7 +1159,14 @@ gcloud dataproc clusters create ${CLUSTER_NAME} \
 
 ## Apache Spark Support
 
-Spark NLP *{{ site.sparknlp_version }}* has been built on top of Apache Spark 3.4 while fully supports Apache Spark 3.0.x, 3.1.x, 3.2.x, 3.3.x, 3.4.x, and 3.5.x
+Spark NLP supports Spark 3.x with Scala 2.12 and the following Spark 4/Scala 2.13 lanes:
+
+| Spark runtime | Scala | Java | Maven artifact |
+|---|---:|---:|---|
+| Spark 4.0.0 | 2.13 | 17 | `spark-nlp-spark400_2.13` |
+| Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2 | 2.13 | 17 | `spark-nlp_2.13` |
+
+Spark 3.x with Scala 2.13 and Spark 4.x with Scala 2.12 are not supported. The table below records historical Spark NLP 4.x and 5.x compatibility.
 
 {:.table-model-big}
 
@@ -1212,7 +1185,9 @@ Spark NLP *{{ site.sparknlp_version }}* has been built on top of Apache Spark 3.
 
 Find out more about `Spark NLP` versions from our [release notes](https://github.com/JohnSnowLabs/spark-nlp/releases).
 
-## Scala and Python Support
+## Historical Scala and Python Support
+
+The current Spark 3 line uses Scala 2.12 and the Spark 4 line uses Scala 2.13. Supported Python versions follow the selected Apache Spark runtime. The table below records historical Spark NLP 4.x and 5.x compatibility.
 
 {:.table-model-big}
 
@@ -1267,7 +1242,7 @@ Spark NLP {{ site.sparknlp_version }} has been tested and is compatible with the
 - emr-6.2.0
 - emr-6.3.0
 - emr-6.3.1
-- emr-6.4.2
+- emr-6.4.1
 - emr-6.5.0
 - emr-6.6.0
 - emr-6.7.0

--- a/python/docs/getting_started/index.rst
+++ b/python/docs/getting_started/index.rst
@@ -43,6 +43,12 @@ This cheat sheet can be used as a quick reference on how to set up your environm
     # Load Spark NLP with Spark Submit
     spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.12:|release|
 
+    # Spark 4.0.0 / Scala 2.13
+    spark-submit --packages com.johnsnowlabs.nlp:spark-nlp-spark400_2.13:|release|
+
+    # Spark 4.0.1 and later validated Spark 4 versions / Scala 2.13
+    spark-submit --packages com.johnsnowlabs.nlp:spark-nlp_2.13:|release|
+
     # Load Spark NLP as external JAR after compiling and building Spark NLP by `sbt assembly`
     spark-shell --jar spark-nlp-assembly-|release|
 
@@ -51,15 +57,15 @@ This cheat sheet can be used as a quick reference on how to set up your environm
 Requirements
 ************
 
-Spark NLP is built on top of Apache Spark `3.x`. For using Spark NLP you need:
+Spark NLP supports explicit Spark/Scala runtime lanes:
 
-* Java 8
-* Apache Spark (from ``2.3.x`` to ``3.3.x``)
-* Python ``3.8.x`` if you are using PySpark ``3.x``
+* Spark 3.x with Scala 2.12
+* Spark 4.0.0 with Scala 2.13 through the dedicated ``spark400`` artifact
+* Spark 4.0.1, 4.1.0, 4.1.1, and 4.1.2 with Scala 2.13 through the default ``_2.13`` artifact
 
-    * **NOTE**: Since Spark version 3.2, Python 3.6 is deprecated. If you are using this
-      python version, consider sticking to lower versions of Spark.
-    * For Python ``3.6.x`` and ``3.7.x`` we recommend PySpark ``2.3.x`` or ``2.4.x``
+Spark 3.x with Scala 2.13 and Spark 4.x with Scala 2.12 are not supported. Use a
+Java and Python version supported by the selected Apache Spark runtime; Spark 4
+validation uses Java 17.
 
 It is recommended to have basic knowledge of the framework and a working environment before using Spark NLP.
 Please refer to `Spark documentation <https://spark.apache.org/docs/latest/api/python/index.html>`_ to get started with Spark.
@@ -68,12 +74,14 @@ Please refer to `Spark documentation <https://spark.apache.org/docs/latest/api/p
 Installation
 ************
 
-First, let's make sure the installed java version is Java 8 (Oracle or OpenJDK):
+First, make sure the installed Java version matches the selected Spark runtime.
+Use the existing Java 8/11 support baseline for Spark 3.x and Java 17 for Spark 4.x:
 
 .. code-block:: bash
 
     java -version
-    # openjdk version "1.8.0_292"
+    # Spark 3.x: Java 8/11 baseline
+    # Spark 4.x: Java 17
 
 Using Conda
 ===========
@@ -124,6 +132,20 @@ A Spark session for Spark NLP can be created (or retrieved) by using :func:`spar
     import sparknlp
     spark = sparknlp.start()
 
+The same Python wheel supports the declared Spark 3 and Spark 4 lanes.
+``sparknlp.start()`` detects the installed PySpark version and resolves:
+
+* Spark 3.x to ``spark-nlp_2.12``
+* Spark 4.0.0 to ``spark-nlp-spark400_2.13``
+* Spark 4.0.1, 4.1.0, 4.1.1, and 4.1.2 to ``spark-nlp_2.13``
+
+The ``gpu``, ``apple_silicon``, and ``aarch64`` options select the corresponding
+hardware artifact in the same runtime lane. Only one hardware option may be enabled.
+
+The release line that introduces this mapping removes the experimental
+``scala213`` argument. Install a supported PySpark version and allow
+``sparknlp.start()`` to select Scala and the Maven lane automatically.
+
 If you need to manually start SparkSession because you have other configurations and ``sparknlp.start()`` is not including them,
 you can manually start the SparkSession with:
 
@@ -139,3 +161,7 @@ you can manually start the SparkSession with:
         .config("spark.driver.maxResultSize", "0") \
         .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:|release|") \
         .getOrCreate()
+
+The manual example above is for Spark 3.x. Use
+``spark-nlp-spark400_2.13`` for Spark 4.0.0 or ``spark-nlp_2.13`` for
+Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2.

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -16,12 +16,14 @@ import subprocess
 import sys
 import threading
 
+from pyspark import __version__ as pyspark_version
 from pyspark.conf import SparkConf
 from pyspark.context import SparkContext
 from pyspark.java_gateway import launch_gateway
 from pyspark.sql import SparkSession
 
 from sparknlp import annotator
+from sparknlp._maven import resolve_spark_nlp_coordinate
 # Must be declared here one by one or else PretrainedPipeline will fail with AttributeError
 from sparknlp.base import DocumentAssembler, MultiDocumentAssembler, Finisher, EmbeddingsFinisher, TokenAssembler, \
     Doc2Chunk, AudioAssembler, GraphFinisher, ImageAssembler, TableAssembler, MultiColumnAssembler
@@ -96,7 +98,7 @@ def start(gpu=False,
             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer") \\
             .config("spark.kryoserializer.buffer.max", "2000M") \\
             .config("spark.driver.maxResultSize", "0") \\
-            .config("spark.jars.packages", "com.johnsnowlabs.nlp:spark-nlp_2.12:|release|") \\
+            .config("spark.jars.packages", "<resolved Spark NLP Maven coordinate>") \\
             .getOrCreate()
 
     Parameters
@@ -134,8 +136,9 @@ def start(gpu=False,
 
     Notes
     -----
-    Since Spark version 3.2, Python 3.6 is deprecated. If you are using this
-    python version, consider sticking to lower versions of Spark.
+    The Maven artifact is selected from the installed PySpark version. Spark 3.x
+    uses Scala 2.12. Spark 4.0.0 uses the dedicated ``spark400`` Scala 2.13
+    artifact. Spark 4.0.1, 4.1.0, 4.1.1, and 4.1.2 use the default Scala 2.13 artifact.
 
     Returns
     -------
@@ -167,6 +170,16 @@ def start(gpu=False,
 
     skip_sparknlp_maven = is_skip_sparknlp_maven_enabled()
 
+    spark_jars_packages = ""
+    if not skip_sparknlp_maven:
+        spark_jars_packages = resolve_spark_nlp_coordinate(
+            pyspark_version,
+            maven_version,
+            gpu=gpu,
+            apple_silicon=apple_silicon,
+            aarch64=aarch64,
+        )
+
     driver_cores = "*"
     for key, value in params.items():
         if key == "spark.driver.cores":
@@ -180,13 +193,6 @@ def start(gpu=False,
             self.master, self.app_name = "local[{}]".format(driver_cores), "Spark NLP"
             self.serializer, self.serializer_max_buffer = "org.apache.spark.serializer.KryoSerializer", "2000M"
             self.driver_max_result_size = "0"
-            # Spark NLP on CPU or GPU
-            self.maven_spark3 = "com.johnsnowlabs.nlp:spark-nlp_2.12:{}".format(maven_version)
-            self.maven_gpu_spark3 = "com.johnsnowlabs.nlp:spark-nlp-gpu_2.12:{}".format(maven_version)
-            # Spark NLP on Apple Silicon
-            self.maven_silicon = "com.johnsnowlabs.nlp:spark-nlp-silicon_2.12:{}".format(maven_version)
-            # Spark NLP on Linux Aarch64
-            self.maven_aarch64 = "com.johnsnowlabs.nlp:spark-nlp-aarch64_2.12:{}".format(maven_version)
 
     def start_without_realtime_output():
         builder = SparkSession.builder \
@@ -196,15 +202,6 @@ def start(gpu=False,
             .config("spark.serializer", spark_nlp_config.serializer) \
             .config("spark.kryoserializer.buffer.max", spark_nlp_config.serializer_max_buffer) \
             .config("spark.driver.maxResultSize", spark_nlp_config.driver_max_result_size)
-
-        if apple_silicon:
-            spark_jars_packages = spark_nlp_config.maven_silicon
-        elif aarch64:
-            spark_jars_packages = spark_nlp_config.maven_aarch64
-        elif gpu:
-            spark_jars_packages = spark_nlp_config.maven_gpu_spark3
-        else:
-            spark_jars_packages = spark_nlp_config.maven_spark3
 
         if cache_folder != '':
             builder.config("spark.jsl.settings.pretrained.cache_folder", cache_folder)
@@ -241,15 +238,6 @@ def start(gpu=False,
                 spark_conf.set("spark.serializer", spark_nlp_config.serializer)
                 spark_conf.set("spark.kryoserializer.buffer.max", spark_nlp_config.serializer_max_buffer)
                 spark_conf.set("spark.driver.maxResultSize", spark_nlp_config.driver_max_result_size)
-
-                if apple_silicon:
-                    spark_jars_packages = spark_nlp_config.maven_silicon
-                elif aarch64:
-                    spark_jars_packages = spark_nlp_config.maven_aarch64
-                elif gpu:
-                    spark_jars_packages = spark_nlp_config.maven_gpu_spark3
-                else:
-                    spark_jars_packages = spark_nlp_config.maven_spark3
 
                 if cache_folder != '':
                     spark_conf.set("spark.jsl.settings.pretrained.cache_folder", cache_folder)

--- a/python/sparknlp/_maven.py
+++ b/python/sparknlp/_maven.py
@@ -1,0 +1,86 @@
+#  Copyright 2017-2026 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import re
+
+
+SUPPORTED_FORWARD_SPARK4_VERSIONS = frozenset(
+    {"4.0.1", "4.1.0", "4.1.1", "4.1.2"}
+)
+
+_VARIANT_ARTIFACTS = {
+    "cpu": "spark-nlp",
+    "gpu": "spark-nlp-gpu",
+    "silicon": "spark-nlp-silicon",
+    "aarch64": "spark-nlp-aarch64",
+}
+
+_RELEASE_VERSION_PATTERN = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def resolve_spark_nlp_coordinate(
+    pyspark_version,
+    spark_nlp_version,
+    gpu=False,
+    apple_silicon=False,
+    aarch64=False,
+):
+    """Resolve the Spark NLP Maven coordinate for a supported PySpark runtime."""
+    selected_variants = [
+        name
+        for name, enabled in (
+            ("gpu", gpu),
+            ("silicon", apple_silicon),
+            ("aarch64", aarch64),
+        )
+        if enabled
+    ]
+    if len(selected_variants) > 1:
+        raise ValueError(
+            "Only one Spark NLP hardware variant can be enabled: "
+            "gpu, apple_silicon, or aarch64."
+        )
+
+    normalized_version = str(pyspark_version)
+    version_match = _RELEASE_VERSION_PATTERN.fullmatch(normalized_version)
+    if version_match is None:
+        raise _unsupported_pyspark_version(normalized_version)
+
+    spark_major = int(version_match.group(1))
+    if spark_major == 3:
+        scala_binary_version = "2.12"
+        profile_suffix = ""
+    elif normalized_version == "4.0.0":
+        scala_binary_version = "2.13"
+        profile_suffix = "-spark400"
+    elif normalized_version in SUPPORTED_FORWARD_SPARK4_VERSIONS:
+        scala_binary_version = "2.13"
+        profile_suffix = ""
+    else:
+        raise _unsupported_pyspark_version(normalized_version)
+
+    variant = selected_variants[0] if selected_variants else "cpu"
+    artifact = f"{_VARIANT_ARTIFACTS[variant]}{profile_suffix}_{scala_binary_version}"
+    return f"com.johnsnowlabs.nlp:{artifact}:{spark_nlp_version}"
+
+
+def _unsupported_pyspark_version(pyspark_version):
+    supported_spark4_versions = ", ".join(
+        ["4.0.0"] + sorted(SUPPORTED_FORWARD_SPARK4_VERSIONS)
+    )
+    return ValueError(
+        f"Unsupported PySpark version '{pyspark_version}'. "
+        "Spark NLP supports Spark 3.x with Scala 2.12 and the validated "
+        f"Spark 4 versions {supported_spark4_versions} with Scala 2.13."
+    )

--- a/python/test/maven_coordinate_resolver_test.py
+++ b/python/test/maven_coordinate_resolver_test.py
@@ -19,6 +19,9 @@ import pytest
 import sparknlp
 
 
+SPARK_NLP_MAVEN_VERSION = sparknlp.__version__.split("-")[0].split("+")[0]
+
+
 class FakeHadoopConfiguration:
     def set(self, key, value):
         pass
@@ -119,9 +122,11 @@ def resolve_coordinate(*args, **kwargs):
     ],
 )
 def test_resolves_cpu_artifact_from_pyspark_version(spark_version, expected_artifact):
-    coordinate = resolve_coordinate(spark_version, "6.4.1")
+    coordinate = resolve_coordinate(spark_version, SPARK_NLP_MAVEN_VERSION)
 
-    assert coordinate == f"com.johnsnowlabs.nlp:{expected_artifact}:6.4.1"
+    assert coordinate == (
+        f"com.johnsnowlabs.nlp:{expected_artifact}:{SPARK_NLP_MAVEN_VERSION}"
+    )
 
 
 @pytest.mark.fast
@@ -135,9 +140,12 @@ def test_resolves_cpu_artifact_from_pyspark_version(spark_version, expected_arti
     ],
 )
 def test_resolves_all_spark3_hardware_variants(variant_flags, expected_base_artifact):
-    coordinate = resolve_coordinate("3.5.8", "6.4.1", **variant_flags)
+    coordinate = resolve_coordinate("3.5.8", SPARK_NLP_MAVEN_VERSION, **variant_flags)
 
-    assert coordinate == f"com.johnsnowlabs.nlp:{expected_base_artifact}_2.12:6.4.1"
+    assert coordinate == (
+        f"com.johnsnowlabs.nlp:{expected_base_artifact}_2.12:"
+        f"{SPARK_NLP_MAVEN_VERSION}"
+    )
 
 
 @pytest.mark.fast
@@ -151,10 +159,11 @@ def test_resolves_all_spark3_hardware_variants(variant_flags, expected_base_arti
     ],
 )
 def test_resolves_all_spark400_hardware_variants(variant_flags, expected_base_artifact):
-    coordinate = resolve_coordinate("4.0.0", "6.4.1", **variant_flags)
+    coordinate = resolve_coordinate("4.0.0", SPARK_NLP_MAVEN_VERSION, **variant_flags)
 
     assert coordinate == (
-        f"com.johnsnowlabs.nlp:{expected_base_artifact}-spark400_2.13:6.4.1"
+        f"com.johnsnowlabs.nlp:{expected_base_artifact}-spark400_2.13:"
+        f"{SPARK_NLP_MAVEN_VERSION}"
     )
 
 
@@ -171,9 +180,12 @@ def test_resolves_all_spark400_hardware_variants(variant_flags, expected_base_ar
 def test_resolves_all_forward_spark4_hardware_variants(
     variant_flags, expected_base_artifact
 ):
-    coordinate = resolve_coordinate("4.1.2", "6.4.1", **variant_flags)
+    coordinate = resolve_coordinate("4.1.2", SPARK_NLP_MAVEN_VERSION, **variant_flags)
 
-    assert coordinate == f"com.johnsnowlabs.nlp:{expected_base_artifact}_2.13:6.4.1"
+    assert coordinate == (
+        f"com.johnsnowlabs.nlp:{expected_base_artifact}_2.13:"
+        f"{SPARK_NLP_MAVEN_VERSION}"
+    )
 
 
 @pytest.mark.fast
@@ -183,7 +195,7 @@ def test_resolves_all_forward_spark4_hardware_variants(
 )
 def test_rejects_unsupported_or_unvalidated_pyspark_versions(spark_version):
     with pytest.raises(ValueError, match="Unsupported PySpark version"):
-        resolve_coordinate(spark_version, "6.4.1")
+        resolve_coordinate(spark_version, SPARK_NLP_MAVEN_VERSION)
 
 
 @pytest.mark.fast
@@ -192,8 +204,9 @@ def test_normalizes_version_like_objects_before_comparison():
         def __str__(self):
             return "4.0.0"
 
-    assert resolve_coordinate(VersionLike(), "6.4.1") == (
-        "com.johnsnowlabs.nlp:spark-nlp-spark400_2.13:6.4.1"
+    assert resolve_coordinate(VersionLike(), SPARK_NLP_MAVEN_VERSION) == (
+        "com.johnsnowlabs.nlp:spark-nlp-spark400_2.13:"
+        f"{SPARK_NLP_MAVEN_VERSION}"
     )
 
 
@@ -204,7 +217,10 @@ def test_start_does_not_expose_manual_scala_selector():
 
 @pytest.mark.fast
 def test_start_uses_resolver_coordinate_for_standard_session(monkeypatch):
-    coordinate = "com.johnsnowlabs.nlp:spark-nlp-spark400_2.13:6.4.1"
+    coordinate = (
+        "com.johnsnowlabs.nlp:spark-nlp-spark400_2.13:"
+        f"{SPARK_NLP_MAVEN_VERSION}"
+    )
     calls = []
 
     def fake_resolver(*args, **kwargs):
@@ -220,7 +236,7 @@ def test_start_uses_resolver_coordinate_for_standard_session(monkeypatch):
 
     assert calls == [
         (
-            ("4.0.0", "6.4.1"),
+            ("4.0.0", SPARK_NLP_MAVEN_VERSION),
             {
                 "gpu": False,
                 "apple_silicon": False,
@@ -233,7 +249,10 @@ def test_start_uses_resolver_coordinate_for_standard_session(monkeypatch):
 
 @pytest.mark.fast
 def test_start_uses_resolver_coordinate_for_realtime_session(monkeypatch):
-    coordinate = "com.johnsnowlabs.nlp:spark-nlp-gpu_2.13:6.4.1"
+    coordinate = (
+        "com.johnsnowlabs.nlp:spark-nlp-gpu_2.13:"
+        f"{SPARK_NLP_MAVEN_VERSION}"
+    )
     calls = []
 
     def fake_resolver(*args, **kwargs):
@@ -258,7 +277,7 @@ def test_start_uses_resolver_coordinate_for_realtime_session(monkeypatch):
 
     assert calls == [
         (
-            ("4.1.2", "6.4.1"),
+            ("4.1.2", SPARK_NLP_MAVEN_VERSION),
             {
                 "gpu": True,
                 "apple_silicon": False,
@@ -312,7 +331,7 @@ def test_skip_maven_param_bypasses_runtime_resolution(monkeypatch):
 
 @pytest.mark.fast
 def test_start_merges_resolved_coordinate_with_caller_packages(monkeypatch):
-    coordinate = "com.johnsnowlabs.nlp:spark-nlp_2.13:6.4.1"
+    coordinate = f"com.johnsnowlabs.nlp:spark-nlp_2.13:{SPARK_NLP_MAVEN_VERSION}"
     caller_package = "org.example:extra-package_2.13:1.0.0"
 
     FakeSparkSession.builder = FakeBuilder()
@@ -334,4 +353,6 @@ def test_start_merges_resolved_coordinate_with_caller_packages(monkeypatch):
 @pytest.mark.fast
 def test_rejects_conflicting_hardware_variants():
     with pytest.raises(ValueError, match="Only one Spark NLP hardware variant"):
-        resolve_coordinate("4.0.1", "6.4.1", gpu=True, apple_silicon=True)
+        resolve_coordinate(
+            "4.0.1", SPARK_NLP_MAVEN_VERSION, gpu=True, apple_silicon=True
+        )

--- a/python/test/maven_coordinate_resolver_test.py
+++ b/python/test/maven_coordinate_resolver_test.py
@@ -1,0 +1,337 @@
+#  Copyright 2017-2026 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+import sparknlp
+
+
+class FakeHadoopConfiguration:
+    def set(self, key, value):
+        pass
+
+
+class FakeJsc:
+    def hadoopConfiguration(self):
+        return FakeHadoopConfiguration()
+
+
+class FakeSparkContext:
+    def __init__(self, gateway=None):
+        self.gateway = gateway
+        self._jsc = FakeJsc()
+
+
+class FakeSparkSessionInstance:
+    def __init__(self, spark_context=None):
+        self.sparkContext = spark_context or FakeSparkContext()
+
+
+class FakeBuilder:
+    def __init__(self):
+        self.settings = {}
+
+    def appName(self, value):
+        self.settings["spark.app.name"] = value
+        return self
+
+    def master(self, value):
+        self.settings["spark.master"] = value
+        return self
+
+    def config(self, key, value):
+        self.settings[key] = value
+        return self
+
+    def getOrCreate(self):
+        return FakeSparkSessionInstance()
+
+
+class FakeSparkSession:
+    _instantiatedSession = None
+    builder = FakeBuilder()
+
+    def __new__(cls, spark_context=None):
+        return FakeSparkSessionInstance(spark_context)
+
+
+class FakeSparkConf:
+    latest = None
+
+    def __init__(self):
+        self.settings = {}
+        type(self).latest = self
+
+    def setAppName(self, value):
+        self.settings["spark.app.name"] = value
+        return self
+
+    def setMaster(self, value):
+        self.settings["spark.master"] = value
+        return self
+
+    def set(self, key, value):
+        self.settings[key] = value
+        return self
+
+
+class FakeThread:
+    def __init__(self, target):
+        self.target = target
+
+    def start(self):
+        pass
+
+    def join(self):
+        pass
+
+
+def resolve_coordinate(*args, **kwargs):
+    from sparknlp._maven import resolve_spark_nlp_coordinate
+
+    return resolve_spark_nlp_coordinate(*args, **kwargs)
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "spark_version,expected_artifact",
+    [
+        ("3.0.0", "spark-nlp_2.12"),
+        ("3.5.6", "spark-nlp_2.12"),
+        ("4.0.0", "spark-nlp-spark400_2.13"),
+        ("4.0.1", "spark-nlp_2.13"),
+        ("4.1.0", "spark-nlp_2.13"),
+        ("4.1.1", "spark-nlp_2.13"),
+        ("4.1.2", "spark-nlp_2.13"),
+    ],
+)
+def test_resolves_cpu_artifact_from_pyspark_version(spark_version, expected_artifact):
+    coordinate = resolve_coordinate(spark_version, "6.4.1")
+
+    assert coordinate == f"com.johnsnowlabs.nlp:{expected_artifact}:6.4.1"
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "variant_flags,expected_base_artifact",
+    [
+        ({}, "spark-nlp"),
+        ({"gpu": True}, "spark-nlp-gpu"),
+        ({"apple_silicon": True}, "spark-nlp-silicon"),
+        ({"aarch64": True}, "spark-nlp-aarch64"),
+    ],
+)
+def test_resolves_all_spark3_hardware_variants(variant_flags, expected_base_artifact):
+    coordinate = resolve_coordinate("3.5.8", "6.4.1", **variant_flags)
+
+    assert coordinate == f"com.johnsnowlabs.nlp:{expected_base_artifact}_2.12:6.4.1"
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "variant_flags,expected_base_artifact",
+    [
+        ({}, "spark-nlp"),
+        ({"gpu": True}, "spark-nlp-gpu"),
+        ({"apple_silicon": True}, "spark-nlp-silicon"),
+        ({"aarch64": True}, "spark-nlp-aarch64"),
+    ],
+)
+def test_resolves_all_spark400_hardware_variants(variant_flags, expected_base_artifact):
+    coordinate = resolve_coordinate("4.0.0", "6.4.1", **variant_flags)
+
+    assert coordinate == (
+        f"com.johnsnowlabs.nlp:{expected_base_artifact}-spark400_2.13:6.4.1"
+    )
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "variant_flags,expected_base_artifact",
+    [
+        ({}, "spark-nlp"),
+        ({"gpu": True}, "spark-nlp-gpu"),
+        ({"apple_silicon": True}, "spark-nlp-silicon"),
+        ({"aarch64": True}, "spark-nlp-aarch64"),
+    ],
+)
+def test_resolves_all_forward_spark4_hardware_variants(
+    variant_flags, expected_base_artifact
+):
+    coordinate = resolve_coordinate("4.1.2", "6.4.1", **variant_flags)
+
+    assert coordinate == f"com.johnsnowlabs.nlp:{expected_base_artifact}_2.13:6.4.1"
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "spark_version",
+    ["2.4.8", "4.0.2", "4.2.0", "5.0.0", "4.0.0.dev1", "invalid"],
+)
+def test_rejects_unsupported_or_unvalidated_pyspark_versions(spark_version):
+    with pytest.raises(ValueError, match="Unsupported PySpark version"):
+        resolve_coordinate(spark_version, "6.4.1")
+
+
+@pytest.mark.fast
+def test_normalizes_version_like_objects_before_comparison():
+    class VersionLike:
+        def __str__(self):
+            return "4.0.0"
+
+    assert resolve_coordinate(VersionLike(), "6.4.1") == (
+        "com.johnsnowlabs.nlp:spark-nlp-spark400_2.13:6.4.1"
+    )
+
+
+@pytest.mark.fast
+def test_start_does_not_expose_manual_scala_selector():
+    assert "scala213" not in inspect.signature(sparknlp.start).parameters
+
+
+@pytest.mark.fast
+def test_start_uses_resolver_coordinate_for_standard_session(monkeypatch):
+    coordinate = "com.johnsnowlabs.nlp:spark-nlp-spark400_2.13:6.4.1"
+    calls = []
+
+    def fake_resolver(*args, **kwargs):
+        calls.append((args, kwargs))
+        return coordinate
+
+    FakeSparkSession.builder = FakeBuilder()
+    monkeypatch.setattr(sparknlp, "pyspark_version", "4.0.0")
+    monkeypatch.setattr(sparknlp, "resolve_spark_nlp_coordinate", fake_resolver)
+    monkeypatch.setattr(sparknlp, "SparkSession", FakeSparkSession)
+
+    sparknlp.start()
+
+    assert calls == [
+        (
+            ("4.0.0", "6.4.1"),
+            {
+                "gpu": False,
+                "apple_silicon": False,
+                "aarch64": False,
+            },
+        )
+    ]
+    assert FakeSparkSession.builder.settings["spark.jars.packages"] == coordinate
+
+
+@pytest.mark.fast
+def test_start_uses_resolver_coordinate_for_realtime_session(monkeypatch):
+    coordinate = "com.johnsnowlabs.nlp:spark-nlp-gpu_2.13:6.4.1"
+    calls = []
+
+    def fake_resolver(*args, **kwargs):
+        calls.append((args, kwargs))
+        return coordinate
+
+    process = SimpleNamespace(
+        stdout=SimpleNamespace(readline=lambda: b""),
+        stderr=SimpleNamespace(readline=lambda: b""),
+    )
+    gateway = SimpleNamespace(proc=process)
+
+    monkeypatch.setattr(sparknlp, "pyspark_version", "4.1.2")
+    monkeypatch.setattr(sparknlp, "resolve_spark_nlp_coordinate", fake_resolver)
+    monkeypatch.setattr(sparknlp, "SparkConf", FakeSparkConf)
+    monkeypatch.setattr(sparknlp, "SparkContext", FakeSparkContext)
+    monkeypatch.setattr(sparknlp, "SparkSession", FakeSparkSession)
+    monkeypatch.setattr(sparknlp, "launch_gateway", lambda **kwargs: gateway)
+    monkeypatch.setattr(sparknlp.threading, "Thread", FakeThread)
+
+    session = sparknlp.start(gpu=True, real_time_output=True)
+
+    assert calls == [
+        (
+            ("4.1.2", "6.4.1"),
+            {
+                "gpu": True,
+                "apple_silicon": False,
+                "aarch64": False,
+            },
+        )
+    ]
+    assert isinstance(session, FakeSparkSessionInstance)
+    assert FakeSparkConf.latest is not None
+    assert FakeSparkConf.latest.settings["spark.jars.packages"] == coordinate
+
+
+@pytest.mark.fast
+def test_skip_maven_bypasses_runtime_resolution(monkeypatch):
+    def unexpected_resolver(*args, **kwargs):
+        raise AssertionError("Resolver must not run when Maven injection is disabled")
+
+    FakeSparkSession.builder = FakeBuilder()
+    monkeypatch.setattr(sparknlp, "resolve_spark_nlp_coordinate", unexpected_resolver)
+    monkeypatch.setattr(sparknlp, "SparkSession", FakeSparkSession)
+
+    sparknlp.start(
+        params={"spark.jars": "/tmp/sparknlp.jar"},
+        skip_sparknlp_maven=True,
+    )
+
+    assert "spark.jars.packages" not in FakeSparkSession.builder.settings
+    assert FakeSparkSession.builder.settings["spark.jars"] == "/tmp/sparknlp.jar"
+
+
+@pytest.mark.fast
+def test_skip_maven_param_bypasses_runtime_resolution(monkeypatch):
+    def unexpected_resolver(*args, **kwargs):
+        raise AssertionError("Resolver must not run when Maven injection is disabled")
+
+    FakeSparkSession.builder = FakeBuilder()
+    monkeypatch.setattr(sparknlp, "resolve_spark_nlp_coordinate", unexpected_resolver)
+    monkeypatch.setattr(sparknlp, "SparkSession", FakeSparkSession)
+
+    sparknlp.start(
+        params={
+            "spark.jars": "/tmp/sparknlp.jar",
+            "skip_sparknlp_maven": "true",
+        }
+    )
+
+    assert "spark.jars.packages" not in FakeSparkSession.builder.settings
+    assert FakeSparkSession.builder.settings["spark.jars"] == "/tmp/sparknlp.jar"
+    assert "skip_sparknlp_maven" not in FakeSparkSession.builder.settings
+
+
+@pytest.mark.fast
+def test_start_merges_resolved_coordinate_with_caller_packages(monkeypatch):
+    coordinate = "com.johnsnowlabs.nlp:spark-nlp_2.13:6.4.1"
+    caller_package = "org.example:extra-package_2.13:1.0.0"
+
+    FakeSparkSession.builder = FakeBuilder()
+    monkeypatch.setattr(sparknlp, "pyspark_version", "4.0.1")
+    monkeypatch.setattr(
+        sparknlp,
+        "resolve_spark_nlp_coordinate",
+        lambda *args, **kwargs: coordinate,
+    )
+    monkeypatch.setattr(sparknlp, "SparkSession", FakeSparkSession)
+
+    sparknlp.start(params={"spark.jars.packages": caller_package})
+
+    assert FakeSparkSession.builder.settings["spark.jars.packages"] == (
+        coordinate + "," + caller_package
+    )
+
+
+@pytest.mark.fast
+def test_rejects_conflicting_hardware_variants():
+    with pytest.raises(ValueError, match="Only one Spark NLP hardware variant"):
+        resolve_coordinate("4.0.1", "6.4.1", gpu=True, apple_silicon=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds explicit updates to `sparknlp.start()` to select the matching Spark NLP Maven artifact from the installed PySpark version.

The Python API uses the same compatibility matrix automatically:

- Spark 3.x resolves to the existing Scala 2.12 artifacts.
- Spark 4.0.0 resolves to the dedicated `spark400` Scala 2.13 artifacts.
- Spark 4.0.1, 4.1.0, 4.1.1, and 4.1.2 resolve to the default Scala 2.13 artifacts.

This removes the manual `scala213` selector while preserving local/custom JAR workflows through `skip_sparknlp_maven`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Spark NLP should continue publishing one Python wheel without requiring users to understand Scala binary versions or select an internal build profile. Resolving the Maven coordinate from the installed PySpark version keeps the Python API simple, preserves Spark 3 compatibility, and prevents a Spark runtime from loading an incompatible Spark NLP artifact.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
