### PR TITLE
[Spark 4.x] fix addFile collision for models with external ONNX data

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
@@ -106,19 +106,22 @@ object OnnxWrapper {
     * using the default "model.onnx" name) — in that case we deliberately do *not* silently skip,
     * since that could serve one model's weights under another model's name with no error at all.
     * We let the real `addFile` call happen so Spark's own mismatch check fails loudly instead.
+    *
+    * Note for callers/tests: actually triggering that loud-failure path (calling `sc.addFile`
+    * with a basename that's already registered under different content) leaves the `SparkContext`
+    * broken for the rest of its life, not just for this basename — Spark records the new file's
+    * URI in its own dependency map *before* the fetch that validates the content runs, and every
+    * task on this `SparkContext` re-syncs *all* registered dependencies on every run regardless
+    * of relevance, so that one dangling bad entry makes every subsequent task on this
+    * `SparkContext`, unrelated ones included, fail forever with the same error. Don't exercise
+    * this path against a long-lived/shared `SparkContext` (e.g. `ResourceHelper.spark` in a test
+    * suite) — use [[wouldSkipAddFile]] to test the decision without paying that price.
     */
   private def addFileOnce(sparkSession: SparkSession, path: String): Unit = {
     val sc = sparkSession.sparkContext
     val basename = new File(path).getName
     val size = new File(path).length()
-    val alreadyRegisteredWithSameSize = this.synchronized {
-      val registeredSizes = addedFilesPerContext.computeIfAbsent(
-        sc,
-        (_: SparkContext) => new java.util.concurrent.ConcurrentHashMap[String, Long]())
-      val previousSize = Option(registeredSizes.putIfAbsent(basename, size)).map(_.longValue())
-      previousSize.contains(size)
-    }
-    if (alreadyRegisteredWithSameSize) {
+    if (wouldSkipAddFile(sc, basename, size)) {
       logger.info(
         s"Skipping SparkContext.addFile for '$basename': a file with this name and size was " +
           "already registered on this SparkContext (expected when reloading the same model).")
@@ -126,6 +129,20 @@ object OnnxWrapper {
       sc.addFile(path)
     }
   }
+
+  /** The decision half of [[addFileOnce]], isolated so it can be exercised without ever calling
+    * the real `sc.addFile` (see the warning above about what that does to `sc` on a mismatch).
+    * Returns true if a file with this basename and size is already registered on `sc` — i.e. the
+    * caller should skip re-adding it.
+    */
+  private[onnx] def wouldSkipAddFile(sc: SparkContext, basename: String, size: Long): Boolean =
+    this.synchronized {
+      val registeredSizes = addedFilesPerContext.computeIfAbsent(
+        sc,
+        (_: SparkContext) => new java.util.concurrent.ConcurrentHashMap[String, Long]())
+      val previousSize = Option(registeredSizes.putIfAbsent(basename, size)).map(_.longValue())
+      previousSize.contains(size)
+    }
 
   // TODO: make sure this.synchronized is needed or it's not a bottleneck
   private def withSafeOnnxModelLoader(

--- a/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
@@ -22,7 +22,7 @@ import ai.onnxruntime.providers.OrtCUDAProviderOptions
 import ai.onnxruntime.{OrtEnvironment, OrtSession}
 import com.johnsnowlabs.ml.util.LoadExternalModel
 import com.johnsnowlabs.util.{ConfigHelper, FileHelper, ZipArchiveUtil}
-import org.apache.spark.SparkFiles
+import org.apache.spark.{SparkContext, SparkFiles}
 import org.apache.spark.sql.SparkSession
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -80,6 +80,39 @@ class OnnxWrapper(var modelFileName: Option[String] = None, var dataFileDirector
 /** Companion object */
 object OnnxWrapper {
   private[OnnxWrapper] val logger: Logger = LoggerFactory.getLogger("OnnxWrapper")
+
+  /** Basenames already registered via `SparkContext.addFile`, per `SparkContext`. */
+  private val addedFilesPerContext: java.util.Map[SparkContext, java.util.Set[String]] =
+    new java.util.WeakHashMap[SparkContext, java.util.Set[String]]()
+
+  /** `SparkContext.addFile` only allows a given basename to be registered once: on Spark 4.x,
+    * re-adding a different file under a basename that's already registered throws (Spark 3.x only
+    * warned and silently kept the first copy). Large ONNX models split their weights into an
+    * external `.onnx_data` file whose exact name is embedded in the graph itself (onnxruntime
+    * looks it up by that name, relative to the `.onnx` file, inside Spark's flat SparkFiles
+    * directory) — so the basename can't be changed to dodge the collision without breaking that
+    * lookup. Instead, track what's already been registered per `SparkContext` and skip re-adding
+    * a basename we've already served, which is exactly what happens when the same model gets
+    * loaded more than once in a session (e.g. `loadSavedModel` called twice, or the standard
+    * save-then-reload pattern).
+    */
+  private def addFileOnce(sparkSession: SparkSession, path: String): Unit = {
+    val sc = sparkSession.sparkContext
+    val basename = new File(path).getName
+    val isNewlyRegistered = this.synchronized {
+      val registeredNames = addedFilesPerContext.computeIfAbsent(
+        sc,
+        (_: SparkContext) => java.util.concurrent.ConcurrentHashMap.newKeySet[String]())
+      registeredNames.add(basename)
+    }
+    if (isNewlyRegistered) {
+      sc.addFile(path)
+    } else {
+      logger.info(
+        s"Skipping SparkContext.addFile for '$basename': a file with this name was already " +
+          "registered on this SparkContext (expected when reloading the same model).")
+    }
+  }
 
   // TODO: make sure this.synchronized is needed or it's not a bottleneck
   private def withSafeOnnxModelLoader(
@@ -145,10 +178,10 @@ object OnnxWrapper {
       }
 
       if (onnxDataFileExist) {
-        sparkSession.sparkContext.addFile(onnxDataFile.toString)
+        addFileOnce(sparkSession, onnxDataFile.toString)
       }
 
-      sparkSession.sparkContext.addFile(onnxFile)
+      addFileOnce(sparkSession, onnxFile)
 
       val onnxFileName = Some(new File(onnxFile).getName)
       val dataFileDirectory = if (onnxDataFileExist) Some(onnxDataFile.toString) else None

--- a/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
@@ -81,9 +81,13 @@ class OnnxWrapper(var modelFileName: Option[String] = None, var dataFileDirector
 object OnnxWrapper {
   private[OnnxWrapper] val logger: Logger = LoggerFactory.getLogger("OnnxWrapper")
 
-  /** Basenames already registered via `SparkContext.addFile`, per `SparkContext`. */
-  private val addedFilesPerContext: java.util.Map[SparkContext, java.util.Set[String]] =
-    new java.util.WeakHashMap[SparkContext, java.util.Set[String]]()
+  /** For each `SparkContext`, the file size registered under each basename via
+    * `SparkContext.addFile`. Used to distinguish "the same model reloaded" (safe to skip
+    * re-adding) from "a different file that happens to share our basename" (must not be silently
+    * treated as the same file).
+    */
+  private val addedFilesPerContext: java.util.Map[SparkContext, java.util.Map[String, Long]] =
+    new java.util.WeakHashMap[SparkContext, java.util.Map[String, Long]]()
 
   /** `SparkContext.addFile` only allows a given basename to be registered once: on Spark 4.x,
     * re-adding a different file under a basename that's already registered throws (Spark 3.x only
@@ -91,26 +95,35 @@ object OnnxWrapper {
     * external `.onnx_data` file whose exact name is embedded in the graph itself (onnxruntime
     * looks it up by that name, relative to the `.onnx` file, inside Spark's flat SparkFiles
     * directory) — so the basename can't be changed to dodge the collision without breaking that
-    * lookup. Instead, track what's already been registered per `SparkContext` and skip re-adding
-    * a basename we've already served, which is exactly what happens when the same model gets
-    * loaded more than once in a session (e.g. `loadSavedModel` called twice, or the standard
-    * save-then-reload pattern).
+    * lookup.
+    *
+    * Instead, track the file size registered per basename per `SparkContext`. If the same
+    * basename is requested again with a matching size, skip re-adding it — this is what happens
+    * when the same model gets loaded more than once in a session (e.g. `loadSavedModel` called
+    * twice, or the standard save-then-reload pattern), and a size check is enough to catch that
+    * without paying for a full content comparison on every load. If the size differs, this is a
+    * genuinely different file that happens to share a basename (e.g. two unrelated models both
+    * using the default "model.onnx" name) — in that case we deliberately do *not* silently skip,
+    * since that could serve one model's weights under another model's name with no error at all.
+    * We let the real `addFile` call happen so Spark's own mismatch check fails loudly instead.
     */
   private def addFileOnce(sparkSession: SparkSession, path: String): Unit = {
     val sc = sparkSession.sparkContext
     val basename = new File(path).getName
-    val isNewlyRegistered = this.synchronized {
-      val registeredNames = addedFilesPerContext.computeIfAbsent(
+    val size = new File(path).length()
+    val alreadyRegisteredWithSameSize = this.synchronized {
+      val registeredSizes = addedFilesPerContext.computeIfAbsent(
         sc,
-        (_: SparkContext) => java.util.concurrent.ConcurrentHashMap.newKeySet[String]())
-      registeredNames.add(basename)
+        (_: SparkContext) => new java.util.concurrent.ConcurrentHashMap[String, Long]())
+      val previousSize = Option(registeredSizes.putIfAbsent(basename, size)).map(_.longValue())
+      previousSize.contains(size)
     }
-    if (isNewlyRegistered) {
-      sc.addFile(path)
-    } else {
+    if (alreadyRegisteredWithSameSize) {
       logger.info(
-        s"Skipping SparkContext.addFile for '$basename': a file with this name was already " +
-          "registered on this SparkContext (expected when reloading the same model).")
+        s"Skipping SparkContext.addFile for '$basename': a file with this name and size was " +
+          "already registered on this SparkContext (expected when reloading the same model).")
+    } else {
+      sc.addFile(path)
     }
   }
 

--- a/src/test/scala/com/johnsnowlabs/ml/onnx/OnnxWrapperTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/onnx/OnnxWrapperTestSpec.scala
@@ -146,33 +146,25 @@ class OnnxWrapperTestSpec extends AnyFlatSpec with BeforeAndAfter {
     wrapperB.getSession(onnxSessionOptions)
   }
 
-  it should "still fail loudly when two different-sized files collide on the same basename" taggedAs FastTest in {
-    // The safety net: a same-named file with a *different* size is treated as a genuinely
+  "OnnxWrapper.wouldSkipAddFile" should "skip only when both basename and size already match" taggedAs FastTest in {
+    // The safety net: a same-named file with a *different* size must be treated as a genuinely
     // different model (e.g. two unrelated annotators both defaulting to "model.onnx"), not a
-    // reload of the same one, so it must not be silently served under the wrong wrapper.
-    val modelName = uniqueModelName()
-    val dirA = persistentModelDir("dirA2")
-    val dirB = persistentModelDir("dirB2")
+    // reload of the same one -- addFileOnce must not skip re-adding it, so Spark's own mismatch
+    // check gets a chance to fail loudly instead of silently serving the wrong model's weights.
+    //
+    // We test that decision directly against OnnxWrapper.wouldSkipAddFile rather than driving it
+    // through a real OnnxWrapper.read/sc.addFile call: actually triggering Spark's mismatch
+    // exception poisons the SparkContext for its remaining lifetime (see the warning on
+    // addFileOnce) -- every later task on this shared, FastTest-suite-wide SparkContext would
+    // start failing with the same error, well beyond this test.
+    val basename = uniqueModelName() + ".onnx"
+    val sc = ResourceHelper.spark.sparkContext
 
-    val originalBytes = Files.readAllBytes(Paths.get(modelPath))
-    Files.write(dirA.resolve(s"$modelName.onnx"), originalBytes)
-    Files.write(dirB.resolve(s"$modelName.onnx"), originalBytes ++ Array[Byte](0))
-
-    OnnxWrapper.read(
-      ResourceHelper.spark,
-      dirA.toString,
-      zipped = false,
-      useBundle = true,
-      modelName = modelName)
-
-    assertThrows[org.apache.spark.SparkException] {
-      OnnxWrapper.read(
-        ResourceHelper.spark,
-        dirB.toString,
-        zipped = false,
-        useBundle = true,
-        modelName = modelName)
-    }
+    assert(!OnnxWrapper.wouldSkipAddFile(sc, basename, size = 2244L))
+    // same basename, same size again -- e.g. reloading the same model: safe to skip.
+    assert(OnnxWrapper.wouldSkipAddFile(sc, basename, size = 2244L))
+    // same basename, different size -- a genuinely different file: must not skip.
+    assert(!OnnxWrapper.wouldSkipAddFile(sc, basename, size = 2245L))
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/ml/onnx/OnnxWrapperTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/onnx/OnnxWrapperTestSpec.scala
@@ -86,31 +86,82 @@ class OnnxWrapperTestSpec extends AnyFlatSpec with BeforeAndAfter {
     assert(new File(tmpFolder, "modelFromTest.zip").exists())
   }
 
-  "OnnxWrapper.read" should "not fail when loading two different files that share the same basename" taggedAs FastTest in {
-    // Reproduces the SparkContext.addFile collision: on Spark 4.x, adding two different files
-    // under the same registered basename within one SparkContext throws
-    // "File ... exists and does not match contents of ...". This happens in practice whenever a
-    // model with externally-stored ONNX weights gets loaded more than once per session (e.g. the
-    // standard save-then-reload pattern), since the external data file's basename is fixed.
+  // The basenames used below must be unique per test (not the common default "model.onnx"):
+  // FastTest suites share one JVM/SparkContext (fork := false), so registering a generic name
+  // here would leak into SparkContext.addFile's own registry for the rest of the suite and could
+  // break unrelated tests that happen to load a real model also named "model.onnx".
+  private def uniqueModelName(): String =
+    "onnx_wrapper_test_" + UUID.randomUUID().toString.take(8)
+
+  "OnnxWrapper.read" should "not fail when reloading the same-size model under the same basename" taggedAs FastTest in {
+    // Reproduces the SparkContext.addFile collision: on Spark 4.x, adding a different file under
+    // a basename that's already registered within one SparkContext throws "File ... exists and
+    // does not match contents of ...". This happens in practice whenever a model with
+    // externally-stored ONNX weights gets loaded more than once per session (e.g. the standard
+    // save-then-reload pattern, where the reload is a re-serialization of the same architecture
+    // and so has the same file size), since the external data file's basename is fixed.
+    val modelName = uniqueModelName()
     val dirA = Paths.get(tmpFolder, "dirA")
     val dirB = Paths.get(tmpFolder, "dirB")
     Files.createDirectories(dirA)
     Files.createDirectories(dirB)
 
     val originalBytes = Files.readAllBytes(Paths.get(modelPath))
-    Files.write(dirA.resolve("model.onnx"), originalBytes)
-    // dirB's model.onnx has different content but the same basename as dirA's
-    Files.write(dirB.resolve("model.onnx"), originalBytes ++ Array[Byte](0))
+    Files.write(dirA.resolve(s"$modelName.onnx"), originalBytes)
+    // same size as dirA's copy (bytes flipped, not appended) -- the case addFileOnce treats as
+    // safe to skip re-adding, matching a reload of the same underlying model.
+    val sameSizeDifferentContent = originalBytes.clone()
+    sameSizeDifferentContent(0) = (sameSizeDifferentContent(0) + 1).toByte
+    Files.write(dirB.resolve(s"$modelName.onnx"), sameSizeDifferentContent)
 
-    val wrapperA =
-      OnnxWrapper.read(ResourceHelper.spark, dirA.toString, zipped = false, useBundle = true)
+    val wrapperA = OnnxWrapper.read(
+      ResourceHelper.spark,
+      dirA.toString,
+      zipped = false,
+      useBundle = true,
+      modelName = modelName)
     wrapperA.getSession(onnxSessionOptions)
 
-    // Before the fix, this second read (different file, same basename "model.onnx") would throw
-    // a SparkException from SparkContext.addFile instead of completing.
-    val wrapperB =
-      OnnxWrapper.read(ResourceHelper.spark, dirB.toString, zipped = false, useBundle = true)
+    // Before the fix, this second read (different file, same basename) would throw a
+    // SparkException from SparkContext.addFile instead of completing.
+    val wrapperB = OnnxWrapper.read(
+      ResourceHelper.spark,
+      dirB.toString,
+      zipped = false,
+      useBundle = true,
+      modelName = modelName)
     wrapperB.getSession(onnxSessionOptions)
+  }
+
+  it should "still fail loudly when two different-sized files collide on the same basename" taggedAs FastTest in {
+    // The safety net: a same-named file with a *different* size is treated as a genuinely
+    // different model (e.g. two unrelated annotators both defaulting to "model.onnx"), not a
+    // reload of the same one, so it must not be silently served under the wrong wrapper.
+    val modelName = uniqueModelName()
+    val dirA = Paths.get(tmpFolder, "dirA2")
+    val dirB = Paths.get(tmpFolder, "dirB2")
+    Files.createDirectories(dirA)
+    Files.createDirectories(dirB)
+
+    val originalBytes = Files.readAllBytes(Paths.get(modelPath))
+    Files.write(dirA.resolve(s"$modelName.onnx"), originalBytes)
+    Files.write(dirB.resolve(s"$modelName.onnx"), originalBytes ++ Array[Byte](0))
+
+    OnnxWrapper.read(
+      ResourceHelper.spark,
+      dirA.toString,
+      zipped = false,
+      useBundle = true,
+      modelName = modelName)
+
+    assertThrows[org.apache.spark.SparkException] {
+      OnnxWrapper.read(
+        ResourceHelper.spark,
+        dirB.toString,
+        zipped = false,
+        useBundle = true,
+        modelName = modelName)
+    }
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/ml/onnx/OnnxWrapperTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/onnx/OnnxWrapperTestSpec.scala
@@ -93,6 +93,21 @@ class OnnxWrapperTestSpec extends AnyFlatSpec with BeforeAndAfter {
   private def uniqueModelName(): String =
     "onnx_wrapper_test_" + UUID.randomUUID().toString.take(8)
 
+  // SparkContext.addFile only populates the driver's own copy immediately; the copy a task
+  // actually reads from is fetched lazily by Executor.updateDependencies() the next time *any*
+  // task runs on this SparkContext, which may well be a later, unrelated suite sharing this JVM.
+  // If we deleted the source directory (e.g. via the `after` hook) before that fetch happens,
+  // Spark's fetch-time content check fails and surfaces as a mismatch in whatever suite happened
+  // to trigger it. So these directories must outlive the test method -- use a directory Spark
+  // itself won't race to clean up, and leave it for the JVM's lifetime (like OnnxWrapper.read
+  // itself does with FileUtils.forceDeleteOnExit) rather than deleting it in `after`.
+  private def persistentModelDir(name: String): Path = {
+    val dir = Files.createTempDirectory(name).toAbsolutePath
+    import org.apache.commons.io.FileUtils
+    FileUtils.forceDeleteOnExit(dir.toFile)
+    dir
+  }
+
   "OnnxWrapper.read" should "not fail when reloading the same-size model under the same basename" taggedAs FastTest in {
     // Reproduces the SparkContext.addFile collision: on Spark 4.x, adding a different file under
     // a basename that's already registered within one SparkContext throws "File ... exists and
@@ -101,10 +116,8 @@ class OnnxWrapperTestSpec extends AnyFlatSpec with BeforeAndAfter {
     // save-then-reload pattern, where the reload is a re-serialization of the same architecture
     // and so has the same file size), since the external data file's basename is fixed.
     val modelName = uniqueModelName()
-    val dirA = Paths.get(tmpFolder, "dirA")
-    val dirB = Paths.get(tmpFolder, "dirB")
-    Files.createDirectories(dirA)
-    Files.createDirectories(dirB)
+    val dirA = persistentModelDir("dirA")
+    val dirB = persistentModelDir("dirB")
 
     val originalBytes = Files.readAllBytes(Paths.get(modelPath))
     Files.write(dirA.resolve(s"$modelName.onnx"), originalBytes)
@@ -138,10 +151,8 @@ class OnnxWrapperTestSpec extends AnyFlatSpec with BeforeAndAfter {
     // different model (e.g. two unrelated annotators both defaulting to "model.onnx"), not a
     // reload of the same one, so it must not be silently served under the wrong wrapper.
     val modelName = uniqueModelName()
-    val dirA = Paths.get(tmpFolder, "dirA2")
-    val dirB = Paths.get(tmpFolder, "dirB2")
-    Files.createDirectories(dirA)
-    Files.createDirectories(dirB)
+    val dirA = persistentModelDir("dirA2")
+    val dirB = persistentModelDir("dirB2")
 
     val originalBytes = Files.readAllBytes(Paths.get(modelPath))
     Files.write(dirA.resolve(s"$modelName.onnx"), originalBytes)

--- a/src/test/scala/com/johnsnowlabs/ml/onnx/OnnxWrapperTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/onnx/OnnxWrapperTestSpec.scala
@@ -86,4 +86,31 @@ class OnnxWrapperTestSpec extends AnyFlatSpec with BeforeAndAfter {
     assert(new File(tmpFolder, "modelFromTest.zip").exists())
   }
 
+  "OnnxWrapper.read" should "not fail when loading two different files that share the same basename" taggedAs FastTest in {
+    // Reproduces the SparkContext.addFile collision: on Spark 4.x, adding two different files
+    // under the same registered basename within one SparkContext throws
+    // "File ... exists and does not match contents of ...". This happens in practice whenever a
+    // model with externally-stored ONNX weights gets loaded more than once per session (e.g. the
+    // standard save-then-reload pattern), since the external data file's basename is fixed.
+    val dirA = Paths.get(tmpFolder, "dirA")
+    val dirB = Paths.get(tmpFolder, "dirB")
+    Files.createDirectories(dirA)
+    Files.createDirectories(dirB)
+
+    val originalBytes = Files.readAllBytes(Paths.get(modelPath))
+    Files.write(dirA.resolve("model.onnx"), originalBytes)
+    // dirB's model.onnx has different content but the same basename as dirA's
+    Files.write(dirB.resolve("model.onnx"), originalBytes ++ Array[Byte](0))
+
+    val wrapperA =
+      OnnxWrapper.read(ResourceHelper.spark, dirA.toString, zipped = false, useBundle = true)
+    wrapperA.getSession(onnxSessionOptions)
+
+    // Before the fix, this second read (different file, same basename "model.onnx") would throw
+    // a SparkException from SparkContext.addFile instead of completing.
+    val wrapperB =
+      OnnxWrapper.read(ResourceHelper.spark, dirB.toString, zipped = false, useBundle = true)
+    wrapperB.getSession(onnxSessionOptions)
+  }
+
 }


### PR DESCRIPTION
large ONNX models (>2GB) split their weights into a separate `.onnx_data` file with a fixed basename embedded in the graph itself, which `OnnxWrapper.read` registers via `SparkContext.addFile`. spark 4.x enforces that a given basename can only be added once per SparkContext and throws if a second, different file claims the same name (spark 3.x only warned and silently kept the first copy). any scenario that calls `OnnxWrapper.read` more than once for the same model within one session, including the completely standard `model.write().save(path)` then `Model.load(path)` pattern, re-registers that same fixed basename and hits this on spark4, even though the model itself is fine.

we can't just rename the target to dodge the collision since onnxruntime looks up the external data file by its exact embedded name inside Spark's flat SparkFiles directory. instead we track which basenames we've already registered per SparkContext and skip the redundant addFile call, which is what happens in the common "reload the same model" case anyway.

found while porting SPARKNLP-1199 (BGE-M3 embeddings, #14830 / spark4 port #14833) to Spark4, where the save/load round trip failed consistently from python. scala wasn't affected in that testing since it never happened to trigger a second `addFile` within the test runs, but the bug applies to any annotator with externally-stored ONNX weights, not just BGE-M3.
