### PR TITLE
[Spark 4.x] [SPARKNLP-1153] Add PairwiseVectorSimilarity annotator

### DIFF
--- a/docs/en/annotator_entries/PairwiseVectorSimilarity.md
+++ b/docs/en/annotator_entries/PairwiseVectorSimilarity.md
@@ -1,0 +1,216 @@
+{%- capture title -%}
+PairwiseVectorSimilarity
+{%- endcapture -%}
+
+{%- capture description -%}
+Computes pairwise vector similarity between two sets of sentence embeddings.
+
+The annotator takes two `SENTENCE_EMBEDDINGS` input columns and, for every row, scores all N x M
+pairs between the embeddings in column A and the embeddings in column B. Each pair produces one
+`VECTOR_SIMILARITY` output annotation whose `result` holds the score as a string and whose
+`metadata` contains the following fields for easy downstream extraction:
+
+{:.table-model-big}
+| metadata key | value |
+|---|---|
+| `sentence_a_idx` | 0-based index of the embedding in column A |
+| `sentence_b_idx` | 0-based index of the embedding in column B |
+| `sentence_a_text` | the `.result` text of the source annotation in column A |
+| `sentence_b_text` | the `.result` text of the source annotation in column B |
+| `similarity` | the score (same as `result`, available by name) |
+| `similarityMethod` | the method used to compute the score |
+
+**Parameters:**
+
+{:.table-model-big}
+| Parameter | Description | Default |
+|---|---|---|
+| `similarityMethod` | Similarity function: `cosine`, `dotProduct`, or `euclidean` | `"cosine"` |
+
+**Supported similarity methods and sign conventions:**
+
+{:.table-model-big}
+| method | range | higher means |
+|---|---|---|
+| `cosine` (default) | -1.0 to 1.0 | more similar |
+| `dotProduct` | no fixed bound | more similar |
+| `euclidean` | negative infinity to 0.0 | more similar (0.0 means identical vectors) |
+
+The `euclidean` method returns the negative L2 distance so that "higher is better" is consistent
+across all three methods.
+
+**Input data shape.** For standard document retrieval each input column should contain exactly one
+embedding per row. If a column contains N > 1 embeddings (produced by a sentence-split pipeline),
+all N x M cross-pairs are scored and emitted as separate annotations.
+
+**LightPipeline is not supported.** Because `LightPipeline` merges all input columns into a single
+flat sequence, the two-column distinction required by this annotator cannot be preserved. Use
+`transform()` on a Spark DataFrame instead.
+
+**Prerequisite: crossJoin.** To score every query against every document, join a query DataFrame
+and a corpus DataFrame before applying the annotator:
+
+```python
+paired = query_df.crossJoin(corpus_df)
+```
+
+For extended examples and a full RAG-style retrieval pattern see the
+[PairwiseVectorSimilarity notebook](https://github.com/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-similarity/PairwiseVectorSimilarity.ipynb).
+{%- endcapture -%}
+
+{%- capture input_anno -%}
+SENTENCE_EMBEDDINGS, SENTENCE_EMBEDDINGS
+{%- endcapture -%}
+
+{%- capture output_anno -%}
+VECTOR_SIMILARITY
+{%- endcapture -%}
+
+{%- capture python_example -%}
+import sparknlp
+from sparknlp.base import *
+from sparknlp.annotator import *
+from pyspark.ml import Pipeline
+from pyspark.sql.functions import col, desc, explode
+
+# Produce sentence embeddings with any Spark NLP embedding model.
+# Here we use a pretrained BGE model as an example.
+document_assembler = DocumentAssembler() \
+    .setInputCol("text") \
+    .setOutputCol("document")
+
+embeddings = BGEEmbeddings.pretrained("bge_small_en_v1.5") \
+    .setInputCols(["document"]) \
+    .setOutputCol("embeddings")
+
+embedding_pipeline = Pipeline(stages=[document_assembler, embeddings])
+
+queries = spark.createDataFrame([
+    ("What is the capital of France?",),
+    ("How does photosynthesis work?",),
+], ["text"])
+
+corpus = spark.createDataFrame([
+    ("Paris is the capital and largest city of France.",),
+    ("Photosynthesis is the process by which plants convert sunlight into energy.",),
+    ("The Eiffel Tower is located in Paris, France.",),
+    ("Chlorophyll is the pigment that gives plants their green color.",),
+], ["text"])
+
+query_df = embedding_pipeline.fit(queries).transform(queries) \
+    .select(col("embeddings").alias("query_emb"))
+corpus_df = embedding_pipeline.fit(corpus).transform(corpus) \
+    .select(col("embeddings").alias("doc_emb"), col("text").alias("doc_text"))
+
+# CrossJoin to produce one (query, document) pair per row, then score.
+paired = query_df.crossJoin(corpus_df)
+
+pvs = PairwiseVectorSimilarity() \
+    .setInputCols(["query_emb", "doc_emb"]) \
+    .setOutputCol("similarity") \
+    .setSimilarityMethod("cosine")
+
+pvs.transform(paired) \
+    .select(explode(col("similarity")).alias("s")) \
+    .select(
+        col("s.metadata")["sentence_a_text"].alias("query"),
+        col("s.metadata")["sentence_b_text"].alias("document"),
+        col("s.result").cast("double").alias("score")) \
+    .orderBy(desc("score")) \
+    .show(truncate=False)
++-------------------------------+---------------------------------------------------------------------------+------------------+
+|query                          |document                                                                   |score             |
++-------------------------------+---------------------------------------------------------------------------+------------------+
+|What is the capital of France? |Paris is the capital and largest city of France.                           |0.9321...         |
+|What is the capital of France? |The Eiffel Tower is located in Paris, France.                              |0.8764...         |
+|How does photosynthesis work?  |Photosynthesis is the process by which plants convert sunlight into energy.|0.9105...         |
+|How does photosynthesis work?  |Chlorophyll is the pigment that gives plants their green color.             |0.8231...         |
++-------------------------------+---------------------------------------------------------------------------+------------------+
+{%- endcapture -%}
+
+{%- capture scala_example -%}
+import com.johnsnowlabs.nlp.base.DocumentAssembler
+import com.johnsnowlabs.nlp.annotators.similarity.PairwiseVectorSimilarity
+import com.johnsnowlabs.nlp.embeddings.BGEEmbeddings
+import org.apache.spark.ml.Pipeline
+import org.apache.spark.sql.functions.{col, desc, explode}
+
+import spark.implicits._
+
+// Produce sentence embeddings with any Spark NLP embedding model.
+val documentAssembler = new DocumentAssembler()
+  .setInputCol("text")
+  .setOutputCol("document")
+
+val embeddings = BGEEmbeddings.pretrained("bge_small_en_v1.5")
+  .setInputCols("document")
+  .setOutputCol("embeddings")
+
+val embeddingPipeline = new Pipeline()
+  .setStages(Array(documentAssembler, embeddings))
+
+val queries = Seq(
+  "What is the capital of France?",
+  "How does photosynthesis work?").toDF("text")
+
+val corpus = Seq(
+  "Paris is the capital and largest city of France.",
+  "Photosynthesis is the process by which plants convert sunlight into energy.",
+  "The Eiffel Tower is located in Paris, France.",
+  "Chlorophyll is the pigment that gives plants their green color.").toDF("text")
+
+val queryDf = embeddingPipeline.fit(queries).transform(queries)
+  .select(col("embeddings").as("query_emb"))
+
+val corpusDf = embeddingPipeline.fit(corpus).transform(corpus)
+  .select(col("embeddings").as("doc_emb"), col("text").as("doc_text"))
+
+// CrossJoin to produce one (query, document) pair per row, then score.
+val paired = queryDf.crossJoin(corpusDf)
+
+val pvs = new PairwiseVectorSimilarity()
+  .setInputCols("query_emb", "doc_emb")
+  .setOutputCol("similarity")
+  .setSimilarityMethod("cosine")
+
+pvs.transform(paired)
+  .select(explode(col("similarity")).as("s"))
+  .select(
+    col("s.metadata")("sentence_a_text").as("query"),
+    col("s.metadata")("sentence_b_text").as("document"),
+    col("s.result").cast("double").as("score"))
+  .orderBy(desc("score"))
+  .show(truncate = false)
++-------------------------------+---------------------------------------------------------------------------+------------------+
+|query                          |document                                                                   |score             |
++-------------------------------+---------------------------------------------------------------------------+------------------+
+|What is the capital of France? |Paris is the capital and largest city of France.                           |0.9321...         |
+|What is the capital of France? |The Eiffel Tower is located in Paris, France.                              |0.8764...         |
+|How does photosynthesis work?  |Photosynthesis is the process by which plants convert sunlight into energy.|0.9105...         |
+|How does photosynthesis work?  |Chlorophyll is the pigment that gives plants their green color.             |0.8231...         |
++-------------------------------+---------------------------------------------------------------------------+------------------+
+{%- endcapture -%}
+
+{%- capture api_link -%}
+[PairwiseVectorSimilarity](/api/com/johnsnowlabs/nlp/annotators/similarity/PairwiseVectorSimilarity)
+{%- endcapture -%}
+
+{%- capture python_api_link -%}
+[PairwiseVectorSimilarity](/api/python/reference/autosummary/sparknlp/annotator/similarity/pairwise_vector_similarity/index.html#sparknlp.annotator.similarity.pairwise_vector_similarity.PairwiseVectorSimilarity)
+{%- endcapture -%}
+
+{%- capture source_link -%}
+[PairwiseVectorSimilarity](https://github.com/JohnSnowLabs/spark-nlp/tree/master/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/PairwiseVectorSimilarity.scala)
+{%- endcapture -%}
+
+{% include templates/anno_template.md
+title=title
+description=description
+input_anno=input_anno
+output_anno=output_anno
+python_example=python_example
+scala_example=scala_example
+python_api_link=python_api_link
+api_link=api_link
+source_link=source_link
+%}

--- a/docs/en/annotators.md
+++ b/docs/en/annotators.md
@@ -90,6 +90,7 @@ There are two types of Annotators:
 {% include templates/anno_table_entry.md path="" name="NerOverwriter" summary="Overwrites entities of specified strings."%}
 {% include templates/anno_table_entry.md path="" name="Normalizer" summary="Removes all dirty characters from text following a regex pattern and transforms words based on a provided dictionary."%}
 {% include templates/anno_table_entry.md path="" name="NorvigSweeting Spellchecker" summary="Retrieves tokens and makes corrections automatically if not found in an English dictionary."%}
+{% include templates/anno_table_entry.md path="" name="PairwiseVectorSimilarity" summary="Computes pairwise cosine, dot-product, or euclidean similarity between two sets of sentence embeddings."%}
 {% include templates/anno_table_entry.md path="" name="POSTagger (Part of speech tagger)" summary="Averaged Perceptron model to tag words part-of-speech."%}
 {% include templates/anno_table_entry.md path="" name="PromptAssembler" summary="Assembles a sequence of messages into a single string using a template."%}
 {% include templates/anno_table_entry.md path="" name="Reader2Doc" summary="Reads documents from files or directories and outputs structured text for NLP pipelines."%}

--- a/examples/python/annotation/text/english/text-similarity/PairwiseVectorSimilarity.ipynb
+++ b/examples/python/annotation/text/english/text-similarity/PairwiseVectorSimilarity.ipynb
@@ -1,0 +1,844 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "v_IKugaXgB9O"
+      },
+      "source": [
+        "![JohnSnowLabs](https://sparknlp.org/assets/images/logo.png)\n",
+        "\n",
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/JohnSnowLabs/spark-nlp/blob/master/examples/python/annotation/text/english/text-similarity/PairwiseVectorSimilarity.ipynb)\n",
+        "\n",
+        "# PairwiseVectorSimilarity\n",
+        "\n",
+        "`PairwiseVectorSimilarity` is a Spark NLP annotator that scores every pair of sentence\n",
+        "embeddings across two input columns. Given N embeddings in column A and M embeddings in\n",
+        "column B, it computes all N x M scores in a single `transform()` call and returns one\n",
+        "`VECTOR_SIMILARITY` annotation per pair.\n",
+        "\n",
+        "**Typical use cases**\n",
+        "\n",
+        "| Pattern | Setup |\n",
+        "|---|---|\n",
+        "| Query vs corpus (retrieval) | CrossJoin a query DataFrame with a corpus DataFrame, then transform |\n",
+        "| Sentence-level document pairs | Use a sentence-split pipeline; the annotator scores all sentence cross-pairs per row |\n",
+        "| Two-stage retrieval | BM25 narrows the candidate set; vector similarity re-ranks them |\n",
+        "\n",
+        "**Similarity methods**\n",
+        "\n",
+        "| method | range | higher means |\n",
+        "|---|---|---|\n",
+        "| `cosine` (default) | -1.0 to 1.0 | more similar |\n",
+        "| `dotProduct` | unbounded | more similar |\n",
+        "| `euclidean` | (-inf, 0.0] | more similar (0.0 = identical) |\n",
+        "\n",
+        "The `euclidean` method returns the negative L2 distance so that higher is always better\n",
+        "regardless of which method you choose.\n",
+        "\n",
+        "This notebook covers:\n",
+        "1. Embedding a query set and a document corpus with a pretrained model\n",
+        "2. Scoring all query-document pairs and ranking results per query\n",
+        "3. Comparing the three similarity methods on the same data\n",
+        "4. Scoring sentence-level pairs (multiple embeddings per row)\n",
+        "5. Two-stage retrieval: BM25 candidate filtering followed by vector re-ranking\n",
+        "6. Inspecting the full annotation output and metadata fields"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Vf1H3c8vgB9Q"
+      },
+      "outputs": [],
+      "source": [
+        "# Only run this cell when you are using Spark NLP on Google Colab\n",
+        "!wget http://setup.johnsnowlabs.com/colab.sh -O - | bash"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "nNlN8AU1gB9S"
+      },
+      "outputs": [],
+      "source": [
+        "import sparknlp\n",
+        "from sparknlp.base import DocumentAssembler\n",
+        "from sparknlp.annotator import (\n",
+        "    BM25Approach, E5Embeddings, PairwiseVectorSimilarity,\n",
+        "    SentenceDetector, StopWordsCleaner, Tokenizer,\n",
+        ")\n",
+        "from pyspark.ml import Pipeline\n",
+        "from pyspark.sql import functions as F\n",
+        "from pyspark.sql.window import Window\n",
+        "\n",
+        "spark = sparknlp.start()\n",
+        "\n",
+        "print(\"Spark NLP version :\", sparknlp.version())\n",
+        "print(\"Apache Spark version:\", spark.version)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RCbFYx9hgB9T"
+      },
+      "source": [
+        "## 1. Sample data\n",
+        "\n",
+        "A corpus of twelve sentences spanning four topics (nutrition, machine learning, travel,\n",
+        "astronomy) and four queries, one per topic.\n",
+        "This diversity makes it easy to see whether the annotator retrieves topically relevant\n",
+        "documents at the top of the ranking."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "8vHanoKwgB9T",
+        "outputId": "8736b6dc-88c6-49d0-da59-ec8ba52c3eea"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Corpus:\n",
+            "+---+---------------------------------------------------------------------------+\n",
+            "| id|                                                                       text|\n",
+            "+---+---------------------------------------------------------------------------+\n",
+            "|  1|                     Apples and oranges are excellent sources of vitamin C.|\n",
+            "|  2|   Bananas are rich in potassium, which supports heart and muscle function.|\n",
+            "|  3|    A diet high in fiber helps regulate blood sugar and cholesterol levels.|\n",
+            "|  4|Machine learning is a branch of artificial intelligence that learns from...|\n",
+            "|  5|  Deep learning uses multi-layer neural networks to model complex patterns.|\n",
+            "|  6|Transformers are a neural network architecture that rely on self-attention.|\n",
+            "|  7|  Florence is a city in Tuscany known for Renaissance art and architecture.|\n",
+            "|  8|  The Amalfi Coast in southern Italy is one of Europe's most scenic drives.|\n",
+            "|  9|Kyoto offers ancient temples, bamboo forests, and traditional tea ceremo...|\n",
+            "| 10|    The James Webb Space Telescope observes the universe in infrared light.|\n",
+            "| 11|      Black holes form when massive stars collapse under their own gravity.|\n",
+            "| 12|       The Milky Way galaxy contains an estimated 100 to 400 billion stars.|\n",
+            "+---+---------------------------------------------------------------------------+\n",
+            "\n",
+            "Queries:\n",
+            "+---+-------------------------------------------------+\n",
+            "|qid|                                             text|\n",
+            "+---+-------------------------------------------------+\n",
+            "| q1|     Which fruits and foods are high in vitamins?|\n",
+            "| q2|      How do neural networks process information?|\n",
+            "| q3|Best destinations for cultural tourism in Europe.|\n",
+            "| q4|     Recent discoveries about stars and galaxies.|\n",
+            "+---+-------------------------------------------------+\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "corpus = spark.createDataFrame([\n",
+        "    (1,  \"Apples and oranges are excellent sources of vitamin C.\"),\n",
+        "    (2,  \"Bananas are rich in potassium, which supports heart and muscle function.\"),\n",
+        "    (3,  \"A diet high in fiber helps regulate blood sugar and cholesterol levels.\"),\n",
+        "    (4,  \"Machine learning is a branch of artificial intelligence that learns from data.\"),\n",
+        "    (5,  \"Deep learning uses multi-layer neural networks to model complex patterns.\"),\n",
+        "    (6,  \"Transformers are a neural network architecture that rely on self-attention.\"),\n",
+        "    (7,  \"Florence is a city in Tuscany known for Renaissance art and architecture.\"),\n",
+        "    (8,  \"The Amalfi Coast in southern Italy is one of Europe's most scenic drives.\"),\n",
+        "    (9,  \"Kyoto offers ancient temples, bamboo forests, and traditional tea ceremonies.\"),\n",
+        "    (10, \"The James Webb Space Telescope observes the universe in infrared light.\"),\n",
+        "    (11, \"Black holes form when massive stars collapse under their own gravity.\"),\n",
+        "    (12, \"The Milky Way galaxy contains an estimated 100 to 400 billion stars.\"),\n",
+        "], [\"id\", \"text\"])\n",
+        "\n",
+        "queries = spark.createDataFrame([\n",
+        "    (\"q1\", \"Which fruits and foods are high in vitamins?\"),\n",
+        "    (\"q2\", \"How do neural networks process information?\"),\n",
+        "    (\"q3\", \"Best destinations for cultural tourism in Europe.\"),\n",
+        "    (\"q4\", \"Recent discoveries about stars and galaxies.\"),\n",
+        "], [\"qid\", \"text\"])\n",
+        "\n",
+        "print(\"Corpus:\")\n",
+        "corpus.show(truncate=75)\n",
+        "print(\"Queries:\")\n",
+        "queries.show(truncate=75)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OJGYtspHgB9T"
+      },
+      "source": [
+        "## 2. Embedding pipeline\n",
+        "\n",
+        "`e5_small_v2` is a 33 MB sentence embedding model that produces 384-dimensional\n",
+        "`SENTENCE_EMBEDDINGS` directly from a `DOCUMENT` input — no tokenizer or pooling stage\n",
+        "required. The same fitted pipeline is reused to embed both the corpus and the queries."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "CHM1m2zsgB9U",
+        "outputId": "e04a423c-9eca-46fa-acc3-34b2b268d97b"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "e5_small_v2 download started this may take some time.\n",
+            "Approximate size to download 76.2 MB\n",
+            "[OK!]\n",
+            "Embedding dimension: 384\n"
+          ]
+        }
+      ],
+      "source": [
+        "doc_assembler = DocumentAssembler() \\\n",
+        "    .setInputCol(\"text\") \\\n",
+        "    .setOutputCol(\"document\")\n",
+        "\n",
+        "embeddings = E5Embeddings.pretrained(\"e5_small_v2\", \"en\") \\\n",
+        "    .setInputCols([\"document\"]) \\\n",
+        "    .setOutputCol(\"embeddings\")\n",
+        "\n",
+        "emb_pipeline = Pipeline(stages=[doc_assembler, embeddings])\n",
+        "emb_model = emb_pipeline.fit(corpus)\n",
+        "\n",
+        "corpus_emb = emb_model.transform(corpus).select(\n",
+        "    F.col(\"id\"), F.col(\"text\"), F.col(\"embeddings\").alias(\"doc_emb\")\n",
+        ")\n",
+        "query_emb = emb_model.transform(queries).select(\n",
+        "    F.col(\"qid\"), F.col(\"text\").alias(\"query_text\"), F.col(\"embeddings\").alias(\"query_emb\")\n",
+        ")\n",
+        "\n",
+        "dim = len(corpus_emb.select(F.explode(\"doc_emb\").alias(\"e\")).select(\"e.embeddings\").first()[0])\n",
+        "print(f\"Embedding dimension: {dim}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "-6SzCdFTgB9U"
+      },
+      "source": [
+        "## 3. Scoring all query-document pairs\n",
+        "\n",
+        "`PairwiseVectorSimilarity` processes one row at a time, so we `crossJoin` the query and\n",
+        "corpus DataFrames first. With 4 queries and 12 documents this produces 48 rows.\n",
+        "Each row gets one output annotation holding the cosine similarity score."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "M4tfuUs9gB9V",
+        "outputId": "4a050bdb-2314-4a7b-c3a7-7ba0a738f86e"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Rows after crossJoin: 48  (4 queries x 12 docs)\n",
+            "Total scored pairs: 48\n",
+            "+---+--------------------------------------------+---+------------------------------------------------------------+------+\n",
+            "|qid|                                  query_text| id|                                                    doc_text|cosine|\n",
+            "+---+--------------------------------------------+---+------------------------------------------------------------+------+\n",
+            "| q1|Which fruits and foods are high in vitamins?|  1|      Apples and oranges are excellent sources of vitamin C.| 0.865|\n",
+            "| q2| How do neural networks process information?|  5|Deep learning uses multi-layer neural networks to model c...|0.8623|\n",
+            "| q4|Recent discoveries about stars and galaxies.| 10|The James Webb Space Telescope observes the universe in i...|0.8514|\n",
+            "| q4|Recent discoveries about stars and galaxies.| 11|Black holes form when massive stars collapse under their ...|0.8486|\n",
+            "| q2| How do neural networks process information?|  6|Transformers are a neural network architecture that rely ...|0.8457|\n",
+            "| q2| How do neural networks process information?|  4|Machine learning is a branch of artificial intelligence t...|0.8425|\n",
+            "| q4|Recent discoveries about stars and galaxies.| 12|The Milky Way galaxy contains an estimated 100 to 400 bil...|0.8407|\n",
+            "| q1|Which fruits and foods are high in vitamins?|  3|A diet high in fiber helps regulate blood sugar and chole...|0.8317|\n",
+            "+---+--------------------------------------------+---+------------------------------------------------------------+------+\n",
+            "only showing top 8 rows\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "paired = query_emb.crossJoin(corpus_emb)\n",
+        "print(f\"Rows after crossJoin: {paired.count()}  (4 queries x 12 docs)\")\n",
+        "\n",
+        "pvs = PairwiseVectorSimilarity() \\\n",
+        "    .setInputCols([\"query_emb\", \"doc_emb\"]) \\\n",
+        "    .setOutputCol(\"similarity\") \\\n",
+        "    .setSimilarityMethod(\"cosine\")\n",
+        "\n",
+        "scored = (\n",
+        "    pvs.transform(paired)\n",
+        "    .select(\n",
+        "        F.col(\"qid\"),\n",
+        "        F.col(\"query_text\"),\n",
+        "        F.col(\"id\"),\n",
+        "        F.col(\"text\").alias(\"doc_text\"),\n",
+        "        F.explode(F.col(\"similarity\")).alias(\"s\"),\n",
+        "    )\n",
+        "    .select(\n",
+        "        F.col(\"qid\"),\n",
+        "        F.col(\"query_text\"),\n",
+        "        F.col(\"id\"),\n",
+        "        F.col(\"doc_text\"),\n",
+        "        F.round(F.col(\"s.result\").cast(\"double\"), 4).alias(\"cosine\"),\n",
+        "    )\n",
+        "    .cache()\n",
+        ")\n",
+        "\n",
+        "print(f\"Total scored pairs: {scored.count()}\")\n",
+        "scored.orderBy(F.desc(\"cosine\")).show(8, truncate=60)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IOwR5s1bgB9W"
+      },
+      "source": [
+        "## 4. Top-3 documents per query\n",
+        "\n",
+        "A window function ranks scored pairs within each query group so we can retrieve the\n",
+        "top-K documents in a single pass without a per-query sort.\n",
+        "The results show whether the annotator correctly groups each query with its topic."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "-lSQV15fgB9W",
+        "outputId": "7e9504d2-6b45-4a4d-beb2-be8395aa1c6f"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "+---+-------------------------------------------------+----+---+-------------------------------------------------------+------+\n",
+            "|qid|                                       query_text|rank| id|                                               doc_text|cosine|\n",
+            "+---+-------------------------------------------------+----+---+-------------------------------------------------------+------+\n",
+            "| q1|     Which fruits and foods are high in vitamins?|   1|  1| Apples and oranges are excellent sources of vitamin C.| 0.865|\n",
+            "| q1|     Which fruits and foods are high in vitamins?|   2|  3|A diet high in fiber helps regulate blood sugar and ...|0.8317|\n",
+            "| q1|     Which fruits and foods are high in vitamins?|   3|  2|Bananas are rich in potassium, which supports heart ...|0.8298|\n",
+            "| q2|      How do neural networks process information?|   1|  5|Deep learning uses multi-layer neural networks to mo...|0.8623|\n",
+            "| q2|      How do neural networks process information?|   2|  6|Transformers are a neural network architecture that ...|0.8457|\n",
+            "| q2|      How do neural networks process information?|   3|  4|Machine learning is a branch of artificial intellige...|0.8425|\n",
+            "| q3|Best destinations for cultural tourism in Europe.|   1|  8|The Amalfi Coast in southern Italy is one of Europe'...|0.8058|\n",
+            "| q3|Best destinations for cultural tourism in Europe.|   2|  7|Florence is a city in Tuscany known for Renaissance ...|0.7939|\n",
+            "| q3|Best destinations for cultural tourism in Europe.|   3|  9|Kyoto offers ancient temples, bamboo forests, and tr...| 0.769|\n",
+            "| q4|     Recent discoveries about stars and galaxies.|   1| 10|The James Webb Space Telescope observes the universe...|0.8514|\n",
+            "| q4|     Recent discoveries about stars and galaxies.|   2| 11|Black holes form when massive stars collapse under t...|0.8486|\n",
+            "| q4|     Recent discoveries about stars and galaxies.|   3| 12|The Milky Way galaxy contains an estimated 100 to 40...|0.8407|\n",
+            "+---+-------------------------------------------------+----+---+-------------------------------------------------------+------+\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "window = Window.partitionBy(\"qid\").orderBy(F.desc(\"cosine\"))\n",
+        "\n",
+        "(\n",
+        "    scored\n",
+        "    .withColumn(\"rank\", F.rank().over(window))\n",
+        "    .filter(F.col(\"rank\") <= 3)\n",
+        "    .orderBy(\"qid\", \"rank\")\n",
+        "    .select(\"qid\", \"query_text\", \"rank\", \"id\", \"doc_text\", \"cosine\")\n",
+        "    .show(truncate=55)\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fYvOB4rFgB9W"
+      },
+      "source": [
+        "## 5. Comparing similarity methods\n",
+        "\n",
+        "All three methods score the same (query, document) pairs.\n",
+        "The relative ranking order is usually consistent across methods, but the score scales\n",
+        "differ significantly.\n",
+        "\n",
+        "- `cosine` is bounded in [-1.0, 1.0] and scale-invariant (only vector direction matters).\n",
+        "- `dotProduct` is unbounded and sensitive to vector magnitude; scores depend on the model.\n",
+        "- `euclidean` returns the negative L2 distance: 0.0 means identical vectors, more negative\n",
+        "  means less similar.\n",
+        "\n",
+        "Note: `e5_small_v2` produces L2-normalized (unit) embeddings, so for this model\n",
+        "`dotProduct` and `cosine` will produce identical scores. On models that do not normalize\n",
+        "their output vectors the two methods will diverge."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "L6j_kdxegB9X",
+        "outputId": "8def4a00-f312-4fd1-91f1-1bb59e496f7f"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Method comparison for q2 — 'How do neural networks process information?'\n",
+            "+---+---+------------------------------------------------+------+----------+---------+\n",
+            "|qid| id|                                        doc_text|cosine|dotProduct|euclidean|\n",
+            "+---+---+------------------------------------------------+------+----------+---------+\n",
+            "| q2|  5|Deep learning uses multi-layer neural network...|0.8623|    0.8623|  -0.5248|\n",
+            "| q2|  6|Transformers are a neural network architectur...|0.8457|    0.8457|  -0.5556|\n",
+            "| q2|  4|Machine learning is a branch of artificial in...|0.8425|    0.8425|  -0.5612|\n",
+            "| q2| 11|Black holes form when massive stars collapse ...| 0.821|     0.821|  -0.5984|\n",
+            "| q2| 10|The James Webb Space Telescope observes the u...|0.7958|    0.7958|   -0.639|\n",
+            "| q2|  3|A diet high in fiber helps regulate blood sug...|0.7816|    0.7816|  -0.6608|\n",
+            "| q2|  2|Bananas are rich in potassium, which supports...|0.7717|    0.7717|  -0.6757|\n",
+            "| q2|  1|Apples and oranges are excellent sources of v...|0.7685|    0.7685|  -0.6805|\n",
+            "| q2| 12|The Milky Way galaxy contains an estimated 10...|0.7632|    0.7632|  -0.6881|\n",
+            "| q2|  9|Kyoto offers ancient temples, bamboo forests,...|0.7416|    0.7416|  -0.7189|\n",
+            "| q2|  7|Florence is a city in Tuscany known for Renai...|0.7344|    0.7344|  -0.7289|\n",
+            "| q2|  8|The Amalfi Coast in southern Italy is one of ...|0.7115|    0.7115|  -0.7596|\n",
+            "+---+---+------------------------------------------------+------+----------+---------+\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "def score_with_method(method):\n",
+        "    return (\n",
+        "        PairwiseVectorSimilarity()\n",
+        "        .setInputCols([\"query_emb\", \"doc_emb\"])\n",
+        "        .setOutputCol(\"similarity\")\n",
+        "        .setSimilarityMethod(method)\n",
+        "        .transform(paired)\n",
+        "        .select(\n",
+        "            F.col(\"qid\"),\n",
+        "            F.col(\"id\"),\n",
+        "            F.col(\"text\").alias(\"doc_text\"),\n",
+        "            F.explode(F.col(\"similarity\")).alias(\"s\"),\n",
+        "        )\n",
+        "        .select(\n",
+        "            F.col(\"qid\"),\n",
+        "            F.col(\"id\"),\n",
+        "            F.col(\"doc_text\"),\n",
+        "            F.round(F.col(\"s.result\").cast(\"double\"), 4).alias(method),\n",
+        "        )\n",
+        "    )\n",
+        "\n",
+        "cosine_df    = score_with_method(\"cosine\")\n",
+        "dot_df       = score_with_method(\"dotProduct\")\n",
+        "euclidean_df = score_with_method(\"euclidean\")\n",
+        "\n",
+        "# Join all three on the same (qid, id) key and filter to one query for readability.\n",
+        "comparison = (\n",
+        "    cosine_df\n",
+        "    .join(dot_df.select(\"qid\", \"id\", \"dotProduct\"), on=[\"qid\", \"id\"])\n",
+        "    .join(euclidean_df.select(\"qid\", \"id\", \"euclidean\"), on=[\"qid\", \"id\"])\n",
+        "    .filter(F.col(\"qid\") == \"q2\")\n",
+        "    .orderBy(F.desc(\"cosine\"))\n",
+        "    .select(\"qid\", \"id\", \"doc_text\", \"cosine\", \"dotProduct\", \"euclidean\")\n",
+        ")\n",
+        "\n",
+        "print(\"Method comparison for q2 — 'How do neural networks process information?'\")\n",
+        "comparison.show(truncate=48)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "bKKXKaNagB9X"
+      },
+      "source": [
+        "## 6. Multiple sentences per row (N x M pairs)\n",
+        "\n",
+        "When each input column contains more than one embedding per row — for example when using\n",
+        "a `SentenceDetector` pipeline — the annotator scores **all N x M cross-pairs** and emits\n",
+        "one annotation per pair. This is useful for fine-grained passage-level matching.\n",
+        "\n",
+        "In this example, document A has 3 sentences and document B has 2 sentences.\n",
+        "The annotator produces 3 x 2 = 6 output annotations, each carrying the pair indices\n",
+        "in its metadata so the results can be matched back to specific sentence combinations."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "XcSx-EaLgB9X",
+        "outputId": "3c30d00e-5617-4a8c-9c6a-e843ecff3c3d"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "e5_small_v2 download started this may take some time.\n",
+            "Approximate size to download 76.2 MB\n",
+            "[OK!]\n",
+            "Output annotation count: 6  (3 sentences x 2 sentences = 6 pairs)\n",
+            "+------+------+----------------------------------------------------+----------------------------------------------------+------+\n",
+            "|sent_a|sent_b|                                              text_a|                                              text_b|cosine|\n",
+            "+------+------+----------------------------------------------------+----------------------------------------------------+------+\n",
+            "|     0|     0|                Vitamin C is found in citrus fruits.|Potassium is an essential electrolyte for heart a...|0.8102|\n",
+            "|     0|     1|                Vitamin C is found in citrus fruits.|Bananas, leafy greens, and beans are excellent di...|0.8285|\n",
+            "|     1|     0| It supports immune function and collagen synthesis.|Potassium is an essential electrolyte for heart a...|0.8398|\n",
+            "|     1|     1| It supports immune function and collagen synthesis.|Bananas, leafy greens, and beans are excellent di...| 0.841|\n",
+            "|     2|     0|A daily intake of 65 to 90 milligrams is recommen...|Potassium is an essential electrolyte for heart a...|0.8181|\n",
+            "|     2|     1|A daily intake of 65 to 90 milligrams is recommen...|Bananas, leafy greens, and beans are excellent di...|0.8349|\n",
+            "+------+------+----------------------------------------------------+----------------------------------------------------+------+\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "sent_assembler = DocumentAssembler() \\\n",
+        "    .setInputCol(\"text\") \\\n",
+        "    .setOutputCol(\"document\")\n",
+        "\n",
+        "sentence_detector = SentenceDetector() \\\n",
+        "    .setInputCols([\"document\"]) \\\n",
+        "    .setOutputCol(\"sentence\")\n",
+        "\n",
+        "sent_embeddings = E5Embeddings.pretrained(\"e5_small_v2\", \"en\") \\\n",
+        "    .setInputCols([\"sentence\"]) \\\n",
+        "    .setOutputCol(\"sent_emb\")\n",
+        "\n",
+        "sent_pipeline = Pipeline(stages=[sent_assembler, sentence_detector, sent_embeddings])\n",
+        "\n",
+        "# Document A: 3 sentences about vitamins\n",
+        "doc_a = spark.createDataFrame([(\n",
+        "    \"Vitamin C is found in citrus fruits. \"\n",
+        "    \"It supports immune function and collagen synthesis. \"\n",
+        "    \"A daily intake of 65 to 90 milligrams is recommended for adults.\",\n",
+        ")], [\"text\"])\n",
+        "\n",
+        "# Document B: 2 sentences about minerals\n",
+        "doc_b = spark.createDataFrame([(\n",
+        "    \"Potassium is an essential electrolyte for heart and muscle function. \"\n",
+        "    \"Bananas, leafy greens, and beans are excellent dietary sources.\",\n",
+        ")], [\"text\"])\n",
+        "\n",
+        "sent_model = sent_pipeline.fit(doc_a)\n",
+        "emb_a = sent_model.transform(doc_a).select(F.col(\"sent_emb\").alias(\"emb_a\"))\n",
+        "emb_b = sent_model.transform(doc_b).select(F.col(\"sent_emb\").alias(\"emb_b\"))\n",
+        "\n",
+        "sent_pvs = PairwiseVectorSimilarity() \\\n",
+        "    .setInputCols([\"emb_a\", \"emb_b\"]) \\\n",
+        "    .setOutputCol(\"sim\") \\\n",
+        "    .setSimilarityMethod(\"cosine\")\n",
+        "\n",
+        "sent_result = (\n",
+        "    sent_pvs.transform(emb_a.crossJoin(emb_b))\n",
+        "    .select(F.explode(F.col(\"sim\")).alias(\"s\"))\n",
+        "    .select(\n",
+        "        F.col(\"s.metadata\")[\"sentence_a_idx\"].cast(\"int\").alias(\"sent_a\"),\n",
+        "        F.col(\"s.metadata\")[\"sentence_b_idx\"].cast(\"int\").alias(\"sent_b\"),\n",
+        "        F.col(\"s.metadata\")[\"sentence_a_text\"].alias(\"text_a\"),\n",
+        "        F.col(\"s.metadata\")[\"sentence_b_text\"].alias(\"text_b\"),\n",
+        "        F.round(F.col(\"s.result\").cast(\"double\"), 4).alias(\"cosine\"),\n",
+        "    )\n",
+        "    .orderBy(\"sent_a\", \"sent_b\")\n",
+        ")\n",
+        "\n",
+        "print(f\"Output annotation count: {sent_result.count()}  (3 sentences x 2 sentences = 6 pairs)\")\n",
+        "sent_result.show(truncate=52)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "B3BXOEysgB9X"
+      },
+      "source": [
+        "## 7. Two-stage retrieval: BM25 + vector re-ranking\n",
+        "\n",
+        "Running vector similarity over an entire corpus scales as O(Q x D), which becomes\n",
+        "expensive for large D. A common production pattern is to use a fast lexical retriever\n",
+        "as a first stage to narrow the candidate set to a few hundred documents, then re-rank\n",
+        "only those candidates with the slower but more accurate vector similarity.\n",
+        "\n",
+        "Here we:\n",
+        "1. Train `BM25Approach` on the corpus to build a term-frequency index.\n",
+        "2. Run a query to retrieve only documents that share at least one term with the query.\n",
+        "3. Embed those candidates and re-rank them with `PairwiseVectorSimilarity`.\n",
+        "\n",
+        "Comparing `bm25_score` and `vector_score` in the output shows where the two methods agree\n",
+        "and where vector similarity corrects lexical mismatches."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Ye_TfYdugB9Y",
+        "outputId": "d12dae56-3cba-4fa6-bbe6-4c3262d2d539"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "BM25 candidates: 3 of 12 documents passed the filter\n",
+            "+---+------------------------------------------------------------------------+----------+\n",
+            "| id|                                                                    text|bm25_score|\n",
+            "+---+------------------------------------------------------------------------+----------+\n",
+            "|  1|                  Apples and oranges are excellent sources of vitamin C.|    4.7354|\n",
+            "|  2|Bananas are rich in potassium, which supports heart and muscle function.|    4.3025|\n",
+            "|  3| A diet high in fiber helps regulate blood sugar and cholesterol levels.|    2.0572|\n",
+            "+---+------------------------------------------------------------------------+----------+\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "bm25_pipeline = Pipeline(stages=[\n",
+        "    DocumentAssembler().setInputCol(\"text\").setOutputCol(\"document\"),\n",
+        "    Tokenizer().setInputCols([\"document\"]).setOutputCol(\"token\"),\n",
+        "    StopWordsCleaner().setInputCols([\"token\"]).setOutputCol(\"clean\").setCaseSensitive(False),\n",
+        "    BM25Approach().setInputCols([\"clean\"]).setOutputCol(\"bm25\").setMinDocFreq(1),\n",
+        "]).fit(corpus)\n",
+        "\n",
+        "# Use words that appear verbatim in the corpus so BM25 returns multiple candidates.\n",
+        "bm25_pipeline.stages[-1].setQuery(\"vitamin potassium apples bananas fiber\")\n",
+        "\n",
+        "candidates = (\n",
+        "    bm25_pipeline.transform(corpus)\n",
+        "    .select(F.col(\"id\"), F.col(\"text\"), F.explode(F.col(\"bm25\")).alias(\"b\"))\n",
+        "    .select(\n",
+        "        F.col(\"id\"),\n",
+        "        F.col(\"text\"),\n",
+        "        F.round(F.col(\"b.metadata\")[\"bm25_score\"].cast(\"double\"), 4).alias(\"bm25_score\"),\n",
+        "    )\n",
+        "    .filter(F.col(\"bm25_score\") > 0)\n",
+        "    .orderBy(F.desc(\"bm25_score\"))\n",
+        ")\n",
+        "\n",
+        "print(f\"BM25 candidates: {candidates.count()} of {corpus.count()} documents passed the filter\")\n",
+        "candidates.show(truncate=72)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "CZO4H-zQgB9Y",
+        "outputId": "c183bb88-8c27-4aa5-a237-84772f0c8460"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Re-ranked candidates (ordered by vector similarity):\n",
+            "+--------------------------------------------+---+-------------------------------------------------------+----------+------------+\n",
+            "|                                  query_text| id|                                               doc_text|bm25_score|vector_score|\n",
+            "+--------------------------------------------+---+-------------------------------------------------------+----------+------------+\n",
+            "|Which fruits and foods are high in vitamins?|  1| Apples and oranges are excellent sources of vitamin C.|    4.7354|       0.865|\n",
+            "|Which fruits and foods are high in vitamins?|  3|A diet high in fiber helps regulate blood sugar and ...|    2.0572|      0.8317|\n",
+            "|Which fruits and foods are high in vitamins?|  2|Bananas are rich in potassium, which supports heart ...|    4.3025|      0.8298|\n",
+            "+--------------------------------------------+---+-------------------------------------------------------+----------+------------+\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "candidates_emb = emb_model.transform(candidates).select(\n",
+        "    \"id\", \"text\", \"bm25_score\", F.col(\"embeddings\").alias(\"doc_emb\")\n",
+        ")\n",
+        "\n",
+        "rerank_query = spark.createDataFrame(\n",
+        "    [(\"q1\", \"Which fruits and foods are high in vitamins?\")], [\"qid\", \"text\"]\n",
+        ")\n",
+        "rerank_query_emb = emb_model.transform(rerank_query).select(\n",
+        "    \"qid\", F.col(\"text\").alias(\"query_text\"), F.col(\"embeddings\").alias(\"query_emb\")\n",
+        ")\n",
+        "\n",
+        "print(\"Re-ranked candidates (ordered by vector similarity):\")\n",
+        "(\n",
+        "    pvs.transform(rerank_query_emb.crossJoin(candidates_emb))\n",
+        "    .select(\n",
+        "        F.col(\"query_text\"),\n",
+        "        F.col(\"id\"),\n",
+        "        F.col(\"text\").alias(\"doc_text\"),\n",
+        "        F.col(\"bm25_score\"),\n",
+        "        F.explode(F.col(\"similarity\")).alias(\"s\"),\n",
+        "    )\n",
+        "    .select(\n",
+        "        F.col(\"query_text\"),\n",
+        "        F.col(\"id\"),\n",
+        "        F.col(\"doc_text\"),\n",
+        "        F.col(\"bm25_score\"),\n",
+        "        F.round(F.col(\"s.result\").cast(\"double\"), 4).alias(\"vector_score\"),\n",
+        "    )\n",
+        "    .orderBy(F.desc(\"vector_score\"))\n",
+        "    .show(truncate=55)\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dyqFcSxfgB9Y"
+      },
+      "source": [
+        "## 8. Inspecting annotation output\n",
+        "\n",
+        "Each `VECTOR_SIMILARITY` annotation is a standard Spark NLP struct. Its `metadata` map\n",
+        "contains all information needed to identify the pair and its score without any secondary\n",
+        "join back to the source DataFrames."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "wKVusmxlgB9Y",
+        "outputId": "4977c309-f9e0-41d5-ab06-fc797e031824"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Full annotation struct (q1 vs document 1):\n",
+            "+-----------------+-----+---+------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+\n",
+            "|annotatorType    |begin|end|result            |metadata                                                                                                                                                                                                                                            |\n",
+            "+-----------------+-----+---+------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+\n",
+            "|vector_similarity|0    |0  |0.8650460961445957|{sentence_b_idx -> 0, similarity -> 0.8650460961445957, sentence_a_idx -> 0, similarityMethod -> cosine, sentence_b_text -> Apples and oranges are excellent sources of vitamin C., sentence_a_text -> Which fruits and foods are high in vitamins?}|\n",
+            "+-----------------+-----+---+------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+\n",
+            "\n",
+            "Metadata fields (unpacked):\n",
+            "+-----+-----+--------------------------------------------+------------------------------------------------------+------------------+------+\n",
+            "|a_idx|b_idx|query                                       |document                                              |score             |method|\n",
+            "+-----+-----+--------------------------------------------+------------------------------------------------------+------------------+------+\n",
+            "|0    |0    |Which fruits and foods are high in vitamins?|Apples and oranges are excellent sources of vitamin C.|0.8650460961445957|cosine|\n",
+            "+-----+-----+--------------------------------------------+------------------------------------------------------+------------------+------+\n",
+            "\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Show the full annotation struct for one specific (query, document) pair.\n",
+        "print(\"Full annotation struct (q1 vs document 1):\")\n",
+        "(\n",
+        "    pvs.transform(paired)\n",
+        "    .filter(F.col(\"qid\") == \"q1\")\n",
+        "    .filter(F.col(\"id\") == 1)\n",
+        "    .select(F.explode(F.col(\"similarity\")).alias(\"s\"))\n",
+        "    .select(\n",
+        "        F.col(\"s.annotatorType\"),\n",
+        "        F.col(\"s.begin\"),\n",
+        "        F.col(\"s.end\"),\n",
+        "        F.col(\"s.result\"),\n",
+        "        F.col(\"s.metadata\"),\n",
+        "    )\n",
+        "    .show(truncate=False)\n",
+        ")\n",
+        "\n",
+        "# Unpack each metadata field individually for easy downstream access.\n",
+        "print(\"Metadata fields (unpacked):\")\n",
+        "(\n",
+        "    pvs.transform(paired)\n",
+        "    .filter(F.col(\"qid\") == \"q1\")\n",
+        "    .filter(F.col(\"id\") == 1)\n",
+        "    .select(F.explode(F.col(\"similarity\")).alias(\"s\"))\n",
+        "    .select(\n",
+        "        F.col(\"s.metadata\")[\"sentence_a_idx\"].alias(\"a_idx\"),\n",
+        "        F.col(\"s.metadata\")[\"sentence_b_idx\"].alias(\"b_idx\"),\n",
+        "        F.col(\"s.metadata\")[\"sentence_a_text\"].alias(\"query\"),\n",
+        "        F.col(\"s.metadata\")[\"sentence_b_text\"].alias(\"document\"),\n",
+        "        F.col(\"s.metadata\")[\"similarity\"].cast(\"double\").alias(\"score\"),\n",
+        "        F.col(\"s.metadata\")[\"similarityMethod\"].alias(\"method\"),\n",
+        "    )\n",
+        "    .show(truncate=False)\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "QKqrc24VgB9Z"
+      },
+      "source": [
+        "## Notes\n",
+        "\n",
+        "**Choosing a similarity method**\n",
+        "\n",
+        "- Use `cosine` (default) when comparing embeddings from most pretrained models.\n",
+        "  Cosine similarity is scale-invariant — only the direction of the vector matters,\n",
+        "  not its magnitude — which makes it robust across different model families.\n",
+        "- Use `dotProduct` when the model was trained with a dot-product objective\n",
+        "  (e.g. bi-encoders trained with in-batch negatives). In that case the vector magnitude\n",
+        "  carries a confidence signal that cosine would discard.\n",
+        "- Use `euclidean` when you need a proper distance metric. The annotator returns the\n",
+        "  negative L2 distance so that higher scores still mean more similar, consistent with\n",
+        "  the other two methods.\n",
+        "\n",
+        "**LightPipeline is not supported**\n",
+        "\n",
+        "`LightPipeline` merges all input columns into a single flat list, making it impossible\n",
+        "to distinguish column A embeddings from column B embeddings. Always call `transform()`\n",
+        "on a Spark DataFrame.\n",
+        "\n",
+        "**Scaling to large corpora**\n",
+        "\n",
+        "A raw `crossJoin` grows as O(Q x D): 1,000 queries against 1,000,000 documents produces\n",
+        "one billion rows. For large corpora, use a first-stage filter (BM25, locality-sensitive\n",
+        "hashing, or an ANN index) to reduce D to a few hundred candidates per query before\n",
+        "applying `PairwiseVectorSimilarity`, as shown in section 7."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.0"
+    },
+    "colab": {
+      "provenance": [],
+      "toc_visible": true
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/python/sparknlp/annotator/__init__.py
+++ b/python/sparknlp/annotator/__init__.py
@@ -52,6 +52,7 @@ from sparknlp.annotator.document_title_splitter import *
 from sparknlp.annotator.document_token_splitter import *
 from sparknlp.annotator.vector_db import *
 from sparknlp.annotator.similarity.bm25 import *
+from sparknlp.annotator.similarity.pairwise_vector_similarity import *
 
 if sys.version_info[0] == 2:
     raise ImportError(

--- a/python/sparknlp/annotator/similarity/__init__.py
+++ b/python/sparknlp/annotator/similarity/__init__.py
@@ -15,3 +15,4 @@
 """Module of annotators for document similarity and lexical ranking."""
 from sparknlp.annotator.similarity.document_similarity_ranker import *
 from sparknlp.annotator.similarity.bm25 import *
+from sparknlp.annotator.similarity.pairwise_vector_similarity import *

--- a/python/sparknlp/annotator/similarity/pairwise_vector_similarity.py
+++ b/python/sparknlp/annotator/similarity/pairwise_vector_similarity.py
@@ -1,0 +1,132 @@
+#  Copyright 2017-2025 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Contains class for PairwiseVectorSimilarity."""
+
+from sparknlp.common import *
+from pyspark import keyword_only
+from pyspark.ml.param import TypeConverters, Params, Param
+
+
+class PairwiseVectorSimilarity(AnnotatorModel):
+    """Computes pairwise vector similarity between two sets of sentence embeddings.
+
+    Takes **two** ``SENTENCE_EMBEDDINGS`` input columns (e.g. query embeddings and document
+    embeddings already joined on the same row) and scores all N×M pairs between the embeddings
+    in column A and the embeddings in column B. Each pair produces one ``VECTOR_SIMILARITY``
+    output annotation whose ``result`` holds the score as a string, and whose ``metadata``
+    contains typed fields for easy extraction.
+
+    **Sign conventions**
+
+    ============  ===========  ========================
+    Method        Range        Higher means
+    ============  ===========  ========================
+    cosine        [-1.0, 1.0]  more similar
+    dotProduct    (−∞, +∞)     more similar
+    euclidean     (−∞, 0.0]    more similar (0.0 = identical vectors)
+    ============  ===========  ========================
+
+    The ``euclidean`` method returns the **negative** L2 distance so that "higher is better"
+    holds uniformly across all three methods. A score of ``0.0`` means the two vectors are
+    identical.
+
+    **Important: input data shape**
+
+    Each input column should contain **exactly one** embedding per row for standard document
+    retrieval. If a column contains N > 1 embeddings (e.g. from ``SentenceDetector`` + embedder),
+    all N×M cross-pairs are scored and returned as separate annotations.
+
+    To compare queries against a corpus, crossJoin them first so each row holds one
+    (query, document) pair:
+
+    ======================= ========================
+    Input Annotation types  Output Annotation type
+    ======================= ========================
+    ``SENTENCE_EMBEDDINGS`` ``VECTOR_SIMILARITY``
+    ``SENTENCE_EMBEDDINGS``
+    ======================= ========================
+
+    Parameters
+    ----------
+    similarityMethod
+        Similarity function: ``"cosine"`` (default), ``"dotProduct"``, or ``"euclidean"``
+        (negative L2 distance).
+
+    Examples
+    --------
+    >>> from sparknlp.annotator import PairwiseVectorSimilarity
+    >>> from pyspark.sql.functions import col, explode, desc
+
+    >>> # Assume embedding_pipeline produces a "embeddings" SENTENCE_EMBEDDINGS column.
+    >>> query_df = embedding_pipeline.transform(queries).select(col("embeddings").alias("query_emb"))
+    >>> corpus_df = embedding_pipeline.transform(corpus).select(col("embeddings").alias("doc_emb"), col("id"))
+    >>> paired = query_df.crossJoin(corpus_df)
+
+    >>> pvs = PairwiseVectorSimilarity() \\
+    ...     .setInputCols(["query_emb", "doc_emb"]) \\
+    ...     .setOutputCol("similarity") \\
+    ...     .setSimilarityMethod("cosine")
+
+    >>> result = pvs.transform(paired) \\
+    ...     .select(explode(col("similarity")).alias("s")) \\
+    ...     .select(
+    ...         col("s.metadata")["sentence_a_text"].alias("query"),
+    ...         col("s.metadata")["sentence_b_text"].alias("document"),
+    ...         col("s.result").cast("double").alias("score")) \\
+    ...     .orderBy(desc("score"))
+    >>> result.show(truncate=False)
+    """
+
+    name = "PairwiseVectorSimilarity"
+    inputAnnotatorTypes = [AnnotatorType.SENTENCE_EMBEDDINGS, AnnotatorType.SENTENCE_EMBEDDINGS]
+    outputAnnotatorType = AnnotatorType.VECTOR_SIMILARITY
+
+    similarityMethod = Param(
+        Params._dummy(),
+        "similarityMethod",
+        'Similarity function: "cosine" (default), "dotProduct", or "euclidean" '
+        '(negative L2 distance — 0.0 = identical, more negative = less similar).',
+        typeConverter=TypeConverters.toString)
+
+    def setSimilarityMethod(self, value):
+        """Sets the similarity function used to score pairs.
+
+        Parameters
+        ----------
+        value : str
+            One of ``"cosine"`` (default), ``"dotProduct"``, or ``"euclidean"``.
+            The ``"euclidean"`` option returns the **negative** L2 distance so that
+            higher scores consistently mean more similar across all three methods.
+        """
+        return self._set(similarityMethod=value)
+
+    def getSimilarityMethod(self):
+        """Gets the currently configured similarity method.
+
+        Returns
+        -------
+        str
+            The similarity method name.
+        """
+        return self.getOrDefault(self.similarityMethod)
+
+    @keyword_only
+    def __init__(self,
+                 classname="com.johnsnowlabs.nlp.annotators.similarity.PairwiseVectorSimilarity",
+                 java_model=None):
+        super(PairwiseVectorSimilarity, self).__init__(
+            classname=classname,
+            java_model=java_model
+        )
+        self._setDefault(similarityMethod="cosine")

--- a/python/sparknlp/common/annotator_type.py
+++ b/python/sparknlp/common/annotator_type.py
@@ -37,3 +37,4 @@ class AnnotatorType(object):
     DUMMY = "dummy"
     DOC_SIMILARITY_RANKINGS = "doc_similarity_rankings"
     BM25_RANKINGS = "bm25_rankings"
+    VECTOR_SIMILARITY = "vector_similarity"

--- a/python/test/annotator/similarity/pairwise_vector_similarity_test.py
+++ b/python/test/annotator/similarity/pairwise_vector_similarity_test.py
@@ -194,7 +194,7 @@ class PairwiseVectorSimilarityTestSpec(unittest.TestCase):
         df = _make_df(self.spark,
                       [_se("a", [1.0, 0.0])],
                       [_se("b", [0.0, 1.0])])
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "similarityMethod|invalid"):
             (PairwiseVectorSimilarity()
              .setInputCols(["emb_a", "emb_b"])
              .setOutputCol("similarity")

--- a/python/test/annotator/similarity/pairwise_vector_similarity_test.py
+++ b/python/test/annotator/similarity/pairwise_vector_similarity_test.py
@@ -1,0 +1,207 @@
+#  Copyright 2017-2025 John Snow Labs
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import math
+import unittest
+
+import pytest
+from pyspark.sql import Row
+from pyspark.sql.functions import col, explode
+from pyspark.sql.types import (
+    ArrayType,
+    FloatType,
+    IntegerType,
+    MapType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from sparknlp.annotator import PairwiseVectorSimilarity
+from test.util import SparkSessionForTest
+
+# Schema for a single SENTENCE_EMBEDDINGS annotation struct.
+_ANNOTATION_STRUCT = StructType([
+    StructField("annotatorType", StringType(), nullable=False),
+    StructField("begin", IntegerType(), nullable=False),
+    StructField("end", IntegerType(), nullable=False),
+    StructField("result", StringType(), nullable=False),
+    StructField("metadata", MapType(StringType(), StringType(), valueContainsNull=True), nullable=True),
+    StructField("embeddings", ArrayType(FloatType(), containsNull=False), nullable=False),
+])
+
+_SE_META = {"annotatorType": "sentence_embeddings"}
+
+
+def _se(text, vec):
+    """Build a SENTENCE_EMBEDDINGS annotation dict."""
+    return {
+        "annotatorType": "sentence_embeddings",
+        "begin": 0,
+        "end": max(len(text) - 1, 0),
+        "result": text,
+        "metadata": {"sentence": "0"},
+        "embeddings": list(vec),
+    }
+
+
+def _make_df(spark, col_a_annots, col_b_annots, col_a="emb_a", col_b="emb_b"):
+    schema = StructType([
+        StructField(col_a, ArrayType(_ANNOTATION_STRUCT), nullable=False, metadata=_SE_META),
+        StructField(col_b, ArrayType(_ANNOTATION_STRUCT), nullable=False, metadata=_SE_META),
+    ])
+    row = Row(**{col_a: col_a_annots, col_b: col_b_annots})
+    return spark.createDataFrame([row], schema)
+
+
+def _scores(df, method="cosine", col_a="emb_a", col_b="emb_b"):
+    result = (
+        PairwiseVectorSimilarity()
+        .setInputCols([col_a, col_b])
+        .setOutputCol("similarity")
+        .setSimilarityMethod(method)
+        .transform(df)
+        .select(explode(col("similarity")).alias("s"))
+        .select(col("s.result").cast("double").alias("score"))
+        .collect()
+    )
+    return [r["score"] for r in result]
+
+
+@pytest.mark.fast
+class PairwiseVectorSimilarityTestSpec(unittest.TestCase):
+
+    def setUp(self):
+        self.spark = SparkSessionForTest.spark
+
+    def test_cosine_identical(self):
+        df = _make_df(self.spark,
+                      [_se("hello", [1.0, 0.0, 0.0])],
+                      [_se("hello", [1.0, 0.0, 0.0])])
+        scores = _scores(df)
+        self.assertEqual(len(scores), 1)
+        self.assertAlmostEqual(scores[0], 1.0, places=9)
+
+    def test_cosine_orthogonal(self):
+        df = _make_df(self.spark,
+                      [_se("q", [1.0, 0.0])],
+                      [_se("d", [0.0, 1.0])])
+        self.assertAlmostEqual(_scores(df)[0], 0.0, places=9)
+
+    def test_cosine_opposite(self):
+        df = _make_df(self.spark,
+                      [_se("pos", [1.0, 0.0])],
+                      [_se("neg", [-1.0, 0.0])])
+        self.assertAlmostEqual(_scores(df)[0], -1.0, places=9)
+
+    def test_cross_product_count(self):
+        """2 embeddings in col A x 3 in col B = 6 output annotations."""
+        df = _make_df(self.spark,
+                      [_se("q1", [1.0, 0.0]), _se("q2", [0.0, 1.0])],
+                      [_se("d1", [1.0, 0.0]), _se("d2", [0.0, 1.0]), _se("d3", [-1.0, 0.0])])
+        pvs = (
+            PairwiseVectorSimilarity()
+            .setInputCols(["emb_a", "emb_b"])
+            .setOutputCol("similarity")
+        )
+        count = (
+            pvs.transform(df)
+            .select(explode(col("similarity")).alias("s"))
+            .count()
+        )
+        self.assertEqual(count, 6)
+
+    def test_metadata_text_passthrough(self):
+        df = _make_df(self.spark,
+                      [_se("my query", [1.0, 0.0])],
+                      [_se("my document", [0.0, 1.0])])
+        row = (
+            PairwiseVectorSimilarity()
+            .setInputCols(["emb_a", "emb_b"])
+            .setOutputCol("similarity")
+            .transform(df)
+            .select(explode(col("similarity")).alias("s"))
+            .select(
+                col("s.metadata")["sentence_a_text"].alias("a_text"),
+                col("s.metadata")["sentence_b_text"].alias("b_text"))
+            .collect()[0]
+        )
+        self.assertEqual(row["a_text"], "my query")
+        self.assertEqual(row["b_text"], "my document")
+
+    def test_result_equals_metadata_similarity(self):
+        df = _make_df(self.spark,
+                      [_se("a", [0.6, 0.8])],
+                      [_se("b", [0.8, 0.6])])
+        row = (
+            PairwiseVectorSimilarity()
+            .setInputCols(["emb_a", "emb_b"])
+            .setOutputCol("similarity")
+            .transform(df)
+            .select(explode(col("similarity")).alias("s"))
+            .select(
+                col("s.result").cast("double").alias("from_result"),
+                col("s.metadata")["similarity"].cast("double").alias("from_meta"))
+            .collect()[0]
+        )
+        self.assertAlmostEqual(row["from_result"], row["from_meta"], places=15)
+
+    def test_euclidean_identical(self):
+        df = _make_df(self.spark,
+                      [_se("x", [1.0, 2.0, 3.0])],
+                      [_se("x", [1.0, 2.0, 3.0])])
+        self.assertAlmostEqual(_scores(df, method="euclidean")[0], 0.0, places=9)
+
+    def test_euclidean_negative_for_distinct(self):
+        df = _make_df(self.spark,
+                      [_se("a", [1.0, 0.0])],
+                      [_se("b", [0.0, 1.0])])
+        score = _scores(df, method="euclidean")[0]
+        self.assertLess(score, 0.0)
+        self.assertAlmostEqual(score, -math.sqrt(2.0), places=9)
+
+    def test_dot_product(self):
+        df = _make_df(self.spark,
+                      [_se("a", [2.0, 3.0])],
+                      [_se("b", [4.0, 5.0])])
+        # 2*4 + 3*5 = 23
+        self.assertAlmostEqual(_scores(df, method="dotProduct")[0], 23.0, places=9)
+
+    def test_cosine_zero_vector(self):
+        df = _make_df(self.spark,
+                      [_se("zero", [0.0, 0.0])],
+                      [_se("nonzero", [1.0, 0.0])])
+        self.assertEqual(_scores(df)[0], 0.0)
+
+    def test_default_method_is_cosine(self):
+        df = _make_df(self.spark,
+                      [_se("x", [1.0, 0.0])],
+                      [_se("x", [1.0, 0.0])])
+        pvs = PairwiseVectorSimilarity().setInputCols(["emb_a", "emb_b"]).setOutputCol("similarity")
+        self.assertEqual(pvs.getSimilarityMethod(), "cosine")
+
+    def test_invalid_method_raises(self):
+        df = _make_df(self.spark,
+                      [_se("a", [1.0, 0.0])],
+                      [_se("b", [0.0, 1.0])])
+        with self.assertRaises(Exception):
+            (PairwiseVectorSimilarity()
+             .setInputCols(["emb_a", "emb_b"])
+             .setOutputCol("similarity")
+             .setSimilarityMethod("invalid")
+             .transform(df)
+             .collect())
+
+    def test_set_get_similarity_method(self):
+        pvs = PairwiseVectorSimilarity().setSimilarityMethod("dotProduct")
+        self.assertEqual(pvs.getSimilarityMethod(), "dotProduct")

--- a/src/main/scala/com/johnsnowlabs/nlp/AnnotatorType.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/AnnotatorType.scala
@@ -40,4 +40,5 @@ object AnnotatorType {
   val DUMMY = "dummy"
   val DOC_SIMILARITY_RANKINGS = "doc_similarity_rankings"
   val BM25_RANKINGS = "bm25_rankings"
+  val VECTOR_SIMILARITY = "vector_similarity"
 }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/PairwiseVectorSimilarity.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/PairwiseVectorSimilarity.scala
@@ -145,19 +145,36 @@ class PairwiseVectorSimilarity(override val uid: String)
     outputCol -> VECTOR_SIMILARITY,
     similarityMethod -> "cosine")
 
-  /** Verifies that both named input columns exist in the schema with the correct annotator type.
+  /** Verifies that exactly two named input columns are present, each carrying the
+    * SENTENCE_EMBEDDINGS annotator type.
     *
     * The base `RawAnnotator.validate` uses `exists` (any column of the right type satisfies each
     * entry in `inputAnnotatorTypes`), which would pass validation even when only one
-    * SENTENCE_EMBEDDINGS column is present. This override checks each column by name.
+    * SENTENCE_EMBEDDINGS column is present, and the generic failure message only mentions
+    * annotator types. This override checks each column by name and raises a specific error so the
+    * "two distinct columns" requirement is clear, rather than returning `false` and surfacing the
+    * generic base message.
     */
-  override protected def validate(schema: StructType): Boolean =
-    getInputCols.forall { colName =>
-      schema.exists(f =>
+  override protected def validate(schema: StructType): Boolean = {
+    val inputColNames = getInputCols
+    require(
+      inputColNames.length == 2,
+      s"PairwiseVectorSimilarity requires exactly two input columns (got ${inputColNames.length}). " +
+        "Set both with setInputCols(Array(colA, colB)), each a distinct SENTENCE_EMBEDDINGS column " +
+        "(e.g. query embeddings and document embeddings).")
+    inputColNames.foreach { colName =>
+      val isEmbeddingsCol = schema.fields.exists(f =>
         f.name == colName &&
           f.metadata.contains("annotatorType") &&
           f.metadata.getString("annotatorType") == SENTENCE_EMBEDDINGS)
+      require(
+        isEmbeddingsCol,
+        s"PairwiseVectorSimilarity input column '$colName' must be a SENTENCE_EMBEDDINGS column " +
+          "produced by an embeddings annotator. Provide two distinct SENTENCE_EMBEDDINGS columns " +
+          "(e.g. query embeddings and document embeddings).")
     }
+    true
+  }
 
   /** Scores all N×M pairs between the two input annotation sets.
     *

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/PairwiseVectorSimilarity.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/PairwiseVectorSimilarity.scala
@@ -27,7 +27,6 @@ import com.johnsnowlabs.nlp.{
 }
 import org.apache.spark.ml.param.{Param, ParamValidators}
 import org.apache.spark.ml.util.Identifiable
-import org.apache.spark.sql.Row
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.types.StructType
@@ -250,14 +249,23 @@ class PairwiseVectorSimilarity(override val uid: String)
     -math.sqrt(sum)
   }
 
-  /** Overrides the default `dfAnnotate` so the two input columns are kept separate rather than
-    * being flattened into a single Seq. The first element of `rows` corresponds to col A (index 0
-    * in `getInputCols`) and the second to col B (index 1).
+  /** Overrides the default `annotateColumnGroups` so the two input columns are kept separate
+    * rather than being flattened into a single Seq (the trait default flattens both columns and
+    * delegates to `annotate`, which this class deliberately does not support). The first element
+    * of `annotationProperties` corresponds to col A (index 0 in `getInputCols`) and the second to
+    * col B (index 1). This path is used directly on Spark 4+ (see `AnnotatorModel._transform`)
+    * and via `dfAnnotate` below on Spark 3.x.
     */
-  override def dfAnnotate: UserDefinedFunction = udf { rows: Seq[Seq[Row]] =>
-    val setA = rows.headOption.map(_.map(Annotation(_))).getOrElse(Seq.empty)
-    val setB = rows.lift(1).map(_.map(Annotation(_))).getOrElse(Seq.empty)
+  override private[nlp] def annotateColumnGroups(
+      annotationProperties: Seq[AnnotationContent]): Seq[Annotation] = {
+    val setA = annotationProperties.headOption.map(_.map(Annotation(_))).getOrElse(Seq.empty)
+    val setB = annotationProperties.lift(1).map(_.map(Annotation(_))).getOrElse(Seq.empty)
     computeSimilarities(setA, setB)
+  }
+
+  override def dfAnnotate: UserDefinedFunction = udf {
+    annotationProperties: Seq[AnnotationContent] =>
+      annotateColumnGroups(annotationProperties)
   }
 
   /** Not supported — `LightPipeline` flattens both input columns into a single Seq, making it

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/PairwiseVectorSimilarity.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/similarity/PairwiseVectorSimilarity.scala
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2017-2025 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.similarity
+
+import com.johnsnowlabs.nlp.AnnotatorType.{SENTENCE_EMBEDDINGS, VECTOR_SIMILARITY}
+import com.johnsnowlabs.nlp.{
+  Annotation,
+  AnnotatorModel,
+  AnnotatorType,
+  HasSimpleAnnotate,
+  ParamsAndFeaturesReadable,
+  ParamsAndFeaturesWritable
+}
+import org.apache.spark.ml.param.{Param, ParamValidators}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.types.StructType
+
+/** Computes pairwise vector similarity between two sets of sentence embeddings.
+  *
+  * The annotator takes **two** `SENTENCE_EMBEDDINGS` input columns (e.g. query embeddings and
+  * document embeddings already joined on the same row) and, for every row, scores all N×M pairs
+  * between the embeddings in column A and the embeddings in column B. Each pair produces one
+  * `VECTOR_SIMILARITY` output annotation whose `result` holds the score as a String, and whose
+  * `metadata` holds typed fields for easy extraction.
+  *
+  * ==Sign conventions==
+  * {{{
+  * method        range         higher means
+  * ----------    ----------    ------------
+  * cosine        [-1.0, 1.0]   more similar
+  * dotProduct    (−∞, +∞)      more similar
+  * euclidean     (−∞, 0.0]     more similar (0.0 = identical vectors)
+  * }}}
+  * The `euclidean` method returns the **negative** L2 distance so that "higher is better" holds
+  * uniformly across all three methods. A score of `0.0` means the two vectors are identical; more
+  * negative values indicate less similarity.
+  *
+  * ==Important: input data shape==
+  * Each input column should contain **exactly one** embedding per row for standard document
+  * retrieval. If a column contains N > 1 embeddings (e.g. produced by `SentenceDetector` +
+  * embedder), all N×M cross-pairs are scored and returned as separate annotations. To compare
+  * queries against a corpus, join them first:
+  *
+  * ==Example==
+  * {{{
+  * import com.johnsnowlabs.nlp.annotators.similarity.PairwiseVectorSimilarity
+  * import org.apache.spark.sql.functions.{col, desc, explode}
+  *
+  * // Assume embeddingPipeline produces a "embeddings" column of SENTENCE_EMBEDDINGS.
+  * val queryDf  = embeddingPipeline.transform(queries).select(col("embeddings").as("query_emb"))
+  * val corpusDf = embeddingPipeline.transform(corpus).select(col("embeddings").as("doc_emb"), col("id"))
+  *
+  * // CrossJoin to get one (query, document) pair per row, then score.
+  * val paired = queryDf.crossJoin(corpusDf)
+  *
+  * val pvs = new PairwiseVectorSimilarity()
+  *   .setInputCols("query_emb", "doc_emb")
+  *   .setOutputCol("similarity")
+  *   .setSimilarityMethod("cosine")
+  *
+  * pvs.transform(paired)
+  *   .select(explode(col("similarity")).as("s"))
+  *   .select(
+  *     col("s.metadata")("sentence_a_text").as("query"),
+  *     col("s.metadata")("sentence_b_text").as("document"),
+  *     col("s.result").cast("double").as("score"))
+  *   .orderBy(desc("score"))
+  *   .show(false)
+  * }}}
+  *
+  * @groupname anno Annotator types
+  * @groupdesc anno
+  *   Required input and expected output annotator types
+  * @groupname param Parameters
+  * @groupname setParam Parameter setters
+  * @groupname getParam Parameter getters
+  * @groupprio param  1
+  * @groupprio anno  2
+  * @groupprio setParam  4
+  * @groupprio getParam  5
+  */
+class PairwiseVectorSimilarity(override val uid: String)
+    extends AnnotatorModel[PairwiseVectorSimilarity]
+    with HasSimpleAnnotate[PairwiseVectorSimilarity]
+    with ParamsAndFeaturesWritable {
+
+  def this() = this(Identifiable.randomUID("PairwiseVectorSimilarity"))
+
+  /** Input annotator types: two SENTENCE_EMBEDDINGS columns (e.g. queries and documents).
+    *
+    * @group anno
+    */
+  override val inputAnnotatorTypes: Array[AnnotatorType] =
+    Array(SENTENCE_EMBEDDINGS, SENTENCE_EMBEDDINGS)
+
+  /** Output annotator type: VECTOR_SIMILARITY
+    *
+    * @group anno
+    */
+  override val outputAnnotatorType: AnnotatorType = VECTOR_SIMILARITY
+
+  /** Similarity function to use when scoring pairs.
+    *
+    * Supported values:
+    *   - `"cosine"` (default) — cosine similarity in `[-1.0, 1.0]`; higher = more similar.
+    *   - `"dotProduct"` — dot-product score in `(−∞, +∞)`; higher = more similar.
+    *   - `"euclidean"` — **negative** L2 distance in `(−∞, 0.0]`; 0.0 = identical, more negative
+    *     \= less similar. The sign is negated so that "higher is better" holds uniformly across
+    *     all three methods.
+    *
+    * @group param
+    */
+  val similarityMethod: Param[String] = new Param[String](
+    this,
+    "similarityMethod",
+    """Similarity function: "cosine" (default), "dotProduct", or "euclidean" """ +
+      """(negative L2 distance — 0.0 = identical, more negative = less similar).""",
+    ParamValidators.inArray(Array("cosine", "dotProduct", "euclidean")))
+
+  /** @group setParam */
+  def setSimilarityMethod(value: String): this.type = set(similarityMethod, value)
+
+  /** @group getParam */
+  def getSimilarityMethod: String = $(similarityMethod)
+
+  setDefault(
+    inputCols -> Array(SENTENCE_EMBEDDINGS, SENTENCE_EMBEDDINGS),
+    outputCol -> VECTOR_SIMILARITY,
+    similarityMethod -> "cosine")
+
+  /** Verifies that both named input columns exist in the schema with the correct annotator type.
+    *
+    * The base `RawAnnotator.validate` uses `exists` (any column of the right type satisfies each
+    * entry in `inputAnnotatorTypes`), which would pass validation even when only one
+    * SENTENCE_EMBEDDINGS column is present. This override checks each column by name.
+    */
+  override protected def validate(schema: StructType): Boolean =
+    getInputCols.forall { colName =>
+      schema.exists(f =>
+        f.name == colName &&
+          f.metadata.contains("annotatorType") &&
+          f.metadata.getString("annotatorType") == SENTENCE_EMBEDDINGS)
+    }
+
+  /** Scores all N×M pairs between the two input annotation sets.
+    *
+    * Each pair `(i, j)` produces one output annotation with:
+    *   - `result` — score as a full-precision String
+    *   - `metadata("sentence_a_idx")` / `metadata("sentence_b_idx")` — 0-based pair indices
+    *   - `metadata("sentence_a_text")` / `metadata("sentence_b_text")` — source `.result` text
+    *   - `metadata("similarity")` — score (same as `result`, for named access)
+    *   - `metadata("similarityMethod")` — the method used
+    */
+  private def computeSimilarities(
+      setA: Seq[Annotation],
+      setB: Seq[Annotation]): Seq[Annotation] = {
+    val method = $(similarityMethod)
+    for {
+      (annA, i) <- setA.zipWithIndex
+      (annB, j) <- setB.zipWithIndex
+    } yield {
+      val vecA = annA.embeddings.map(_.toDouble)
+      val vecB = annB.embeddings.map(_.toDouble)
+      validateSameDimension(vecA, vecB, i, j)
+      val score = method match {
+        case "cosine" => cosineSimilarity(vecA, vecB)
+        case "dotProduct" => dotProduct(vecA, vecB)
+        case "euclidean" => negativeEuclidean(vecA, vecB)
+        case other => throw new IllegalArgumentException(s"Unknown method: $other")
+      }
+      Annotation(
+        annotatorType = VECTOR_SIMILARITY,
+        begin = 0,
+        end = 0,
+        result = score.toString,
+        metadata = Map(
+          "sentence_a_idx" -> i.toString,
+          "sentence_b_idx" -> j.toString,
+          "sentence_a_text" -> annA.result,
+          "sentence_b_text" -> annB.result,
+          "similarity" -> score.toString,
+          "similarityMethod" -> method),
+        embeddings = Array.emptyFloatArray)
+    }
+  }
+
+  private def validateSameDimension(
+      a: Array[Double],
+      b: Array[Double],
+      indexA: Int,
+      indexB: Int): Unit =
+    require(
+      a.length == b.length,
+      "PairwiseVectorSimilarity requires equal embedding dimensions for each pair. " +
+        s"Found ${a.length} and ${b.length} dimensions at sentence_a_idx=$indexA, " +
+        s"sentence_b_idx=$indexB.")
+
+  private def dotProduct(a: Array[Double], b: Array[Double]): Double = {
+    var sum = 0.0
+    var k = 0
+    while (k < a.length) { sum += a(k) * b(k); k += 1 }
+    sum
+  }
+
+  private def cosineSimilarity(a: Array[Double], b: Array[Double]): Double = {
+    val dot = dotProduct(a, b)
+    val normA = math.sqrt(dotProduct(a, a))
+    val normB = math.sqrt(dotProduct(b, b))
+    if (normA == 0.0 || normB == 0.0) 0.0 else dot / (normA * normB)
+  }
+
+  private def negativeEuclidean(a: Array[Double], b: Array[Double]): Double = {
+    var sum = 0.0
+    var k = 0
+    while (k < a.length) { val d = a(k) - b(k); sum += d * d; k += 1 }
+    -math.sqrt(sum)
+  }
+
+  /** Overrides the default `dfAnnotate` so the two input columns are kept separate rather than
+    * being flattened into a single Seq. The first element of `rows` corresponds to col A (index 0
+    * in `getInputCols`) and the second to col B (index 1).
+    */
+  override def dfAnnotate: UserDefinedFunction = udf { rows: Seq[Seq[Row]] =>
+    val setA = rows.headOption.map(_.map(Annotation(_))).getOrElse(Seq.empty)
+    val setB = rows.lift(1).map(_.map(Annotation(_))).getOrElse(Seq.empty)
+    computeSimilarities(setA, setB)
+  }
+
+  /** Not supported — `LightPipeline` flattens both input columns into a single Seq, making it
+    * impossible to distinguish col A from col B. Use `transform()` on a DataFrame instead.
+    */
+  override def annotate(annotations: Seq[Annotation]): Seq[Annotation] =
+    throw new UnsupportedOperationException(
+      "PairwiseVectorSimilarity requires two named input columns. " +
+        "LightPipeline is not supported — use transform() on a DataFrame instead.")
+}
+
+trait ReadablePairwiseVectorSimilarity extends ParamsAndFeaturesReadable[PairwiseVectorSimilarity]
+
+object PairwiseVectorSimilarity extends ReadablePairwiseVectorSimilarity

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/similarity/PairwiseVectorSimilarityTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/similarity/PairwiseVectorSimilarityTestSpec.scala
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2017-2025 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp.annotators.similarity
+
+import com.johnsnowlabs.nlp.Annotation
+import com.johnsnowlabs.nlp.AnnotationUtils.AnnotationRow
+import com.johnsnowlabs.nlp.AnnotatorType.SENTENCE_EMBEDDINGS
+import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.tags.FastTest
+import org.apache.spark.SparkException
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions.{col, explode}
+import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class PairwiseVectorSimilarityTestSpec extends AnyFlatSpec {
+
+  private val spark = ResourceHelper.spark
+
+  private def seAnnotation(text: String, vec: Array[Float]): Annotation =
+    Annotation(SENTENCE_EMBEDDINGS, 0, text.length - 1, text, Map("sentence" -> "0"), vec)
+
+  private def makeDF(
+      colAAnnots: Seq[Annotation],
+      colBAnnots: Seq[Annotation],
+      colAName: String = "emb_a",
+      colBName: String = "emb_b") = {
+    val meta = new MetadataBuilder().putString("annotatorType", SENTENCE_EMBEDDINGS).build()
+    val schema = StructType(
+      Seq(
+        StructField(colAName, com.johnsnowlabs.nlp.Annotation.arrayType, nullable = false, meta),
+        StructField(colBName, com.johnsnowlabs.nlp.Annotation.arrayType, nullable = false, meta)))
+    val row = Row(colAAnnots.map(_.toRow()).toSeq, colBAnnots.map(_.toRow()).toSeq)
+    spark.createDataFrame(spark.sparkContext.parallelize(Seq(row)), schema)
+  }
+
+  "PairwiseVectorSimilarity" should "compute cosine = 1.0 for identical vectors" taggedAs FastTest in {
+    val vec = Array(1.0f, 0.0f, 0.0f)
+    val df = makeDF(Seq(seAnnotation("hello", vec)), Seq(seAnnotation("hello", vec)))
+
+    val result = new PairwiseVectorSimilarity()
+      .setInputCols("emb_a", "emb_b")
+      .setOutputCol("similarity")
+      .setSimilarityMethod("cosine")
+      .transform(df)
+      .select(explode(col("similarity")).as("s"))
+      .select(col("s.result").cast("double").as("score"))
+      .collect()
+
+    assert(result.length == 1)
+    assert(math.abs(result.head.getAs[Double]("score") - 1.0) < 1e-9)
+  }
+
+  it should "compute cosine = 0.0 for orthogonal vectors" taggedAs FastTest in {
+    val df = makeDF(
+      Seq(seAnnotation("query", Array(1.0f, 0.0f))),
+      Seq(seAnnotation("doc", Array(0.0f, 1.0f))))
+
+    val score = new PairwiseVectorSimilarity()
+      .setInputCols("emb_a", "emb_b")
+      .setOutputCol("similarity")
+      .transform(df)
+      .select(explode(col("similarity")).as("s"))
+      .select(col("s.result").cast("double").as("score"))
+      .collect()
+      .head
+      .getAs[Double]("score")
+
+    assert(math.abs(score) < 1e-9)
+  }
+
+  it should "compute cosine = -1.0 for opposite vectors" taggedAs FastTest in {
+    val df = makeDF(
+      Seq(seAnnotation("pos", Array(1.0f, 0.0f))),
+      Seq(seAnnotation("neg", Array(-1.0f, 0.0f))))
+
+    val score = new PairwiseVectorSimilarity()
+      .setInputCols("emb_a", "emb_b")
+      .setOutputCol("similarity")
+      .transform(df)
+      .select(explode(col("similarity")).as("s"))
+      .select(col("s.result").cast("double").as("score"))
+      .collect()
+      .head
+      .getAs[Double]("score")
+
+    assert(math.abs(score - (-1.0)) < 1e-9)
+  }
+
+  it should "produce N×M annotations for multi-embedding inputs" taggedAs FastTest in {
+    val df = makeDF(
+      Seq(seAnnotation("q1", Array(1.0f, 0.0f)), seAnnotation("q2", Array(0.0f, 1.0f))),
+      Seq(
+        seAnnotation("d1", Array(1.0f, 0.0f)),
+        seAnnotation("d2", Array(0.0f, 1.0f)),
+        seAnnotation("d3", Array(-1.0f, 0.0f))))
+
+    val count = new PairwiseVectorSimilarity()
+      .setInputCols("emb_a", "emb_b")
+      .setOutputCol("similarity")
+      .transform(df)
+      .select(explode(col("similarity")).as("s"))
+      .count()
+
+    assert(count == 6L) // 2 × 3
+  }
+
+  it should "populate sentence_a_text and sentence_b_text in metadata" taggedAs FastTest in {
+    val df = makeDF(
+      Seq(seAnnotation("my query", Array(1.0f, 0.0f))),
+      Seq(seAnnotation("my document", Array(0.0f, 1.0f))))
+
+    val row = new PairwiseVectorSimilarity()
+      .setInputCols("emb_a", "emb_b")
+      .setOutputCol("similarity")
+      .transform(df)
+      .select(explode(col("similarity")).as("s"))
+      .select(
+        col("s.metadata")("sentence_a_text").as("a_text"),
+        col("s.metadata")("sentence_b_text").as("b_text"))
+      .collect()
+      .head
+
+    assert(row.getAs[String]("a_text") == "my query")
+    assert(row.getAs[String]("b_text") == "my document")
+  }
+
+  it should "have result equal to metadata similarity" taggedAs FastTest in {
+    val df =
+      makeDF(Seq(seAnnotation("a", Array(0.6f, 0.8f))), Seq(seAnnotation("b", Array(0.8f, 0.6f))))
+
+    val row = new PairwiseVectorSimilarity()
+      .setInputCols("emb_a", "emb_b")
+      .setOutputCol("similarity")
+      .transform(df)
+      .select(explode(col("similarity")).as("s"))
+      .select(
+        col("s.result").cast("double").as("from_result"),
+        col("s.metadata")("similarity").cast("double").as("from_meta"))
+      .collect()
+      .head
+
+    assert(math.abs(row.getAs[Double]("from_result") - row.getAs[Double]("from_meta")) < 1e-15)
+  }
+
+  it should "return euclidean = 0.0 for identical vectors" taggedAs FastTest in {
+    val vec = Array(1.0f, 2.0f, 3.0f)
+    val df = makeDF(Seq(seAnnotation("x", vec)), Seq(seAnnotation("x", vec)))
+
+    val score = new PairwiseVectorSimilarity()
+      .setInputCols("emb_a", "emb_b")
+      .setOutputCol("similarity")
+      .setSimilarityMethod("euclidean")
+      .transform(df)
+      .select(explode(col("similarity")).as("s"))
+      .select(col("s.result").cast("double").as("score"))
+      .collect()
+      .head
+      .getAs[Double]("score")
+
+    assert(math.abs(score) < 1e-9)
+  }
+
+  it should "return negative euclidean for distinct vectors" taggedAs FastTest in {
+    val df =
+      makeDF(Seq(seAnnotation("a", Array(1.0f, 0.0f))), Seq(seAnnotation("b", Array(0.0f, 1.0f))))
+
+    val score = new PairwiseVectorSimilarity()
+      .setInputCols("emb_a", "emb_b")
+      .setOutputCol("similarity")
+      .setSimilarityMethod("euclidean")
+      .transform(df)
+      .select(explode(col("similarity")).as("s"))
+      .select(col("s.result").cast("double").as("score"))
+      .collect()
+      .head
+      .getAs[Double]("score")
+
+    assert(score < 0.0)
+    // expected: -sqrt(2) ≈ -1.4142
+    assert(math.abs(score - (-math.sqrt(2.0))) < 1e-9)
+  }
+
+  it should "return dotProduct scores correctly" taggedAs FastTest in {
+    val df =
+      makeDF(Seq(seAnnotation("a", Array(2.0f, 3.0f))), Seq(seAnnotation("b", Array(4.0f, 5.0f))))
+
+    val score = new PairwiseVectorSimilarity()
+      .setInputCols("emb_a", "emb_b")
+      .setOutputCol("similarity")
+      .setSimilarityMethod("dotProduct")
+      .transform(df)
+      .select(explode(col("similarity")).as("s"))
+      .select(col("s.result").cast("double").as("score"))
+      .collect()
+      .head
+      .getAs[Double]("score")
+
+    // 2*4 + 3*5 = 23
+    assert(math.abs(score - 23.0) < 1e-9)
+  }
+
+  it should "return 0.0 for cosine with a zero vector" taggedAs FastTest in {
+    val df = makeDF(
+      Seq(seAnnotation("zero", Array(0.0f, 0.0f))),
+      Seq(seAnnotation("nonzero", Array(1.0f, 0.0f))))
+
+    val score = new PairwiseVectorSimilarity()
+      .setInputCols("emb_a", "emb_b")
+      .setOutputCol("similarity")
+      .transform(df)
+      .select(explode(col("similarity")).as("s"))
+      .select(col("s.result").cast("double").as("score"))
+      .collect()
+      .head
+      .getAs[Double]("score")
+
+    assert(score == 0.0)
+  }
+
+  it should "throw a clear error for mismatched embedding dimensions" taggedAs FastTest in {
+    val df = makeDF(
+      Seq(seAnnotation("short", Array(1.0f, 0.0f))),
+      Seq(seAnnotation("long", Array(1.0f, 0.0f, 0.0f))))
+
+    val exception = intercept[SparkException] {
+      new PairwiseVectorSimilarity()
+        .setInputCols("emb_a", "emb_b")
+        .setOutputCol("similarity")
+        .transform(df)
+        .select(explode(col("similarity")).as("s"))
+        .collect()
+    }
+
+    assert(exception.toString.contains("requires equal embedding dimensions"))
+  }
+
+  it should "throw when setInputCols receives only one column" taggedAs FastTest in {
+    assertThrows[IllegalArgumentException] {
+      new PairwiseVectorSimilarity().setInputCols("only_one")
+    }
+  }
+
+  it should "throw UnsupportedOperationException from annotate()" taggedAs FastTest in {
+    assertThrows[UnsupportedOperationException] {
+      new PairwiseVectorSimilarity().annotate(Seq.empty)
+    }
+  }
+}


### PR DESCRIPTION
Spark 4.x / Scala 2.13 / Java 17 port of [#14787](https://github.com/JohnSnowLabs/spark-nlp/issues/14787).

Ported the PairwiseVectorSimilarity commits onto migration/scala213 and fixed one real Spark 4 issue:

PairwiseVectorSimilarity.scala overrode dfAnnotate to keep the two input columns (e.g. query embeddings vs. corpus embeddings) separate instead of flattened. On Spark 4, AnnotatorModel._transform never calls dfAnnotate for HasSimpleAnnotate annotators, it calls annotateColumnGroups directly. Since annotateColumnGroups wasn't overridden, it fell back to the trait default, which flattens both columns and calls annotate(), and this annotator's annotate() unconditionally throws UnsupportedOperationException (LightPipeline isn't supported here, DataFrame transform() is). So every transform() call would have thrown immediately on Spark 4, even standard usage. Fixed by overriding annotateColumnGroups directly instead of dfAnnotate, mirroring the pattern already used in MultiColumnAssembler.scala.

Tested on a Databricks Spark 4.1.0 / Scala 2.13 / JDK17 cluster: sbt -Dis_spark40=true compile clean, unit spec 13/13 pass.