### PR TITLE
Sparknlp 1156 fix all compilation warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -191,6 +191,14 @@ inConfig(SlowTest)(Defaults.testTasks)
 
 /** Test tagging end */
 
+/** These keys are used via commands (`fast:test`, `slow:test`) or for their side effects rather
+  * than by other settings/tasks, so exclude them from sbt's `lintUnused` check.
+  */
+Global / excludeLintKeys ++= Set(
+  mavenProps,
+  FastTest / configuration,
+  SlowTest / configuration)
+
 /** Enable for debugging */
 (Test / testOptions) += Tests.Argument("-oF")
 

--- a/publish.sbt
+++ b/publish.sbt
@@ -13,7 +13,11 @@ scmInfo := Some(
 licenses += "Apache-2.0" -> url("https://opensource.org/licenses/Apache-2.0")
 
 // Maven Central publishing settings
-ThisBuild / credentials += Credentials(Path.userHome / ".sbt" / "sonatype_central_credentials")
+// Only load the credentials file when it exists to avoid a warning on machines that do not publish.
+ThisBuild / credentials ++= {
+  val credentialsFile = Path.userHome / ".sbt" / "sonatype_central_credentials"
+  if (credentialsFile.exists) Seq(Credentials(credentialsFile)) else Seq.empty
+}
 // Remove all additional repository other than Maven Central from POM
 ThisBuild / pomIncludeRepository := { _ => false }
 ThisBuild / publishMavenStyle := true
@@ -26,6 +30,9 @@ ThisBuild / publishTo := {
 }
 
 sonaUploadRequestTimeout := 60.minutes
+
+// Used by the sonatype publishing plugin; exclude from sbt's `lintUnused` check.
+Global / excludeLintKeys += sonaUploadRequestTimeout
 
 // Developers
 (ThisBuild / developers) := List(

--- a/src/main/scala/com/johnsnowlabs/ml/ai/Albert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/Albert.scala
@@ -134,7 +134,6 @@ private[johnsnowlabs] class Albert(
             "attention_mask" -> maskTensors,
             "token_type_ids" -> segmentTensors).asJava
 
-        // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
         try {
           val results = runner.run(inputs)
           try {
@@ -175,11 +174,9 @@ private[johnsnowlabs] class Albert(
         inferRequest.infer()
 
         try {
-          try {
-            inferRequest
-              .get_tensor("last_hidden_state")
-              .data()
-          }
+          inferRequest
+            .get_tensor("last_hidden_state")
+            .data()
         } catch {
           case e: Exception =>
             e.printStackTrace()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/AlbertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/AlbertClassification.scala
@@ -243,11 +243,9 @@ private[johnsnowlabs] class AlbertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -389,13 +387,11 @@ private[johnsnowlabs] class AlbertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val logits = inferRequest
-          .get_output_tensor()
-          .data()
+      val logits = inferRequest
+        .get_output_tensor()
+        .data()
 
-        logits
-      }
+      logits
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -595,16 +591,14 @@ private[johnsnowlabs] class AlbertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val startLogits = inferRequest
-          .get_tensor("start_logits")
-          .data()
-        val endLogits = inferRequest
-          .get_tensor("end_logits")
-          .data()
+      val startLogits = inferRequest
+        .get_tensor("start_logits")
+        .data()
+      val endLogits = inferRequest
+        .get_tensor("end_logits")
+        .data()
 
-        (startLogits.slice(1, startLogits.length), endLogits.slice(1, endLogits.length))
-      }
+      (startLogits.slice(1, startLogits.length), endLogits.slice(1, endLogits.length))
     } catch {
       case e: Exception =>
         // Log the exception as a warning

--- a/src/main/scala/com/johnsnowlabs/ml/ai/BGE.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/BGE.scala
@@ -191,17 +191,14 @@ private[johnsnowlabs] class BGE(
     inferRequest.infer()
 
     try {
-      try {
-        val lastHiddenState = inferRequest
-          .get_tensor("last_hidden_state")
-        val shape = lastHiddenState.get_shape().map(_.toLong)
-        val flattenEmbeddings = lastHiddenState
-          .data()
-        val embeddings = LinAlg.avgPooling(flattenEmbeddings, attentionMask, shape)
-        val normalizedEmbeddings = LinAlg.l2Normalize(embeddings)
-        LinAlg.denseMatrixToArray(normalizedEmbeddings)
-
-      }
+      val lastHiddenState = inferRequest
+        .get_tensor("last_hidden_state")
+      val shape = lastHiddenState.get_shape().map(_.toLong)
+      val flattenEmbeddings = lastHiddenState
+        .data()
+      val embeddings = LinAlg.avgPooling(flattenEmbeddings, attentionMask, shape)
+      val normalizedEmbeddings = LinAlg.l2Normalize(embeddings)
+      LinAlg.denseMatrixToArray(normalizedEmbeddings)
     } catch {
       case e: Exception =>
         e.printStackTrace()
@@ -232,7 +229,6 @@ private[johnsnowlabs] class BGE(
         "attention_mask" -> maskTensors,
         "token_type_ids" -> segmentTensors).asJava
 
-    // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
     try {
       val results = runner.run(inputs)
       try {

--- a/src/main/scala/com/johnsnowlabs/ml/ai/BartClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/BartClassification.scala
@@ -314,11 +314,9 @@ private[johnsnowlabs] class BartClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -344,21 +342,19 @@ private[johnsnowlabs] class BartClassification(
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
+    val results = runner.run(inputs)
     try {
-      val results = runner.run(inputs)
-      try {
-        val embeddings = results
-          .get("logits")
-          .get()
-          .asInstanceOf[OnnxTensor]
-          .getFloatBuffer
-          .array()
-        tokenTensors.close()
-        maskTensors.close()
+      val embeddings = results
+        .get("logits")
+        .get()
+        .asInstanceOf[OnnxTensor]
+        .getFloatBuffer
+        .array()
+      tokenTensors.close()
+      maskTensors.close()
 
-        embeddings
-      } finally if (results != null) results.close()
-    }
+      embeddings
+    } finally if (results != null) results.close()
 
   }
   def computeZeroShotLogitsWithTF(

--- a/src/main/scala/com/johnsnowlabs/ml/ai/Bert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/Bert.scala
@@ -117,7 +117,6 @@ private[johnsnowlabs] class Bert(
             "attention_mask" -> maskTensors,
             "token_type_ids" -> segmentTensors).asJava
 
-        // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
         try {
           val results = runner.run(inputs)
           try {

--- a/src/main/scala/com/johnsnowlabs/ml/ai/BertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/BertClassification.scala
@@ -174,11 +174,9 @@ private[johnsnowlabs] class BertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -371,11 +369,9 @@ private[johnsnowlabs] class BertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -418,22 +414,20 @@ private[johnsnowlabs] class BertClassification(
         "attention_mask" -> maskTensors,
         "token_type_ids" -> segmentTensors).asJava
 
+    val results = runner.run(inputs)
     try {
-      val results = runner.run(inputs)
-      try {
-        val embeddings = results
-          .get("logits")
-          .get()
-          .asInstanceOf[OnnxTensor]
-          .getFloatBuffer
-          .array()
-        tokenTensors.close()
-        maskTensors.close()
-        segmentTensors.close()
+      val embeddings = results
+        .get("logits")
+        .get()
+        .asInstanceOf[OnnxTensor]
+        .getFloatBuffer
+        .array()
+      tokenTensors.close()
+      maskTensors.close()
+      segmentTensors.close()
 
-        embeddings
-      } finally if (results != null) results.close()
-    }
+      embeddings
+    } finally if (results != null) results.close()
 
   }
 
@@ -667,16 +661,14 @@ private[johnsnowlabs] class BertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val startLogits = inferRequest
-          .get_tensor("start_logits")
-          .data()
-        val endLogits = inferRequest
-          .get_tensor("end_logits")
-          .data()
+      val startLogits = inferRequest
+        .get_tensor("start_logits")
+        .data()
+      val endLogits = inferRequest
+        .get_tensor("end_logits")
+        .data()
 
-        (startLogits.slice(1, startLogits.length), endLogits.slice(1, endLogits.length))
-      }
+      (startLogits.slice(1, startLogits.length), endLogits.slice(1, endLogits.length))
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -806,13 +798,11 @@ private[johnsnowlabs] class BertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val logits = inferRequest
-          .get_output_tensor()
-          .data()
+      val logits = inferRequest
+        .get_output_tensor()
+        .data()
 
-        logits
-      }
+      logits
     } catch {
       case e: Exception =>
         // Log the exception as a warning

--- a/src/main/scala/com/johnsnowlabs/ml/ai/CamemBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/CamemBert.scala
@@ -102,7 +102,6 @@ private[johnsnowlabs] class CamemBert(
         val inputs =
           Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
-        // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
         try {
           val results = runner.run(inputs)
           try {
@@ -143,11 +142,9 @@ private[johnsnowlabs] class CamemBert(
         inferRequest.infer()
 
         try {
-          try {
-            inferRequest
-              .get_tensor("last_hidden_state")
-              .data()
-          }
+          inferRequest
+            .get_tensor("last_hidden_state")
+            .data()
         } catch {
           case e: Exception =>
             e.printStackTrace()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/CamemBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/CamemBertClassification.scala
@@ -252,11 +252,9 @@ private[johnsnowlabs] class CamemBertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -320,21 +318,19 @@ private[johnsnowlabs] class CamemBertClassification(
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
+    val results = runner.run(inputs)
     try {
-      val results = runner.run(inputs)
-      try {
-        val embeddings = results
-          .get("logits")
-          .get()
-          .asInstanceOf[OnnxTensor]
-          .getFloatBuffer
-          .array()
-        tokenTensors.close()
-        maskTensors.close()
+      val embeddings = results
+        .get("logits")
+        .get()
+        .asInstanceOf[OnnxTensor]
+        .getFloatBuffer
+        .array()
+      tokenTensors.close()
+      maskTensors.close()
 
-        embeddings
-      } finally if (results != null) results.close()
-    }
+      embeddings
+    } finally if (results != null) results.close()
   }
 
   def computeZeroShotLogitsWithTF(
@@ -413,16 +409,14 @@ private[johnsnowlabs] class CamemBertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val startLogits = inferRequest
-          .get_tensor("start_logits")
-          .data()
-        val endLogits = inferRequest
-          .get_tensor("end_logits")
-          .data()
+      val startLogits = inferRequest
+        .get_tensor("start_logits")
+        .data()
+      val endLogits = inferRequest
+        .get_tensor("end_logits")
+        .data()
 
-        (startLogits, endLogits)
-      }
+      (startLogits, endLogits)
     } catch {
       case e: Exception =>
         // Log the exception as a warning

--- a/src/main/scala/com/johnsnowlabs/ml/ai/DeBerta.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/DeBerta.scala
@@ -128,11 +128,9 @@ class DeBerta(
         inferRequest.infer()
 
         try {
-          try {
-            inferRequest
-              .get_tensor("last_hidden_state")
-              .data()
-          }
+          inferRequest
+            .get_tensor("last_hidden_state")
+            .data()
         } catch {
           case e: Exception =>
             e.printStackTrace()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/DeBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/DeBertaClassification.scala
@@ -261,11 +261,9 @@ private[johnsnowlabs] class DeBertaClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -346,11 +344,9 @@ private[johnsnowlabs] class DeBertaClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -377,21 +373,19 @@ private[johnsnowlabs] class DeBertaClassification(
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
+    val results = runner.run(inputs)
     try {
-      val results = runner.run(inputs)
-      try {
-        val embeddings = results
-          .get("logits")
-          .get()
-          .asInstanceOf[OnnxTensor]
-          .getFloatBuffer
-          .array()
-        tokenTensors.close()
-        maskTensors.close()
+      val embeddings = results
+        .get("logits")
+        .get()
+        .asInstanceOf[OnnxTensor]
+        .getFloatBuffer
+        .array()
+      tokenTensors.close()
+      maskTensors.close()
 
-        embeddings
-      } finally if (results != null) results.close()
-    }
+      embeddings
+    } finally if (results != null) results.close()
 
   }
 
@@ -548,16 +542,14 @@ private[johnsnowlabs] class DeBertaClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val startLogits = inferRequest
-          .get_tensor("start_logits")
-          .data()
-        val endLogits = inferRequest
-          .get_tensor("end_logits")
-          .data()
+      val startLogits = inferRequest
+        .get_tensor("start_logits")
+        .data()
+      val endLogits = inferRequest
+        .get_tensor("end_logits")
+        .data()
 
-        (startLogits, endLogits)
-      }
+      (startLogits, endLogits)
     } catch {
       case e: Exception =>
         // Log the exception as a warning

--- a/src/main/scala/com/johnsnowlabs/ml/ai/DistilBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/DistilBert.scala
@@ -121,7 +121,6 @@ private[johnsnowlabs] class DistilBert(
         val inputs =
           Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
-        // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
         try {
           val results = runner.run(inputs)
           try {
@@ -159,11 +158,9 @@ private[johnsnowlabs] class DistilBert(
         inferRequest.infer()
 
         try {
-          try {
-            inferRequest
-              .get_tensor("last_hidden_state")
-              .data()
-          }
+          inferRequest
+            .get_tensor("last_hidden_state")
+            .data()
         } catch {
           case e: Exception =>
             e.printStackTrace()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/DistilBertClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/DistilBertClassification.scala
@@ -165,11 +165,9 @@ private[johnsnowlabs] class DistilBertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -358,11 +356,9 @@ private[johnsnowlabs] class DistilBertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -387,21 +383,19 @@ private[johnsnowlabs] class DistilBertClassification(
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
+    val results = runner.run(inputs)
     try {
-      val results = runner.run(inputs)
-      try {
-        val embeddings = results
-          .get("logits")
-          .get()
-          .asInstanceOf[OnnxTensor]
-          .getFloatBuffer
-          .array()
-        tokenTensors.close()
-        maskTensors.close()
+      val embeddings = results
+        .get("logits")
+        .get()
+        .asInstanceOf[OnnxTensor]
+        .getFloatBuffer
+        .array()
+      tokenTensors.close()
+      maskTensors.close()
 
-        embeddings
-      } finally if (results != null) results.close()
-    }
+      embeddings
+    } finally if (results != null) results.close()
 
   }
   def computeZeroShotLogitsWithTF(
@@ -544,13 +538,11 @@ private[johnsnowlabs] class DistilBertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val logits = inferRequest
-          .get_output_tensor()
-          .data()
+      val logits = inferRequest
+        .get_output_tensor()
+        .data()
 
-        logits
-      }
+      logits
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -629,16 +621,14 @@ private[johnsnowlabs] class DistilBertClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val startLogits = inferRequest
-          .get_tensor("start_logits")
-          .data()
-        val endLogits = inferRequest
-          .get_tensor("end_logits")
-          .data()
+      val startLogits = inferRequest
+        .get_tensor("start_logits")
+        .data()
+      val endLogits = inferRequest
+        .get_tensor("end_logits")
+        .data()
 
-        (startLogits, endLogits)
-      }
+      (startLogits, endLogits)
     } catch {
       case e: Exception =>
         // Log the exception as a warning

--- a/src/main/scala/com/johnsnowlabs/ml/ai/E5.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/E5.scala
@@ -183,7 +183,6 @@ private[johnsnowlabs] class E5(
         "attention_mask" -> maskTensors,
         "token_type_ids" -> segmentTensors).asJava
 
-    // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
     try {
       val results = runner.run(inputs)
       val lastHiddenState = results.get("last_hidden_state").get()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/Instructor.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/Instructor.scala
@@ -86,17 +86,14 @@ private[johnsnowlabs] class Instructor(
 
     inferRequest.infer()
     try {
-      try {
-        val lastHiddenState = inferRequest
-          .get_tensor("token_embeddings")
-        val shape = lastHiddenState.get_shape().map(_.toLong)
-        val flattenEmbeddings = lastHiddenState
-          .data()
-        val embeddings = LinAlg.avgPooling(flattenEmbeddings, contextMask, shape)
-        val normalizedEmbeddings = LinAlg.l2Normalize(embeddings)
-        LinAlg.denseMatrixToArray(normalizedEmbeddings)
-
-      }
+      val lastHiddenState = inferRequest
+        .get_tensor("token_embeddings")
+      val shape = lastHiddenState.get_shape().map(_.toLong)
+      val flattenEmbeddings = lastHiddenState
+        .data()
+      val embeddings = LinAlg.avgPooling(flattenEmbeddings, contextMask, shape)
+      val normalizedEmbeddings = LinAlg.l2Normalize(embeddings)
+      LinAlg.denseMatrixToArray(normalizedEmbeddings)
     } catch {
       case e: Exception =>
         e.printStackTrace()
@@ -130,7 +127,6 @@ private[johnsnowlabs] class Instructor(
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
-    // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
     try {
       val results = runner.run(inputs)
       val lastHiddenState = results.get("token_embeddings").get()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/MPNet.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/MPNet.scala
@@ -189,17 +189,14 @@ private[johnsnowlabs] class MPNet(
 
     inferRequest.infer()
     try {
-      try {
-        val lastHiddenState = inferRequest
-          .get_tensor("last_hidden_state")
-        val shape = lastHiddenState.get_shape().map(_.toLong)
-        val flattenEmbeddings = lastHiddenState
-          .data()
-        val embeddings = LinAlg.avgPooling(flattenEmbeddings, attentionMask, shape)
-        val normalizedEmbeddings = LinAlg.l2Normalize(embeddings)
-        LinAlg.denseMatrixToArray(normalizedEmbeddings)
-
-      }
+      val lastHiddenState = inferRequest
+        .get_tensor("last_hidden_state")
+      val shape = lastHiddenState.get_shape().map(_.toLong)
+      val flattenEmbeddings = lastHiddenState
+        .data()
+      val embeddings = LinAlg.avgPooling(flattenEmbeddings, attentionMask, shape)
+      val normalizedEmbeddings = LinAlg.l2Normalize(embeddings)
+      LinAlg.denseMatrixToArray(normalizedEmbeddings)
     } catch {
       case e: Exception =>
         e.printStackTrace()
@@ -221,7 +218,6 @@ private[johnsnowlabs] class MPNet(
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
-    // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
     try {
       val results = runner.run(inputs)
       val lastHiddenState = results.get("last_hidden_state").get()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/MPNetClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/MPNetClassification.scala
@@ -182,21 +182,19 @@ private[johnsnowlabs] class MPNetClassification(
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
+    val results = runner.run(inputs)
     try {
-      val results = runner.run(inputs)
-      try {
-        val embeddings = results
-          .get("logits")
-          .get()
-          .asInstanceOf[OnnxTensor]
-          .getFloatBuffer
-          .array()
-        tokenTensors.close()
-        maskTensors.close()
+      val embeddings = results
+        .get("logits")
+        .get()
+        .asInstanceOf[OnnxTensor]
+        .getFloatBuffer
+        .array()
+      tokenTensors.close()
+      maskTensors.close()
 
-        embeddings
-      } finally if (results != null) results.close()
-    }
+      embeddings
+    } finally if (results != null) results.close()
   }
 
   private def getRawScoresWithOv(batch: Seq[Array[Int]]): Array[Float] = {
@@ -213,11 +211,9 @@ private[johnsnowlabs] class MPNetClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -281,11 +277,9 @@ private[johnsnowlabs] class MPNetClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -437,16 +431,14 @@ private[johnsnowlabs] class MPNetClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val startLogits = inferRequest
-          .get_tensor("start_logits")
-          .data()
-        val endLogits = inferRequest
-          .get_tensor("end_logits")
-          .data()
+      val startLogits = inferRequest
+        .get_tensor("start_logits")
+        .data()
+      val endLogits = inferRequest
+        .get_tensor("end_logits")
+        .data()
 
-        (startLogits, endLogits)
-      }
+      (startLogits, endLogits)
     } catch {
       case e: Exception =>
         // Log the exception as a warning

--- a/src/main/scala/com/johnsnowlabs/ml/ai/MiniLM.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/MiniLM.scala
@@ -108,7 +108,6 @@ private[johnsnowlabs] class MiniLM(
         "attention_mask" -> maskTensors,
         "token_type_ids" -> segmentTensors).asJava
 
-    // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
     try {
       val results = runner.run(inputs)
       val lastHiddenState = results.get("last_hidden_state").get()

--- a/src/main/scala/com/johnsnowlabs/ml/ai/ModernBert.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/ModernBert.scala
@@ -223,7 +223,6 @@ private[johnsnowlabs] class ModernBert(
         val inputs =
           Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
-        // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
         try {
           val results = runner.run(inputs)
           try {

--- a/src/main/scala/com/johnsnowlabs/ml/ai/Mxbai.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/Mxbai.scala
@@ -228,26 +228,24 @@ private[johnsnowlabs] class Mxbai(
         "attention_mask" -> maskTensors,
         "token_type_ids" -> segmentTensors).asJava
 
-    // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
-    val embeddings =
+    val embeddings = {
+      val results = runner.run(inputs)
+      val lastHiddenState = results.get("last_hidden_state").get()
+      val info = lastHiddenState.getInfo.asInstanceOf[TensorInfo]
+      val shape = info.getShape.map(_.toInt)
+      val Array(_, sequenceLength, embeddingDim) = shape
       try {
-        val results = runner.run(inputs)
-        val lastHiddenState = results.get("last_hidden_state").get()
-        val info = lastHiddenState.getInfo.asInstanceOf[TensorInfo]
-        val shape = info.getShape.map(_.toInt)
-        val Array(_, sequenceLength, embeddingDim) = shape
-        try {
-          val flattenEmbeddings = lastHiddenState
-            .asInstanceOf[OnnxTensor]
-            .getFloatBuffer
-            .array()
-          tokenTensors.close()
-          maskTensors.close()
-          segmentTensors.close()
+        val flattenEmbeddings = lastHiddenState
+          .asInstanceOf[OnnxTensor]
+          .getFloatBuffer
+          .array()
+        tokenTensors.close()
+        maskTensors.close()
+        segmentTensors.close()
 
-          flattenEmbeddings.grouped(embeddingDim).toArray.grouped(sequenceLength).toArray
-        } finally if (results != null) results.close()
-      }
+        flattenEmbeddings.grouped(embeddingDim).toArray.grouped(sequenceLength).toArray
+      } finally if (results != null) results.close()
+    }
 
     pool(embeddings, attentionMask, poolingStrategy)
   }

--- a/src/main/scala/com/johnsnowlabs/ml/ai/RoBerta.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/RoBerta.scala
@@ -101,7 +101,6 @@ private[johnsnowlabs] class RoBerta(
         val inputs =
           Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
-        // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
         try {
           val results = runner.run(inputs)
           try {

--- a/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
@@ -303,11 +303,9 @@ private[johnsnowlabs] class RoBertaClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -334,11 +332,9 @@ private[johnsnowlabs] class RoBertaClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -365,21 +361,19 @@ private[johnsnowlabs] class RoBertaClassification(
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
+    val results = runner.run(inputs)
     try {
-      val results = runner.run(inputs)
-      try {
-        val embeddings = results
-          .get("logits")
-          .get()
-          .asInstanceOf[OnnxTensor]
-          .getFloatBuffer
-          .array()
-        tokenTensors.close()
-        maskTensors.close()
+      val embeddings = results
+        .get("logits")
+        .get()
+        .asInstanceOf[OnnxTensor]
+        .getFloatBuffer
+        .array()
+      tokenTensors.close()
+      maskTensors.close()
 
-        embeddings
-      } finally if (results != null) results.close()
-    }
+      embeddings
+    } finally if (results != null) results.close()
 
   }
 
@@ -545,13 +539,11 @@ private[johnsnowlabs] class RoBertaClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val logits = inferRequest
-          .get_output_tensor()
-          .data()
+      val logits = inferRequest
+        .get_output_tensor()
+        .data()
 
-        logits
-      }
+      logits
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -630,16 +622,14 @@ private[johnsnowlabs] class RoBertaClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val startLogits = inferRequest
-          .get_tensor("start_logits")
-          .data()
-        val endLogits = inferRequest
-          .get_tensor("end_logits")
-          .data()
+      val startLogits = inferRequest
+        .get_tensor("start_logits")
+        .data()
+      val endLogits = inferRequest
+        .get_tensor("end_logits")
+        .data()
 
-        (startLogits, endLogits)
-      }
+      (startLogits, endLogits)
     } catch {
       case e: Exception =>
         // Log the exception as a warning

--- a/src/main/scala/com/johnsnowlabs/ml/ai/SnowFlake.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/SnowFlake.scala
@@ -237,18 +237,15 @@ private[johnsnowlabs] class SnowFlake(
 
     inferRequest.infer()
 
-    val embeddings =
-      try {
-        val lastHiddenState = inferRequest
-          .get_tensor("last_hidden_state")
-        val shape = lastHiddenState.get_shape()
-        val Array(_, sequenceLength, embeddingDim) = shape
-        try {
-          val flattenEmbeddings = lastHiddenState.data()
+    val embeddings = {
+      val lastHiddenState = inferRequest
+        .get_tensor("last_hidden_state")
+      val shape = lastHiddenState.get_shape()
+      val Array(_, sequenceLength, embeddingDim) = shape
+      val flattenEmbeddings = lastHiddenState.data()
 
-          flattenEmbeddings.grouped(embeddingDim).toArray.grouped(sequenceLength).toArray
-        }
-      }
+      flattenEmbeddings.grouped(embeddingDim).toArray.grouped(sequenceLength).toArray
+    }
 
     pool(embeddings, attentionMask, poolingStrategy)
 
@@ -274,25 +271,24 @@ private[johnsnowlabs] class SnowFlake(
         "attention_mask" -> maskTensors,
         "token_type_ids" -> segmentTensors).asJava
 
-    val embeddings =
+    val embeddings = {
+      val results = runner.run(inputs)
+      val lastHiddenState = results.get("last_hidden_state").get()
+      val info = lastHiddenState.getInfo.asInstanceOf[TensorInfo]
+      val shape = info.getShape.map(_.toInt)
+      val Array(_, sequenceLength, embeddingDim) = shape
       try {
-        val results = runner.run(inputs)
-        val lastHiddenState = results.get("last_hidden_state").get()
-        val info = lastHiddenState.getInfo.asInstanceOf[TensorInfo]
-        val shape = info.getShape.map(_.toInt)
-        val Array(_, sequenceLength, embeddingDim) = shape
-        try {
-          val flattenEmbeddings = lastHiddenState
-            .asInstanceOf[OnnxTensor]
-            .getFloatBuffer
-            .array()
-          tokenTensors.close()
-          maskTensors.close()
-          segmentTensors.close()
+        val flattenEmbeddings = lastHiddenState
+          .asInstanceOf[OnnxTensor]
+          .getFloatBuffer
+          .array()
+        tokenTensors.close()
+        maskTensors.close()
+        segmentTensors.close()
 
-          flattenEmbeddings.grouped(embeddingDim).toArray.grouped(sequenceLength).toArray
-        } finally if (results != null) results.close()
-      }
+        flattenEmbeddings.grouped(embeddingDim).toArray.grouped(sequenceLength).toArray
+      } finally if (results != null) results.close()
+    }
 
     pool(embeddings, attentionMask, poolingStrategy)
   }

--- a/src/main/scala/com/johnsnowlabs/ml/ai/UAE.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/UAE.scala
@@ -237,18 +237,15 @@ private[johnsnowlabs] class UAE(
 
     inferRequest.infer()
 
-    val embeddings =
-      try {
-        val lastHiddenState = inferRequest
-          .get_tensor("last_hidden_state")
-        val shape = lastHiddenState.get_shape()
-        val Array(_, sequenceLength, embeddingDim) = shape
-        try {
-          val flattenEmbeddings = lastHiddenState.data()
+    val embeddings = {
+      val lastHiddenState = inferRequest
+        .get_tensor("last_hidden_state")
+      val shape = lastHiddenState.get_shape()
+      val Array(_, sequenceLength, embeddingDim) = shape
+      val flattenEmbeddings = lastHiddenState.data()
 
-          flattenEmbeddings.grouped(embeddingDim).toArray.grouped(sequenceLength).toArray
-        }
-      }
+      flattenEmbeddings.grouped(embeddingDim).toArray.grouped(sequenceLength).toArray
+    }
 
     pool(embeddings, attentionMask, poolingStrategy)
 
@@ -274,26 +271,24 @@ private[johnsnowlabs] class UAE(
         "attention_mask" -> maskTensors,
         "token_type_ids" -> segmentTensors).asJava
 
-    // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
-    val embeddings =
+    val embeddings = {
+      val results = runner.run(inputs)
+      val lastHiddenState = results.get("last_hidden_state").get()
+      val info = lastHiddenState.getInfo.asInstanceOf[TensorInfo]
+      val shape = info.getShape.map(_.toInt)
+      val Array(_, sequenceLength, embeddingDim) = shape
       try {
-        val results = runner.run(inputs)
-        val lastHiddenState = results.get("last_hidden_state").get()
-        val info = lastHiddenState.getInfo.asInstanceOf[TensorInfo]
-        val shape = info.getShape.map(_.toInt)
-        val Array(_, sequenceLength, embeddingDim) = shape
-        try {
-          val flattenEmbeddings = lastHiddenState
-            .asInstanceOf[OnnxTensor]
-            .getFloatBuffer
-            .array()
-          tokenTensors.close()
-          maskTensors.close()
-          segmentTensors.close()
+        val flattenEmbeddings = lastHiddenState
+          .asInstanceOf[OnnxTensor]
+          .getFloatBuffer
+          .array()
+        tokenTensors.close()
+        maskTensors.close()
+        segmentTensors.close()
 
-          flattenEmbeddings.grouped(embeddingDim).toArray.grouped(sequenceLength).toArray
-        } finally if (results != null) results.close()
-      }
+        flattenEmbeddings.grouped(embeddingDim).toArray.grouped(sequenceLength).toArray
+      } finally if (results != null) results.close()
+    }
 
     pool(embeddings, attentionMask, poolingStrategy)
   }

--- a/src/main/scala/com/johnsnowlabs/ml/ai/ViTClassifier.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/ViTClassifier.scala
@@ -173,13 +173,7 @@ private[johnsnowlabs] class ViTClassifier(
             tags
               .find(_._2 == score.zipWithIndex.maxBy(_._1)._2)
               .map(_._1)
-              .getOrElse(
-                tags
-                  .find(
-                    _._2 == score.zipWithIndex.maxBy(_._1)._2.toString
-                  ) // TODO: We shouldn't compare unrelated types: BigInt and String
-                  .map(_._1)
-                  .getOrElse("NA"))
+              .getOrElse("NA")
           val meta = score.zipWithIndex.flatMap(x =>
             Map(tags.take(10).find(_._2 == x._2).map(_._1).toString -> x._1.toString))
 

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoBertaClassification.scala
@@ -259,11 +259,9 @@ private[johnsnowlabs] class XlmRoBertaClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -322,21 +320,19 @@ private[johnsnowlabs] class XlmRoBertaClassification(
     val inputs =
       Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
+    val results = runner.run(inputs)
     try {
-      val results = runner.run(inputs)
-      try {
-        val embeddings = results
-          .get("logits")
-          .get()
-          .asInstanceOf[OnnxTensor]
-          .getFloatBuffer
-          .array()
-        tokenTensors.close()
-        maskTensors.close()
+      val embeddings = results
+        .get("logits")
+        .get()
+        .asInstanceOf[OnnxTensor]
+        .getFloatBuffer
+        .array()
+      tokenTensors.close()
+      maskTensors.close()
 
-        embeddings
-      } finally if (results != null) results.close()
-    }
+      embeddings
+    } finally if (results != null) results.close()
 
   }
 
@@ -359,11 +355,9 @@ private[johnsnowlabs] class XlmRoBertaClassification(
     inferRequest.infer()
 
     try {
-      try {
-        inferRequest
-          .get_tensor("logits")
-          .data()
-      }
+      inferRequest
+        .get_tensor("logits")
+        .data()
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -537,13 +531,11 @@ private[johnsnowlabs] class XlmRoBertaClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val logits = inferRequest
-          .get_output_tensor()
-          .data()
+      val logits = inferRequest
+        .get_output_tensor()
+        .data()
 
-        logits
-      }
+      logits
     } catch {
       case e: Exception =>
         // Log the exception as a warning
@@ -626,16 +618,14 @@ private[johnsnowlabs] class XlmRoBertaClassification(
     inferRequest.infer()
 
     try {
-      try {
-        val startLogits = inferRequest
-          .get_tensor("start_logits")
-          .data()
-        val endLogits = inferRequest
-          .get_tensor("end_logits")
-          .data()
+      val startLogits = inferRequest
+        .get_tensor("start_logits")
+        .data()
+      val endLogits = inferRequest
+        .get_tensor("end_logits")
+        .data()
 
-        (startLogits.slice(1, startLogits.length), endLogits.slice(1, endLogits.length))
-      }
+      (startLogits.slice(1, startLogits.length), endLogits.slice(1, endLogits.length))
     } catch {
       case e: Exception =>
         // Log the exception as a warning

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoberta.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XlmRoberta.scala
@@ -137,7 +137,6 @@ private[johnsnowlabs] class XlmRoberta(
         val inputs =
           Map("input_ids" -> tokenTensors, "attention_mask" -> maskTensors).asJava
 
-        // TODO:  A try without a catch or finally is equivalent to putting its body in a block; no exceptions are handled.
         try {
           val results = runner.run(inputs)
           try {

--- a/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/tensorflow/TensorflowWrapper.scala
@@ -258,8 +258,8 @@ class TensorflowWrapper(var variables: Variables, var graph: Array[Byte]) extend
     val tfChkPointsVars = FileUtils
       .listFilesAndDirs(
         new File(folder),
-        new WildcardFileFilter("part*"),
-        new WildcardFileFilter("variables*"))
+        WildcardFileFilter.builder().setWildcards("part*").get(),
+        WildcardFileFilter.builder().setWildcards("variables*").get())
       .toArray()
 
     // TF2 Saved Model generate parts for variables on second save
@@ -662,8 +662,8 @@ object TensorflowWrapper {
     val tfChkPointsVars = FileUtils
       .listFilesAndDirs(
         new File(folder),
-        new WildcardFileFilter("part*"),
-        new WildcardFileFilter("variables*"))
+        WildcardFileFilter.builder().setWildcards("part*").get(),
+        WildcardFileFilter.builder().setWildcards("variables*").get())
       .toArray()
 
     val variablesDir = tfChkPointsVars(1).toString

--- a/src/main/scala/com/johnsnowlabs/nlp/HasBatchedAnnotate.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasBatchedAnnotate.scala
@@ -49,10 +49,8 @@ trait HasBatchedAnnotate[M <: Model[M]] {
   def batchProcess(rows: Iterator[_]): Iterator[Row] = {
     val groupedRows = rows.grouped(getBatchSize)
 
-    groupedRows.flatMap {
-      case batchRow: Seq[Row] => processBatchRows(batchRow)
-      case singleRow: Row => processBatchRows(Seq(singleRow))
-      case _ => Seq(Row.empty)
+    groupedRows.flatMap { case batchRow: Seq[Row] @unchecked =>
+      processBatchRows(batchRow)
     }
   }
 

--- a/src/main/scala/com/johnsnowlabs/nlp/HasBatchedAnnotateTextImage.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/HasBatchedAnnotateTextImage.scala
@@ -71,7 +71,7 @@ trait HasBatchedAnnotateTextImage[M <: Model[M]] {
   def batchProcess(rows: Iterator[_]): Iterator[Row] = {
     rows
       .grouped(getBatchSize)
-      .flatMap { case batchedRows: Seq[Row] =>
+      .flatMap { case batchedRows: Seq[Row] @unchecked =>
         val inputAnnotations: Seq[(Annotation, AnnotationImage)] =
           batchedRows.map(getCaptionImageAnnotations)
         val outputAnnotations = batchAnnotate(inputAnnotations)

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DeBertaForQuestionAnswering.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/DeBertaForQuestionAnswering.scala
@@ -408,17 +408,6 @@ trait ReadDeBertaForQuestionAnsweringDLModel
         annotatorModel
           .setModelIfNotSet(spark, None, None, Some(ovWrapper), spModel)
 
-      case Openvino.name =>
-        val ovWrapper: OpenvinoWrapper =
-          OpenvinoWrapper.read(
-            spark,
-            localModelPath,
-            zipped = false,
-            useBundle = true,
-            detectedEngine = detectedEngine)
-        annotatorModel
-          .setModelIfNotSet(spark, None, None, Some(ovWrapper), spModel)
-
       case _ =>
         throw new Exception(notSupportedEngineError)
     }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/cv/feature_extractor/Preprocessor.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/cv/feature_extractor/Preprocessor.scala
@@ -125,20 +125,20 @@ private[johnsnowlabs] object Preprocessor {
 
     def parseSize(config: PreprocessorConfig) = {
       config.size match {
-        case sizeMap: Map[String, BigInt] if sizeMap.contains("width") =>
+        case sizeMap: Map[String, BigInt] @unchecked if sizeMap.contains("width") =>
           val width = sizeMap("width")
           require(
             width == sizeMap("height"),
             "Different sizes for width and height are currently not supported.")
           width.toInt
-        case sizeMap: Map[String, BigInt] if sizeMap.contains("shortest_edge") =>
+        case sizeMap: Map[String, BigInt] @unchecked if sizeMap.contains("shortest_edge") =>
           // ConvNext case: Size of the output image after `resize` has been applied
           sizeMap("shortest_edge").toInt
-        case sizeMap: Map[String, BigInt] if sizeMap.contains("longest_edge") =>
+        case sizeMap: Map[String, BigInt] @unchecked if sizeMap.contains("longest_edge") =>
           // ConvNext case: Size of the output image after `resize` has been applied
           sizeMap("longest_edge").toInt
         case sizeInt: BigInt => sizeInt.toInt
-        case sizeMap: Map[String, BigInt] if sizeMap.contains("max_pixels") =>
+        case sizeMap: Map[String, BigInt] @unchecked if sizeMap.contains("max_pixels") =>
           val max_pixels = sizeMap("max_pixels")
           max_pixels.toInt
         case _ =>

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/parser/typdep/util/DictionarySet.java
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/parser/typdep/util/DictionarySet.java
@@ -79,9 +79,10 @@ public class DictionarySet implements Serializable {
         return dictionaries[tag.ordinal()];
     }
 
+
     public void setCounters() {
         isCounting = true;
-        counters = new HashMap[dictionaries.length];
+        counters = (HashMap<Integer, Integer>[]) new HashMap[dictionaries.length];
         for (int i = 0; i < dictionaries.length; ++i) {
             counters[i] = new HashMap<>();
         }

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFReranker.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/AutoGGUFReranker.scala
@@ -220,7 +220,7 @@ class AutoGGUFReranker(override val uid: String)
           .enableReranking() // enable reranking mode
 
       val model: LlamaModel = getModelIfNotSet.getSession(modelParams)
-      val (completedTexts: Array[String], metadata: Array[Map[String, String]]) =
+      val (completedTexts: Array[String], metadata: Array[Map[String, String]] @unchecked) =
         try {
           val results: Array[Pair[String, java.lang.Float]] =
             LlamaExtensions.rerank(model, true, getQuery, annotationsText: _*).asScala.toArray

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/seq2seq/MarianTransformer.scala
@@ -50,8 +50,6 @@ import org.apache.spark.ml.param.{
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.sql.SparkSession
 
-import scala.jdk.CollectionConverters.asScalaBufferConverter
-
 /** MarianTransformer: Fast Neural Machine Translation
   *
   * Marian is an efficient, free Neural Machine Translation framework written in pure C++ with
@@ -477,10 +475,12 @@ class MarianTransformer(override val uid: String)
 
   /** do not remove or replace with $(vocabulary) due to a bug in some models */
   def getVocabulary: Array[String] = {
-    if ($(vocabulary).isInstanceOf[java.util.ArrayList[String]]) {
-      val arrayListValue = $(vocabulary).asInstanceOf[java.util.ArrayList[String]]
-      arrayListValue.asScala.toArray
-    } else $(vocabulary)
+
+    ($(vocabulary): Any) match {
+      case arrayListValue: java.util.ArrayList[_] =>
+        arrayListValue.toArray.map(_.asInstanceOf[String])
+      case _ => $(vocabulary)
+    }
   }
 
   setDefault(

--- a/src/main/scala/com/johnsnowlabs/nlp/serialization/LegacyObjectInputStream.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/serialization/LegacyObjectInputStream.scala
@@ -1,6 +1,7 @@
 package com.johnsnowlabs.nlp.serialization
 
 import java.io.{ByteArrayInputStream, IOException, ObjectInputStream, ObjectStreamClass}
+import scala.language.existentials
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 

--- a/src/main/scala/com/johnsnowlabs/reader/PdfToText.scala
+++ b/src/main/scala/com/johnsnowlabs/reader/PdfToText.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Dataset}
 
 import java.io.{ByteArrayOutputStream, PrintWriter, StringWriter}
+import scala.annotation.nowarn
 import scala.util.{Failure, Success, Try}
 
 /** Extract text from PDF document to a single string or to several strings per each page. Input
@@ -129,6 +130,7 @@ class PdfToText(override val uid: String)
 
   setDefault(inputCol -> "content", outputCol -> "text")
 
+  @nowarn("cat=deprecation")
   private def transformUDF: UserDefinedFunction = udf(
     (path: String, content: Array[Byte], exception: String) => {
       doProcess(content, exception)

--- a/src/main/scala/com/johnsnowlabs/reader/util/XlsxParser.scala
+++ b/src/main/scala/com/johnsnowlabs/reader/util/XlsxParser.scala
@@ -13,7 +13,7 @@ object XlsxParser {
     def isTitle(titleFontSizeThreshold: Int): Boolean = {
       row.cellIterator().asScala.exists { cell =>
         val cellStyle = cell.getCellStyle
-        val font = row.getSheet.getWorkbook.getFontAt(cellStyle.getFontIndexAsInt)
+        val font = row.getSheet.getWorkbook.getFontAt(cellStyle.getFontIndex)
 
         val isBold = font.getBold
         val isCentered = cellStyle.getAlignment == HorizontalAlignment.CENTER


### PR DESCRIPTION
## Description

A clean compile currently emits 68 scalac warnings, and loading the project emits 4 sbt `lintUnused`
warnings before anything is compiled. This clears all 72 without changing runtime behavior.

The scalac warnings break down as:

| Count | Warning | Fix |
|------:|---------|-----|
| 50 | `A try without a catch or finally is equivalent to putting its body in a block` | Unwrapped the redundant *inner* `try` in 19 `ml/ai` classes. Every `catch`/`finally` clause is preserved verbatim. |
| 6 | `non-variable type argument ... is unchecked since it is eliminated by erasure` | `@unchecked` on the type pattern in `HasBatchedAnnotate`, `HasBatchedAnnotateTextImage`, and `Preprocessor` (x4) |
| 4 | `constructor WildcardFileFilter ... is deprecated` | `WildcardFileFilter.builder().setWildcards(...).get()` in `TensorflowWrapper` |
| 2 | `unreachable code` | `HasBatchedAnnotate:54` and `DeBertaForQuestionAnswering:411` |
| 1 | erasure warning on a `val` pattern | `@unchecked` in `AutoGGUFReranker` |
| 1 | `fruitless type test` | `MarianTransformer.getVocabulary` |
| 1 | `comparing values of types BigInt and String using == will always yield false` | `ViTClassifier:179` |
| 1 | `method udf in object functions is deprecated` | `@nowarn("cat=deprecation")` on `PdfToText.transformUDF` |
| 1 | `method getFontIndexAsInt in trait CellStyle is deprecated` | `XlsxParser` -> `getFontIndex` |
| 1 | `inferred existential type ... should be enabled` | `import scala.language.existentials` in `LegacyObjectInputStream` |

Three of these are worth calling out because the obvious fix is wrong:

`PdfToText.transformUDF` keeps the deprecated `udf` overload rather than migrating. The non-deprecated
overload infers its schema by reflection, which cannot produce struct fields named after the
configurable `$(outputCol)` / `$(pageNumCol)`. The deprecated explicit-`DataType` overload is the only
one that works here, so it is suppressed at the definition with a comment rather than replaced.

`MarianTransformer.getVocabulary` has a `fruitless type test` because `$(vocabulary)` is statically
`Array[String]` but is deliberately probed for `java.util.ArrayList`  the existing comment (*"do not
remove or replace with `$(vocabulary)` due to a bug in some models"*) depends on that runtime check
still being emitted. Widening the scrutinee to `Any` silences the fruitless-test warning but trades it
for an *unchecked* warning on the `[String]` type argument, so the method is rewritten as a match on
`java.util.ArrayList[_]`. It also avoids `asScala`, since inferring through the resulting existential
`Buffer[_]` re-triggers the `scala.language.existentials` warning being fixed elsewhere in this PR.

`ViTClassifier` compared a `BigInt` tag index against `index.toString`, which is always false, so the
fallback lookup it guarded could only ever return `"NA"`. The dead chain is removed and `getOrElse("NA")`
is called directly.

No public signature changes, so the Python API is unaffected.