### PR TITLE
[SPARKNLP-45] Fix ZeroShotNer losing its decode logic under batching

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/ai/ZeroShotNerClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/ZeroShotNerClassification.scala
@@ -19,6 +19,7 @@ package com.johnsnowlabs.ml.ai
 import com.johnsnowlabs.ml.onnx.OnnxWrapper
 import com.johnsnowlabs.ml.openvino.OpenvinoWrapper
 import com.johnsnowlabs.ml.tensorflow.TensorflowWrapper
+import com.johnsnowlabs.nlp.annotators.common.WordpieceTokenizedSentence
 import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 
 private[johnsnowlabs] class ZeroShotNerClassification(
@@ -51,17 +52,25 @@ private[johnsnowlabs] class ZeroShotNerClassification(
     val (startLogits, endLogits) = super.tagSpan(batch)
     val contextStartOffsets = batch.map(_.indexOf(sentenceEndTokenId))
 
-    (
-      startLogits
-        .zip(contextStartOffsets)
-        .map(x =>
-          x._1.zipWithIndex.map(y =>
-            if (((y._2 > 0) && y._2 <= x._2) || (x._2 == startLogits.length - 1)) 0f else y._1)),
-      endLogits
-        .zip(contextStartOffsets)
-        .map(x =>
-          x._1.zipWithIndex.map(y =>
-            if (((y._2 > 0) && y._2 <= x._2) || (x._2 == startLogits.length - 1)) 0f else y._1)))
+    /** Zeroes out the question, and the `</s>` that closes it, so they cannot win the argmax.
+      *
+      * The second clause guards a row that has no context at all (its lone `</s>` is the last
+      * token in the row). It must be compared against the ROW's own width - comparing it against
+      * `startLogits.length` (the number of rows in the batch, i.e. `batchSize`) as this used to
+      * do was harmless only because [[predictSpan]] used to call this with a batch of exactly
+      * one, making that comparison equivalent to `contextStart == 0`. With real batches (see
+      * [[predictSpanGrouped]]) that comparison instead fires whenever a row's `</s>` happens to
+      * land at index `batchSize - 1`, unrelated to that row's own length, spuriously zeroing a
+      * perfectly normal row's scores depending on which other rows share its batch.
+      */
+    def maskQuestion(scores: Array[Array[Float]]): Array[Array[Float]] =
+      scores.zip(contextStartOffsets).map { case (row, contextStart) =>
+        row.zipWithIndex.map { case (score, i) =>
+          if (((i > 0) && i <= contextStart) || (contextStart == row.length - 1)) 0f else score
+        }
+      }
+
+    (maskQuestion(startLogits), maskQuestion(endLogits))
   }
 
   override def predictSpan(
@@ -69,28 +78,136 @@ private[johnsnowlabs] class ZeroShotNerClassification(
       maxSentenceLength: Int,
       caseSensitive: Boolean,
       mergeTokenStrategy: String,
-      engine: String): Seq[Annotation] = {
-    val questionAnnot = Seq(documents.head)
-    val contextAnnot = documents.drop(1)
+      engine: String): Seq[Annotation] =
+    predictSpanGrouped(
+      Seq(documents),
+      batchSize = 1,
+      maxSentenceLength,
+      caseSensitive,
+      mergeTokenStrategy,
+      engine).head
 
-    val wordPieceTokenizedQuestion =
-      tokenizeDocument(questionAnnot, maxSentenceLength, caseSensitive)
-    val wordPieceTokenizedContext =
-      tokenizeDocument(contextAnnot, maxSentenceLength, caseSensitive)
+  /** One row's worth of input to [[predictSpanGrouped]]. Mirrors the trait's own `SpanExample`,
+    * plus the row's context annotation - this class needs it to turn a token span back into
+    * character offsets in the original document.
+    */
+  private case class ZeroShotSpanExample(
+      rowIndex: Int,
+      contextAnnot: Seq[Annotation],
+      wordPieceTokenizedQuestion: Seq[WordpieceTokenizedSentence],
+      wordPieceTokenizedContext: Seq[WordpieceTokenizedSentence],
+      encoded: Array[Int])
 
-    val encodedInput =
-      encodeSequence(wordPieceTokenizedQuestion, wordPieceTokenizedContext, maxSentenceLength)
-    val (startLogits, endLogits) = tagSpan(encodedInput)
+  /** Batched counterpart of [[predictSpan]], and now the single implementation of both.
+    *
+    * `RoBertaForQuestionAnswering.batchAnnotate` (via `ZeroShotNerModel`) calls
+    * `predictSpanGrouped` rather than `predictSpan` since SPARKNLP-45. Without this override
+    * ZeroShotNer silently fell through to `RoBertaClassification.predictSpanGrouped`, which
+    * decodes with plain RoBERTa QA semantics - a different score (average, not what
+    * `RoBertaClassification` itself does) and, critically, `begin = 0 / end = content.length - 1`
+    * instead of the answer's actual character offsets in the context.
+    * `ZeroShotNerModel.isTokenInEntity` matches NER tokens against exactly those character
+    * offsets, so the missing override turned every prediction into either the wrong entity span
+    * or no entity at all.
+    *
+    * Two things [[predictSpan]] got away with only because it always ran one example at a time:
+    *
+    *   1. `tagSpan`'s ONNX path (in the inherited `RoBertaClassification`) builds a rectangular
+    *      tensor out of the raw encoded rows, so every row in a batch has to be the same length -
+    *      trivially true for a batch of one. Rows are padded here to their batch's own max length
+    *      with `sentencePadTokenId`.
+    *   1. `tagSpan` softmaxes across the full padded width, so a short row's scores would be
+    *      diluted by whichever longer row shared its batch, and its argmax could even land on a
+    *      padding position. Scores are confined to the row's own unpadded width before being
+    *      renormalised, which is exactly equivalent to softmaxing over the unpadded row - so a
+    *      row's answer does not depend on what it was batched with.
+    */
+  override def predictSpanGrouped(
+      rowsOfDocuments: Seq[Seq[Annotation]],
+      batchSize: Int,
+      maxSentenceLength: Int,
+      caseSensitive: Boolean,
+      mergeTokenStrategy: String,
+      engine: String): Seq[Seq[Annotation]] = {
 
-    val startScores = startLogits.map(x => x.map(y => y / x.sum)).head
-    val endScores = endLogits.map(x => x.map(y => y / x.sum)).head
+    val examples: Seq[ZeroShotSpanExample] = rowsOfDocuments.zipWithIndex.flatMap {
+      case (documents, rowIndex) =>
+        if (documents.isEmpty) None
+        else {
+          val questionAnnot = Seq(documents.head)
+          val contextAnnot = documents.drop(1)
+
+          val wordPieceTokenizedQuestion =
+            tokenizeDocument(questionAnnot, maxSentenceLength, caseSensitive)
+          val wordPieceTokenizedContext =
+            tokenizeDocument(contextAnnot, maxSentenceLength, caseSensitive)
+          val encoded = encodeSequence(
+            wordPieceTokenizedQuestion,
+            wordPieceTokenizedContext,
+            maxSentenceLength).head
+
+          Some(
+            ZeroShotSpanExample(
+              rowIndex,
+              contextAnnot,
+              wordPieceTokenizedQuestion,
+              wordPieceTokenizedContext,
+              encoded))
+        }
+    }
+
+    if (examples.isEmpty) return rowsOfDocuments.map(_ => Seq.empty[Annotation])
+
+    val resultsWithRow: Seq[(Annotation, Int)] =
+      batchByLength[ZeroShotSpanExample, (Annotation, Int)](
+        examples,
+        batchSize,
+        _.encoded.length) { batch =>
+        val maxLen = batch.map(_.encoded.length).max
+        val paddedEncoded = batch.map { example =>
+          example.encoded ++ Array.fill(maxLen - example.encoded.length)(sentencePadTokenId)
+        }
+        val (startLogits, endLogits) = tagSpan(paddedEncoded)
+
+        batch.zipWithIndex.map { case (example, i) =>
+          (
+            decodeSpan(example, startLogits(i), endLogits(i), mergeTokenStrategy),
+            example.rowIndex)
+        }
+      }
+
+    val byRow =
+      resultsWithRow.groupBy(_._2).map { case (rowIndex, pairs) => rowIndex -> pairs.map(_._1) }
+    rowsOfDocuments.indices.map(rowIndex => byRow.getOrElse(rowIndex, Seq.empty[Annotation]))
+  }
+
+  /** Renormalises so the retained scores sum to 1 again, as `predictSpan` always did - `tagSpan`
+    * has already zeroed the question positions out of an otherwise-normalised softmax row.
+    */
+  private def renormalize(scores: Array[Float]): Array[Float] = {
+    val total = scores.sum
+    if (total <= 0f) scores else scores.map(_ / total)
+  }
+
+  private def decodeSpan(
+      example: ZeroShotSpanExample,
+      rawStartScores: Array[Float],
+      rawEndScores: Array[Float],
+      mergeTokenStrategy: String): Annotation = {
+
+    val contextAnnot = example.contextAnnot
+    // This row's own unpadded width - the batch may be wider.
+    val validLength = example.encoded.length
+    val startScores = renormalize(rawStartScores.take(validLength))
+    val endScores = renormalize(rawEndScores.take(validLength))
 
     val startIndex =
       startScores.zipWithIndex.drop(if (handleImpossibleAnswer) 0 else 1).maxBy(_._1)
     val endIndex = endScores.zipWithIndex.drop(if (handleImpossibleAnswer) 0 else 1).maxBy(_._1)
 
     val allTokenPieces =
-      wordPieceTokenizedQuestion.head.tokens ++ wordPieceTokenizedContext.flatMap(x => x.tokens)
+      example.wordPieceTokenizedQuestion.head.tokens ++
+        example.wordPieceTokenizedContext.flatMap(x => x.tokens)
     val decodedAnswer = allTokenPieces.slice(startIndex._2 - 3, endIndex._2 - 2)
     // Check if the answer span starts at the CLS symbol 0 - if so return empty string
     val content =
@@ -110,39 +227,36 @@ private[johnsnowlabs] class ZeroShotNerClassification(
       else ""
 
     if (content.isEmpty) {
-      Seq(
-        Annotation(
-          annotatorType = AnnotatorType.CHUNK,
-          begin = 0,
-          end = 0,
-          result = content,
-          metadata = Map(
-            "sentence" -> contextAnnot.head.metadata.getOrElse("sentence", "0"),
-            "chunk" -> "0",
-            "start" -> "0",
-            "start_score" -> "0",
-            "end" -> "0",
-            "end_score" -> "0",
-            "score" -> "0",
-            "start_char" -> "0",
-            "end_char" -> "0")))
+      Annotation(
+        annotatorType = AnnotatorType.CHUNK,
+        begin = 0,
+        end = 0,
+        result = content,
+        metadata = Map(
+          "sentence" -> contextAnnot.head.metadata.getOrElse("sentence", "0"),
+          "chunk" -> "0",
+          "start" -> "0",
+          "start_score" -> "0",
+          "end" -> "0",
+          "end_score" -> "0",
+          "score" -> "0",
+          "start_char" -> "0",
+          "end_char" -> "0"))
     } else {
       val sentenceOffset = contextAnnot.head.begin
       val tokenStartAdjustment =
         if (contextAnnot.head.result(decodedAnswer.head.begin - sentenceOffset) == ' ') 1 else 0
       val startPos = decodedAnswer.head.begin + tokenStartAdjustment
       val endPos = decodedAnswer.last.end
-      Seq(
-        Annotation(
-          annotatorType = AnnotatorType.CHUNK,
-          begin = startPos,
-          end = endPos,
-          result = content,
-          metadata = Map(
-            "sentence" -> contextAnnot.head.metadata.getOrElse("sentence", "0"),
-            "score" -> ((startIndex._1 + endIndex._1) / 2).toString)))
+      Annotation(
+        annotatorType = AnnotatorType.CHUNK,
+        begin = startPos,
+        end = endPos,
+        result = content,
+        metadata = Map(
+          "sentence" -> contextAnnot.head.metadata.getOrElse("sentence", "0"),
+          "score" -> ((startIndex._1 + endIndex._1) / 2).toString))
     }
-
   }
 
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForQuestionAnsweringTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/classifier/dl/RoBertaForQuestionAnsweringTestSpec.scala
@@ -16,7 +16,8 @@
 
 package com.johnsnowlabs.nlp.annotators.classifier.dl
 
-import com.johnsnowlabs.nlp.Annotation
+import com.johnsnowlabs.ml.ai.MergeTokenStrategy
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorType, DocumentAssembler}
 import com.johnsnowlabs.nlp.base._
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
 import com.johnsnowlabs.tags.SlowTest
@@ -210,5 +211,104 @@ class RoBertaForQuestionAnsweringTestSpec extends AnyFlatSpec {
 
     implicit val tolerantEq = TolerantNumerics.tolerantFloatEquality(1e-2f)
     assert(score === expectedScore, "Score was not close enough")
+  }
+
+  /** Regression test for SPARKNLP-45 (#14827): `batchAnnotate` switched from calling
+    * `predictSpan` once per row to `predictSpanGrouped`, batching every row in one pass. This
+    * confirms that switch didn't change any answer - batched output must match the old per-row
+    * output exactly, for every batch size and on every compute engine.
+    */
+  "RoBertaForQuestionAnswering" should "give the same answers batched as one row at a time" taggedAs SlowTest in {
+    val text = "My name is Clara, I live in New York and Hellen lives in Paris."
+    val questions = Seq(
+      "What is his name?",
+      "What is my name?",
+      "What is her name?",
+      "Which city?",
+      "Which is the city?")
+
+    def rows: Seq[Seq[Annotation]] =
+      questions.map(q =>
+        Seq(
+          Annotation(AnnotatorType.DOCUMENT, 0, q.length - 1, q, Map("sentence" -> "0")),
+          Annotation(AnnotatorType.DOCUMENT, 0, text.length - 1, text, Map("sentence" -> "0"))))
+
+    // roberta_qa_robertaABSA and roberta_qa_distilroberta_base_squad_v2 are genuinely
+    // TensorFlow- and ONNX-exported checkpoints respectively (confirmed via detectedEngine below,
+    // not assumed from their names - published checkpoints are sometimes re-exported to a
+    // different engine under the same name over time).
+    Seq(
+      "tensorflow" -> "roberta_qa_robertaABSA",
+      "onnx" -> "roberta_qa_distilroberta_base_squad_v2")
+      .foreach { case (engine, modelName) =>
+        val qa = RoBertaForQuestionAnswering.pretrained(modelName, "en", "public/models")
+        val model = qa.getModelIfNotSet
+        assert(
+          model.detectedEngine == engine,
+          "expected detectedEngine=" + engine + " but got " + model.detectedEngine)
+
+        val perRow = rows.map(row =>
+          model
+            .predictSpan(row, 512, caseSensitive = false, MergeTokenStrategy.vocab, engine)
+            .head)
+
+        Seq(1, 2, 3, 5, 8).foreach { batchSize =>
+          val batched = model
+            .predictSpanGrouped(
+              rows,
+              batchSize,
+              512,
+              caseSensitive = false,
+              MergeTokenStrategy.vocab,
+              engine)
+            .map(_.head)
+
+          perRow.zip(batched).zip(questions).foreach { case ((r, b), q) =>
+            assert(
+              r.result == b.result && r.begin == b.begin && r.end == b.end,
+              "[" + engine + "] batchSize=" + batchSize + " question=[" + q + "]\n  expected: " + r + "\n  actual:   " + b)
+          }
+        }
+      }
+  }
+
+  /** Reproduces the exact repro reported for SPARKNLP-45: five questions against one sentence,
+    * run through the pipeline at different batch sizes. Confirms output is unaffected by
+    * `setBatchSize`.
+    */
+  it should "produce identical pipeline output regardless of batch size" taggedAs SlowTest in {
+    val text = "My name is Clara, I live in New York and Hellen lives in Paris."
+    val questions = Seq(
+      "What is his name?",
+      "What is my name?",
+      "What is her name?",
+      "Which city?",
+      "Which is the city?")
+    val data = questions.map(question => (question, text)).toDF("question", "text")
+
+    val documentAssembler = new DocumentAssembler().setInputCol("text").setOutputCol("document")
+    val questionAssembler =
+      new DocumentAssembler().setInputCol("question").setOutputCol("question_document")
+
+    def runWith(batchSize: Int): Seq[String] = {
+      val answering = RoBertaForQuestionAnswering
+        .pretrained()
+        .setInputCols("question_document", "document")
+        .setOutputCol("answer")
+        .setBatchSize(batchSize)
+
+      new Pipeline()
+        .setStages(Array(documentAssembler, questionAssembler, answering))
+        .fit(data)
+        .transform(data)
+        .selectExpr("explode(answer) AS answer")
+        .selectExpr("answer.begin", "answer.end", "answer.result")
+        .collect()
+        .map(_.toString)
+        .toSeq
+    }
+
+    val reference = runWith(1)
+    assert(runWith(8) == reference, "pipeline output changed between batchSize=1 and batchSize=8")
   }
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/ZeroShotNerModelTest.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/ner/dl/ZeroShotNerModelTest.scala
@@ -16,10 +16,12 @@
 
 package com.johnsnowlabs.nlp.annotators.ner.dl
 
+import com.johnsnowlabs.ml.ai.{MergeTokenStrategy, ZeroShotNerClassification}
 import com.johnsnowlabs.nlp.DocumentAssembler
 import com.johnsnowlabs.nlp.annotator._
 import com.johnsnowlabs.nlp.annotators.classifier.dl.RoBertaForQuestionAnswering
 import com.johnsnowlabs.nlp.util.io.ResourceHelper
+import com.johnsnowlabs.nlp.{Annotation, AnnotatorType}
 import com.johnsnowlabs.tags.SlowTest
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.functions._
@@ -108,7 +110,10 @@ class ZeroShotNerModelTest extends AnyFlatSpec {
     results
       .selectExpr("size(ner_chunks)", "nEntities")
       .collect()
-      .map(row => equals(row.get(0).asInstanceOf[Int], row.get(1).asInstanceOf[Int]))
+      .foreach(row =>
+        assert(
+          row.get(0).asInstanceOf[Int] == row.get(1).asInstanceOf[Int],
+          s"expected ${row.get(1)} entities, got ${row.get(0)}"))
 
     results.select("zero_shot_ner.result").show(1, false)
     results.select("ner_chunks.result").show(1, false)
@@ -116,5 +121,91 @@ class ZeroShotNerModelTest extends AnyFlatSpec {
     println(zeroShotNer.getEntityDefinitionsStr.mkString("Array(", ", ", ")"))
     println(zeroShotNer.getIgnoreEntities.mkString("Array(", ", ", ")"))
     println(zeroShotNer.getEntities.mkString("Array(", ", ", ")"))
+  }
+
+  /** Regression test for SPARKNLP-45 (#14827): `RoBertaForQuestionAnswering.batchAnnotate`
+    * switched from calling `predictSpan` once per row to `predictSpanGrouped`. `ZeroShotNerModel`
+    * overrides `predictSpan`/`tagSpan` with its own decode (character offsets, not the base
+    * class's token positions) but did not override `predictSpanGrouped`, so it silently fell
+    * through to the generic RoBERTa QA decode the moment a real batch formed. Confirms the fixed
+    * `predictSpanGrouped` matches the old per-row `predictSpan` exactly, on both compute engines
+    * \- the fix also touches the ONNX attention mask, which the TensorFlow path alone can't
+    * exercise.
+    */
+  "ZeroShotNerClassification" should "decode a batch exactly as it decodes one row at a time, on both engines" taggedAs SlowTest in {
+    val text = "My name is Clara, I live in New York and Hellen lives in Paris."
+    val questions = Seq(
+      "What is his name?",
+      "What is my name?",
+      "What is her name?",
+      "Which city?",
+      "Which is the city?")
+
+    def rows(context: Annotation): Seq[Seq[Annotation]] =
+      questions.map(q =>
+        Seq(
+          Annotation(AnnotatorType.DOCUMENT, 0, q.length, q, Map.empty[String, String]),
+          context))
+
+    val contextAtZero =
+      Annotation(AnnotatorType.DOCUMENT, 0, text.length - 1, text, Map("sentence" -> "0"))
+    val prefix = "Nothing to see here. "
+    val contextOffset = Annotation(
+      AnnotatorType.DOCUMENT,
+      prefix.length,
+      prefix.length + text.length - 1,
+      text,
+      Map("sentence" -> "1"))
+
+    // roberta_base_qa_squad2 and roberta_qa_distilroberta_base_squad_v2 are genuinely
+    // ONNX-exported checkpoints (confirmed via detectedEngine below, not assumed from their
+    // names - published checkpoints are sometimes re-exported to a different engine under the
+    // same name over time). roberta_qa_robertaABSA is genuinely TensorFlow.
+    Seq("tensorflow" -> "roberta_qa_robertaABSA", "onnx" -> "roberta_base_qa_squad2").foreach {
+      case (engine, modelName) =>
+        val qa = RoBertaForQuestionAnswering.pretrained(modelName, "en", "public/models")
+        val inner = qa.getModelIfNotSet
+        val model = new ZeroShotNerClassification(
+          inner.tensorflowWrapper,
+          inner.onnxWrapper,
+          inner.openvinoWrapper,
+          qa.sentenceStartTokenId,
+          qa.sentenceEndTokenId,
+          qa.padTokenId,
+          false,
+          configProtoBytes = qa.getConfigProtoBytes,
+          tags = Map.empty[String, Int],
+          signatures = qa.getSignatures,
+          merges = qa.merges.get.get,
+          vocabulary = qa.vocabulary.get.get)
+        assert(
+          model.detectedEngine == engine,
+          "expected detectedEngine=" + engine + " but got " + model.detectedEngine)
+
+        Seq(contextAtZero, contextOffset).foreach { context =>
+          val reference = rows(context).map(row =>
+            model
+              .predictSpan(row, 512, caseSensitive = true, MergeTokenStrategy.vocab, engine)
+              .head)
+
+          Seq(1, 2, 3, 5, 8, 16).foreach { batchSize =>
+            val batched = model
+              .predictSpanGrouped(
+                rows(context),
+                batchSize,
+                512,
+                caseSensitive = true,
+                MergeTokenStrategy.vocab,
+                engine)
+              .map(_.head)
+
+            reference.zip(batched).zip(questions).foreach { case ((r, b), q) =>
+              assert(
+                r.result == b.result && r.begin == b.begin && r.end == b.end,
+                "[" + engine + "] batchSize=" + batchSize + " question=[" + q + "]\n  expected: " + r + "\n  actual:   " + b)
+            }
+          }
+        }
+    }
   }
 }


### PR DESCRIPTION
batchAnnotate switched from predictSpan to predictSpanGrouped in #14827.
ZeroShotNerClassification overrides predictSpan/tagSpan with its own
decode but never got a matching predictSpanGrouped override, so it ran
the generic decode instead once batching kicked in. Fixed, plus the end
to end test, which computed a boolean and never asserted it, so it
always passed regardless of output.