### PR TITLE
[SPARKNLP-173] Fix RuleBasedMatcher automatic attribute inference dropping the base token column

### DIFF
--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/matcher/RuleBasedMatcherModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/matcher/RuleBasedMatcherModel.scala
@@ -68,7 +68,7 @@ class RuleBasedMatcherModel(override val uid: String)
   def setInputColumnTypes(value: Array[String]): this.type = set(inputColumnTypes, value)
 
   def getInputColumnTypes: Map[String, String] =
-    parseKeyValueEntries($(inputColumnTypes), "inputColumnTypes")
+    parseKeyValueEntries($(inputColumnTypes), "inputColumnTypes", normalizeKeys = false)
 
   override protected def validate(schema: StructType): Boolean = {
     validateInputColumnsOrThrow(schema)

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/RuleBasedMatcherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/RuleBasedMatcherTestSpec.scala
@@ -100,6 +100,17 @@ class RuleBasedMatcherTestSpec extends AnyFlatSpec {
     assert(matches.map(_.result) == Seq("Dogs", "Dogs bark"))
   }
 
+  it should "infer the base token column automatically without an explicit attributeColumns mapping" taggedAs FastTest in {
+    val dataset = simpleDataset("dogs bark")
+    val matcher = new RuleBasedMatcher()
+      .setInputCols("sentence", "token")
+      .setOutputCol("matches")
+      .setRules("""[{"id":"dogs_rule","patterns":[[{"TEXT":"dogs"}]]}]""")
+
+    val matches = collectMatches(matcher.fit(dataset).transform(dataset))
+    assert(matches.map(_.result) == Seq("dogs"))
+  }
+
   it should "support wildcard, optional, star, plus, bounded, regex, and multi-predicate rules" taggedAs FastTest in {
     val dataset = simpleDataset("red very big car", Seq("ADJ", "ADV", "ADJ", "NOUN"))
     val rules =


### PR DESCRIPTION
`RuleBasedMatcher` throws `RuleBasedMatcher requires a TOKEN input column for base token alignment` whenever `attributeColumns` isn't set explicitly (the documented default usage). `getInputColumnTypes` uppercases column names when decoding the persisted param, so `"token"` becomes `"TOKEN"` and never matches the real column name at transform time. Every existing test sets `attributeColumns` explicitly so this never got caught.

Fix: decode without uppercasing.