### PR TITLE
[Spark 4.x] [SPARKNLP-1412] Add configurable fallback logging verbosity

### DIFF
--- a/docs/en/advanced_settings.md
+++ b/docs/en/advanced_settings.md
@@ -5,7 +5,7 @@ seotitle: Spark NLP - Advanced Settings
 title: Spark NLP - Advanced Settings
 permalink: /docs/en/advanced_settings
 key: docs-install
-modify_date: "2024-07-04"
+modify_date: "2026-08-18"
 show_nav: true
 sidebar:
     nav: sparknlp
@@ -32,6 +32,47 @@ You can change the following Spark NLP configurations via Spark Configuration:
 | `spark.jsl.settings.onnx.intraOpNumThreads`             | `6`                  | Sets the size of the CPU thread pool used for executing a single graph, if executing on a CPU.                                                                                                                                                                                     |
 | `spark.jsl.settings.onnx.optimizationLevel`             | `ALL_OPT`            | Sets the optimization level of this options object, overriding the old setting.                                                                                                                                                                                                    |
 | `spark.jsl.settings.onnx.executionMode`                 | `SEQUENTIAL`         | Sets the execution mode of this options object, overriding the old setting.                                                                                                                                                                                                        |
+| `spark.jsl.settings.serialization.fallbackLogMode`      | `off`                | Controls model fallback-loader diagnostics. Valid values are `off`, `summary`, and `full` (case-insensitive). This setting changes observability only; it does not enable or disable fallback loading.                                                                              |
+
+### Fallback loader logging
+
+When primary model deserialization fails but a compatibility fallback is available, use
+`spark.jsl.settings.serialization.fallbackLogMode` to control the model-level diagnostic:
+
+- `off` (default): do not emit a fallback-loader message;
+- `summary`: emit one single-line warning with the model type and root cause; dynamic exception
+  text is limited to 200 characters;
+- `full`: emit the same summary and the complete original exception stack trace.
+
+Unsupported values are treated as `off` and produce a concise configuration warning. The mode
+controls logging only: fallback execution and error propagation remain unchanged. It suppresses
+only the Spark NLP model-level fallback message, so Spark may still emit executor errors before
+the fallback reader begins.
+
+**Scala:**
+
+```scala
+spark.conf.set(
+  "spark.jsl.settings.serialization.fallbackLogMode",
+  "summary")
+```
+
+**Python:**
+
+```python
+spark.conf.set(
+    "spark.jsl.settings.serialization.fallbackLogMode",
+    "summary",
+)
+```
+
+**spark-submit:**
+
+```bash
+spark-submit \
+  --conf spark.jsl.settings.serialization.fallbackLogMode=full \
+  your_application.py
+```
 
 </div><div class="h3-box" markdown="1">
 

--- a/src/main/scala/com/johnsnowlabs/nlp/ParamsAndFeaturesReadable.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/ParamsAndFeaturesReadable.scala
@@ -16,10 +16,13 @@
 
 package com.johnsnowlabs.nlp
 
+import com.johnsnowlabs.util.ConfigHelper
+import org.apache.spark.internal.Logging
 import org.apache.spark.ml.util.{DefaultParamsReadable, MLReader}
 import org.apache.spark.sql.SparkSession
 
 import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 class FeaturesReader[T <: HasFeatures](
@@ -63,6 +66,89 @@ trait ParamsAndFeaturesReadable[T <: HasFeatures] extends DefaultParamsReadable[
       (instance: T, path: String, spark: SparkSession) => onRead(instance, path, spark))
 }
 
+private[nlp] object FallbackLoaderLogging {
+
+  sealed trait Mode
+  case object Off extends Mode
+  case object Summary extends Mode
+  case object Full extends Mode
+
+  final case class ParsedMode(mode: Mode, invalidValue: Option[String] = None)
+
+  val MaxCauseMessageLength: Int = 200
+
+  def parseMode(configuredValue: Option[String]): ParsedMode = configuredValue match {
+    case None => ParsedMode(Off)
+    case Some(value) =>
+      value.trim.toLowerCase(java.util.Locale.ROOT) match {
+        case "off" => ParsedMode(Off)
+        case "summary" => ParsedMode(Summary)
+        case "full" => ParsedMode(Full)
+        case _ => ParsedMode(Off, Some(value))
+      }
+  }
+
+  def summary(modelType: String, throwable: Throwable): String = {
+    val modelDescription = Option(modelType)
+      .map(normalizeWhitespace)
+      .filter(_.nonEmpty)
+      .map(value => s" for $value")
+      .getOrElse("")
+    val causeDescription = deepestMeaningfulCause(throwable)
+
+    s"Spark NLP fallback loader activated$modelDescription. Cause: $causeDescription. " +
+      s"Set ${ConfigHelper.fallbackLoaderLogMode}=full for the complete stack trace."
+  }
+
+  def invalidModeWarning(value: String): String = {
+    val normalizedValue = normalizeWhitespace(value) match {
+      case "" => "<empty>"
+      case other => truncate(other)
+    }
+
+    s"Unsupported value '$normalizedValue' for ${ConfigHelper.fallbackLoaderLogMode}; " +
+      "valid options are off, summary, and full. Treating it as off."
+  }
+
+  private def deepestMeaningfulCause(throwable: Throwable): String = {
+    val causes = ArrayBuffer.empty[Throwable]
+    val visited = scala.collection.mutable.Set.empty[Throwable]
+    var current = throwable
+
+    while (current != null && !visited.contains(current)) {
+      causes.append(current)
+      visited.add(current)
+      current = current.getCause
+    }
+
+    val deepest = causes.lastOption.getOrElse(throwable)
+    causes.reverseIterator
+      .map(cause => (cause, Option(cause.getMessage).map(sanitizeExceptionMessage).getOrElse("")))
+      .find(_._2.nonEmpty)
+      .map { case (cause, message) => s"${exceptionClassName(cause)}: $message" }
+      .getOrElse(exceptionClassName(deepest))
+  }
+
+  private def exceptionClassName(throwable: Throwable): String = {
+    val simpleName = throwable.getClass.getSimpleName
+    if (simpleName.nonEmpty) simpleName else throwable.getClass.getName
+  }
+
+  private def normalizeWhitespace(value: String): String = value.replaceAll("\\s+", " ").trim
+
+  private def sanitizeExceptionMessage(value: String): String = {
+    val normalized = normalizeWhitespace(value)
+    val stackTraceIndex =
+      normalized.toLowerCase(java.util.Locale.ROOT).indexOf("driver stacktrace")
+    val withoutDriverStackTrace =
+      if (stackTraceIndex >= 0) normalized.take(stackTraceIndex).trim else normalized
+    truncate(withoutDriverStackTrace)
+  }
+
+  private def truncate(value: String): String =
+    value.take(MaxCauseMessageLength)
+}
+
 /** MLReader that loads a model with params and features, and has a fallback mechanism.
   *
   * The fallback load will be called in case there is an exception during Spark loading (i.e.
@@ -84,7 +170,31 @@ class FeaturesFallbackReader[T <: HasFeatures](
     baseReader: MLReader[T],
     onRead: (T, String, SparkSession) => Unit,
     fallbackLoad: (String, SparkSession) => T = null)
-    extends MLReader[T] {
+    extends MLReader[T]
+    with Logging {
+
+  protected[nlp] def modelType: String = ""
+
+  protected[nlp] def warn(message: String): Unit = logWarning(message)
+
+  protected[nlp] def warn(message: String, throwable: Throwable): Unit =
+    logWarning(message, throwable)
+
+  private def logFallbackFailure(throwable: Throwable): Unit = {
+    val parsedMode = FallbackLoaderLogging.parseMode(
+      sparkSession.conf.getOption(ConfigHelper.fallbackLoaderLogMode))
+
+    parsedMode.invalidValue.foreach(value =>
+      warn(FallbackLoaderLogging.invalidModeWarning(value)))
+
+    parsedMode.mode match {
+      case FallbackLoaderLogging.Off =>
+      case FallbackLoaderLogging.Summary =>
+        warn(FallbackLoaderLogging.summary(modelType, throwable))
+      case FallbackLoaderLogging.Full =>
+        warn(FallbackLoaderLogging.summary(modelType, throwable), throwable)
+    }
+  }
 
   override def load(path: String): T = {
     Try {
@@ -93,8 +203,10 @@ class FeaturesFallbackReader[T <: HasFeatures](
     } match {
       case Success(value) => value
       case Failure(e: Throwable) =>
-        println(
-          s"Failed to load all parameters from $path: ${e.toString}. Attempting fallback loader.")
+        try logFallbackFailure(e)
+        catch {
+          case NonFatal(_) =>
+        }
         fallbackLoad(path, sparkSession)
     }
   }
@@ -128,5 +240,10 @@ trait ParamsAndFeaturesFallbackReadable[T <: HasFeatures] extends ParamsAndFeatu
     */
   def fallbackLoad(folder: String, spark: SparkSession): T
 
-  override def read: MLReader[T] = new FeaturesFallbackReader(super.read, onRead, fallbackLoad)
+  override def read: MLReader[T] = {
+    val readableModelType = getClass.getSimpleName.stripSuffix("$")
+    new FeaturesFallbackReader(super.read, onRead, fallbackLoad) {
+      override protected[nlp] def modelType: String = readableModelType
+    }
+  }
 }

--- a/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
@@ -59,6 +59,7 @@ object ConfigHelper {
 
   val serializationMode = "spark.jsl.settings.annotatorSerializationFormat"
   val useBroadcast = "spark.jsl.settings.useBroadcastForFeatures"
+  val fallbackLoaderLogMode = "spark.jsl.settings.serialization.fallbackLogMode"
 
   /** used only for internal unit tests */
   val hadoopAwsVersion: String = "3.3.1"

--- a/src/test/scala/com/johnsnowlabs/nlp/FeaturesFallbackReaderLoggingTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/FeaturesFallbackReaderLoggingTestSpec.scala
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.nlp
+
+import com.johnsnowlabs.nlp.annotators.SparkSessionTest
+import com.johnsnowlabs.tags.FastTest
+import com.johnsnowlabs.util.ConfigHelper
+import org.apache.spark.SparkException
+import org.apache.spark.ml.util.MLReader
+import org.apache.spark.sql.SparkSession
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.io.InvalidObjectException
+import java.lang.reflect.InvocationTargetException
+import scala.collection.mutable.ArrayBuffer
+
+class FeaturesFallbackReaderLoggingTestSpec extends AnyFlatSpec with SparkSessionTest {
+
+  private class TestModel extends HasFeatures
+
+  private class FailingReader(failure: Throwable) extends MLReader[TestModel] {
+    override def load(path: String): TestModel = throw failure
+  }
+
+  private class RecordingFeaturesFallbackReader(
+      baseReader: MLReader[TestModel],
+      fallbackLoad: (String, SparkSession) => TestModel,
+      recordedModelType: String = "TokenizerModel")
+      extends FeaturesFallbackReader[TestModel](baseReader, (_, _, _) => (), fallbackLoad) {
+
+    override protected[nlp] def modelType: String = recordedModelType
+
+    val warnings: ArrayBuffer[(String, Option[Throwable])] = ArrayBuffer.empty
+
+    override protected[nlp] def warn(message: String): Unit =
+      warnings.append((message, None))
+
+    override protected[nlp] def warn(message: String, throwable: Throwable): Unit =
+      warnings.append((message, Some(throwable)))
+  }
+
+  private def withFallbackLogMode[T](mode: Option[String])(body: => T): T = {
+    val previous = spark.conf.getOption(ConfigHelper.fallbackLoaderLogMode)
+    mode match {
+      case Some(value) => spark.conf.set(ConfigHelper.fallbackLoaderLogMode, value)
+      case None => spark.conf.unset(ConfigHelper.fallbackLoaderLogMode)
+    }
+
+    try body
+    finally {
+      previous match {
+        case Some(value) => spark.conf.set(ConfigHelper.fallbackLoaderLogMode, value)
+        case None => spark.conf.unset(ConfigHelper.fallbackLoaderLogMode)
+      }
+    }
+  }
+
+  private def readerFor(
+      primaryFailure: Throwable,
+      fallback: (String, SparkSession) => TestModel): RecordingFeaturesFallbackReader =
+    new RecordingFeaturesFallbackReader(new FailingReader(primaryFailure), fallback)
+      .session(spark)
+
+  private def isSingleLine(value: String): Boolean =
+    !value.exists(character => character == '\n' || character == '\r')
+
+  private def wrappedLambdaFailure(): Throwable = {
+    val root = new IllegalArgumentException(
+      "Illegal lambda\tdeserialization\nDriver stacktrace should not leak")
+    val invocation = new InvocationTargetException(root)
+    val invalidObject = new InvalidObjectException("Legacy serialized lambda")
+    invalidObject.initCause(invocation)
+    new SparkException("Spark executor failure\nDriver stacktrace", invalidObject)
+  }
+
+  behavior of "FallbackLoaderLogging"
+
+  it should "parse supported modes case-insensitively and default to off" taggedAs FastTest in {
+    assert(FallbackLoaderLogging.parseMode(None).mode == FallbackLoaderLogging.Off)
+    assert(FallbackLoaderLogging.parseMode(Some("off")).mode == FallbackLoaderLogging.Off)
+    assert(
+      FallbackLoaderLogging.parseMode(Some(" SuMmArY ")).mode == FallbackLoaderLogging.Summary)
+    assert(FallbackLoaderLogging.parseMode(Some("FULL")).mode == FallbackLoaderLogging.Full)
+  }
+
+  it should "treat an invalid mode as off while preserving the invalid value" taggedAs FastTest in {
+    val parsed = FallbackLoaderLogging.parseMode(Some("verbose"))
+
+    assert(parsed.mode == FallbackLoaderLogging.Off)
+    assert(parsed.invalidValue.contains("verbose"))
+  }
+
+  it should "format the deepest meaningful cause as one bounded line" taggedAs FastTest in {
+    val message = FallbackLoaderLogging.summary("TokenizerModel", wrappedLambdaFailure())
+
+    assert(isSingleLine(message))
+    assert(message.contains("Spark NLP fallback loader activated for TokenizerModel"))
+    assert(message.contains("IllegalArgumentException: Illegal lambda deserialization"))
+    assert(!message.contains("Spark executor failure"))
+    assert(!message.contains("Driver stacktrace"))
+    assert(!message.contains("/tmp/legacy/model"))
+    assert(message.contains(s"${ConfigHelper.fallbackLoaderLogMode}=full"))
+  }
+
+  it should "bound only dynamic exception text to 200 characters" taggedAs FastTest in {
+    val dynamicText = "x" * 250
+    val message =
+      FallbackLoaderLogging.summary("TokenizerModel", new IllegalArgumentException(dynamicText))
+    val renderedDynamicText = message
+      .stripPrefix(
+        "Spark NLP fallback loader activated for TokenizerModel. Cause: IllegalArgumentException: ")
+      .takeWhile(_ != '.')
+
+    assert(renderedDynamicText.length == FallbackLoaderLogging.MaxCauseMessageLength)
+    assert(
+      message.endsWith(
+        s"Set ${ConfigHelper.fallbackLoaderLogMode}=full for the complete stack trace."))
+  }
+
+  behavior of "FeaturesFallbackReader"
+
+  it should "run fallback once without warnings when the mode is absent" taggedAs FastTest in {
+    var fallbackInvocations = 0
+    val fallbackResult = new TestModel
+    val reader = readerFor(
+      wrappedLambdaFailure(),
+      (_, _) => {
+        fallbackInvocations += 1
+        fallbackResult
+      })
+
+    val result = withFallbackLogMode(None)(reader.load("/tmp/legacy/model"))
+
+    assert(result eq fallbackResult)
+    assert(fallbackInvocations == 1)
+    assert(reader.warnings.isEmpty)
+  }
+
+  it should "run fallback once without warnings when the mode is off" taggedAs FastTest in {
+    var fallbackInvocations = 0
+    val fallbackResult = new TestModel
+    val reader = readerFor(
+      wrappedLambdaFailure(),
+      (_, _) => {
+        fallbackInvocations += 1
+        fallbackResult
+      })
+
+    val result = withFallbackLogMode(Some("OFF"))(reader.load("/tmp/legacy/model"))
+
+    assert(result eq fallbackResult)
+    assert(fallbackInvocations == 1)
+    assert(reader.warnings.isEmpty)
+  }
+
+  it should "emit one summary warning without attaching the exception" taggedAs FastTest in {
+    val primaryFailure = wrappedLambdaFailure()
+    val fallbackResult = new TestModel
+    val reader = readerFor(primaryFailure, (_, _) => fallbackResult)
+
+    val result = withFallbackLogMode(Some("summary"))(reader.load("/tmp/legacy/model"))
+
+    assert(result eq fallbackResult)
+    assert(reader.warnings.size == 1)
+    assert(reader.warnings.head._2.isEmpty)
+    assert(isSingleLine(reader.warnings.head._1))
+    assert(!reader.warnings.head._1.contains("/tmp/legacy/model"))
+    assert(!reader.warnings.head._1.contains("Driver stacktrace"))
+  }
+
+  it should "emit the same summary and attach the original exception in full mode" taggedAs FastTest in {
+    val primaryFailure = wrappedLambdaFailure()
+    val fallbackResult = new TestModel
+    val reader = readerFor(primaryFailure, (_, _) => fallbackResult)
+
+    withFallbackLogMode(Some("full"))(reader.load("/tmp/legacy/model"))
+
+    assert(reader.warnings.size == 1)
+    assert(
+      reader.warnings.head._1 == FallbackLoaderLogging.summary("TokenizerModel", primaryFailure))
+    assert(reader.warnings.head._2.exists(_ eq primaryFailure))
+  }
+
+  it should "warn about an invalid mode and still run fallback once" taggedAs FastTest in {
+    var fallbackInvocations = 0
+    val fallbackResult = new TestModel
+    val reader = readerFor(
+      wrappedLambdaFailure(),
+      (_, _) => {
+        fallbackInvocations += 1
+        fallbackResult
+      })
+
+    val result = withFallbackLogMode(Some("verbose\nmode"))(reader.load("/tmp/legacy/model"))
+
+    assert(result eq fallbackResult)
+    assert(fallbackInvocations == 1)
+    assert(reader.warnings.size == 1)
+    assert(reader.warnings.head._2.isEmpty)
+    assert(isSingleLine(reader.warnings.head._1))
+    assert(reader.warnings.head._1.contains("verbose mode"))
+    assert(reader.warnings.head._1.contains("off, summary, and full"))
+    assert(!reader.warnings.head._1.contains("fallback loader activated"))
+  }
+
+  it should "propagate fallback failures unchanged" taggedAs FastTest in {
+    val fallbackFailure = new IllegalStateException("fallback failed")
+    val reader = readerFor(wrappedLambdaFailure(), (_, _) => throw fallbackFailure)
+
+    val thrown = withFallbackLogMode(Some("summary")) {
+      intercept[IllegalStateException](reader.load("/tmp/legacy/model"))
+    }
+
+    assert(thrown eq fallbackFailure)
+    assert(reader.warnings.size == 1)
+  }
+
+  it should "run fallback even if warning emission fails" taggedAs FastTest in {
+    var fallbackInvocations = 0
+    val fallbackResult = new TestModel
+    val reader = new RecordingFeaturesFallbackReader(
+      new FailingReader(wrappedLambdaFailure()),
+      (_, _) => {
+        fallbackInvocations += 1
+        fallbackResult
+      }) {
+      override protected[nlp] def warn(message: String): Unit =
+        throw new IllegalStateException("logger failed")
+    }.session(spark)
+
+    val result = withFallbackLogMode(Some("summary"))(reader.load("/tmp/legacy/model"))
+
+    assert(result eq fallbackResult)
+    assert(fallbackInvocations == 1)
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds configurable fallback-loader logging verbosity for model deserialization compatibility paths.

The change introduces a new Spark config:

- `spark.jsl.settings.serialization.fallbackLogMode`

Supported values are:

- `off` (default): do not emit a Spark NLP fallback-loader message.
- `summary`: emit a single-line warning with the model type and the deepest meaningful cause.
- `full`: emit the same summary and attach the original exception stack trace.

The implementation also:

- Replaces direct fallback-path console output with Spark logging.
- Normalizes and bounds summary messages so dynamic exception text stays single-line and capped at 200 characters.
- Treats invalid config values as `off` and emits a concise configuration warning.
- Keeps fallback execution unchanged even if logging itself fails.
- Documents the new setting in `advanced_settings.md` with Scala, Python, and `spark-submit` examples.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When Spark NLP loads older serialized models through the compatibility fallback path, the current behavior does not provide controllable observability. Teams need a way to inspect fallback activation in supported environments without always emitting full stack traces or relying on ad-hoc console output.

This change makes fallback diagnostics configurable while keeping compatibility behavior intact:

- no change to whether fallback loading runs;
- no change to propagated fallback failures;
- better production-friendly logging for release validation and troubleshooting.

It also avoids leaking noisy multi-line driver stacktrace text in the default summary mode while still allowing full exception detail when explicitly requested.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
 Added `FeaturesFallbackReaderLoggingTestSpec` covering:
  - mode parsing (`off`, `summary`, `full`, invalid values);
  - bounded single-line summary formatting;
  - no-warning behavior for unset/`off` mode;
  - summary-mode warning behavior without attached throwable;
  - full-mode warning behavior with attached original throwable;
  - invalid-mode warning behavior;
  - fallback failure propagation;
  - fallback execution continuing even if warning emission fails.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
