### PR TITLE
[Spark 4.x] [SPARKNLP-1411] HC JSL Spark4.x Compatibility

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -132,7 +132,7 @@ object Dependencies {
   val azureIdentity = "com.azure" % "azure-identity" % azureIdentityVersion % Provided
   val azureStorage = "com.azure" % "azure-storage-blob" % azureStorageVersion % Provided
 
-  val llamaCppVersion = "2.0.3"
+  val llamaCppVersion = "2.0.4-rc2"
   val llamaCppCPU = "com.johnsnowlabs.nlp" % "jsl-llamacpp-cpu" % llamaCppVersion
   val llamaCppGPU = "com.johnsnowlabs.nlp" % "jsl-llamacpp-gpu" % llamaCppVersion
   val llamaCppSilicon = "com.johnsnowlabs.nlp" % "jsl-llamacpp-silicon" % llamaCppVersion

--- a/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Annotation.scala
@@ -150,6 +150,12 @@ object Annotation {
 
   val arrayType = new ArrayType(dataType, true)
 
+  private def getEmbeddings(row: Row): Array[Float] =
+    row.get(5) match {
+      case embeddings: Array[Float] => embeddings.clone()
+      case _ => row.getSeq[Float](5).toArray
+    }
+
   /** This method converts a [[org.apache.spark.sql.Row]] into an [[Annotation]]
     *
     * @param row
@@ -164,7 +170,7 @@ object Annotation {
       row.getInt(2),
       row.getString(3),
       row.getMap[String, String](4),
-      row.getSeq[Float](5).toArray)
+      getEmbeddings(row))
   }
 
   def apply(rawText: String): Annotation =

--- a/src/main/scala/com/johnsnowlabs/nlp/Finisher.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/Finisher.scala
@@ -317,7 +317,7 @@ class Finisher(override val uid: String) extends Transformer with DefaultParamsW
     implicit val encoder: ExpressionEncoder[Row] =
       SparkNlpConfig.getEncoder(inputDataFrame, outputSchema)
 
-    inputDataFrame
+    val transformedDataFrame = inputDataFrame
       .mapPartitions { rows =>
         rows.map { row =>
           val inputValuesByName = inputFieldNames.zip(row.toSeq).toMap
@@ -356,6 +356,8 @@ class Finisher(override val uid: String) extends Transformer with DefaultParamsW
         }
       }
       .toDF()
+
+    functions.restoreSchemaMetadata(transformedDataFrame, outputSchema)
   }
 
   override def transform(dataset: Dataset[_]): Dataset[Row] = {

--- a/src/main/scala/com/johnsnowlabs/nlp/functions.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/functions.scala
@@ -103,7 +103,7 @@ object functions {
     dataFrame.col(s"`$escapedColumnName`")
   }
 
-  private def restoreSchemaMetadata(
+  private[nlp] def restoreSchemaMetadata(
       dataFrame: DataFrame,
       intendedSchema: StructType): DataFrame = {
     val columnsWithMetadata = intendedSchema.fields.map { field =>

--- a/src/main/scala/com/johnsnowlabs/nlp/functions.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/functions.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.types.{
   StructField,
   StructType
 }
-import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.{Column, DataFrame, Row}
 
 import scala.reflect.runtime.universe.{typeOf, TypeTag}
 
@@ -98,6 +98,20 @@ object functions {
     else StructType(inputSchema.fields :+ outputField)
   }
 
+  private def exactColumn(dataFrame: DataFrame, columnName: String): Column = {
+    val escapedColumnName = columnName.replace("`", "``")
+    dataFrame.col(s"`$escapedColumnName`")
+  }
+
+  private def restoreSchemaMetadata(
+      dataFrame: DataFrame,
+      intendedSchema: StructType): DataFrame = {
+    val columnsWithMetadata = intendedSchema.fields.map { field =>
+      exactColumn(dataFrame, field.name).as(field.name, field.metadata)
+    }
+    dataFrame.select(columnsWithMetadata.toIndexedSeq: _*)
+  }
+
   private def mapAnnotationsColWithRows[T: TypeTag](
       dataset: DataFrame,
       columns: Seq[String],
@@ -115,7 +129,7 @@ object functions {
     implicit val encoder: ExpressionEncoder[Row] =
       SparkNlpConfig.getEncoder(inputDataFrame, outputSchema)
 
-    inputDataFrame
+    val mappedDataFrame = inputDataFrame
       .mapPartitions { rows =>
         rows.map { row =>
           val annotations = inputIndexes
@@ -130,6 +144,8 @@ object functions {
         }
       }
       .toDF()
+
+    restoreSchemaMetadata(mappedDataFrame, outputSchema)
   }
 
   implicit class FilterAnnotations(dataset: DataFrame) {
@@ -142,7 +158,7 @@ object functions {
         implicit val encoder: ExpressionEncoder[Row] =
           SparkNlpConfig.getEncoder(inputDataFrame, inputDataFrame.schema)
 
-        inputDataFrame
+        val filteredDataFrame = inputDataFrame
           .mapPartitions { rows =>
             rows.filter { row =>
               val annotations =
@@ -151,6 +167,8 @@ object functions {
             }
           }
           .toDF()
+
+        restoreSchemaMetadata(filteredDataFrame, inputDataFrame.schema)
       } else {
         val meta = dataset.schema(column).metadata
         val func = udf { annotatorProperties: Seq[Row] =>

--- a/src/test/scala/com/johnsnowlabs/nlp/FinisherTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/FinisherTestSpec.scala
@@ -21,6 +21,8 @@ import com.johnsnowlabs.nlp.embeddings.WordEmbeddings
 import com.johnsnowlabs.tags.FastTest
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.ml.feature.StopWordsRemover
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.MetadataBuilder
 import org.scalatest.flatspec.AnyFlatSpec
 
 class FinisherTestSpec extends AnyFlatSpec {
@@ -119,6 +121,25 @@ class FinisherTestSpec extends AnyFlatSpec {
       .collect
       .foreach(s => assert(s.contains("->"), "because -> key value was not found"))
 
+  }
+
+  "A Finisher that keeps annotations" should "preserve inherited schema metadata" taggedAs FastTest in {
+    val pipeline = new Pipeline().setStages(Array(documentAssembler, tokenizer))
+    val annotated = pipeline.fit(data).transform(data)
+    val customMetadata = new MetadataBuilder().putString("customMetadata", "kept").build()
+    val input = annotated.withColumn("text", col("text").as("text", customMetadata))
+
+    val finisher = new Finisher()
+      .setInputCols("token")
+      .setOutputCols("token_out")
+      .setCleanAnnotations(false)
+
+    val result = finisher.transform(input)
+
+    result.select("token_out").collect()
+    input.schema.fields.foreach { field =>
+      assert(result.schema(field.name).metadata == field.metadata)
+    }
   }
 
   "A Finisher with array output" should "behave accordingly with SparkML StopWords" taggedAs FastTest in {

--- a/src/test/scala/com/johnsnowlabs/nlp/FunctionsTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/FunctionsTestSpec.scala
@@ -21,7 +21,8 @@ import com.johnsnowlabs.nlp.training.POS
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.tags.FastTest
 import org.apache.spark.ml.Pipeline
-import org.apache.spark.sql.types.ArrayType
+import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.sql.types.{ArrayType, MetadataBuilder}
 import org.junit.Assert.assertEquals
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -151,6 +152,76 @@ class FunctionsTestSpec extends AnyFlatSpec {
     assertEquals(tail_annotation(1).result, "tres tristes tigres")
     assertEquals(tail_annotation(2).result, "un clavito chiquitillo")
     assertEquals(tail_annotation.last.result, "comian trigo en un trigal")
+  }
+
+  "A mapAnnotationsCol" should "preserve schema metadata and exact top-level columns" in {
+    import SparkAccessor.spark.implicits._
+    import functions._
+
+    val documentMetadata = new MetadataBuilder()
+      .putString("annotatorType", AnnotatorType.DOCUMENT)
+      .putString("custom", "document-metadata")
+      .build()
+    val specialColumnMetadata = new MetadataBuilder()
+      .putString("custom", "special-column-metadata")
+      .build()
+
+    val input = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+      .transform(Seq("Metadata must survive").toDF("text"))
+      .withColumn("document", col("document").as("document", documentMetadata))
+      .withColumn("patient.id", lit("patient").as("patient.id", specialColumnMetadata))
+      .withColumn("note`id", lit("note").as("note`id", specialColumnMetadata))
+
+    val mapped = input.mapAnnotationsCol[Seq[Annotation]](
+      "document",
+      "tail_document",
+      AnnotatorType.DOCUMENT,
+      identity)
+
+    assert(mapped.schema("document").metadata.getString("custom") == "document-metadata")
+    assert(
+      mapped
+        .schema("tail_document")
+        .metadata
+        .getString("annotatorType") == AnnotatorType.DOCUMENT)
+    assert(mapped.schema("patient.id").metadata.getString("custom") == "special-column-metadata")
+    assert(mapped.schema("note`id").metadata.getString("custom") == "special-column-metadata")
+
+    val specialColumnValues =
+      mapped.select(mapped.col("`patient.id`"), mapped.col("`note``id`")).head()
+    assert(specialColumnValues.getString(0) == "patient")
+    assert(specialColumnValues.getString(1) == "note")
+    assert(
+      Annotation.collect(mapped, "tail_document").flatten.map(_.result).toSeq ==
+        Seq("Metadata must survive"))
+  }
+
+  "A filterByAnnotationsCol" should "preserve schema metadata" in {
+    import SparkAccessor.spark.implicits._
+    import functions._
+
+    val documentMetadata = new MetadataBuilder()
+      .putString("annotatorType", AnnotatorType.DOCUMENT)
+      .putString("custom", "document-metadata")
+      .build()
+
+    val input = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+      .transform(Seq("Metadata must survive filtering").toDF("text"))
+      .withColumn("document", col("document").as("document", documentMetadata))
+
+    val filtered = input.filterByAnnotationsCol("document", _.nonEmpty)
+
+    assert(
+      filtered.schema("document").metadata.getString("annotatorType") ==
+        AnnotatorType.DOCUMENT)
+    assert(filtered.schema("document").metadata.getString("custom") == "document-metadata")
+    assert(
+      Annotation.collect(filtered, "document").flatten.map(_.result).toSeq ==
+        Seq("Metadata must survive filtering"))
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/util/AnnotationRowUtilsTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/util/AnnotationRowUtilsTest.scala
@@ -51,4 +51,34 @@ class AnnotationRowUtilsTest extends AnyFlatSpec with SparkSessionTest {
     assert(row.getMap[String, String](4) == Map("sentence" -> "0"))
     assert(row.getAs[Array[Float]](5).sameElements(Array(1.0f, 2.0f)))
   }
+
+  it should "round-trip annotations with primitive-array embeddings" in {
+    val original = com.johnsnowlabs.nlp.Annotation(
+      annotatorType = "word_embeddings",
+      begin = 0,
+      end = 4,
+      result = "alpha",
+      metadata = Map("sentence" -> "0", "token" -> "alpha"),
+      embeddings = Array(1.0f, 2.0f))
+
+    val row = AnnotationRowUtils.annotationToRow(original)
+    val restored = com.johnsnowlabs.nlp.Annotation(row)
+
+    assert(restored == original)
+    assert(!(restored.embeddings eq original.embeddings))
+  }
+
+  it should "convert annotations with sequence embeddings" in {
+    val row = Row(
+      "word_embeddings",
+      0,
+      4,
+      "alpha",
+      Map("sentence" -> "0", "token" -> "alpha"),
+      Seq(1.0f, 2.0f))
+
+    val annotation = com.johnsnowlabs.nlp.Annotation(row)
+
+    assert(annotation.embeddings.sameElements(Array(1.0f, 2.0f)))
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR addresses Spark 4 compatibility fixes in spark-nlp that are prerequisites for the HC (spark-nlp-internal) migration. It consolidates four commits under SPARKNLP-1411:

 - Support primitive annotation embeddings on Spark 4: `Annotation` now handles both `Array[Float]` and `Seq[Float]` in the embeddings field, since Spark 4 changed internal Row encoding from primitive arrays to boxed types.

- Preserve annotation metadata in dataframe functions: Added `restoreSchemaMetadata` and `exactColumn` helpers to `functions`. These ensure schema metadata is re-applied after `mapPartitions` operations in `mapAnnotationsColWithRows` and the filter path, resolving metadata loss.

- Preserve metadata in `Finisher` transformations: Applied the same `restoreSchemaMetadata` pattern in `Finisher.transform`, fixing metadata stripping in `Finisher` output.
- Bump jsl-llama version: Updated jsl-llamacpp from 2.0.3 to 2.0.4-rc2 to resolve a symbol issue reported here: https://github.com/JohnSnowLabs/jsl-llama.cpp/pull/9

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Spark NLP Healthcare is migrating from Spark 3.x to Spark 4.x. The baseline shows 77 failing tests driven by two primary incompatibilities:

1. Annotation-row UDF encoder failures: Spark 4 changed how Row columns are encoded in UDFs, causing `UnboundRowEncoder` errors during de-identification, chunk filtering, and classification. The fix replaces inferred
encoders with explicit `SparkNlpConfig.getEncoder`, uses `mapPartitions` for annotation conversion, and adds `restoreSchemaMetadata` to preserve field-level metadata through `DataFrame` transforms.

2. Deserialization: Legacy model deserialization null-resolvers were blocking runtime. The deserialization fix replaces null resolvers with typed no operation resolvers. i.e. It "resolves" the object by just returning it as-is, without any custom logic, avoiding the null crash while preserving the original deserialized object.

The embedded embeddings fix addresses the root cause of `AnnotationRowUtils` round-trip failures: Spark 4 stores embeddings as `Seq[Float]` instead of `Array[Float]`, which `Annotation.apply(Row)` was not handling.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests (new + updated):

- `FunctionsTestSpec`: `mapAnnotationsCol` and `filterByAnnotationsCol` now assert that schema metadata (`annotatorType`, custom fields, escaped column names) survives the `mapPartitions` transform and is recoverable via `Annotation.collect`.
- `FinisherTestSpec`: verifies that `Finisher.transform` with `cleanAnnotations=false` preserves all inherited field-level metadata after the partition map.
- `AnnotationRowUtilsTest`: round-trips an annotation with `Array[Float]` embeddings through `annotationToRow` + `Annotation(Row)`, and separately constructs a Row with `Seq[Float]` embeddings to confirm the fallback path.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
