### PR TITLE
[Spark 4.x] [SPARKNLP-45] Optimized Annotators use BatchAnnotate to actually batch rows and not a single row

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/ai/AlbertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/AlbertClassification.scala
@@ -533,7 +533,9 @@ private[johnsnowlabs] class AlbertClassification(
     val maskTensors =
       OnnxTensor.createTensor(
         env,
-        batch.map(sentence => sentence.map(x => if (x == 0L) 0L else 1L)).toArray)
+        batch
+          .map(sentence => sentence.map(x => if (x == sentencePadTokenId) 0L else 1L))
+          .toArray)
 
     val segmentTensors =
       OnnxTensor.createTensor(env, batch.map(x => Array.fill(maxSentenceLength)(0L)).toArray)
@@ -584,7 +586,11 @@ private[johnsnowlabs] class AlbertClassification(
     val batchLength = batch.length
     val shape = Array(batchLength, maxSentenceLength)
     val (tokenTensors, maskTensors) =
-      PrepareEmbeddings.prepareOvLongBatchTensors(batch, maxSentenceLength, batchLength)
+      PrepareEmbeddings.prepareOvLongBatchTensors(
+        batch,
+        maxSentenceLength,
+        batchLength,
+        sentencePadTokenId = sentencePadTokenId)
     val segmentTensors = new Tensor(shape, Array.fill(batchLength * maxSentenceLength)(0L))
 
     val inferRequest = openvinoWrapper.get.getCompiledModel().create_infer_request()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/BertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/BertClassification.scala
@@ -634,7 +634,11 @@ private[johnsnowlabs] class BertClassification(
     val batchLength = batch.length
     val shape = Array(batchLength, maxSentenceLength)
     val (tokenTensors, maskTensors) =
-      PrepareEmbeddings.prepareOvLongBatchTensors(batch, maxSentenceLength, batchLength)
+      PrepareEmbeddings.prepareOvLongBatchTensors(
+        batch,
+        maxSentenceLength,
+        batchLength,
+        sentencePadTokenId = sentencePadTokenId)
 
     // Initialize the segment tensor as an array of arrays
     val segmentTensor = Array.ofDim[Long](batch.length, maxSentenceLength)
@@ -698,7 +702,9 @@ private[johnsnowlabs] class BertClassification(
     val maskTensors =
       OnnxTensor.createTensor(
         env,
-        batch.map(sentence => sentence.map(x => if (x == 0L) 0L else 1L)).toArray)
+        batch
+          .map(sentence => sentence.map(x => if (x == sentencePadTokenId) 0L else 1L))
+          .toArray)
 
     val segmentTensors =
       OnnxTensor.createTensor(env, batch.map(x => Array.fill(maxSentenceLength)(0L)).toArray)

--- a/src/main/scala/com/johnsnowlabs/ml/ai/BertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/BertClassification.scala
@@ -572,7 +572,7 @@ private[johnsnowlabs] class BertClassification(
       .foreach { case (sentence, idx) =>
         val offset = idx * maxSentenceLength
         tokenBuffers.offset(offset).write(sentence)
-        maskBuffers.offset(offset).write(sentence.map(x => if (x == 0) 0 else 1))
+        maskBuffers.offset(offset).write(sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
         var firstSeq = true
         segmentBuffers
           .offset(offset)

--- a/src/main/scala/com/johnsnowlabs/ml/ai/CamemBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/CamemBertClassification.scala
@@ -404,7 +404,11 @@ private[johnsnowlabs] class CamemBertClassification(
     val batchLength = batch.length
     val shape = Array(batchLength, maxSentenceLength)
     val (tokenTensors, maskTensors) =
-      PrepareEmbeddings.prepareOvLongBatchTensors(batch, maxSentenceLength, batchLength)
+      PrepareEmbeddings.prepareOvLongBatchTensors(
+        batch,
+        maxSentenceLength,
+        batchLength,
+        sentencePadTokenId = sentencePadTokenId)
 
     val inferRequest = openvinoWrapper.get.getCompiledModel().create_infer_request()
     inferRequest.set_tensor("input_ids", tokenTensors)
@@ -534,7 +538,16 @@ private[johnsnowlabs] class CamemBertClassification(
 
   private def computeLogitsWithOnnx(batch: Seq[Array[Int]]): (Array[Float], Array[Float]) = {
     val (runner, env) = onnxWrapper.get.getSession(onnxSessionOptions)
-    val (tokenTensors, maskTensors) = initializeOnnxTensorResources(batch, env)
+    // Not initializeOnnxTensorResources: that helper masks against a hardcoded 0, but CamemBert's
+    // pad id is derived from its sentencepiece model. That only became load-bearing once
+    // predictSpanGrouped started padding batches to a common width - a batch of 1 is never
+    // padded, so any mask was previously as good as any other here.
+    val tokenTensors =
+      OnnxTensor.createTensor(env, batch.map(x => x.map(_.toLong)).toArray)
+    val maskTensors =
+      OnnxTensor.createTensor(
+        env,
+        batch.map(sentence => sentence.map(x => if (x == sentencePadTokenId) 0L else 1L)).toArray)
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 

--- a/src/main/scala/com/johnsnowlabs/ml/ai/DeBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/DeBertaClassification.scala
@@ -539,7 +539,11 @@ private[johnsnowlabs] class DeBertaClassification(
     val batchLength = batch.length
     val maxSentenceLength = batch.map(_.length).max
     val (tokenTensors, maskTensors) =
-      PrepareEmbeddings.prepareOvLongBatchTensors(batch, maxSentenceLength, batchLength)
+      PrepareEmbeddings.prepareOvLongBatchTensors(
+        batch,
+        maxSentenceLength,
+        batchLength,
+        sentencePadTokenId = sentencePadTokenId)
 
     val inferRequest = openvinoWrapper.get.getCompiledModel().create_infer_request()
     inferRequest.set_tensor("input_ids", tokenTensors)
@@ -576,7 +580,9 @@ private[johnsnowlabs] class DeBertaClassification(
     val maskTensors =
       OnnxTensor.createTensor(
         env,
-        batch.map(sentence => sentence.map(x => if (x == 0L) 0L else 1L)).toArray)
+        batch
+          .map(sentence => sentence.map(x => if (x == sentencePadTokenId) 0L else 1L))
+          .toArray)
 
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava

--- a/src/main/scala/com/johnsnowlabs/ml/ai/DistilBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/DistilBertClassification.scala
@@ -576,7 +576,7 @@ private[johnsnowlabs] class DistilBertClassification(
       .foreach { case (sentence, idx) =>
         val offset = idx * maxSentenceLength
         tokenBuffers.offset(offset).write(sentence)
-        maskBuffers.offset(offset).write(sentence.map(x => if (x == 0) 0 else 1))
+        maskBuffers.offset(offset).write(sentence.map(x => if (x == sentencePadTokenId) 0 else 1))
       }
 
     val session = tensorflowWrapper.get.getTFSessionWithSignature(

--- a/src/main/scala/com/johnsnowlabs/ml/ai/DistilBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/DistilBertClassification.scala
@@ -620,7 +620,11 @@ private[johnsnowlabs] class DistilBertClassification(
     val batchLength = batch.length
     val maxSentenceLength = batch.map(_.length).max
     val (tokenTensors, maskTensors) =
-      PrepareEmbeddings.prepareOvLongBatchTensors(batch, maxSentenceLength, batchLength)
+      PrepareEmbeddings.prepareOvLongBatchTensors(
+        batch,
+        maxSentenceLength,
+        batchLength,
+        sentencePadTokenId = sentencePadTokenId)
 
     val inferRequest = openvinoWrapper.get.getCompiledModel().create_infer_request()
     inferRequest.set_tensor("input_ids", tokenTensors)
@@ -656,7 +660,9 @@ private[johnsnowlabs] class DistilBertClassification(
     val maskTensors =
       OnnxTensor.createTensor(
         env,
-        batch.map(sentence => sentence.map(x => if (x == 0L) 0L else 1L)).toArray)
+        batch
+          .map(sentence => sentence.map(x => if (x == sentencePadTokenId) 0L else 1L))
+          .toArray)
 
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava

--- a/src/main/scala/com/johnsnowlabs/ml/ai/MPNetClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/MPNetClassification.scala
@@ -426,9 +426,8 @@ private[johnsnowlabs] class MPNetClassification(
     val maskTensors = new org.intel.openvino.Tensor(
       shape,
       batch
-        .flatMap(sentence => sentence.map(x => Array.fill(sentence.length)(1L)))
-        .toArray
-        .flatten)
+        .flatMap(sentence => sentence.map(x => if (x == sentencePadTokenId) 0L else 1L))
+        .toArray)
 
     val inferRequest = openvinoWrapper.get.getCompiledModel().create_infer_request()
     inferRequest.set_tensor("input_ids", tokenTensors)
@@ -461,7 +460,9 @@ private[johnsnowlabs] class MPNetClassification(
     val tokenTensors =
       OnnxTensor.createTensor(env, batch.map(x => x.map(_.toLong)).toArray)
     val maskTensors =
-      OnnxTensor.createTensor(env, batch.map(sentence => Array.fill(sentence.length)(1L)).toArray)
+      OnnxTensor.createTensor(
+        env,
+        batch.map(sentence => sentence.map(x => if (x == sentencePadTokenId) 0L else 1L)).toArray)
 
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
@@ -554,10 +555,17 @@ private[johnsnowlabs] class MPNetClassification(
       startLogits: Array[Float],
       endLogits: Array[Float],
       questionLength: Int,
-      contextLength: Int): (Array[Float], Array[Float]) = {
+      contextLength: Int,
+      validLength: Int): (Array[Float], Array[Float]) = {
 
     /** Sets log-logits to (almost) 0 for question and padding tokens so they can't contribute to
       * the final softmax score.
+      *
+      * `validLength` is this example's own unpadded length. When a batch mixes lengths, `scores`
+      * is as wide as the batch's longest example, so the trailing slots are padding belonging to
+      * no example - the real end-of-sequence sits at `validLength - 1`, not at `scores.length -
+      * 1`. Deriving both from `validLength` keeps the mask (and therefore the renormalised
+      * softmax below) identical to what an unbatched, unpadded call would produce.
       *
       * @param scores
       *   Logits of the combined sequences
@@ -566,12 +574,12 @@ private[johnsnowlabs] class MPNetClassification(
       */
     def maskUndesiredTokens(scores: Array[Float]): Array[Float] = {
       val numSpecialTokens = 4 // 4 added special tokens in encoded sequence (1 bos, 2 eos, 1 eos)
-      val totalLength = scores.length
       scores.zipWithIndex.map { case (score, i) =>
         val inQuestionTokens = i > 0 && i < questionLength + numSpecialTokens
-        val isEosToken = i == totalLength - 1
+        val isEosToken = i == validLength - 1
+        val isPadding = i >= validLength
 
-        if (inQuestionTokens || isEosToken) -10000.0f
+        if (inQuestionTokens || isEosToken || isPadding) -10000.0f
         else score
       }
     }
@@ -603,7 +611,12 @@ private[johnsnowlabs] class MPNetClassification(
       encodeSequence(wordPieceTokenizedQuestion, wordPieceTokenizedContext, maxSentenceLength)
     val (rawStartLogits, rawEndLogits) = tagSpan(encodedInput)
     val (startScores, endScores) =
-      processLogits(rawStartLogits.head, rawEndLogits.head, questionLength, contextLength)
+      processLogits(
+        rawStartLogits.head,
+        rawEndLogits.head,
+        questionLength,
+        contextLength,
+        validLength = rawStartLogits.head.length)
 
     // Drop BOS token from valid results
     val startIndex = startScores.zipWithIndex.drop(1).maxBy(_._1)
@@ -695,12 +708,19 @@ private[johnsnowlabs] class MPNetClassification(
           batch.zipWithIndex.map { case (example, i) =>
             val questionLength = example.wordPieceTokenizedQuestion.head.tokens.length
             val contextLength = example.wordPieceTokenizedContext.head.tokens.length
+            // This example's own unpadded width - the batch may be wider (see processLogits).
+            val validLength = example.encoded.length
             val (startScores, endScores) =
-              processLogits(rawStartLogits(i), rawEndLogits(i), questionLength, contextLength)
+              processLogits(
+                rawStartLogits(i),
+                rawEndLogits(i),
+                questionLength,
+                contextLength,
+                validLength)
 
-            // Drop BOS token from valid results
-            val startIndex = startScores.zipWithIndex.drop(1).maxBy(_._1)
-            val endIndex = endScores.zipWithIndex.drop(1).maxBy(_._1)
+            // Drop BOS token from valid results, and never let a padding slot win the argmax.
+            val startIndex = startScores.take(validLength).zipWithIndex.drop(1).maxBy(_._1)
+            val endIndex = endScores.take(validLength).zipWithIndex.drop(1).maxBy(_._1)
 
             val offsetStartIndex = 3 // 3 added special tokens
             val offsetEndIndex = offsetStartIndex - 1

--- a/src/main/scala/com/johnsnowlabs/ml/ai/MPNetClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/MPNetClassification.scala
@@ -648,4 +648,110 @@ private[johnsnowlabs] class MPNetClassification(
 
   }
 
+  /** Batched counterpart of [[predictSpan]], carrying over the same MPNet-specific handling that
+    * the shared trait's generic `predictSpanGrouped` does not know about: masking question and
+    * EOS positions before taking the argmax (`processLogits`), MPNet's own 3-special-token offset
+    * (one more separator than the generic BERT-style encoding), a product (not average) score,
+    * and character-position (not model-position) start/end metadata.
+    */
+  override def predictSpanGrouped(
+      rowsOfDocuments: Seq[Seq[Annotation]],
+      batchSize: Int,
+      maxSentenceLength: Int,
+      caseSensitive: Boolean,
+      mergeTokenStrategy: String = MergeTokenStrategy.vocab,
+      engine: String = TensorFlow.name): Seq[Seq[Annotation]] = {
+
+    val examples: Seq[SpanExample] = rowsOfDocuments.zipWithIndex.flatMap {
+      case (documents, rowIndex) =>
+        if (documents.isEmpty) None
+        else {
+          val questionAnnot = Seq(documents.head)
+          val contextAnnot = documents.drop(1)
+          val wordPieceTokenizedQuestion =
+            tokenizeDocument(questionAnnot, maxSentenceLength, caseSensitive)
+          val wordPieceTokenizedContext =
+            tokenizeDocument(contextAnnot, maxSentenceLength, caseSensitive)
+          val encoded = encodeSequence(
+            wordPieceTokenizedQuestion,
+            wordPieceTokenizedContext,
+            maxSentenceLength).head
+          Some(
+            SpanExample(rowIndex, wordPieceTokenizedQuestion, wordPieceTokenizedContext, encoded))
+        }
+    }
+
+    if (examples.isEmpty) return rowsOfDocuments.map(_ => Seq.empty[Annotation])
+
+    val resultsWithRow: Seq[(Annotation, Int)] =
+      batchByLength[SpanExample, (Annotation, Int)](examples, batchSize, _.encoded.length) {
+        batch =>
+          val maxLen = batch.map(_.encoded.length).max
+          val paddedEncoded = batch.map { example =>
+            example.encoded ++ Array.fill(maxLen - example.encoded.length)(sentencePadTokenId)
+          }
+          val (rawStartLogits, rawEndLogits) = tagSpan(paddedEncoded)
+
+          batch.zipWithIndex.map { case (example, i) =>
+            val questionLength = example.wordPieceTokenizedQuestion.head.tokens.length
+            val contextLength = example.wordPieceTokenizedContext.head.tokens.length
+            val (startScores, endScores) =
+              processLogits(rawStartLogits(i), rawEndLogits(i), questionLength, contextLength)
+
+            // Drop BOS token from valid results
+            val startIndex = startScores.zipWithIndex.drop(1).maxBy(_._1)
+            val endIndex = endScores.zipWithIndex.drop(1).maxBy(_._1)
+
+            val offsetStartIndex = 3 // 3 added special tokens
+            val offsetEndIndex = offsetStartIndex - 1
+
+            val allTokenPieces =
+              example.wordPieceTokenizedQuestion.head.tokens ++
+                example.wordPieceTokenizedContext.flatMap(x => x.tokens)
+            val decodedAnswer =
+              allTokenPieces.slice(startIndex._2 - offsetStartIndex, endIndex._2 - offsetEndIndex)
+            val content =
+              mergeTokenStrategy match {
+                case MergeTokenStrategy.vocab =>
+                  decodedAnswer.filter(_.isWordStart).map(x => x.token).mkString(" ")
+                case MergeTokenStrategy.sentencePiece =>
+                  val token = ""
+                  decodedAnswer
+                    .map(x =>
+                      if (x.isWordStart) " " + token + x.token
+                      else token + x.token)
+                    .mkString("")
+                    .trim
+              }
+
+            val totalScore = startIndex._1 * endIndex._1
+            // decodedAnswer can legitimately be empty (invalid start/end span after masking, e.g.
+            // a genuinely unanswerable question) - fall back to the raw model-position indices
+            // for start/end metadata rather than crashing on decodedAnswer.head/.last.
+            val (startMeta, endMeta) =
+              if (decodedAnswer.isEmpty) (startIndex._2.toString, endIndex._2.toString)
+              else (decodedAnswer.head.begin.toString, decodedAnswer.last.end.toString)
+            val annotation = Annotation(
+              annotatorType = AnnotatorType.CHUNK,
+              begin = 0,
+              end = if (content.isEmpty) 0 else content.length - 1,
+              result = content,
+              metadata = Map(
+                "sentence" -> "0",
+                "chunk" -> "0",
+                "start" -> startMeta,
+                "start_score" -> startIndex._1.toString,
+                "end" -> endMeta,
+                "end_score" -> endIndex._1.toString,
+                "score" -> totalScore.toString))
+
+            (annotation, example.rowIndex)
+          }
+      }
+
+    val byRow =
+      resultsWithRow.groupBy(_._2).map { case (rowIndex, pairs) => rowIndex -> pairs.map(_._1) }
+    rowsOfDocuments.indices.map(rowIndex => byRow.getOrElse(rowIndex, Seq.empty[Annotation]))
+  }
+
 }

--- a/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
@@ -838,4 +838,111 @@ private[johnsnowlabs] class RoBertaClassification(
 
   }
 
+  /** Batched counterpart of [[predictSpan]], carrying over the same RoBERTa-specific handling
+    * that the shared trait's generic `predictSpanGrouped` does not know about: masking question
+    * and EOS positions before taking the argmax (`processLogits`), RoBERTa's own 3-special-token
+    * offset (`<s> Q </s></s> C </s>` has one more separator than the generic BERT-style
+    * encoding), a product (not average) score, and character-position (not model-position)
+    * start/end metadata.
+    */
+  override def predictSpanGrouped(
+      rowsOfDocuments: Seq[Seq[Annotation]],
+      batchSize: Int,
+      maxSentenceLength: Int,
+      caseSensitive: Boolean,
+      mergeTokenStrategy: String = MergeTokenStrategy.vocab,
+      engine: String = TensorFlow.name): Seq[Seq[Annotation]] = {
+
+    val examples: Seq[SpanExample] = rowsOfDocuments.zipWithIndex.flatMap {
+      case (documents, rowIndex) =>
+        if (documents.isEmpty) None
+        else {
+          val questionAnnot = Seq(documents.head)
+          val contextAnnot = documents.drop(1)
+          val wordPieceTokenizedQuestion =
+            tokenizeDocument(questionAnnot, maxSentenceLength, caseSensitive)
+          val wordPieceTokenizedContext =
+            tokenizeDocument(contextAnnot, maxSentenceLength, caseSensitive)
+          val encoded = encodeSequence(
+            wordPieceTokenizedQuestion,
+            wordPieceTokenizedContext,
+            maxSentenceLength).head
+          Some(
+            SpanExample(rowIndex, wordPieceTokenizedQuestion, wordPieceTokenizedContext, encoded))
+        }
+    }
+
+    if (examples.isEmpty) return rowsOfDocuments.map(_ => Seq.empty[Annotation])
+
+    val resultsWithRow: Seq[(Annotation, Int)] =
+      batchByLength[SpanExample, (Annotation, Int)](examples, batchSize, _.encoded.length) {
+        batch =>
+          val maxLen = batch.map(_.encoded.length).max
+          val paddedEncoded = batch.map { example =>
+            example.encoded ++ Array.fill(maxLen - example.encoded.length)(sentencePadTokenId)
+          }
+          val (rawStartLogits, rawEndLogits) = tagSpan(paddedEncoded)
+
+          batch.zipWithIndex.map { case (example, i) =>
+            val questionLength = example.wordPieceTokenizedQuestion.head.tokens.length
+            val contextLength = example.wordPieceTokenizedContext.head.tokens.length
+            val (startScores, endScores) =
+              processLogits(rawStartLogits(i), rawEndLogits(i), questionLength, contextLength)
+
+            // Drop BOS token from valid results
+            val startIndex = startScores.zipWithIndex.drop(1).maxBy(_._1)
+            val endIndex = endScores.zipWithIndex.drop(1).maxBy(_._1)
+
+            val offsetStartIndex = 3 // 3 added special tokens
+            val offsetEndIndex = offsetStartIndex - 1
+
+            val allTokenPieces =
+              example.wordPieceTokenizedQuestion.head.tokens ++
+                example.wordPieceTokenizedContext.flatMap(x => x.tokens)
+            val decodedAnswer =
+              allTokenPieces.slice(startIndex._2 - offsetStartIndex, endIndex._2 - offsetEndIndex)
+            val content =
+              mergeTokenStrategy match {
+                case MergeTokenStrategy.vocab =>
+                  decodedAnswer.filter(_.isWordStart).map(x => x.token).mkString(" ")
+                case MergeTokenStrategy.sentencePiece =>
+                  val token = ""
+                  decodedAnswer
+                    .map(x =>
+                      if (x.isWordStart) " " + token + x.token
+                      else token + x.token)
+                    .mkString("")
+                    .trim
+              }
+
+            val totalScore = startIndex._1 * endIndex._1
+            // decodedAnswer can legitimately be empty (invalid start/end span after masking, e.g.
+            // a genuinely unanswerable question) - fall back to the raw model-position indices
+            // for start/end metadata rather than crashing on decodedAnswer.head/.last.
+            val (startMeta, endMeta) =
+              if (decodedAnswer.isEmpty) (startIndex._2.toString, endIndex._2.toString)
+              else (decodedAnswer.head.begin.toString, decodedAnswer.last.end.toString)
+            val annotation = Annotation(
+              annotatorType = AnnotatorType.CHUNK,
+              begin = 0,
+              end = if (content.isEmpty) 0 else content.length - 1,
+              result = content,
+              metadata = Map(
+                "sentence" -> "0",
+                "chunk" -> "0",
+                "start" -> startMeta,
+                "start_score" -> startIndex._1.toString,
+                "end" -> endMeta,
+                "end_score" -> endIndex._1.toString,
+                "score" -> totalScore.toString))
+
+            (annotation, example.rowIndex)
+          }
+      }
+
+    val byRow =
+      resultsWithRow.groupBy(_._2).map { case (rowIndex, pairs) => rowIndex -> pairs.map(_._1) }
+    rowsOfDocuments.indices.map(rowIndex => byRow.getOrElse(rowIndex, Seq.empty[Annotation]))
+  }
+
 }

--- a/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
@@ -621,7 +621,11 @@ private[johnsnowlabs] class RoBertaClassification(
     val batchLength = batch.length
     val maxSentenceLength = batch.map(_.length).max
     val (tokenTensors, maskTensors) =
-      PrepareEmbeddings.prepareOvLongBatchTensors(batch, maxSentenceLength, batchLength)
+      PrepareEmbeddings.prepareOvLongBatchTensors(
+        batch,
+        maxSentenceLength,
+        batchLength,
+        sentencePadTokenId = sentencePadTokenId)
 
     val inferRequest = openvinoWrapper.get.getCompiledModel().create_infer_request()
     inferRequest.set_tensor("input_ids", tokenTensors)
@@ -655,7 +659,9 @@ private[johnsnowlabs] class RoBertaClassification(
     val tokenTensors =
       OnnxTensor.createTensor(env, batch.map(x => x.map(x => x.toLong)).toArray)
     val maskTensors =
-      OnnxTensor.createTensor(env, batch.map(sentence => Array.fill(sentence.length)(1L)).toArray)
+      OnnxTensor.createTensor(
+        env,
+        batch.map(sentence => sentence.map(x => if (x == sentencePadTokenId) 0L else 1L)).toArray)
 
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
@@ -744,10 +750,17 @@ private[johnsnowlabs] class RoBertaClassification(
       startLogits: Array[Float],
       endLogits: Array[Float],
       questionLength: Int,
-      contextLength: Int): (Array[Float], Array[Float]) = {
+      contextLength: Int,
+      validLength: Int): (Array[Float], Array[Float]) = {
 
     /** Sets log-logits to (almost) 0 for question and padding tokens so they can't contribute to
       * the final softmax score.
+      *
+      * `validLength` is this example's own unpadded length. When a batch mixes lengths, `scores`
+      * is as wide as the batch's longest example, so the trailing slots are padding belonging to
+      * no example - the real end-of-sequence sits at `validLength - 1`, not at `scores.length -
+      * 1`. Deriving both from `validLength` keeps the mask (and therefore the renormalised
+      * softmax below) identical to what an unbatched, unpadded call would produce.
       *
       * @param scores
       *   Logits of the combined sequences
@@ -756,12 +769,12 @@ private[johnsnowlabs] class RoBertaClassification(
       */
     def maskUndesiredTokens(scores: Array[Float]): Array[Float] = {
       val numSpecialTokens = 4 // 4 added special tokens in encoded sequence (1 bos, 2 eos, 1 eos)
-      val totalLength = scores.length
       scores.zipWithIndex.map { case (score, i) =>
         val inQuestionTokens = i > 0 && i < questionLength + numSpecialTokens
-        val isEosToken = i == totalLength - 1
+        val isEosToken = i == validLength - 1
+        val isPadding = i >= validLength
 
-        if (inQuestionTokens || isEosToken) -10000.0f
+        if (inQuestionTokens || isEosToken || isPadding) -10000.0f
         else score
       }
     }
@@ -793,7 +806,12 @@ private[johnsnowlabs] class RoBertaClassification(
       encodeSequence(wordPieceTokenizedQuestion, wordPieceTokenizedContext, maxSentenceLength)
     val (rawStartLogits, rawEndLogits) = tagSpan(encodedInput)
     val (startScores, endScores) =
-      processLogits(rawStartLogits.head, rawEndLogits.head, questionLength, contextLength)
+      processLogits(
+        rawStartLogits.head,
+        rawEndLogits.head,
+        questionLength,
+        contextLength,
+        validLength = rawStartLogits.head.length)
 
     // Drop BOS token from valid results
     val startIndex = startScores.zipWithIndex.drop(1).maxBy(_._1)
@@ -886,12 +904,19 @@ private[johnsnowlabs] class RoBertaClassification(
           batch.zipWithIndex.map { case (example, i) =>
             val questionLength = example.wordPieceTokenizedQuestion.head.tokens.length
             val contextLength = example.wordPieceTokenizedContext.head.tokens.length
+            // This example's own unpadded width - the batch may be wider (see processLogits).
+            val validLength = example.encoded.length
             val (startScores, endScores) =
-              processLogits(rawStartLogits(i), rawEndLogits(i), questionLength, contextLength)
+              processLogits(
+                rawStartLogits(i),
+                rawEndLogits(i),
+                questionLength,
+                contextLength,
+                validLength)
 
-            // Drop BOS token from valid results
-            val startIndex = startScores.zipWithIndex.drop(1).maxBy(_._1)
-            val endIndex = endScores.zipWithIndex.drop(1).maxBy(_._1)
+            // Drop BOS token from valid results, and never let a padding slot win the argmax.
+            val startIndex = startScores.take(validLength).zipWithIndex.drop(1).maxBy(_._1)
+            val endIndex = endScores.take(validLength).zipWithIndex.drop(1).maxBy(_._1)
 
             val offsetStartIndex = 3 // 3 added special tokens
             val offsetEndIndex = offsetStartIndex - 1

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
@@ -63,6 +63,88 @@ private[johnsnowlabs] trait XXXForClassification {
 
   }
 
+  /** Groups items into batches of similar length (to minimise padding waste, since `encode` pads
+    * every item in a batch to that batch's own max length) then restores the caller's original
+    * ordering once inference is done.
+    *
+    * `f` is handed one length-homogeneous batch and MUST return exactly one result per input
+    * element, in the same order as that batch.
+    */
+  protected def batchByLength[T, R](items: Seq[T], batchSize: Int, lengthOf: T => Int)(
+      f: Seq[T] => Seq[R]): Seq[R] = {
+    items.zipWithIndex
+      .sortBy { case (item, _) => lengthOf(item) }
+      .grouped(batchSize)
+      .flatMap { batch => f(batch.map(_._1)).zip(batch.map(_._2)) }
+      .toSeq
+      .sortBy(_._2)
+      .map(_._1)
+  }
+
+  /** Batches token-classification inference across every sentence from every row in ONE pass,
+    * instead of the caller invoking [[predict]] once per row - which would otherwise leave
+    * `batchSize` capped at a single row's sentence count (typically 1-3), making it a no-op for
+    * the common case.
+    *
+    * `tokenizedSentences` is still supplied per row (not flattened) because
+    * [[wordAndSpanLevelAlignmentWithTokenizer]] / [[findIndexedToken]] resolve a sentence's
+    * original tokens by indexing directly into that row's own list
+    * (`tokenizedSentences(sentence._2)`) - that indexing must stay row-local, so only the
+    * inference step is batched across rows, not the alignment step.
+    *
+    * @return
+    *   one `Seq[Annotation]` per row, in the same order as `rowsOfTokenizedSentences`, with each
+    *   row's own sentence/token order preserved regardless of how batches were grouped for
+    *   inference.
+    */
+  def predictGrouped(
+      rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]],
+      batchSize: Int,
+      maxSentenceLength: Int,
+      caseSensitive: Boolean,
+      tags: Map[String, Int]): Seq[Seq[Annotation]] = {
+
+    // (wordpiece-tokenized sentence, its row index, its row-LOCAL sentence index)
+    val items: Seq[(WordpieceTokenizedSentence, Int, Int)] =
+      rowsOfTokenizedSentences.zipWithIndex.flatMap { case (tokenizedSentences, rowIndex) =>
+        tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive).zipWithIndex
+          .map { case (wordpieceTokenizedSentence, localIndex) =>
+            (wordpieceTokenizedSentence, rowIndex, localIndex)
+          }
+      }
+
+    if (items.isEmpty) return rowsOfTokenizedSentences.map(_ => Seq.empty[Annotation])
+
+    // one Seq[Annotation] (that single sentence's own token annotations) per item, in items' order
+    val perSentenceAnnotations: Seq[Seq[Annotation]] =
+      batchByLength[(WordpieceTokenizedSentence, Int, Int), Seq[Annotation]](
+        items,
+        batchSize,
+        { case (wordpieceTokenizedSentence, _, _) => wordpieceTokenizedSentence.tokens.length }) {
+        batch =>
+          // encode's second tuple element is unused by encode itself; it only exists so callers
+          // of `predict` can carry a position through, which we don't need here.
+          val encoded = encode(batch.map { case (wpts, _, _) => (wpts, 0) }, maxSentenceLength)
+          val logits = tag(encoded)
+          batch.zip(logits).map {
+            case ((wordpieceTokenizedSentence, rowIndex, localIndex), tokenVectors) =>
+              val tokenLength = wordpieceTokenizedSentence.tokens.length
+              val tokenLogits: Array[Array[Float]] = tokenVectors.slice(1, tokenLength + 1)
+              wordAndSpanLevelAlignmentWithTokenizer(
+                tokenLogits,
+                rowsOfTokenizedSentences(rowIndex),
+                (wordpieceTokenizedSentence, localIndex),
+                tags)
+          }
+      }
+
+    val byRow = Array.fill(rowsOfTokenizedSentences.length)(Seq.empty[Annotation])
+    items.zip(perSentenceAnnotations).foreach { case ((_, rowIndex, _), sentenceAnnotations) =>
+      byRow(rowIndex) = byRow(rowIndex) ++ sentenceAnnotations
+    }
+    byRow.toSeq
+  }
+
   def predictSequence(
       tokenizedSentences: Seq[TokenizedSentence],
       sentences: Seq[Sentence],

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
@@ -76,53 +76,31 @@ private[johnsnowlabs] trait XXXForClassification {
     val wordPieceTokenizedSentences =
       tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
 
-    /*Run calculation by batches*/
-    wordPieceTokenizedSentences
-      .zip(sentences)
-      .zipWithIndex
-      .grouped(batchSize)
-      .flatMap { batch =>
-        val tokensBatch = batch.map(x => (x._1._1, x._2))
-        val encoded = encode(tokensBatch, maxSentenceLength)
-        val logits = tagSequence(encoded, activation)
-        activation match {
-          case ActivationFunction.softmax =>
-            if (coalesceSentences) {
-              val scores = logits.transpose.map(_.sum / logits.length)
-              val label = scoresToLabelForSequenceClassifier(tags, scores)
-              val meta = constructMetaForSequenceClassifier(tags, scores)
-              Array(constructAnnotationForSequenceClassifier(sentences.head, label, meta))
-            } else {
-              sentences.zip(logits).map { case (sentence, scores) =>
-                val label = scoresToLabelForSequenceClassifier(tags, scores)
-                val meta = constructMetaForSequenceClassifier(tags, scores)
-                constructAnnotationForSequenceClassifier(sentence, label, meta)
-              }
-            }
+    if (sentences.isEmpty) return Seq.empty[Annotation]
 
-          case ActivationFunction.sigmoid =>
-            if (coalesceSentences) {
-              val scores = logits.transpose.map(_.sum / logits.length)
-              val labels = scores.zipWithIndex
-                .filter(x => x._1 > sigmoidThreshold)
-                .flatMap(x => tags.filter(_._2 == x._2))
-              val meta = constructMetaForSequenceClassifier(tags, scores)
-              labels.map(label =>
-                constructAnnotationForSequenceClassifier(sentences.head, label._1, meta))
-            } else {
-              sentences.zip(logits).flatMap { case (sentence, scores) =>
-                val labels = scores.zipWithIndex
-                  .filter(x => x._1 > sigmoidThreshold)
-                  .flatMap(x => tags.filter(_._2 == x._2))
-                val meta = constructMetaForSequenceClassifier(tags, scores)
-                labels.map(label =>
-                  constructAnnotationForSequenceClassifier(sentence, label._1, meta))
-              }
-            }
-
+    /* Stage 1: run inference batch by batch, pairing each sentence with its OWN batch's
+     * logits (not the full outer `sentences` list, which would misalign past the first batch) */
+    val sentencesWithScores: Seq[(Sentence, Array[Float])] =
+      wordPieceTokenizedSentences
+        .zip(sentences)
+        .zipWithIndex
+        .grouped(batchSize)
+        .flatMap { batch =>
+          val tokensBatch = batch.map(x => (x._1._1, x._2))
+          val encoded = encode(tokensBatch, maxSentenceLength)
+          val logits = tagSequence(encoded, activation)
+          batch.map(_._1._2).zip(logits)
         }
-      }
-      .toSeq
+        .toSeq
+
+    /* Stage 2: aggregate once over every sentence collected across all batches */
+    aggregateSequenceScores(
+      sentencesWithScores,
+      coalesceSentences,
+      activation,
+      tags,
+      sentences.head,
+      sigmoidThreshold)
 
   }
 
@@ -142,77 +120,60 @@ private[johnsnowlabs] trait XXXForClassification {
     val wordPieceTokenizedSentences =
       tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
 
+    if (sentences.isEmpty) return Seq.empty[Annotation]
+
     val candidateLabelsKeyValue = candidateLabels.zipWithIndex.toMap
     val contradiction_id: Int = if (entailmentId == 0) contradictionId else 0
 
     val labelsTokenized =
       tokenizeSeqString(candidateLabels, maxSentenceLength, caseSensitive)
 
-    /*Run calculation by batches*/
-    wordPieceTokenizedSentences
-      .zip(sentences)
-      .zipWithIndex
-      .grouped(batchSize)
-      .flatMap { batch =>
-        val tokensBatch = batch.map(x => (x._1._1, x._2))
+    /* Stage 1: run inference batch by batch, pairing each sentence with its OWN batch's
+     * scores (not the full outer `sentences` list, which would misalign past the first batch) */
+    val sentencesWithScores: Seq[(Sentence, Array[Float])] =
+      wordPieceTokenizedSentences
+        .zip(sentences)
+        .zipWithIndex
+        .grouped(batchSize)
+        .flatMap { batch =>
+          val tokensBatch = batch.map(x => (x._1._1, x._2))
 
-        /* Start internal batching for zero shot */
-        val encodedTokensLabels = tokensBatch.map { sent =>
-          labelsTokenized.flatMap(labels =>
-            encodeSequence(Seq(sent._1), Seq(labels), maxSentenceLength))
+          /* Start internal batching for zero shot */
+          val encodedTokensLabels = tokensBatch.map { sent =>
+            labelsTokenized.flatMap(labels =>
+              encodeSequence(Seq(sent._1), Seq(labels), maxSentenceLength))
+          }
+
+          val logits = encodedTokensLabels.map { encodedSeq =>
+            tagZeroShotSequence(encodedSeq, entailmentId, contradictionId, activation)
+          }
+
+          val multiClassScores =
+            logits.map(scores => calculateSoftmax(scores.map(x => x(entailmentId))))
+          val multiLabelScores =
+            logits
+              .map(scores =>
+                scores
+                  .map(x => calculateSoftmax(Array(x(contradiction_id), x(entailmentId))))
+                  .map(_.last))
+
+          val scoresForActivation = activation match {
+            case ActivationFunction.softmax => multiClassScores
+            case ActivationFunction.sigmoid => multiLabelScores
+          }
+
+          batch.map(_._1._2).zip(scoresForActivation)
         }
+        .toSeq
 
-        val logits = encodedTokensLabels.map { encodedSeq =>
-          tagZeroShotSequence(encodedSeq, entailmentId, contradictionId, activation)
-        }
-
-        val multiClassScores =
-          logits.map(scores => calculateSoftmax(scores.map(x => x(entailmentId)))).toArray
-        val multiLabelScores =
-          logits
-            .map(scores =>
-              scores
-                .map(x => calculateSoftmax(Array(x(contradiction_id), x(entailmentId))))
-                .map(_.last))
-            .toArray
-
-        activation match {
-          case ActivationFunction.softmax =>
-            if (coalesceSentences) {
-              val scores = multiClassScores.transpose.map(_.sum / multiClassScores.length)
-              val label = scoresToLabelForSequenceClassifier(candidateLabelsKeyValue, scores)
-              val meta = constructMetaForSequenceClassifier(candidateLabelsKeyValue, scores)
-              Array(constructAnnotationForSequenceClassifier(sentences.head, label, meta))
-            } else {
-              sentences.zip(multiClassScores).map { case (sentence, scores) =>
-                val label = scoresToLabelForSequenceClassifier(candidateLabelsKeyValue, scores)
-                val meta = constructMetaForSequenceClassifier(candidateLabelsKeyValue, scores)
-                constructAnnotationForSequenceClassifier(sentence, label, meta)
-              }
-            }
-
-          case ActivationFunction.sigmoid =>
-            if (coalesceSentences) {
-              val scores = multiLabelScores.transpose.map(_.sum / multiLabelScores.length)
-              val labels = scores.zipWithIndex
-                .filter(x => x._1 > 0.5)
-                .flatMap(x => candidateLabelsKeyValue.filter(_._2 == x._2))
-              val meta = constructMetaForSequenceClassifier(candidateLabelsKeyValue, scores)
-              labels.map(label =>
-                constructAnnotationForSequenceClassifier(sentences.head, label._1, meta))
-            } else {
-              sentences.zip(multiLabelScores).flatMap { case (sentence, scores) =>
-                val labels = scores.zipWithIndex
-                  .filter(x => x._1 > 0.5)
-                  .flatMap(x => candidateLabelsKeyValue.filter(_._2 == x._2))
-                val meta = constructMetaForSequenceClassifier(candidateLabelsKeyValue, scores)
-                labels.map(label =>
-                  constructAnnotationForSequenceClassifier(sentence, label._1, meta))
-              }
-            }
-        }
-      }
-      .toSeq
+    /* Stage 2: aggregate once over every sentence collected across all batches */
+    aggregateSequenceScores(
+      sentencesWithScores,
+      coalesceSentences,
+      activation,
+      candidateLabelsKeyValue,
+      sentences.head,
+      sigmoidThreshold = 0.5f)
 
   }
 
@@ -239,6 +200,66 @@ private[johnsnowlabs] trait XXXForClassification {
       result = label,
       metadata = Map("sentence" -> sentence.index.toString) ++ meta)
 
+  }
+
+  /** Aggregates per-sentence classification scores into annotations.
+    *
+    * When `coalesceSentences` is true, scores are averaged across every sentence passed in (i.e.
+    * across the whole document, not per inference batch) and a single annotation is returned
+    * anchored at `documentAnchor`. Otherwise one annotation is returned per sentence.
+    *
+    * Shared by [[predictSequence]] and [[predictSequenceWithZeroShot]] so both aggregate over the
+    * full collected result set rather than per-batch.
+    */
+  protected def aggregateSequenceScores(
+      sentencesWithScores: Seq[(Sentence, Array[Float])],
+      coalesceSentences: Boolean,
+      activation: String,
+      tags: Map[String, Int],
+      documentAnchor: Sentence,
+      sigmoidThreshold: Float): Seq[Annotation] = {
+
+    if (sentencesWithScores.isEmpty) return Seq.empty[Annotation]
+
+    val allScores = sentencesWithScores.map(_._2).toArray
+
+    activation match {
+      case ActivationFunction.softmax =>
+        if (coalesceSentences) {
+          val scores = allScores.transpose.map(_.sum / allScores.length)
+          val label = scoresToLabelForSequenceClassifier(tags, scores)
+          val meta = constructMetaForSequenceClassifier(tags, scores)
+          Seq(constructAnnotationForSequenceClassifier(documentAnchor, label, meta))
+        } else {
+          sentencesWithScores.map { case (sentence, scores) =>
+            val label = scoresToLabelForSequenceClassifier(tags, scores)
+            val meta = constructMetaForSequenceClassifier(tags, scores)
+            constructAnnotationForSequenceClassifier(sentence, label, meta)
+          }
+        }
+
+      case ActivationFunction.sigmoid =>
+        if (coalesceSentences) {
+          val scores = allScores.transpose.map(_.sum / allScores.length)
+          val labels = scores.zipWithIndex
+            .filter(x => x._1 > sigmoidThreshold)
+            .flatMap(x => tags.filter(_._2 == x._2))
+          val meta = constructMetaForSequenceClassifier(tags, scores)
+          labels
+            .map(label =>
+              constructAnnotationForSequenceClassifier(documentAnchor, label._1, meta))
+            .toSeq
+        } else {
+          sentencesWithScores.flatMap { case (sentence, scores) =>
+            val labels = scores.zipWithIndex
+              .filter(x => x._1 > sigmoidThreshold)
+              .flatMap(x => tags.filter(_._2 == x._2))
+            val meta = constructMetaForSequenceClassifier(tags, scores)
+            labels.map(label =>
+              constructAnnotationForSequenceClassifier(sentence, label._1, meta))
+          }
+        }
+    }
   }
 
   def predictSpan(

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
@@ -63,6 +63,22 @@ private[johnsnowlabs] trait XXXForClassification {
 
   }
 
+  /** Restricts a span score row produced over a padded batch back to the example's own unpadded
+    * length, renormalising so the retained scores sum to 1 again.
+    *
+    * `tagSpan` softmaxes across the full padded width, so padding positions hold a share of the
+    * probability mass and are themselves eligible for an argmax. Dropping them and dividing by
+    * the retained sum is exactly equivalent to having softmaxed over the unpadded row alone
+    * (`exp(x_i) / sum_{j in valid} exp(x_j)`), which keeps a row's answer and reported scores
+    * independent of whichever other rows happened to share its batch.
+    */
+  protected def unpaddedScores(scores: Array[Float], validLength: Int): Array[Float] = {
+    if (validLength >= scores.length) return scores
+    val valid = scores.take(validLength)
+    val total = valid.sum
+    if (total <= 0f) valid else valid.map(_ / total)
+  }
+
   /** Groups items into batches of similar length (to minimise padding waste, since `encode` pads
     * every item in a batch to that batch's own max length) then restores the caller's original
     * ordering once inference is done.
@@ -138,11 +154,14 @@ private[johnsnowlabs] trait XXXForClassification {
           }
       }
 
-    val byRow = Array.fill(rowsOfTokenizedSentences.length)(Seq.empty[Annotation])
+    // Accumulate into per-row builders rather than repeatedly `++`-ing an immutable Seq, which
+    // would be quadratic in a row's sentence count.
+    val byRow =
+      Array.fill(rowsOfTokenizedSentences.length)(Seq.newBuilder[Annotation])
     items.zip(perSentenceAnnotations).foreach { case ((_, rowIndex, _), sentenceAnnotations) =>
-      byRow(rowIndex) = byRow(rowIndex) ++ sentenceAnnotations
+      byRow(rowIndex) ++= sentenceAnnotations
     }
-    byRow.toSeq
+    byRow.map(_.result()).toSeq
   }
 
   def predictSequence(
@@ -596,22 +615,31 @@ private[johnsnowlabs] trait XXXForClassification {
   /** Batches question-answering span prediction across every row in ONE pass, instead of the
     * caller invoking [[predictSpan]] once per row (which has no `batchSize` at all today).
     *
-    * Three things [[predictSpan]] gets away with only because it is always called with exactly
-    * one example, which this method can no longer assume:
+    * Four things [[predictSpan]] gets away with only because it is always called with exactly one
+    * example, which this method can no longer assume:
     *
     *   1. `startLogits.transpose.map(_.sum / startLogits.length)` looks like it "unwraps" a batch
     *      dimension, but it is actually an AVERAGE across the batch. With one example that
     *      average is a no-op; with several it would blend different questions' answer-position
     *      scores together. This method indexes `startScores(i)`/`endScores(i)` per example
-    *      instead. 2. `tagSpan`'s ONNX path builds a rectangular tensor from the raw encoded
-    *      arrays (`OnnxTensor.createTensor` on a `batch.map(...).toArray)`), which requires every
-    *      row to be the same length - fine for a batch of 1, which is trivially rectangular
-    *      regardless of its own length, but not for a real multi-example batch. This method pads
-    *      every example in a batch to that batch's own max length with `sentencePadTokenId`
-    *      before calling `tagSpan`. 3. Padding must use each model family's own
-    *      `sentencePadTokenId` (NOT a hardcoded 0 - for example XLM-RoBERTa and MPNet use 1),
-    *      since every concrete `tagSpan` implementation derives its attention mask by comparing
-    *      against that same field.
+    *      instead.
+    *   1. `tagSpan`'s ONNX path builds a rectangular tensor from the raw encoded arrays
+    *      (`OnnxTensor.createTensor` on a `batch.map(...).toArray)`), which requires every row to
+    *      be the same length - fine for a batch of 1, which is trivially rectangular regardless
+    *      of its own length, but not for a real multi-example batch. This method pads every
+    *      example in a batch to that batch's own max length with `sentencePadTokenId` before
+    *      calling `tagSpan`.
+    *   1. Padding must use each model family's own `sentencePadTokenId` (NOT a hardcoded 0 - for
+    *      example RoBERTa and MPNet use 1), because that is the value the concrete `tagSpan`
+    *      implementations compare against when deriving their attention mask. Note this was NOT
+    *      uniformly true before this method existed: several span paths hardcoded `x == 0` or
+    *      built an all-ones mask, which was harmless only because a batch of 1 is never padded.
+    *      Those were fixed alongside this method.
+    *   1. `tagSpan` softmaxes over the FULL padded width, so a short example's scores would be
+    *      diluted by whatever longer example shared its batch, and its argmax could even land on
+    *      a padding position. This method restricts both to the example's own unpadded length and
+    *      renormalises, which is exactly equivalent to softmaxing over the unpadded row - so a
+    *      given row's answer and scores do not depend on which other rows it was batched with.
     *
     * @return
     *   one `Seq[Annotation]` per row, in the same order as `rowsOfDocuments`.
@@ -655,8 +683,11 @@ private[johnsnowlabs] trait XXXForClassification {
           val (startScores, endScores) = tagSpan(paddedEncoded)
 
           batch.zipWithIndex.map { case (example, i) =>
-            val startIndex = startScores(i).zipWithIndex.maxBy(_._1)
-            val endIndex = endScores(i).zipWithIndex.maxBy(_._1)
+            // Confine argmax/scores to this example's own unpadded region - see point 4 above.
+            val startIndex =
+              unpaddedScores(startScores(i), example.encoded.length).zipWithIndex.maxBy(_._1)
+            val endIndex =
+              unpaddedScores(endScores(i), example.encoded.length).zipWithIndex.maxBy(_._1)
 
             val offsetStartIndex = if (engine == TensorFlow.name) 2 else 1
             val offsetEndIndex = if (engine == TensorFlow.name) 1 else 0

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
@@ -186,6 +186,80 @@ private[johnsnowlabs] trait XXXForClassification {
 
   }
 
+  /** Batches sequence-classification inference across every sentence from every row in ONE pass,
+    * instead of the caller invoking [[predictSequence]] once per row - which would otherwise
+    * leave `batchSize` capped at a single row's sentence count.
+    *
+    * Unlike token classification, sequence classification doesn't need row-local positional
+    * indexing - each result is anchored to its own `Sentence` object (which already carries its
+    * row-local `.index`/`.start`/`.end`), so sentences can be freely flattened across rows for
+    * inference. The one thing that DOES need to stay row-scoped is `coalesceSentences`: it means
+    * "average every sentence into one annotation for the document", and once inference spans
+    * multiple rows in a single call, "the document" is no longer implicitly "the call" - it has
+    * to mean "the row". So scores are grouped back by row before calling the (unmodified)
+    * [[aggregateSequenceScores]] once per row, rather than once for the whole batch.
+    *
+    * @return
+    *   one `Seq[Annotation]` per row, in the same order as `rowsOfTokenizedSentences`.
+    */
+  def predictSequenceGrouped(
+      rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]],
+      rowsOfSentences: Seq[Seq[Sentence]],
+      batchSize: Int,
+      maxSentenceLength: Int,
+      caseSensitive: Boolean,
+      coalesceSentences: Boolean = false,
+      tags: Map[String, Int],
+      activation: String = ActivationFunction.softmax): Seq[Seq[Annotation]] = {
+
+    // (wordpiece-tokenized sentence, its own Sentence, its row index)
+    val items: Seq[(WordpieceTokenizedSentence, Sentence, Int)] =
+      rowsOfTokenizedSentences.zip(rowsOfSentences).zipWithIndex.flatMap {
+        case ((tokenizedSentences, sentences), rowIndex) =>
+          tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
+            .zip(sentences)
+            .map { case (wordpieceTokenizedSentence, sentence) =>
+              (wordpieceTokenizedSentence, sentence, rowIndex)
+            }
+      }
+
+    if (items.isEmpty) return rowsOfTokenizedSentences.map(_ => Seq.empty[Annotation])
+
+    // Stage 1: run inference batch by batch (length-bucketed), carrying each sentence's own row
+    // index through so coalescing can be resolved per row afterward.
+    val sentencesWithScoresAndRow: Seq[(Sentence, Array[Float], Int)] =
+      batchByLength[(WordpieceTokenizedSentence, Sentence, Int), (Sentence, Array[Float], Int)](
+        items,
+        batchSize,
+        { case (wordpieceTokenizedSentence, _, _) => wordpieceTokenizedSentence.tokens.length }) {
+        batch =>
+          val encoded = encode(batch.map { case (wpts, _, _) => (wpts, 0) }, maxSentenceLength)
+          val logits = tagSequence(encoded, activation)
+          batch.zip(logits).map { case ((_, sentence, rowIndex), scores) =>
+            (sentence, scores, rowIndex)
+          }
+      }
+
+    // Stage 2: aggregate per row, so coalesceSentences averages within a row, not across rows
+    val byRow = sentencesWithScoresAndRow.groupBy(_._3)
+    rowsOfTokenizedSentences.indices.map { rowIndex =>
+      byRow.get(rowIndex) match {
+        case None => Seq.empty[Annotation]
+        case Some(rowItems) =>
+          val sentencesWithScores = rowItems.map { case (sentence, scores, _) =>
+            (sentence, scores)
+          }
+          aggregateSequenceScores(
+            sentencesWithScores,
+            coalesceSentences,
+            activation,
+            tags,
+            sentencesWithScores.head._1,
+            sigmoidThreshold)
+      }
+    }
+  }
+
   def predictSequenceWithZeroShot(
       tokenizedSentences: Seq[TokenizedSentence],
       sentences: Seq[Sentence],

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
@@ -584,6 +584,125 @@ private[johnsnowlabs] trait XXXForClassification {
 
   }
 
+  /** One row's worth of input to [[predictSpanGrouped]]: the row's own tokenized question/context
+    * plus that row's (unpadded) encoded sequence, tagged with its row index.
+    */
+  private case class SpanExample(
+      rowIndex: Int,
+      wordPieceTokenizedQuestion: Seq[WordpieceTokenizedSentence],
+      wordPieceTokenizedContext: Seq[WordpieceTokenizedSentence],
+      encoded: Array[Int])
+
+  /** Batches question-answering span prediction across every row in ONE pass, instead of the
+    * caller invoking [[predictSpan]] once per row (which has no `batchSize` at all today).
+    *
+    * Three things [[predictSpan]] gets away with only because it is always called with exactly
+    * one example, which this method can no longer assume:
+    *
+    *   1. `startLogits.transpose.map(_.sum / startLogits.length)` looks like it "unwraps" a batch
+    *      dimension, but it is actually an AVERAGE across the batch. With one example that
+    *      average is a no-op; with several it would blend different questions' answer-position
+    *      scores together. This method indexes `startScores(i)`/`endScores(i)` per example
+    *      instead. 2. `tagSpan`'s ONNX path builds a rectangular tensor from the raw encoded
+    *      arrays (`OnnxTensor.createTensor` on a `batch.map(...).toArray)`), which requires every
+    *      row to be the same length - fine for a batch of 1, which is trivially rectangular
+    *      regardless of its own length, but not for a real multi-example batch. This method pads
+    *      every example in a batch to that batch's own max length with `sentencePadTokenId`
+    *      before calling `tagSpan`. 3. Padding must use each model family's own
+    *      `sentencePadTokenId` (NOT a hardcoded 0 - for example XLM-RoBERTa and MPNet use 1),
+    *      since every concrete `tagSpan` implementation derives its attention mask by comparing
+    *      against that same field.
+    *
+    * @return
+    *   one `Seq[Annotation]` per row, in the same order as `rowsOfDocuments`.
+    */
+  def predictSpanGrouped(
+      rowsOfDocuments: Seq[Seq[Annotation]],
+      batchSize: Int,
+      maxSentenceLength: Int,
+      caseSensitive: Boolean,
+      mergeTokenStrategy: String = MergeTokenStrategy.vocab,
+      engine: String = TensorFlow.name): Seq[Seq[Annotation]] = {
+
+    val examples: Seq[SpanExample] = rowsOfDocuments.zipWithIndex.flatMap {
+      case (documents, rowIndex) =>
+        if (documents.isEmpty) None
+        else {
+          val questionAnnot = Seq(documents.head)
+          val contextAnnot = documents.drop(1)
+          val wordPieceTokenizedQuestion =
+            tokenizeDocument(questionAnnot, maxSentenceLength, caseSensitive)
+          val wordPieceTokenizedContext =
+            tokenizeDocument(contextAnnot, maxSentenceLength, caseSensitive)
+          val encoded = encodeSequence(
+            wordPieceTokenizedQuestion,
+            wordPieceTokenizedContext,
+            maxSentenceLength).head
+          Some(
+            SpanExample(rowIndex, wordPieceTokenizedQuestion, wordPieceTokenizedContext, encoded))
+        }
+    }
+
+    if (examples.isEmpty) return rowsOfDocuments.map(_ => Seq.empty[Annotation])
+
+    val resultsWithRow: Seq[(Annotation, Int)] =
+      batchByLength[SpanExample, (Annotation, Int)](examples, batchSize, _.encoded.length) {
+        batch =>
+          val maxLen = batch.map(_.encoded.length).max
+          val paddedEncoded = batch.map { example =>
+            example.encoded ++ Array.fill(maxLen - example.encoded.length)(sentencePadTokenId)
+          }
+          val (startScores, endScores) = tagSpan(paddedEncoded)
+
+          batch.zipWithIndex.map { case (example, i) =>
+            val startIndex = startScores(i).zipWithIndex.maxBy(_._1)
+            val endIndex = endScores(i).zipWithIndex.maxBy(_._1)
+
+            val offsetStartIndex = if (engine == TensorFlow.name) 2 else 1
+            val offsetEndIndex = if (engine == TensorFlow.name) 1 else 0
+
+            val allTokenPieces =
+              example.wordPieceTokenizedQuestion.head.tokens ++
+                example.wordPieceTokenizedContext.flatMap(x => x.tokens)
+            val decodedAnswer =
+              allTokenPieces.slice(startIndex._2 - offsetStartIndex, endIndex._2 - offsetEndIndex)
+            val content =
+              mergeTokenStrategy match {
+                case MergeTokenStrategy.vocab =>
+                  decodedAnswer.filter(_.isWordStart).map(x => x.token).mkString(" ")
+                case MergeTokenStrategy.sentencePiece =>
+                  val token = ""
+                  decodedAnswer
+                    .map(x =>
+                      if (x.isWordStart) " " + token + x.token
+                      else token + x.token)
+                    .mkString("")
+                    .trim
+              }
+
+            val annotation = Annotation(
+              annotatorType = AnnotatorType.CHUNK,
+              begin = 0,
+              end = if (content.isEmpty) 0 else content.length - 1,
+              result = content,
+              metadata = Map(
+                "sentence" -> "0",
+                "chunk" -> "0",
+                "start" -> startIndex._2.toString,
+                "start_score" -> startIndex._1.toString,
+                "end" -> endIndex._2.toString,
+                "end_score" -> endIndex._1.toString,
+                "score" -> ((startIndex._1 + endIndex._1) / 2).toString))
+
+            (annotation, example.rowIndex)
+          }
+      }
+
+    val byRow =
+      resultsWithRow.groupBy(_._2).map { case (rowIndex, pairs) => rowIndex -> pairs.map(_._1) }
+    rowsOfDocuments.indices.map(rowIndex => byRow.getOrElse(rowIndex, Seq.empty[Annotation]))
+  }
+
   def predictSpanMultipleChoice(
       documents: Seq[Annotation],
       choicesDelimiter: String,

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
@@ -333,6 +333,109 @@ private[johnsnowlabs] trait XXXForClassification {
 
   }
 
+  /** Batches zero-shot classification inference across every sentence from every row in ONE pass,
+    * instead of the caller invoking [[predictSequenceWithZeroShot]] once per row.
+    *
+    * Same row-handling as [[predictSequenceGrouped]]: sentences flatten freely across rows for
+    * inference (no positional-index constraint, since results are anchored to their own
+    * `Sentence` object), and `coalesceSentences` is resolved per row via a groupBy before the
+    * (unmodified) [[aggregateSequenceScores]], so "coalesce the document" means "coalesce the
+    * row" even though a single inference batch may now span several rows.
+    *
+    * The per-sentence loop over candidate labels (`tagZeroShotSequence` called once per sentence,
+    * batched only across that sentence's own labels) is unchanged from
+    * [[predictSequenceWithZeroShot]] - flattening that into a single batch of sentence x label
+    * pairs is a further optimisation left for a separate change, not bundled here.
+    *
+    * @return
+    *   one `Seq[Annotation]` per row, in the same order as `rowsOfTokenizedSentences`.
+    */
+  def predictSequenceWithZeroShotGrouped(
+      rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]],
+      rowsOfSentences: Seq[Seq[Sentence]],
+      candidateLabels: Array[String],
+      entailmentId: Int,
+      contradictionId: Int,
+      batchSize: Int,
+      maxSentenceLength: Int,
+      caseSensitive: Boolean,
+      coalesceSentences: Boolean = false,
+      tags: Map[String, Int],
+      activation: String = ActivationFunction.softmax): Seq[Seq[Annotation]] = {
+
+    val candidateLabelsKeyValue = candidateLabels.zipWithIndex.toMap
+    val contradiction_id: Int = if (entailmentId == 0) contradictionId else 0
+    val labelsTokenized =
+      tokenizeSeqString(candidateLabels, maxSentenceLength, caseSensitive)
+
+    // (wordpiece-tokenized sentence, its own Sentence, its row index)
+    val items: Seq[(WordpieceTokenizedSentence, Sentence, Int)] =
+      rowsOfTokenizedSentences.zip(rowsOfSentences).zipWithIndex.flatMap {
+        case ((tokenizedSentences, sentences), rowIndex) =>
+          tokenizeWithAlignment(tokenizedSentences, maxSentenceLength, caseSensitive)
+            .zip(sentences)
+            .map { case (wordpieceTokenizedSentence, sentence) =>
+              (wordpieceTokenizedSentence, sentence, rowIndex)
+            }
+      }
+
+    if (items.isEmpty) return rowsOfTokenizedSentences.map(_ => Seq.empty[Annotation])
+
+    val sentencesWithScoresAndRow: Seq[(Sentence, Array[Float], Int)] =
+      batchByLength[(WordpieceTokenizedSentence, Sentence, Int), (Sentence, Array[Float], Int)](
+        items,
+        batchSize,
+        { case (wordpieceTokenizedSentence, _, _) => wordpieceTokenizedSentence.tokens.length }) {
+        batch =>
+          /* Start internal batching for zero shot: one tagZeroShotSequence call per sentence,
+           * batched across that sentence's own candidate labels */
+          val encodedTokensLabels = batch.map { case (wordpieceTokenizedSentence, _, _) =>
+            labelsTokenized.flatMap(labels =>
+              encodeSequence(Seq(wordpieceTokenizedSentence), Seq(labels), maxSentenceLength))
+          }
+
+          val logits = encodedTokensLabels.map { encodedSeq =>
+            tagZeroShotSequence(encodedSeq, entailmentId, contradictionId, activation)
+          }
+
+          val multiClassScores =
+            logits.map(scores => calculateSoftmax(scores.map(x => x(entailmentId))))
+          val multiLabelScores =
+            logits.map(scores =>
+              scores
+                .map(x => calculateSoftmax(Array(x(contradiction_id), x(entailmentId))))
+                .map(_.last))
+
+          val scoresForActivation = activation match {
+            case ActivationFunction.softmax => multiClassScores
+            case ActivationFunction.sigmoid => multiLabelScores
+          }
+
+          batch
+            .map { case (_, sentence, rowIndex) => (sentence, rowIndex) }
+            .zip(scoresForActivation)
+            .map { case ((sentence, rowIndex), scores) => (sentence, scores, rowIndex) }
+      }
+
+    val byRow = sentencesWithScoresAndRow.groupBy(_._3)
+    rowsOfTokenizedSentences.indices.map { rowIndex =>
+      byRow.get(rowIndex) match {
+        case None => Seq.empty[Annotation]
+        case Some(rowItems) =>
+          val sentencesWithScores = rowItems.map { case (sentence, scores, _) =>
+            (sentence, scores)
+          }
+          aggregateSequenceScores(
+            sentencesWithScores,
+            coalesceSentences,
+            activation,
+            candidateLabelsKeyValue,
+            sentencesWithScores.head._1,
+            sigmoidThreshold = 0.5f)
+      }
+    }
+  }
+
   def scoresToLabelForSequenceClassifier(tags: Map[String, Int], scores: Array[Float]): String = {
     tags.find(_._2 == scores.zipWithIndex.maxBy(_._1)._2).map(_._1).getOrElse("NA")
   }

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
@@ -587,7 +587,7 @@ private[johnsnowlabs] trait XXXForClassification {
   /** One row's worth of input to [[predictSpanGrouped]]: the row's own tokenized question/context
     * plus that row's (unpadded) encoded sequence, tagged with its row index.
     */
-  private case class SpanExample(
+  protected case class SpanExample(
       rowIndex: Int,
       wordPieceTokenizedQuestion: Seq[WordpieceTokenizedSentence],
       wordPieceTokenizedContext: Seq[WordpieceTokenizedSentence],

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForQuestionAnswering.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForQuestionAnswering.scala
@@ -241,23 +241,17 @@ class AlbertForQuestionAnswering(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
+    val rowsOfDocuments: Seq[Seq[Annotation]] =
+      batchedAnnotations.map(annotations =>
+        annotations.filter(_.annotatorType == AnnotatorType.DOCUMENT).toSeq)
 
-      val documents = annotations
-        .filter(_.annotatorType == AnnotatorType.DOCUMENT)
-        .toSeq
-
-      if (documents.nonEmpty) {
-        getModelIfNotSet.predictSpan(
-          documents,
-          $(maxSentenceLength),
-          $(caseSensitive),
-          MergeTokenStrategy.sentencePiece,
-          getEngine)
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSpanGrouped(
+      rowsOfDocuments,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      MergeTokenStrategy.sentencePiece,
+      getEngine)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForSequenceClassification.scala
@@ -291,24 +291,20 @@ class AlbertForSequenceClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequence(
-          tokenizedSentences,
-          sentences,
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          $(activation))
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      $(activation))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForTokenClassification.scala
@@ -264,22 +264,15 @@ class AlbertForTokenClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations
-      .map(annotations => TokenizedWithSentence.unpack(annotations).toArray)
-      .toArray
-    /*Return empty if the real tokens are empty*/
-    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      getModelIfNotSet.predict(
-        tokenizedSentences,
-        $(batchSize),
-        $(maxSentenceLength),
-        $(caseSensitive),
-        $$(labels))
-    })
-    else {
-      Seq(Seq.empty[Annotation])
-    }
+    getModelIfNotSet.predictGrouped(
+      rowsOfTokenizedSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $$(labels))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForZeroShotClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/AlbertForZeroShotClassification.scala
@@ -37,7 +37,12 @@ import com.johnsnowlabs.ml.util.LoadExternalModel.{
 }
 import com.johnsnowlabs.ml.util.{ONNX, TensorFlow}
 import com.johnsnowlabs.nlp._
-import com.johnsnowlabs.nlp.annotators.common.{SentenceSplit, TokenizedWithSentence}
+import com.johnsnowlabs.nlp.annotators.common.{
+  Sentence,
+  SentenceSplit,
+  TokenizedSentence,
+  TokenizedWithSentence
+}
 import com.johnsnowlabs.nlp.serialization.MapFeature
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.ml.param.{BooleanParam, IntArrayParam, IntParam}
@@ -220,28 +225,23 @@ class AlbertForZeroShotClassification(override val uid: String)
     * that belong to the same original row !! (challenging)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequenceWithZeroShot(
-          tokenizedSentences,
-          sentences,
-          $(candidateLabels),
-          $(entailmentIdParam),
-          $(contradictionIdParam),
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          getActivation)
-
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceWithZeroShotGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(candidateLabels),
+      $(entailmentIdParam),
+      $(contradictionIdParam),
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      getActivation)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BartForZeroShotClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BartForZeroShotClassification.scala
@@ -331,28 +331,23 @@ class BartForZeroShotClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequenceWithZeroShot(
-          tokenizedSentences,
-          sentences,
-          $(candidateLabels),
-          $(entailmentIdParam),
-          $(contradictionIdParam),
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          $(activation))
-
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceWithZeroShotGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(candidateLabels),
+      $(entailmentIdParam),
+      $(contradictionIdParam),
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      $(activation))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForQuestionAnswering.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForQuestionAnswering.scala
@@ -256,23 +256,16 @@ class BertForQuestionAnswering(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
+    val rowsOfDocuments: Seq[Seq[Annotation]] =
+      batchedAnnotations.map(annotations =>
+        annotations.filter(_.annotatorType == AnnotatorType.DOCUMENT).toSeq)
 
-    batchedAnnotations.map(annotations => {
-
-      val documents = annotations
-        .filter(_.annotatorType == AnnotatorType.DOCUMENT)
-        .toSeq
-
-      if (documents.nonEmpty) {
-        getModelIfNotSet.predictSpan(
-          documents,
-          $(maxSentenceLength),
-          $(caseSensitive),
-          MergeTokenStrategy.vocab)
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSpanGrouped(
+      rowsOfDocuments,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      MergeTokenStrategy.vocab)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForSequenceClassification.scala
@@ -304,25 +304,20 @@ class BertForSequenceClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequence(
-          tokenizedSentences,
-          sentences,
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          $(activation))
-
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      $(activation))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForTokenClassification.scala
@@ -277,22 +277,15 @@ class BertForTokenClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations
-      .map(annotations => TokenizedWithSentence.unpack(annotations).toArray)
-      .toArray
-    /*Return empty if the real tokens are empty*/
-    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      getModelIfNotSet.predict(
-        tokenizedSentences,
-        $(batchSize),
-        $(maxSentenceLength),
-        $(caseSensitive),
-        $$(labels))
-    })
-    else {
-      Seq(Seq.empty[Annotation])
-    }
+    getModelIfNotSet.predictGrouped(
+      rowsOfTokenizedSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $$(labels))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/BertForZeroShotClassification.scala
@@ -317,28 +317,23 @@ class BertForZeroShotClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequenceWithZeroShot(
-          tokenizedSentences,
-          sentences,
-          $(candidateLabels),
-          $(entailmentIdParam),
-          $(contradictionIdParam),
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          getActivation)
-
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceWithZeroShotGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(candidateLabels),
+      $(entailmentIdParam),
+      $(contradictionIdParam),
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      getActivation)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForQuestionAnswering.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForQuestionAnswering.scala
@@ -241,22 +241,16 @@ class CamemBertForQuestionAnswering(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
+    val rowsOfDocuments: Seq[Seq[Annotation]] =
+      batchedAnnotations.map(annotations =>
+        annotations.filter(_.annotatorType == AnnotatorType.DOCUMENT).toSeq)
 
-      val documents = annotations
-        .filter(_.annotatorType == AnnotatorType.DOCUMENT)
-        .toSeq
-
-      if (documents.nonEmpty) {
-        getModelIfNotSet.predictSpan(
-          documents,
-          $(maxSentenceLength),
-          $(caseSensitive),
-          MergeTokenStrategy.sentencePiece)
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSpanGrouped(
+      rowsOfDocuments,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      MergeTokenStrategy.sentencePiece)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForSequenceClassification.scala
@@ -291,24 +291,20 @@ class CamemBertForSequenceClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequence(
-          tokenizedSentences,
-          sentences,
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          $(activation))
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      $(activation))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForTokenClassification.scala
@@ -264,22 +264,15 @@ class CamemBertForTokenClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations
-      .map(annotations => TokenizedWithSentence.unpack(annotations).toArray)
-      .toArray
-    /*Return empty if the real tokens are empty*/
-    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      getModelIfNotSet.predict(
-        tokenizedSentences,
-        $(batchSize),
-        $(maxSentenceLength),
-        $(caseSensitive),
-        $$(labels))
-    })
-    else {
-      Seq(Seq.empty[Annotation])
-    }
+    getModelIfNotSet.predictGrouped(
+      rowsOfTokenizedSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $$(labels))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForZeroShotClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/CamemBertForZeroShotClassification.scala
@@ -36,7 +36,12 @@ import com.johnsnowlabs.ml.util.LoadExternalModel.{
   notSupportedEngineError
 }
 import com.johnsnowlabs.ml.util.{ONNX, Openvino, TensorFlow}
-import com.johnsnowlabs.nlp.annotators.common.{SentenceSplit, TokenizedWithSentence}
+import com.johnsnowlabs.nlp.annotators.common.{
+  Sentence,
+  SentenceSplit,
+  TokenizedSentence,
+  TokenizedWithSentence
+}
 import com.johnsnowlabs.nlp.serialization.MapFeature
 import com.johnsnowlabs.nlp.{
   Annotation,
@@ -230,28 +235,23 @@ class CamemBertForZeroShotClassification(override val uid: String)
     * that belong to the same original row !! (challenging)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequenceWithZeroShot(
-          tokenizedSentences,
-          sentences,
-          $(candidateLabels),
-          $(entailmentIdParam),
-          $(contradictionIdParam),
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          getActivation)
-
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceWithZeroShotGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(candidateLabels),
+      $(entailmentIdParam),
+      $(contradictionIdParam),
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      getActivation)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DeBertaForQuestionAnswering.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DeBertaForQuestionAnswering.scala
@@ -241,22 +241,16 @@ class DeBertaForQuestionAnswering(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
+    val rowsOfDocuments: Seq[Seq[Annotation]] =
+      batchedAnnotations.map(annotations =>
+        annotations.filter(_.annotatorType == AnnotatorType.DOCUMENT).toSeq)
 
-      val documents = annotations
-        .filter(_.annotatorType == AnnotatorType.DOCUMENT)
-        .toSeq
-
-      if (documents.nonEmpty) {
-        getModelIfNotSet.predictSpan(
-          documents,
-          $(maxSentenceLength),
-          $(caseSensitive),
-          MergeTokenStrategy.sentencePiece)
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSpanGrouped(
+      rowsOfDocuments,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      MergeTokenStrategy.sentencePiece)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DeBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DeBertaForSequenceClassification.scala
@@ -291,24 +291,20 @@ class DeBertaForSequenceClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequence(
-          tokenizedSentences,
-          sentences,
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          $(activation))
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      $(activation))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DeBertaForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DeBertaForTokenClassification.scala
@@ -265,22 +265,15 @@ class DeBertaForTokenClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations
-      .map(annotations => TokenizedWithSentence.unpack(annotations).toArray)
-      .toArray
-    /*Return empty if the real tokens are empty*/
-    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      getModelIfNotSet.predict(
-        tokenizedSentences,
-        $(batchSize),
-        $(maxSentenceLength),
-        $(caseSensitive),
-        $$(labels))
-    })
-    else {
-      Seq(Seq.empty[Annotation])
-    }
+    getModelIfNotSet.predictGrouped(
+      rowsOfTokenizedSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $$(labels))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DeBertaForZeroShotClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DeBertaForZeroShotClassification.scala
@@ -301,28 +301,23 @@ class DeBertaForZeroShotClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequenceWithZeroShot(
-          tokenizedSentences,
-          sentences,
-          $(candidateLabels),
-          $(entailmentIdParam),
-          $(contradictionIdParam),
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          getActivation)
-
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceWithZeroShotGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(candidateLabels),
+      $(entailmentIdParam),
+      $(contradictionIdParam),
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      getActivation)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForQuestionAnswering.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForQuestionAnswering.scala
@@ -255,21 +255,16 @@ class DistilBertForQuestionAnswering(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val documents = annotations
-        .filter(_.annotatorType == AnnotatorType.DOCUMENT)
-        .toSeq
+    val rowsOfDocuments: Seq[Seq[Annotation]] =
+      batchedAnnotations.map(annotations =>
+        annotations.filter(_.annotatorType == AnnotatorType.DOCUMENT).toSeq)
 
-      if (documents.nonEmpty) {
-        getModelIfNotSet.predictSpan(
-          documents,
-          $(maxSentenceLength),
-          $(caseSensitive),
-          MergeTokenStrategy.vocab)
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSpanGrouped(
+      rowsOfDocuments,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      MergeTokenStrategy.vocab)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForSequenceClassification.scala
@@ -304,24 +304,20 @@ class DistilBertForSequenceClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequence(
-          tokenizedSentences,
-          sentences,
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          $(activation))
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      $(activation))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForTokenClassification.scala
@@ -277,22 +277,15 @@ class DistilBertForTokenClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations
-      .map(annotations => TokenizedWithSentence.unpack(annotations).toArray)
-      .toArray
-    /*Return empty if the real tokens are empty*/
-    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      getModelIfNotSet.predict(
-        tokenizedSentences,
-        $(batchSize),
-        $(maxSentenceLength),
-        $(caseSensitive),
-        $$(labels))
-    })
-    else {
-      Seq(Seq.empty[Annotation])
-    }
+    getModelIfNotSet.predictGrouped(
+      rowsOfTokenizedSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $$(labels))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForZeroShotClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DistilBertForZeroShotClassification.scala
@@ -317,28 +317,23 @@ class DistilBertForZeroShotClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequenceWithZeroShot(
-          tokenizedSentences,
-          sentences,
-          $(candidateLabels),
-          $(entailmentIdParam),
-          $(contradictionIdParam),
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          getActivation)
-
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceWithZeroShotGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(candidateLabels),
+      $(entailmentIdParam),
+      $(contradictionIdParam),
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      getActivation)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForQuestionAnswering.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForQuestionAnswering.scala
@@ -266,21 +266,16 @@ class LongformerForQuestionAnswering(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val documents = annotations
-        .filter(_.annotatorType == AnnotatorType.DOCUMENT)
-        .toSeq
+    val rowsOfDocuments: Seq[Seq[Annotation]] =
+      batchedAnnotations.map(annotations =>
+        annotations.filter(_.annotatorType == AnnotatorType.DOCUMENT).toSeq)
 
-      if (documents.nonEmpty) {
-        getModelIfNotSet.predictSpan(
-          documents,
-          $(maxSentenceLength),
-          $(caseSensitive),
-          MergeTokenStrategy.vocab)
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSpanGrouped(
+      rowsOfDocuments,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      MergeTokenStrategy.vocab)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForSequenceClassification.scala
@@ -315,24 +315,20 @@ class LongformerForSequenceClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequence(
-          tokenizedSentences,
-          sentences,
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          $(activation))
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      $(activation))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/LongformerForTokenClassification.scala
@@ -288,22 +288,15 @@ class LongformerForTokenClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations
-      .map(annotations => TokenizedWithSentence.unpack(annotations).toArray)
-      .toArray
-    /*Return empty if the real tokens are empty*/
-    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      getModelIfNotSet.predict(
-        tokenizedSentences,
-        $(batchSize),
-        $(maxSentenceLength),
-        $(caseSensitive),
-        $$(labels))
-    })
-    else {
-      Seq(Seq.empty[Annotation])
-    }
+    getModelIfNotSet.predictGrouped(
+      rowsOfTokenizedSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $$(labels))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MPNetForQuestionAnswering.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MPNetForQuestionAnswering.scala
@@ -236,21 +236,16 @@ class MPNetForQuestionAnswering(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val documents = annotations
-        .filter(_.annotatorType == AnnotatorType.DOCUMENT)
-        .toSeq
+    val rowsOfDocuments: Seq[Seq[Annotation]] =
+      batchedAnnotations.map(annotations =>
+        annotations.filter(_.annotatorType == AnnotatorType.DOCUMENT).toSeq)
 
-      if (documents.nonEmpty) {
-        getModelIfNotSet.predictSpan(
-          documents,
-          $(maxSentenceLength),
-          $(caseSensitive),
-          MergeTokenStrategy.vocab)
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSpanGrouped(
+      rowsOfDocuments,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      MergeTokenStrategy.vocab)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MPNetForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MPNetForSequenceClassification.scala
@@ -287,24 +287,20 @@ class MPNetForSequenceClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequence(
-          tokenizedSentences,
-          sentences,
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          $(activation))
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      $(activation))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MPNetForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/MPNetForTokenClassification.scala
@@ -282,22 +282,15 @@ class MPNetForTokenClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations
-      .map(annotations => TokenizedWithSentence.unpack(annotations).toArray)
-      .toArray
-    /*Return empty if the real tokens are empty*/
-    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      getModelIfNotSet.predict(
-        tokenizedSentences,
-        $(batchSize),
-        $(maxSentenceLength),
-        $(caseSensitive),
-        $$(labels))
-    })
-    else {
-      Seq(Seq.empty[Annotation])
-    }
+    getModelIfNotSet.predictGrouped(
+      rowsOfTokenizedSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $$(labels))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForQuestionAnswering.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForQuestionAnswering.scala
@@ -268,21 +268,16 @@ class RoBertaForQuestionAnswering(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val documents = annotations
-        .filter(_.annotatorType == AnnotatorType.DOCUMENT)
-        .toSeq
+    val rowsOfDocuments: Seq[Seq[Annotation]] =
+      batchedAnnotations.map(annotations =>
+        annotations.filter(_.annotatorType == AnnotatorType.DOCUMENT).toSeq)
 
-      if (documents.nonEmpty) {
-        getModelIfNotSet.predictSpan(
-          documents,
-          $(maxSentenceLength),
-          $(caseSensitive),
-          MergeTokenStrategy.vocab)
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSpanGrouped(
+      rowsOfDocuments,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      MergeTokenStrategy.vocab)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForSequenceClassification.scala
@@ -317,24 +317,20 @@ class RoBertaForSequenceClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequence(
-          tokenizedSentences,
-          sentences,
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          $(activation))
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      $(activation))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForTokenClassification.scala
@@ -290,22 +290,15 @@ class RoBertaForTokenClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations
-      .map(annotations => TokenizedWithSentence.unpack(annotations).toArray)
-      .toArray
-    /*Return empty if the real tokens are empty*/
-    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      getModelIfNotSet.predict(
-        tokenizedSentences,
-        $(batchSize),
-        $(maxSentenceLength),
-        $(caseSensitive),
-        $$(labels))
-    })
-    else {
-      Seq(Seq.empty[Annotation])
-    }
+    getModelIfNotSet.predictGrouped(
+      rowsOfTokenizedSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $$(labels))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForZeroShotClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForZeroShotClassification.scala
@@ -331,28 +331,23 @@ class RoBertaForZeroShotClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequenceWithZeroShot(
-          tokenizedSentences,
-          sentences,
-          $(candidateLabels),
-          $(entailmentIdParam),
-          $(contradictionIdParam),
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          getActivation)
-
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceWithZeroShotGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(candidateLabels),
+      $(entailmentIdParam),
+      $(contradictionIdParam),
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      getActivation)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForSequenceClassification.scala
@@ -290,24 +290,20 @@ class XlmRoBertaForSequenceClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequence(
-          tokenizedSentences,
-          sentences,
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          $(activation))
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      $(activation))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForTokenClassification.scala
@@ -264,22 +264,15 @@ class XlmRoBertaForTokenClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations
-      .map(annotations => TokenizedWithSentence.unpack(annotations).toArray)
-      .toArray
-    /*Return empty if the real tokens are empty*/
-    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      getModelIfNotSet.predict(
-        tokenizedSentences,
-        $(batchSize),
-        $(maxSentenceLength),
-        $(caseSensitive),
-        $$(labels))
-    })
-    else {
-      Seq(Seq.empty[Annotation])
-    }
+    getModelIfNotSet.predictGrouped(
+      rowsOfTokenizedSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $$(labels))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForZeroShotClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlmRoBertaForZeroShotClassification.scala
@@ -301,28 +301,23 @@ class XlmRoBertaForZeroShotClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequenceWithZeroShot(
-          tokenizedSentences,
-          sentences,
-          $(candidateLabels),
-          $(entailmentIdParam),
-          $(contradictionIdParam),
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          getActivation)
-
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceWithZeroShotGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(candidateLabels),
+      $(entailmentIdParam),
+      $(contradictionIdParam),
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      getActivation)
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForSequenceClassification.scala
@@ -283,24 +283,20 @@ class XlnetForSequenceClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
-      val tokenizedSentences = TokenizedWithSentence.unpack(annotations).toArray
+    val rowsOfSentences: Seq[Seq[Sentence]] =
+      batchedAnnotations.map(annotations => SentenceSplit.unpack(annotations))
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      if (tokenizedSentences.nonEmpty) {
-        getModelIfNotSet.predictSequence(
-          tokenizedSentences,
-          sentences,
-          $(batchSize),
-          $(maxSentenceLength),
-          $(caseSensitive),
-          $(coalesceSentences),
-          $$(labels),
-          $(activation))
-      } else {
-        Seq.empty[Annotation]
-      }
-    })
+    getModelIfNotSet.predictSequenceGrouped(
+      rowsOfTokenizedSentences,
+      rowsOfSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $(coalesceSentences),
+      $$(labels),
+      $(activation))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForTokenClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/XlnetForTokenClassification.scala
@@ -256,22 +256,15 @@ class XlnetForTokenClassification(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    val batchedTokenizedSentences: Array[Array[TokenizedSentence]] = batchedAnnotations
-      .map(annotations => TokenizedWithSentence.unpack(annotations).toArray)
-      .toArray
-    /*Return empty if the real tokens are empty*/
-    if (batchedTokenizedSentences.nonEmpty) batchedTokenizedSentences.map(tokenizedSentences => {
+    val rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]] =
+      batchedAnnotations.map(annotations => TokenizedWithSentence.unpack(annotations))
 
-      getModelIfNotSet.predict(
-        tokenizedSentences,
-        $(batchSize),
-        $(maxSentenceLength),
-        $(caseSensitive),
-        $$(labels))
-    })
-    else {
-      Seq(Seq.empty[Annotation])
-    }
+    getModelIfNotSet.predictGrouped(
+      rowsOfTokenizedSentences,
+      $(batchSize),
+      $(maxSentenceLength),
+      $(caseSensitive),
+      $$(labels))
   }
 
   override def onWrite(path: String, spark: SparkSession): Unit = {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/BartTransformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/BartTransformer.scala
@@ -311,9 +311,7 @@ class BartTransformer(override val uid: String)
 
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val allAnnotations = batchedAnnotations
-      .filter(_.nonEmpty)
-      .zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2Transformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/GPT2Transformer.scala
@@ -450,9 +450,7 @@ class GPT2Transformer(override val uid: String)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val allAnnotations = batchedAnnotations
-      .filter(_.nonEmpty)
-      .zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
@@ -508,9 +508,7 @@ class MarianTransformer(override val uid: String)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val nonEmptyBatch = batchedAnnotations.filter(_.nonEmpty)
-
-    val allAnnotations = nonEmptyBatch.zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/T5Transformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/T5Transformer.scala
@@ -524,9 +524,7 @@ class T5Transformer(override val uid: String)
 
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val allAnnotations = batchedAnnotations
-      .filter(_.nonEmpty)
-      .zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/BGEEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/BGEEmbeddings.scala
@@ -317,9 +317,7 @@ class BGEEmbeddings(override val uid: String)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val allAnnotations = batchedAnnotations
-      .filter(_.nonEmpty)
-      .zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/E5Embeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/E5Embeddings.scala
@@ -307,9 +307,7 @@ class E5Embeddings(override val uid: String)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val allAnnotations = batchedAnnotations
-      .filter(_.nonEmpty)
-      .zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/InstructorEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/InstructorEmbeddings.scala
@@ -289,9 +289,7 @@ class InstructorEmbeddings(override val uid: String)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val allAnnotations = batchedAnnotations
-      .filter(_.nonEmpty)
-      .zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/MPNetEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/MPNetEmbeddings.scala
@@ -304,9 +304,7 @@ class MPNetEmbeddings(override val uid: String)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val allAnnotations = batchedAnnotations
-      .filter(_.nonEmpty)
-      .zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/MiniLMEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/MiniLMEmbeddings.scala
@@ -298,9 +298,7 @@ class MiniLMEmbeddings(override val uid: String)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val allAnnotations = batchedAnnotations
-      .filter(_.nonEmpty)
-      .zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/MxbaiEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/MxbaiEmbeddings.scala
@@ -323,9 +323,7 @@ class MxbaiEmbeddings(override val uid: String)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val allAnnotations = batchedAnnotations
-      .filter(_.nonEmpty)
-      .zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/NomicEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/NomicEmbeddings.scala
@@ -279,9 +279,7 @@ class NomicEmbeddings(override val uid: String)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val allAnnotations = batchedAnnotations
-      .filter(_.nonEmpty)
-      .zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaSentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/RoBertaSentenceEmbeddings.scala
@@ -334,16 +334,34 @@ class RoBertaSentenceEmbeddings(override val uid: String)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    /*Return empty if the real sentences are empty*/
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
+    // Unpack annotations and zip each sentence to the index of the row it belongs to
+    val sentencesWithRow = batchedAnnotations.zipWithIndex
+      .flatMap { case (annotations, i) => SentenceSplit.unpack(annotations).map(x => (x, i)) }
 
-      if (sentences.nonEmpty) {
-        val tokenized = tokenize(sentences)
-        getModelIfNotSet.predictSequence(tokenized, sentences, $(batchSize), $(maxSentenceLength))
-      } else {
+    // Tokenize sentences
+    val tokenizedSentences = tokenize(sentencesWithRow.map(_._1))
+
+    // Process all sentences
+    val allAnnotations = getModelIfNotSet.predictSequence(
+      tokenizedSentences,
+      sentencesWithRow.map(_._1),
+      $(batchSize),
+      $(maxSentenceLength))
+
+    // Group resulting annotations by rows. If there are not sentences in a given row, return empty sequence
+    batchedAnnotations.indices.map(rowIndex => {
+      val rowAnnotations = allAnnotations
+        // zip each annotation with its corresponding row index
+        .zip(sentencesWithRow)
+        // select the sentences belonging to the current row
+        .filter(_._2._2 == rowIndex)
+        // leave the annotation only
+        .map(_._1)
+
+      if (rowAnnotations.nonEmpty)
+        rowAnnotations
+      else
         Seq.empty[Annotation]
-      }
     })
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/SnowFlakeEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/SnowFlakeEmbeddings.scala
@@ -348,9 +348,7 @@ class SnowFlakeEmbeddings(override val uid: String)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val allAnnotations = batchedAnnotations
-      .filter(_.nonEmpty)
-      .zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/UAEEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/UAEEmbeddings.scala
@@ -357,9 +357,7 @@ class UAEEmbeddings(override val uid: String)
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
 
-    val allAnnotations = batchedAnnotations
-      .filter(_.nonEmpty)
-      .zipWithIndex
+    val allAnnotations = batchedAnnotations.zipWithIndex
       .flatMap { case (annotations, i) =>
         annotations.filter(_.result.nonEmpty).map(x => (x, i))
       }

--- a/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaSentenceEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/embeddings/XlmRoBertaSentenceEmbeddings.scala
@@ -289,15 +289,31 @@ class XlmRoBertaSentenceEmbeddings(override val uid: String)
     *   relationship
     */
   override def batchAnnotate(batchedAnnotations: Seq[Array[Annotation]]): Seq[Seq[Annotation]] = {
-    /*Return empty if the real sentences are empty*/
-    batchedAnnotations.map(annotations => {
-      val sentences = SentenceSplit.unpack(annotations).toArray
 
-      if (sentences.nonEmpty) {
-        getModelIfNotSet.predictSequence(sentences, $(batchSize), $(maxSentenceLength))
-      } else {
+    // Unpack annotations and zip each sentence to the index of the row it belongs to
+    val sentencesWithRow = batchedAnnotations.zipWithIndex
+      .flatMap { case (annotations, i) => SentenceSplit.unpack(annotations).map(x => (x, i)) }
+
+    // Process all sentences
+    val allAnnotations = getModelIfNotSet.predictSequence(
+      sentencesWithRow.map(_._1),
+      $(batchSize),
+      $(maxSentenceLength))
+
+    // Group resulting annotations by rows. If there are not sentences in a given row, return empty sequence
+    batchedAnnotations.indices.map(rowIndex => {
+      val rowAnnotations = allAnnotations
+        // zip each annotation with its corresponding row index
+        .zip(sentencesWithRow)
+        // select the sentences belonging to the current row
+        .filter(_._2._2 == rowIndex)
+        // leave the annotation only
+        .map(_._1)
+
+      if (rowAnnotations.nonEmpty)
+        rowAnnotations
+      else
         Seq.empty[Annotation]
-      }
     })
   }
 

--- a/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationBatchAlignmentTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationBatchAlignmentTestSpec.scala
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.ml.ai
+
+import com.johnsnowlabs.nlp.ActivationFunction
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.tags.FastTest
+import org.scalatest.flatspec.AnyFlatSpec
+
+/** Regression coverage for the logit/sentence pairing bug in `predictSequence` and
+  * `predictSequenceWithZeroShot` (XXXForClassification.scala).
+  *
+  * Prior to the fix, aggregation happened inside the `.grouped(batchSize).flatMap { batch => ...
+  * }` loop against the FULL outer `sentences` parameter instead of the current batch's own slice.
+  * `sentences.zip(logits)` then paired batch 2+'s scores with sentences 0..batchSize-1 (zip
+  * truncates to the shorter side), so any row with more sentences than `batchSize` got some
+  * annotations anchored at the wrong sentence and carrying another sentence's classification
+  * scores. Row *counts* stayed correct, which is why this was silent.
+  *
+  * These tests exercise `predictSequence`/`predictSequenceWithZeroShot` directly against a
+  * minimal fake implementation of the trait (no TensorFlow/ONNX session, no downloaded model, no
+  * Spark session needed) so they run fast and deterministically. Each fake sentence's identity is
+  * threaded through tokenization -> encoding -> tagging via its wordpiece `pieceId`, so the
+  * stubbed `tagSequence`/`tagZeroShotSequence` can produce a score that is a pure function of
+  * which sentence it was actually given, making any cross-sentence mispairing observable.
+  *
+  * NOTE: this file does not cover the separate row-misalignment fix (`.filter(_.nonEmpty)` before
+  * `.zipWithIndex` in 13 annotators' `batchAnnotate`, e.g. MarianTransformer, T5Transformer, and
+  * the embeddings that batch across rows). That fix was verified by direct diff review since
+  * exercising it end-to-end requires a loaded model via `.pretrained()` / `.loadSavedModel()`,
+  * which needs network access or local test-only model resources not available in all
+  * environments. Once local test model resources are available, add empty-row-in-the-middle
+  * DataFrame tests to MarianTestSpec / T5TestSpec / E5EmbeddingsTestSpec etc. asserting that a
+  * non-empty row's output is unaffected by an empty row appearing before it.
+  */
+class XXXForClassificationBatchAlignmentTestSpec extends AnyFlatSpec {
+
+  /** Fake classification head. Sentence identity is smuggled through as the wordpiece pieceId
+    * (offset by ID_OFFSET to stay clear of the special token ids), so the stubbed tag methods can
+    * recover "which sentence is this really" from the encoded token ids they were handed.
+    */
+  class FakeClassification extends XXXForClassification {
+    override protected val sentencePadTokenId: Int = 0
+    override protected val sentenceStartTokenId: Int = 101
+    override protected val sentenceEndTokenId: Int = 102
+    override protected val sigmoidThreshold: Float = 0.5f
+
+    val ID_OFFSET = 1000
+
+    override def tokenizeWithAlignment(
+        sentences: Seq[TokenizedSentence],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] =
+      sentences.map { ts =>
+        WordpieceTokenizedSentence(
+          Array(TokenPiece(
+            wordpiece = ts.tokens.headOption.getOrElse(""),
+            token = ts.tokens.headOption.getOrElse(""),
+            pieceId = ts.sentenceIndex + ID_OFFSET,
+            isWordStart = true,
+            begin = 0,
+            end = 0)))
+      }
+
+    override def tokenizeSeqString(
+        candidateLabels: Seq[String],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] =
+      candidateLabels.zipWithIndex.map { case (label, i) =>
+        WordpieceTokenizedSentence(
+          Array(TokenPiece(label, label, pieceId = i, isWordStart = true, begin = 0, end = 0)))
+      }
+
+    override def tokenizeDocument(
+        docs: Seq[com.johnsnowlabs.nlp.Annotation],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = Seq.empty
+
+    override def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] =
+      batch.map(_ => Array(Array(0f)))
+
+    override def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) =
+      (Array(Array(0f)), Array(Array(0f)))
+
+    override def findIndexedToken(
+        tokenizedSentences: Seq[TokenizedSentence],
+        sentence: (WordpieceTokenizedSentence, Int),
+        tokenPiece: TokenPiece): Option[IndexedToken] = None
+
+    /** Decodes each row's true sentence identity from its own encoded token ids (position 1,
+      * right after the start token) and returns a 2-class score that strongly favors class 0 for
+      * even identities and class 1 for odd identities. If a row is ever paired with the wrong
+      * sentence's position, its returned label/metadata will disagree with its own identity's
+      * parity.
+      */
+    override def tagSequence(batch: Seq[Array[Int]], activation: String): Array[Array[Float]] =
+      batch.map { encoded =>
+        val identity = encoded(1) - ID_OFFSET
+        if (identity % 2 == 0) Array(10f, 0f) else Array(0f, 10f)
+      }.toArray
+
+    override def tagZeroShotSequence(
+        batch: Seq[Array[Int]],
+        entailmentId: Int,
+        contradictionId: Int,
+        activation: String): Array[Array[Float]] =
+      batch.map { encoded =>
+        // encodeSequence layout: [start, questionToken, qEnd, labelToken, end].
+        // position 1 = this sentence's identity (from tokenizeWithAlignment's pieceId);
+        // position 3 = which candidate label this row is scoring (0="even", 1="odd", from
+        // tokenizeSeqString's pieceId). Score entailment high only when the label matches the
+        // sentence's own parity, so softmax over labels actually discriminates.
+        val identity = encoded(1) - ID_OFFSET
+        val labelId = encoded(3)
+        val correctLabelId = if (identity % 2 == 0) 0 else 1
+        if (labelId == correctLabelId) Array(10f, 0f) else Array(0f, 10f)
+      }.toArray
+  }
+
+  private def sentenceAt(i: Int): (TokenizedSentence, Sentence) = {
+    val content = s"s$i"
+    val tokenized = TokenizedSentence(Array(IndexedToken(content, 0, content.length - 1)), i)
+    val sentence = Sentence(content, start = i * 10, end = i * 10 + content.length - 1, index = i)
+    (tokenized, sentence)
+  }
+
+  private def buildInput(n: Int): (Seq[TokenizedSentence], Seq[Sentence]) = {
+    val pairs = (0 until n).map(sentenceAt)
+    (pairs.map(_._1), pairs.map(_._2))
+  }
+
+  "predictSequence" should "anchor every annotation at its own originating sentence across multiple batches" taggedAs FastTest in {
+    val model = new FakeClassification
+    val (tokenized, sentences) = buildInput(5)
+
+    val result = model.predictSequence(
+      tokenized,
+      sentences,
+      batchSize = 2, // forces 3 batches: [0,1], [2,3], [4]
+      maxSentenceLength = 128,
+      caseSensitive = true,
+      coalesceSentences = false,
+      tags = Map("even" -> 0, "odd" -> 1),
+      activation = ActivationFunction.softmax)
+
+    assert(result.length == 5, "one annotation per sentence")
+
+    val sentenceIndices = result.map(_.metadata("sentence").toInt).sorted
+    assert(
+      sentenceIndices == (0 until 5),
+      s"every original sentence index must appear exactly once, got $sentenceIndices")
+
+    result.foreach { annotation =>
+      val idx = annotation.metadata("sentence").toInt
+      val expectedLabel = if (idx % 2 == 0) "even" else "odd"
+      assert(
+        annotation.result == expectedLabel,
+        s"sentence $idx got label ${annotation.result}, expected $expectedLabel " +
+          "(a mismatch here means the annotation was scored using a different sentence's batch)")
+    }
+  }
+
+  it should "average scores over ALL sentences, not just the last batch, when coalesceSentences=true" taggedAs FastTest in {
+    val model = new FakeClassification
+    val (tokenized, sentences) = buildInput(5) // identities 0,1,2,3,4 -> 3 even, 2 odd
+
+    val result = model.predictSequence(
+      tokenized,
+      sentences,
+      batchSize = 2,
+      maxSentenceLength = 128,
+      caseSensitive = true,
+      coalesceSentences = true,
+      tags = Map("even" -> 0, "odd" -> 1),
+      activation = ActivationFunction.softmax)
+
+    assert(
+      result.length == 1,
+      "coalesceSentences must produce exactly one annotation, not one per batch")
+
+    val evenScore = result.head.metadata("even").toFloat
+    val oddScore = result.head.metadata("odd").toFloat
+    // 3 identities score (10,0), 2 identities score (0,10) -> average = (30/5, 20/5) = (6, 4)
+    assert(
+      math.abs(evenScore - 6f) < 1e-3f,
+      s"expected averaged 'even' score ~6.0, got $evenScore")
+    assert(math.abs(oddScore - 4f) < 1e-3f, s"expected averaged 'odd' score ~4.0, got $oddScore")
+  }
+
+  it should "keep per-sentence label sets correctly attributed under sigmoid activation across batches" taggedAs FastTest in {
+    val model = new FakeClassification
+    val (tokenized, sentences) = buildInput(5)
+
+    val result = model.predictSequence(
+      tokenized,
+      sentences,
+      batchSize = 2,
+      maxSentenceLength = 128,
+      caseSensitive = true,
+      coalesceSentences = false,
+      tags = Map("even" -> 0, "odd" -> 1),
+      activation = ActivationFunction.sigmoid)
+
+    val bySentence = result.groupBy(_.metadata("sentence").toInt)
+    (0 until 5).foreach { idx =>
+      val labels = bySentence.getOrElse(idx, Seq.empty).map(_.result).toSet
+      val expected = if (idx % 2 == 0) Set("even") else Set("odd")
+      assert(labels == expected, s"sentence $idx got labels $labels, expected $expected")
+    }
+  }
+
+  "predictSequenceWithZeroShot" should "anchor every annotation at its own originating sentence across multiple batches" taggedAs FastTest in {
+    val model = new FakeClassification
+    val (tokenized, sentences) = buildInput(4)
+
+    val result = model.predictSequenceWithZeroShot(
+      tokenized,
+      sentences,
+      candidateLabels = Array("even", "odd"),
+      entailmentId = 0,
+      contradictionId = 1,
+      batchSize = 1, // forces one sentence per batch: worst case for the old bug
+      maxSentenceLength = 128,
+      caseSensitive = true,
+      coalesceSentences = false,
+      tags = Map.empty,
+      activation = ActivationFunction.softmax)
+
+    assert(result.length == 4, "one annotation per sentence")
+
+    val sentenceIndices = result.map(_.metadata("sentence").toInt).sorted
+    assert(
+      sentenceIndices == (0 until 4),
+      s"every original sentence index must appear exactly once, got $sentenceIndices " +
+        "(duplicates/missing indices indicate later batches were mis-anchored)")
+
+    result.foreach { annotation =>
+      val idx = annotation.metadata("sentence").toInt
+      val expectedLabel = if (idx % 2 == 0) "even" else "odd"
+      assert(
+        annotation.result == expectedLabel,
+        s"sentence $idx got label ${annotation.result}, expected $expectedLabel")
+    }
+  }
+
+  it should "coalesce to exactly one annotation averaged across all sentences" taggedAs FastTest in {
+    val model = new FakeClassification
+    val (tokenized, sentences) = buildInput(4) // 2 even, 2 odd
+
+    val result = model.predictSequenceWithZeroShot(
+      tokenized,
+      sentences,
+      candidateLabels = Array("even", "odd"),
+      entailmentId = 0,
+      contradictionId = 1,
+      batchSize = 1,
+      maxSentenceLength = 128,
+      caseSensitive = true,
+      coalesceSentences = true,
+      tags = Map.empty,
+      activation = ActivationFunction.softmax)
+
+    assert(result.length == 1, "coalesceSentences must produce exactly one annotation")
+  }
+
+  "predictSequence" should "return an empty sequence for empty input without throwing" taggedAs FastTest in {
+    val model = new FakeClassification
+    val result = model.predictSequence(
+      Seq.empty,
+      Seq.empty,
+      batchSize = 8,
+      maxSentenceLength = 128,
+      caseSensitive = true,
+      coalesceSentences = true, // would previously reach `sentences.head` if not guarded
+      tags = Map("even" -> 0, "odd" -> 1),
+      activation = ActivationFunction.softmax)
+    assert(result.isEmpty)
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationPredictGroupedTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationPredictGroupedTestSpec.scala
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.ml.ai
+
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.tags.FastTest
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.util.Random
+
+/** Regression coverage for `predictGrouped` (the cross-row batched token-classification path
+  * added to flatten `*ForTokenClassification` annotators - see XXXForClassification.scala).
+  *
+  * `predictGrouped` batches inference across every sentence from every row in one pass, using
+  * length-bucketing (sort-by-length, batch, restore order) to limit padding waste. It must:
+  *   1. Produce the exact same annotations as calling the original per-row [[predict]] once per
+  *      row and concatenating - regardless of `batchSize`, row count, or sentence-length spread
+  *      (which drives how length-bucketing reorders things internally). 2. Keep each row's own
+  *      annotations in original sentence/token order, since NER-style consumers (e.g.
+  *      NerConverter) rely on adjacency for BIO-tag reconstruction. 3. Correctly attribute
+  *      annotations to their originating row with no cross-row leakage, and handle empty rows
+  *      without the row-misalignment bug fixed elsewhere in this branch (predictGrouped never
+  *      filters-then-zipWithIndex; it always allocates a row-indexed array).
+  *
+  * The fake `tag` stub below returns, for a token's encoded id, a score that depends only on that
+  * token's own id - never on neighboring padding or batch composition - so it behaves like a
+  * correctly-masked real model for the purpose of this test: any observed difference between
+  * `predictGrouped` and the per-row golden reference must come from the grouping/regrouping logic
+  * itself, not from padding artifacts.
+  */
+class XXXForClassificationPredictGroupedTestSpec extends AnyFlatSpec {
+
+  class FakeTokenClassification extends XXXForClassification {
+    override protected val sentencePadTokenId: Int = 0
+    override protected val sentenceStartTokenId: Int = 101
+    override protected val sentenceEndTokenId: Int = 102
+    override protected val sigmoidThreshold: Float = 0.5f
+
+    override def tokenizeWithAlignment(
+        sentences: Seq[TokenizedSentence],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] =
+      sentences.map { ts =>
+        WordpieceTokenizedSentence(ts.indexedTokens.map { tok =>
+          // pieceId derived from begin offset: unique per token across the whole test, stable
+          // regardless of which row/batch the token ends up grouped into.
+          TokenPiece(
+            wordpiece = tok.token,
+            token = tok.token,
+            pieceId = tok.begin + 1, // +1 to stay clear of pad/special ids (0-2)
+            isWordStart = true,
+            begin = tok.begin,
+            end = tok.end)
+        })
+      }
+
+    override def tokenizeSeqString(
+        candidateLabels: Seq[String],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = Seq.empty
+
+    override def tokenizeDocument(
+        docs: Seq[com.johnsnowlabs.nlp.Annotation],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = Seq.empty
+
+    /** Score for a token only depends on its own encoded id - no cross-position mixing, so
+      * padding/batch composition can never change a real position's result (mirrors what
+      * attention masking guarantees in a correctly implemented real model).
+      */
+    override def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] =
+      batch.map(_.map(id => Array(id.toFloat, -id.toFloat)))
+
+    override def tagSequence(batch: Seq[Array[Int]], activation: String): Array[Array[Float]] =
+      throw new NotImplementedError("not exercised by this spec")
+
+    override def tagZeroShotSequence(
+        batch: Seq[Array[Int]],
+        entailmentId: Int,
+        contradictionId: Int,
+        activation: String): Array[Array[Float]] =
+      throw new NotImplementedError("not exercised by this spec")
+
+    override def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) =
+      throw new NotImplementedError("not exercised by this spec")
+
+    override def findIndexedToken(
+        tokenizedSentences: Seq[TokenizedSentence],
+        sentence: (WordpieceTokenizedSentence, Int),
+        tokenPiece: TokenPiece): Option[IndexedToken] =
+      tokenizedSentences(sentence._2).indexedTokens.find(p => p.begin == tokenPiece.begin)
+  }
+
+  private val classTags = Map("A" -> 0, "B" -> 1)
+
+  /** Builds `numRows` rows, each with a random number of sentences (0-3) and each sentence a
+    * random number of tokens (1-6), with globally unique begin/end offsets so tokens are
+    * unambiguously identifiable regardless of which row/sentence they end up attributed to.
+    */
+  private def randomRows(numRows: Int, seed: Long): Seq[Seq[TokenizedSentence]] = {
+    val rnd = new Random(seed)
+    var cursor = 0
+    (0 until numRows).map { _ =>
+      val numSentences = rnd.nextInt(4) // 0..3, so some rows are empty
+      (0 until numSentences).map { sentenceIdx =>
+        val numTokens = 1 + rnd.nextInt(6) // 1..6
+        val tokens = (0 until numTokens).map { _ =>
+          val begin = cursor
+          val end = cursor + 2
+          cursor += 4
+          IndexedToken(s"tok$begin", begin, end)
+        }.toArray
+        TokenizedSentence(tokens, sentenceIdx)
+      }
+    }
+  }
+
+  private def goldenReference(
+      model: FakeTokenClassification,
+      rows: Seq[Seq[TokenizedSentence]]): Seq[Seq[com.johnsnowlabs.nlp.Annotation]] =
+    rows.map { rowSentences =>
+      // large batchSize so the per-row reference is never itself split across multiple batches
+      model.predict(
+        rowSentences,
+        batchSize = 1000,
+        maxSentenceLength = 512,
+        caseSensitive = true,
+        classTags)
+    }
+
+  Seq(1, 2, 3, 5, 8, 16).foreach { batchSize =>
+    it should s"match the per-row predict() reference exactly with batchSize=$batchSize" taggedAs FastTest in {
+      val model = new FakeTokenClassification
+      val rows = randomRows(numRows = 12, seed = 42)
+
+      val expected = goldenReference(model, rows)
+      val actual = model.predictGrouped(
+        rows,
+        batchSize = batchSize,
+        maxSentenceLength = 512,
+        caseSensitive = true,
+        classTags)
+
+      assert(actual.length == expected.length, "one result per row")
+      rows.indices.foreach { rowIdx =>
+        assert(
+          actual(rowIdx) == expected(rowIdx),
+          s"row $rowIdx mismatched at batchSize=$batchSize:\n  actual=${actual(
+              rowIdx)}\n  expected=${expected(rowIdx)}")
+      }
+    }
+  }
+
+  it should "leave every row empty when all rows have zero sentences" taggedAs FastTest in {
+    val model = new FakeTokenClassification
+    val rows: Seq[Seq[TokenizedSentence]] = Seq(Seq.empty, Seq.empty, Seq.empty)
+
+    val result = model.predictGrouped(
+      rows,
+      batchSize = 8,
+      maxSentenceLength = 512,
+      caseSensitive = true,
+      classTags)
+
+    assert(result.length == 3)
+    assert(result.forall(_.isEmpty))
+  }
+
+  it should "not leak annotations across rows when empty rows are interleaved with non-empty ones" taggedAs FastTest in {
+    val model = new FakeTokenClassification
+    val nonEmptyRows = randomRows(numRows = 4, seed = 7)
+    // interleave: empty, row0, empty, empty, row1, row2, empty, row3
+    val rows: Seq[Seq[TokenizedSentence]] =
+      Seq(
+        Seq.empty,
+        nonEmptyRows(0),
+        Seq.empty,
+        Seq.empty,
+        nonEmptyRows(1),
+        nonEmptyRows(2),
+        Seq.empty,
+        nonEmptyRows(3))
+
+    val expectedNonEmpty = goldenReference(model, nonEmptyRows)
+    val actual = model.predictGrouped(
+      rows,
+      batchSize = 3,
+      maxSentenceLength = 512,
+      caseSensitive = true,
+      classTags)
+
+    assert(actual.length == rows.length)
+    assert(actual(0).isEmpty)
+    assert(actual(2).isEmpty)
+    assert(actual(3).isEmpty)
+    assert(actual(6).isEmpty)
+    assert(actual(1) == expectedNonEmpty(0))
+    assert(actual(4) == expectedNonEmpty(1))
+    assert(actual(5) == expectedNonEmpty(2))
+    assert(actual(7) == expectedNonEmpty(3))
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationPredictSequenceGroupedTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationPredictSequenceGroupedTestSpec.scala
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.ml.ai
+
+import com.johnsnowlabs.nlp.ActivationFunction
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.tags.FastTest
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.util.Random
+
+/** Regression coverage for `predictSequenceGrouped` (the cross-row batched
+  * sequence-classification path added to flatten `*ForSequenceClassification` annotators - see
+  * XXXForClassification.scala).
+  *
+  * Two things must hold:
+  *   1. With `coalesceSentences=false`, results must exactly match calling the per-row
+  *      [[predictSequence]] once per row and concatenating - regardless of batchSize or how
+  *      length-bucketing reorders sentences internally. 2. With `coalesceSentences=true`, each
+  *      row must still get exactly ONE annotation, averaged over only that row's own sentences -
+  *      not averaged across the whole cross-row batch. This is the part that's easy to get wrong
+  *      once a single inference call spans multiple rows: "coalesce the document" has to mean
+  *      "coalesce the row", not "coalesce the call".
+  */
+class XXXForClassificationPredictSequenceGroupedTestSpec extends AnyFlatSpec {
+
+  class FakeSequenceClassification extends XXXForClassification {
+    override protected val sentencePadTokenId: Int = 0
+    override protected val sentenceStartTokenId: Int = 101
+    override protected val sentenceEndTokenId: Int = 102
+    override protected val sigmoidThreshold: Float = 0.5f
+
+    override def tokenizeWithAlignment(
+        sentences: Seq[TokenizedSentence],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] =
+      sentences.map { ts =>
+        WordpieceTokenizedSentence(ts.indexedTokens.map { tok =>
+          TokenPiece(
+            wordpiece = tok.token,
+            token = tok.token,
+            pieceId = tok.begin + 1,
+            isWordStart = true,
+            begin = tok.begin,
+            end = tok.end)
+        })
+      }
+
+    override def tokenizeSeqString(
+        candidateLabels: Seq[String],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = Seq.empty
+
+    override def tokenizeDocument(
+        docs: Seq[com.johnsnowlabs.nlp.Annotation],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = Seq.empty
+
+    override def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] =
+      throw new NotImplementedError("not exercised by this spec")
+
+    /** Score for a sentence is a pure function of the token ids actually present in its own
+      * encoded row (sum of non-special ids, split into two classes) - never a function of which
+      * other sentences share its batch or of padding, so batching/bucketing/cross-row mixing can
+      * never legitimately change a sentence's own result.
+      */
+    override def tagSequence(batch: Seq[Array[Int]], activation: String): Array[Array[Float]] =
+      batch.map { encoded =>
+        val real = encoded.filter(id =>
+          id != sentenceStartTokenId && id != sentenceEndTokenId && id != sentencePadTokenId)
+        val sum = real.sum.toFloat
+        Array(sum, -sum)
+      }.toArray
+
+    override def tagZeroShotSequence(
+        batch: Seq[Array[Int]],
+        entailmentId: Int,
+        contradictionId: Int,
+        activation: String): Array[Array[Float]] =
+      throw new NotImplementedError("not exercised by this spec")
+
+    override def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) =
+      throw new NotImplementedError("not exercised by this spec")
+
+    override def findIndexedToken(
+        tokenizedSentences: Seq[TokenizedSentence],
+        sentence: (WordpieceTokenizedSentence, Int),
+        tokenPiece: TokenPiece): Option[IndexedToken] = None
+  }
+
+  private val classTags = Map("pos" -> 0, "neg" -> 1)
+
+  /** Builds `numRows` rows, each with 0-3 sentences and each sentence 1-5 tokens, all with
+    * globally unique begin/end offsets.
+    */
+  private def randomRows(
+      numRows: Int,
+      seed: Long,
+      minSentencesPerRow: Int = 0): (Seq[Seq[TokenizedSentence]], Seq[Seq[Sentence]]) = {
+    val rnd = new Random(seed)
+    var cursor = 0
+    val rows = (0 until numRows).map { _ =>
+      val numSentences = minSentencesPerRow + rnd.nextInt(4 - minSentencesPerRow)
+      (0 until numSentences).map { sentenceIdx =>
+        val numTokens = 1 + rnd.nextInt(5)
+        val tokens = (0 until numTokens).map { _ =>
+          val begin = cursor
+          val end = cursor + 2
+          cursor += 4
+          IndexedToken(s"tok$begin", begin, end)
+        }.toArray
+        val tokenizedSentence = TokenizedSentence(tokens, sentenceIdx)
+        val sentStart = tokens.head.begin
+        val sentEnd = tokens.last.end
+        val sentence = Sentence(s"s$sentStart", sentStart, sentEnd, sentenceIdx)
+        (tokenizedSentence, sentence)
+      }
+    }
+    (rows.map(_.map(_._1)), rows.map(_.map(_._2)))
+  }
+
+  private def goldenReference(
+      model: FakeSequenceClassification,
+      rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]],
+      rowsOfSentences: Seq[Seq[Sentence]],
+      coalesceSentences: Boolean): Seq[Seq[com.johnsnowlabs.nlp.Annotation]] =
+    rowsOfTokenizedSentences.zip(rowsOfSentences).map { case (tokenizedSentences, sentences) =>
+      if (tokenizedSentences.isEmpty) Seq.empty[com.johnsnowlabs.nlp.Annotation]
+      else
+        model.predictSequence(
+          tokenizedSentences,
+          sentences,
+          batchSize = 1000,
+          maxSentenceLength = 512,
+          caseSensitive = true,
+          coalesceSentences = coalesceSentences,
+          classTags,
+          ActivationFunction.softmax)
+    }
+
+  Seq(1, 2, 3, 5, 8, 16).foreach { batchSize =>
+    it should s"match the per-row predictSequence() reference exactly with batchSize=$batchSize (coalesceSentences=false)" taggedAs FastTest in {
+      val model = new FakeSequenceClassification
+      val (tokenizedRows, sentenceRows) = randomRows(numRows = 12, seed = 99)
+
+      val expected =
+        goldenReference(model, tokenizedRows, sentenceRows, coalesceSentences = false)
+      val actual = model.predictSequenceGrouped(
+        tokenizedRows,
+        sentenceRows,
+        batchSize = batchSize,
+        maxSentenceLength = 512,
+        caseSensitive = true,
+        coalesceSentences = false,
+        classTags,
+        ActivationFunction.softmax)
+
+      assert(actual.length == expected.length)
+      tokenizedRows.indices.foreach { rowIdx =>
+        assert(
+          actual(rowIdx) == expected(rowIdx),
+          s"row $rowIdx mismatched at batchSize=$batchSize:\n  actual=${actual(
+              rowIdx)}\n  expected=${expected(rowIdx)}")
+      }
+    }
+  }
+
+  it should "coalesce PER ROW, not across the whole cross-row batch" taggedAs FastTest in {
+    val model = new FakeSequenceClassification
+    // every row has at least 2 sentences so a bug that coalesces across the whole call (instead
+    // of per row) would visibly average in other rows' scores
+    val (tokenizedRows, sentenceRows) =
+      randomRows(numRows = 6, seed = 123, minSentencesPerRow = 2)
+
+    val expected = goldenReference(model, tokenizedRows, sentenceRows, coalesceSentences = true)
+    val actual = model.predictSequenceGrouped(
+      tokenizedRows,
+      sentenceRows,
+      batchSize = 3, // forces multiple rows' sentences into the same inference batch
+      maxSentenceLength = 512,
+      caseSensitive = true,
+      coalesceSentences = true,
+      classTags,
+      ActivationFunction.softmax)
+
+    assert(actual.length == 6)
+    actual.foreach(rowResult =>
+      assert(
+        rowResult.length == 1,
+        "coalesceSentences must yield exactly one annotation per row"))
+    tokenizedRows.indices.foreach { rowIdx =>
+      assert(
+        actual(rowIdx) == expected(rowIdx),
+        s"row $rowIdx mismatched:\n  actual=${actual(rowIdx)}\n  expected=${expected(rowIdx)}")
+    }
+  }
+
+  it should "leave every row empty when all rows have zero sentences" taggedAs FastTest in {
+    val model = new FakeSequenceClassification
+    val rows: Seq[Seq[TokenizedSentence]] = Seq(Seq.empty, Seq.empty, Seq.empty)
+    val sentenceRows: Seq[Seq[Sentence]] = Seq(Seq.empty, Seq.empty, Seq.empty)
+
+    val result = model.predictSequenceGrouped(
+      rows,
+      sentenceRows,
+      batchSize = 8,
+      maxSentenceLength = 512,
+      caseSensitive = true,
+      coalesceSentences = false,
+      classTags,
+      ActivationFunction.softmax)
+
+    assert(result.length == 3)
+    assert(result.forall(_.isEmpty))
+  }
+
+  it should "not leak annotations across rows when empty rows are interleaved with non-empty ones" taggedAs FastTest in {
+    val model = new FakeSequenceClassification
+    val (tokenizedNonEmpty, sentenceNonEmpty) =
+      randomRows(numRows = 4, seed = 55, minSentencesPerRow = 1)
+
+    val tokenizedRows: Seq[Seq[TokenizedSentence]] =
+      Seq(
+        Seq.empty,
+        tokenizedNonEmpty(0),
+        Seq.empty,
+        Seq.empty,
+        tokenizedNonEmpty(1),
+        tokenizedNonEmpty(2),
+        Seq.empty,
+        tokenizedNonEmpty(3))
+    val sentenceRows: Seq[Seq[Sentence]] =
+      Seq(
+        Seq.empty,
+        sentenceNonEmpty(0),
+        Seq.empty,
+        Seq.empty,
+        sentenceNonEmpty(1),
+        sentenceNonEmpty(2),
+        Seq.empty,
+        sentenceNonEmpty(3))
+
+    val expectedNonEmpty =
+      goldenReference(model, tokenizedNonEmpty, sentenceNonEmpty, coalesceSentences = false)
+    val actual = model.predictSequenceGrouped(
+      tokenizedRows,
+      sentenceRows,
+      batchSize = 3,
+      maxSentenceLength = 512,
+      caseSensitive = true,
+      coalesceSentences = false,
+      classTags,
+      ActivationFunction.softmax)
+
+    assert(actual.length == tokenizedRows.length)
+    assert(actual(0).isEmpty)
+    assert(actual(2).isEmpty)
+    assert(actual(3).isEmpty)
+    assert(actual(6).isEmpty)
+    assert(actual(1) == expectedNonEmpty(0))
+    assert(actual(4) == expectedNonEmpty(1))
+    assert(actual(5) == expectedNonEmpty(2))
+    assert(actual(7) == expectedNonEmpty(3))
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationPredictSpanGroupedTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationPredictSpanGroupedTestSpec.scala
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.ml.ai
+
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
+import com.johnsnowlabs.tags.FastTest
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.util.Random
+
+/** Regression coverage for `predictSpanGrouped` (the new batched question-answering path added to
+  * flatten `*ForQuestionAnswering` annotators). `predictSpan` itself had no `batchSize` at all -
+  * it always ran exactly one example per `tagSpan` call - so this is new code, not a refactor of
+  * an existing batched path, and it has to get three things right that `predictSpan` got away
+  * with only because its batch was always size 1:
+  *
+  *   1. `startLogits.transpose.map(_.sum / startLogits.length)` in predictSpan looks like a
+  *      batch-dimension unwrap but is actually an AVERAGE. With batch size 1 that average is a
+  *      no-op; with more than one example sharing a batch it would blend different questions'
+  *      answer scores together. predictSpanGrouped must index per example instead. 2. tagSpan's
+  *      ONNX path needs a rectangular batch (same length every row); predictSpanGrouped must pad
+  *      shorter examples in a batch up to that batch's own max length. 3. Padding must use
+  *      `sentencePadTokenId`, not a hardcoded 0 - this fake deliberately uses a non-zero pad id
+  *      (999) to catch any such hardcoding.
+  *
+  * The fake `tagSpan` below scores every position as a triangular peak centered on a position
+  * that is a pure function of that example's OWN real (non-padding) tokens - never a function of
+  * neighboring examples or how much trailing padding was added - so any observed difference
+  * between predictSpanGrouped and the per-row predictSpan reference must come from the
+  * batching/regrouping logic itself.
+  */
+class XXXForClassificationPredictSpanGroupedTestSpec extends AnyFlatSpec {
+
+  class FakeSpanClassification extends XXXForClassification {
+    override protected val sentencePadTokenId: Int = 999 // deliberately non-zero
+    override protected val sentenceStartTokenId: Int = 101
+    override protected val sentenceEndTokenId: Int = 102
+    override protected val sigmoidThreshold: Float = 0.5f
+
+    override def tokenizeWithAlignment(
+        sentences: Seq[TokenizedSentence],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = Seq.empty
+
+    override def tokenizeSeqString(
+        candidateLabels: Seq[String],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = Seq.empty
+
+    /** One WordpieceTokenizedSentence per input document/annotation, with a single token whose
+      * pieceId is derived from the annotation's own begin offset - unique per document across the
+      * whole test.
+      */
+    override def tokenizeDocument(
+        docs: Seq[Annotation],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] =
+      docs.map { doc =>
+        WordpieceTokenizedSentence(
+          Array(
+            TokenPiece(
+              wordpiece = doc.result,
+              token = doc.result,
+              pieceId = doc.begin + 1,
+              isWordStart = true,
+              begin = doc.begin,
+              end = doc.end)))
+      }
+
+    override def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] =
+      throw new NotImplementedError("not exercised by this spec")
+
+    override def tagSequence(batch: Seq[Array[Int]], activation: String): Array[Array[Float]] =
+      throw new NotImplementedError("not exercised by this spec")
+
+    override def tagZeroShotSequence(
+        batch: Seq[Array[Int]],
+        entailmentId: Int,
+        contradictionId: Int,
+        activation: String): Array[Array[Float]] =
+      throw new NotImplementedError("not exercised by this spec")
+
+    /** Peaks (score 0, decaying by 1 per position away) exactly at a target position derived from
+      * that row's own real content - start target = position right after the question's own end
+      * token (first occurrence of sentenceEndTokenId); end target = the last non-padding
+      * position. Neither depends on other rows sharing the batch or on how much padding was
+      * added, so the argmax is stable regardless of batching/bucketing.
+      */
+    override def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) = {
+      val maxLen = batch.map(_.length).max
+      // offset by +1000 so the peak score is unambiguously positive: -math.abs(0) is -0.0f, and
+      // predictSpan's transpose-average (`Array(-0.0f).sum`) incidentally normalizes that to
+      // +0.0f while predictSpanGrouped's direct indexing does not - same numeric value either way
+      // (-0.0f == 0.0f), but the toString stored in annotation metadata would differ. Avoid the
+      // edge case entirely rather than mask it.
+      def peakAt(target: Int): Array[Float] =
+        Array.tabulate(maxLen)(i => 1000f - math.abs(i - target).toFloat)
+
+      val starts = batch.map { row =>
+        val target = row.indexOf(sentenceEndTokenId)
+        peakAt(target)
+      }.toArray
+      val ends = batch.map { row =>
+        val target = row.lastIndexWhere(_ != sentencePadTokenId)
+        peakAt(target)
+      }.toArray
+      (starts, ends)
+    }
+
+    override def findIndexedToken(
+        tokenizedSentences: Seq[TokenizedSentence],
+        sentence: (WordpieceTokenizedSentence, Int),
+        tokenPiece: TokenPiece): Option[IndexedToken] = None
+  }
+
+  /** Builds `numRows` rows, each either empty or a [question, context] pair of DOCUMENT
+    * annotations with globally unique begin/end offsets, so every token is unambiguously
+    * identifiable.
+    */
+  private def randomRows(
+      numRows: Int,
+      seed: Long,
+      allEmpty: Boolean = false): Seq[Seq[Annotation]] = {
+    val rnd = new Random(seed)
+    var cursor = 0
+    (0 until numRows).map { _ =>
+      if (allEmpty || rnd.nextInt(5) == 0) Seq.empty
+      else {
+        def nextDoc(): Annotation = {
+          val begin = cursor
+          val len = 1 + rnd.nextInt(6)
+          val end = begin + len
+          cursor += len + 2
+          Annotation(AnnotatorType.DOCUMENT, begin, end, s"doc$begin", Map.empty)
+        }
+        Seq(nextDoc(), nextDoc()) // [question, context]
+      }
+    }
+  }
+
+  private def goldenReference(
+      model: FakeSpanClassification,
+      rows: Seq[Seq[Annotation]]): Seq[Seq[Annotation]] =
+    rows.map { documents =>
+      if (documents.isEmpty) Seq.empty[Annotation]
+      else model.predictSpan(documents, maxSentenceLength = 512, caseSensitive = true)
+    }
+
+  Seq(1, 2, 3, 5, 8).foreach { batchSize =>
+    it should s"match the per-row predictSpan() reference exactly with batchSize=$batchSize" taggedAs FastTest in {
+      val model = new FakeSpanClassification
+      val rows = randomRows(numRows = 15, seed = 42)
+
+      val expected = goldenReference(model, rows)
+      val actual =
+        model.predictSpanGrouped(
+          rows,
+          batchSize = batchSize,
+          maxSentenceLength = 512,
+          caseSensitive = true)
+
+      assert(actual.length == expected.length)
+      rows.indices.foreach { rowIdx =>
+        assert(
+          actual(rowIdx) == expected(rowIdx),
+          s"row $rowIdx mismatched at batchSize=$batchSize:\n  actual=${actual(
+              rowIdx)}\n  expected=${expected(rowIdx)}")
+      }
+    }
+  }
+
+  it should "pad shorter examples up to the batch's own max length without changing their answer" taggedAs FastTest in {
+    val model = new FakeSpanClassification
+    val rnd = new Random(7)
+    var cursor = 0
+    // deliberately mix a very short row with much longer ones in the same batch
+    def doc(len: Int): Annotation = {
+      val begin = cursor
+      val end = begin + len
+      cursor += len + 2
+      Annotation(AnnotatorType.DOCUMENT, begin, end, s"doc$begin", Map.empty)
+    }
+    val shortRow = Seq(doc(1), doc(1))
+    val longRow = Seq(doc(20), doc(20))
+    val rows = Seq(shortRow, longRow, shortRow, longRow)
+
+    val expected = goldenReference(model, rows)
+    val actual =
+      model.predictSpanGrouped(rows, batchSize = 4, maxSentenceLength = 512, caseSensitive = true)
+
+    assert(actual == expected)
+  }
+
+  it should "leave every row empty when all rows have no documents" taggedAs FastTest in {
+    val model = new FakeSpanClassification
+    val rows = randomRows(numRows = 4, seed = 1, allEmpty = true)
+
+    val result =
+      model.predictSpanGrouped(rows, batchSize = 8, maxSentenceLength = 512, caseSensitive = true)
+
+    assert(result.length == 4)
+    assert(result.forall(_.isEmpty))
+  }
+
+  it should "not leak answers across rows when empty rows are interleaved with non-empty ones" taggedAs FastTest in {
+    val model = new FakeSpanClassification
+    val nonEmpty = randomRows(numRows = 4, seed = 2).filter(_.nonEmpty)
+    assert(nonEmpty.length >= 3, "need at least 3 non-empty rows for this test to be meaningful")
+
+    val rows: Seq[Seq[Annotation]] =
+      Seq(Seq.empty, nonEmpty(0), Seq.empty, Seq.empty, nonEmpty(1), nonEmpty(2), Seq.empty)
+
+    val expectedNonEmpty = goldenReference(model, nonEmpty)
+    val actual =
+      model.predictSpanGrouped(rows, batchSize = 2, maxSentenceLength = 512, caseSensitive = true)
+
+    assert(actual.length == rows.length)
+    assert(actual(0).isEmpty)
+    assert(actual(2).isEmpty)
+    assert(actual(3).isEmpty)
+    assert(actual(6).isEmpty)
+    assert(actual(1) == expectedNonEmpty(0))
+    assert(actual(4) == expectedNonEmpty(1))
+    assert(actual(5) == expectedNonEmpty(2))
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationPredictSpanPaddingTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationPredictSpanPaddingTestSpec.scala
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.ml.ai
+
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
+import com.johnsnowlabs.tags.FastTest
+import org.scalatest.flatspec.AnyFlatSpec
+
+/** Padding-specific coverage for `predictSpanGrouped`.
+  *
+  * The sibling spec (`XXXForClassificationPredictSpanGroupedTestSpec`) checks ordering and
+  * regrouping, but it cannot say anything about padding for two reasons: its fake emits exactly
+  * one token per document, so every encoded row comes out the same width and no padding is ever
+  * added; and its fake `tagSpan` derives its peak from `lastIndexWhere(_ != sentencePadTokenId)`,
+  * i.e. it models a backend that already ignores padding perfectly. A real backend does not:
+  * `tagSpan` softmaxes across the whole padded width, and several concrete `tagSpan`
+  * implementations historically built an all-ones (or hardcoded-`0`-compared) attention mask, so
+  * padding positions carry real probability mass and can win an argmax outright.
+  *
+  * This spec therefore does the opposite on both counts:
+  *
+  *   - documents tokenize to a length derived from their own text, so a batch genuinely mixes
+  *     widths and shorter rows really are padded;
+  *   - the fake `tagSpan` is deliberately padding-NAIVE - it scores strictly increasing with
+  *     position, so the highest-scoring slot in a padded row is always the LAST PAD. Any
+  *     implementation that does not confine the argmax to the row's own unpadded region will pick
+  *     a padding position and fail these tests.
+  */
+class XXXForClassificationPredictSpanPaddingTestSpec extends AnyFlatSpec {
+
+  class PaddingNaiveSpanClassification extends XXXForClassification {
+    override protected val sentencePadTokenId: Int = 999 // deliberately non-zero
+    override protected val sentenceStartTokenId: Int = 101
+    override protected val sentenceEndTokenId: Int = 102
+    override protected val sigmoidThreshold: Float = 0.5f
+
+    override def tokenizeWithAlignment(
+        sentences: Seq[TokenizedSentence],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = Seq.empty
+
+    override def tokenizeSeqString(
+        candidateLabels: Seq[String],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = Seq.empty
+
+    /** Emits one token per character of the document's text, so documents of different lengths
+      * produce encoded rows of different widths - which is what forces real padding once several
+      * rows share a batch.
+      */
+    override def tokenizeDocument(
+        docs: Seq[Annotation],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] =
+      docs.map { doc =>
+        val pieces = doc.result.zipWithIndex.map { case (ch, i) =>
+          TokenPiece(
+            wordpiece = ch.toString,
+            token = ch.toString,
+            pieceId = doc.begin + i + 1,
+            isWordStart = true,
+            begin = doc.begin + i,
+            end = doc.begin + i)
+        }.toArray
+        WordpieceTokenizedSentence(pieces)
+      }
+
+    override def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] =
+      throw new NotImplementedError("not exercised by this spec")
+
+    override def tagSequence(batch: Seq[Array[Int]], activation: String): Array[Array[Float]] =
+      throw new NotImplementedError("not exercised by this spec")
+
+    override def tagZeroShotSequence(
+        batch: Seq[Array[Int]],
+        entailmentId: Int,
+        contradictionId: Int,
+        activation: String): Array[Array[Float]] =
+      throw new NotImplementedError("not exercised by this spec")
+
+    /** Deliberately padding-naive: the raw logit increases with position, so in a padded row the
+      * highest-scoring slot is always the final PAD. Mirrors a backend whose attention mask does
+      * not exclude padding.
+      *
+      * Softmaxed across the full padded width, exactly as every real `tagSpan` does before
+      * returning - that is what makes "restrict to the valid prefix and renormalise" equivalent
+      * to having never padded at all, and it is the property the invariance test below pins down.
+      */
+    override def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) = {
+      val maxLen = batch.map(_.length).max
+
+      def softmax(logits: Array[Float]): Array[Float] = {
+        val shifted = logits.map(_ - logits.max) // max-subtraction for numerical stability
+        val exps = shifted.map(x => math.exp(x.toDouble))
+        val total = exps.sum
+        exps.map(e => (e / total).toFloat)
+      }
+
+      val scores =
+        batch.map(_ => softmax(Array.tabulate(maxLen)(i => (i + 1).toFloat))).toArray
+      (scores, scores.map(_.clone()))
+    }
+
+    override def findIndexedToken(
+        tokenizedSentences: Seq[TokenizedSentence],
+        sentence: (WordpieceTokenizedSentence, Int),
+        tokenPiece: TokenPiece): Option[IndexedToken] = None
+  }
+
+  /** Rows of [question, context] whose text lengths vary widely, guaranteeing that any batch
+    * larger than one mixes widths and therefore pads.
+    */
+  private def mixedWidthRows(): Seq[Seq[Annotation]] = {
+    val widths = Seq(1, 7, 2, 12, 3, 20, 1, 9, 4, 15)
+    var cursor = 0
+    widths.map { w =>
+      def nextDoc(len: Int): Annotation = {
+        val begin = cursor
+        val end = begin + len - 1
+        cursor += len + 2
+        Annotation(AnnotatorType.DOCUMENT, begin, end, "x" * len, Map.empty)
+      }
+      Seq(nextDoc(2), nextDoc(w)) // short question, variable-width context
+    }
+  }
+
+  /** Each row's own unpadded encoded width, per the trait's own encodeSequence. */
+  private def encodedWidth(model: PaddingNaiveSpanClassification, row: Seq[Annotation]): Int = {
+    val q = model.tokenizeDocument(Seq(row.head), 512, caseSensitive = true)
+    val c = model.tokenizeDocument(row.drop(1), 512, caseSensitive = true)
+    model.encodeSequence(q, c, 512).head.length
+  }
+
+  Seq(2, 3, 5, 10).foreach { batchSize =>
+    it should s"never select a padding position as the answer span with batchSize=$batchSize" taggedAs FastTest in {
+      val model = new PaddingNaiveSpanClassification
+      val rows = mixedWidthRows()
+
+      val actual =
+        model.predictSpanGrouped(
+          rows,
+          batchSize = batchSize,
+          maxSentenceLength = 512,
+          caseSensitive = true)
+
+      rows.zip(actual).foreach { case (row, annotations) =>
+        val width = encodedWidth(model, row)
+        annotations.foreach { a =>
+          val start = a.metadata("start").toInt
+          val end = a.metadata("end").toInt
+          assert(
+            start < width,
+            s"start index $start landed in padding (row's own width is $width)")
+          assert(end < width, s"end index $end landed in padding (row's own width is $width)")
+        }
+      }
+    }
+  }
+
+  it should "produce identical answers and scores no matter which rows share a batch" taggedAs FastTest in {
+    val model = new PaddingNaiveSpanClassification
+    val rows = mixedWidthRows()
+
+    // batchSize=1 is the unpadded ground truth: a batch of one is never padded.
+    val unbatched =
+      model.predictSpanGrouped(rows, batchSize = 1, maxSentenceLength = 512, caseSensitive = true)
+
+    Seq(2, 3, 5, 10).foreach { batchSize =>
+      val batched =
+        model.predictSpanGrouped(
+          rows,
+          batchSize = batchSize,
+          maxSentenceLength = 512,
+          caseSensitive = true)
+
+      assert(
+        batched.map(_.map(_.result)) == unbatched.map(_.map(_.result)),
+        s"answer text changed with batchSize=$batchSize")
+
+      unbatched.zip(batched).foreach { case (expectedRow, actualRow) =>
+        expectedRow.zip(actualRow).foreach { case (expected, actual) =>
+          // Positions are exact integers.
+          Seq("start", "end").foreach { key =>
+            assert(
+              expected.metadata(key) == actual.metadata(key),
+              s"metadata '$key' changed with batchSize=$batchSize: " +
+                s"${expected.metadata(key)} -> ${actual.metadata(key)}")
+          }
+          // Scores are mathematically identical but go through a renormalisation, so compare
+          // numerically rather than by their rendered string.
+          Seq("score", "start_score", "end_score").foreach { key =>
+            val e = expected.metadata(key).toFloat
+            val a = actual.metadata(key).toFloat
+            assert(
+              math.abs(e - a) < 1e-5f,
+              s"metadata '$key' changed with batchSize=$batchSize: $e -> $a")
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationPredictZeroShotGroupedTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationPredictZeroShotGroupedTestSpec.scala
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.ml.ai
+
+import com.johnsnowlabs.nlp.ActivationFunction
+import com.johnsnowlabs.nlp.annotators.common._
+import com.johnsnowlabs.tags.FastTest
+import org.scalatest.flatspec.AnyFlatSpec
+
+import scala.util.Random
+
+/** Regression coverage for `predictSequenceWithZeroShotGrouped` (the cross-row batched zero-shot
+  * path added to flatten `*ForZeroShotClassification` annotators).
+  *
+  * Same two properties as the sequence-classification grouped path:
+  *   1. `coalesceSentences=false` results must exactly match the per-row
+  *      [[predictSequenceWithZeroShot]] reference, regardless of batchSize/bucketing. 2.
+  *      `coalesceSentences=true` must average within a row only, never across rows sharing an
+  *      inference batch.
+  */
+class XXXForClassificationPredictZeroShotGroupedTestSpec extends AnyFlatSpec {
+
+  class FakeZeroShotClassification extends XXXForClassification {
+    override protected val sentencePadTokenId: Int = 0
+    override protected val sentenceStartTokenId: Int = 101
+    override protected val sentenceEndTokenId: Int = 102
+    override protected val sigmoidThreshold: Float = 0.5f
+
+    override def tokenizeWithAlignment(
+        sentences: Seq[TokenizedSentence],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] =
+      sentences.map { ts =>
+        WordpieceTokenizedSentence(ts.indexedTokens.map { tok =>
+          TokenPiece(
+            wordpiece = tok.token,
+            token = tok.token,
+            pieceId = tok.begin + 1,
+            isWordStart = true,
+            begin = tok.begin,
+            end = tok.end)
+        })
+      }
+
+    override def tokenizeSeqString(
+        candidateLabels: Seq[String],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] =
+      candidateLabels.zipWithIndex.map { case (label, i) =>
+        WordpieceTokenizedSentence(
+          Array(
+            TokenPiece(label, label, pieceId = 5000 + i, isWordStart = true, begin = 0, end = 0)))
+      }
+
+    override def tokenizeDocument(
+        docs: Seq[com.johnsnowlabs.nlp.Annotation],
+        maxSeqLength: Int,
+        caseSensitive: Boolean): Seq[WordpieceTokenizedSentence] = Seq.empty
+
+    override def tag(batch: Seq[Array[Int]]): Seq[Array[Array[Float]]] =
+      throw new NotImplementedError("not exercised by this spec")
+
+    override def tagSequence(batch: Seq[Array[Int]], activation: String): Array[Array[Float]] =
+      throw new NotImplementedError("not exercised by this spec")
+
+    /** entailment logit is a pure function of (sentence's own token ids, this row's label id) -
+      * never a function of neighboring sentences/padding/batch composition.
+      */
+    override def tagZeroShotSequence(
+        batch: Seq[Array[Int]],
+        entailmentId: Int,
+        contradictionId: Int,
+        activation: String): Array[Array[Float]] =
+      batch.map { encoded =>
+        val sentenceSum = encoded
+          .filter(id => id != sentenceStartTokenId && id != sentenceEndTokenId && id < 5000)
+          .sum
+        val labelId = encoded.find(_ >= 5000).getOrElse(5000) - 5000
+        val score = (sentenceSum + labelId).toFloat
+        val row = new Array[Float](math.max(entailmentId, contradictionId) + 1)
+        row(entailmentId) = score
+        row(contradictionId) = -score
+        row
+      }.toArray
+
+    override def tagSpan(batch: Seq[Array[Int]]): (Array[Array[Float]], Array[Array[Float]]) =
+      throw new NotImplementedError("not exercised by this spec")
+
+    override def findIndexedToken(
+        tokenizedSentences: Seq[TokenizedSentence],
+        sentence: (WordpieceTokenizedSentence, Int),
+        tokenPiece: TokenPiece): Option[IndexedToken] = None
+  }
+
+  private def randomRows(
+      numRows: Int,
+      seed: Long,
+      minSentencesPerRow: Int = 0): (Seq[Seq[TokenizedSentence]], Seq[Seq[Sentence]]) = {
+    val rnd = new Random(seed)
+    var cursor = 0
+    val rows = (0 until numRows).map { _ =>
+      val numSentences = minSentencesPerRow + rnd.nextInt(4 - minSentencesPerRow)
+      (0 until numSentences).map { sentenceIdx =>
+        val numTokens = 1 + rnd.nextInt(4)
+        val tokens = (0 until numTokens).map { _ =>
+          val begin = cursor
+          val end = cursor + 2
+          cursor += 4
+          IndexedToken(s"tok$begin", begin, end)
+        }.toArray
+        val tokenizedSentence = TokenizedSentence(tokens, sentenceIdx)
+        val sentence =
+          Sentence(s"s${tokens.head.begin}", tokens.head.begin, tokens.last.end, sentenceIdx)
+        (tokenizedSentence, sentence)
+      }
+    }
+    (rows.map(_.map(_._1)), rows.map(_.map(_._2)))
+  }
+
+  private val candidateLabels = Array("pos", "neg", "neutral")
+
+  private def goldenReference(
+      model: FakeZeroShotClassification,
+      rowsOfTokenizedSentences: Seq[Seq[TokenizedSentence]],
+      rowsOfSentences: Seq[Seq[Sentence]],
+      coalesceSentences: Boolean): Seq[Seq[com.johnsnowlabs.nlp.Annotation]] =
+    rowsOfTokenizedSentences.zip(rowsOfSentences).map { case (tokenizedSentences, sentences) =>
+      if (tokenizedSentences.isEmpty) Seq.empty[com.johnsnowlabs.nlp.Annotation]
+      else
+        model.predictSequenceWithZeroShot(
+          tokenizedSentences,
+          sentences,
+          candidateLabels,
+          entailmentId = 0,
+          contradictionId = 1,
+          batchSize = 1000,
+          maxSentenceLength = 512,
+          caseSensitive = true,
+          coalesceSentences = coalesceSentences,
+          tags = Map.empty,
+          ActivationFunction.softmax)
+    }
+
+  Seq(1, 2, 3, 5, 8).foreach { batchSize =>
+    it should s"match the per-row predictSequenceWithZeroShot() reference exactly with batchSize=$batchSize" taggedAs FastTest in {
+      val model = new FakeZeroShotClassification
+      val (tokenizedRows, sentenceRows) = randomRows(numRows = 10, seed = 321)
+
+      val expected =
+        goldenReference(model, tokenizedRows, sentenceRows, coalesceSentences = false)
+      val actual = model.predictSequenceWithZeroShotGrouped(
+        tokenizedRows,
+        sentenceRows,
+        candidateLabels,
+        entailmentId = 0,
+        contradictionId = 1,
+        batchSize = batchSize,
+        maxSentenceLength = 512,
+        caseSensitive = true,
+        coalesceSentences = false,
+        tags = Map.empty,
+        ActivationFunction.softmax)
+
+      assert(actual.length == expected.length)
+      tokenizedRows.indices.foreach { rowIdx =>
+        assert(
+          actual(rowIdx) == expected(rowIdx),
+          s"row $rowIdx mismatched at batchSize=$batchSize:\n  actual=${actual(
+              rowIdx)}\n  expected=${expected(rowIdx)}")
+      }
+    }
+  }
+
+  it should "coalesce PER ROW, not across the whole cross-row batch" taggedAs FastTest in {
+    val model = new FakeZeroShotClassification
+    val (tokenizedRows, sentenceRows) =
+      randomRows(numRows = 5, seed = 654, minSentencesPerRow = 2)
+
+    val expected = goldenReference(model, tokenizedRows, sentenceRows, coalesceSentences = true)
+    val actual = model.predictSequenceWithZeroShotGrouped(
+      tokenizedRows,
+      sentenceRows,
+      candidateLabels,
+      entailmentId = 0,
+      contradictionId = 1,
+      batchSize = 4,
+      maxSentenceLength = 512,
+      caseSensitive = true,
+      coalesceSentences = true,
+      tags = Map.empty,
+      ActivationFunction.softmax)
+
+    assert(actual.length == 5)
+    actual.foreach(rowResult =>
+      assert(
+        rowResult.length == 1,
+        "coalesceSentences must yield exactly one annotation per row"))
+    tokenizedRows.indices.foreach { rowIdx =>
+      assert(actual(rowIdx) == expected(rowIdx), s"row $rowIdx mismatched")
+    }
+  }
+
+  it should "leave every row empty when all rows have zero sentences" taggedAs FastTest in {
+    val model = new FakeZeroShotClassification
+    val rows: Seq[Seq[TokenizedSentence]] = Seq(Seq.empty, Seq.empty)
+    val sentenceRows: Seq[Seq[Sentence]] = Seq(Seq.empty, Seq.empty)
+
+    val result = model.predictSequenceWithZeroShotGrouped(
+      rows,
+      sentenceRows,
+      candidateLabels,
+      entailmentId = 0,
+      contradictionId = 1,
+      batchSize = 8,
+      maxSentenceLength = 512,
+      caseSensitive = true,
+      coalesceSentences = false,
+      tags = Map.empty,
+      ActivationFunction.softmax)
+
+    assert(result.length == 2)
+    assert(result.forall(_.isEmpty))
+  }
+}


### PR DESCRIPTION
spark 4 port for #14827