### PR TITLE
feat: add configurable OpenAI API URL to OpenAI annotators

### DIFF
--- a/python/sparknlp/annotator/openai/openai_completion.py
+++ b/python/sparknlp/annotator/openai/openai_completion.py
@@ -55,6 +55,9 @@ class OpenAICompletion(AnnotatorModel):
       Modify the likelihood of specified tokens appearing in the completion.
    user
       A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+   apiUrl
+      Base URL of the OpenAI-compatible API. Defaults to the value of spark.jsl.settings.openai.api.url
+      or https://api.openai.com/v1.
 
    Examples
    --------
@@ -163,6 +166,26 @@ class OpenAICompletion(AnnotatorModel):
                  "user",
                  "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.",
                  typeConverter=TypeConverters.toString)
+
+    apiUrl = Param(Params._dummy(),
+                   "apiUrl",
+                   "Base URL of the OpenAI-compatible API. Defaults to the value of spark.jsl.settings.openai.api.url or https://api.openai.com/v1.",
+                   typeConverter=TypeConverters.toString)
+
+    def setApiUrl(self, value):
+        """Sets the base URL of the OpenAI-compatible API.
+
+        By default this is the value of the ``spark.jsl.settings.openai.api.url`` Spark property,
+        or ``https://api.openai.com/v1`` when the property is not set. Pointing it at an
+        OpenAI-compatible gateway (for example OrcaRouter) lets this annotator call any provider
+        that exposes the same API without changing application code.
+
+        Parameters
+        ----------
+        value : str
+           Base URL of the OpenAI-compatible API.
+        """
+        return self._set(apiUrl=value)
 
     def setModel(self, value):
         """Sets model ID of the OpenAI model to use

--- a/python/sparknlp/annotator/openai/openai_embeddings.py
+++ b/python/sparknlp/annotator/openai/openai_embeddings.py
@@ -31,6 +31,9 @@ class OpenAIEmbeddings(AnnotatorModel):
         ID of the OpenAI model to use.
     user
         A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
+    apiUrl
+        Base URL of the OpenAI-compatible API. Defaults to the value of spark.jsl.settings.openai.api.url
+        or https://api.openai.com/v1.
 
     Examples
     --------
@@ -77,6 +80,26 @@ class OpenAIEmbeddings(AnnotatorModel):
                  "user",
                  "A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.",
                  typeConverter=TypeConverters.toString)
+
+    apiUrl = Param(Params._dummy(),
+                   "apiUrl",
+                   "Base URL of the OpenAI-compatible API. Defaults to the value of spark.jsl.settings.openai.api.url or https://api.openai.com/v1.",
+                   typeConverter=TypeConverters.toString)
+
+    def setApiUrl(self, value):
+        """Sets the base URL of the OpenAI-compatible API.
+
+        By default this is the value of the ``spark.jsl.settings.openai.api.url`` Spark property,
+        or ``https://api.openai.com/v1`` when the property is not set. Pointing it at an
+        OpenAI-compatible gateway (for example OrcaRouter) lets this annotator call any provider
+        that exposes the same API without changing application code.
+
+        Parameters
+        ----------
+        value : str
+           Base URL of the OpenAI-compatible API.
+        """
+        return self._set(apiUrl=value)
 
     def setModel(self, value):
         """Sets model ID of the OpenAI model to use

--- a/src/main/scala/com/johnsnowlabs/ml/ai/OpenAICompletion.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/OpenAICompletion.scala
@@ -110,6 +110,18 @@ class OpenAICompletion(override val uid: String)
 
   def setModel(value: String): this.type = set(model, value)
 
+  val apiUrl = new Param[String](
+    this,
+    "apiUrl",
+    "Base URL of the OpenAI-compatible API. Defaults to the value of spark.jsl.settings.openai.api.url or https://api.openai.com/v1.")
+
+  def setApiUrl(value: String): this.type = set(apiUrl, value)
+
+  def getApiUrlOrDefault: String = {
+    if (isSet(apiUrl)) $(apiUrl)
+    else ConfigLoader.getConfigStringValue(ConfigHelper.openAIApiUrl)
+  }
+
   val suffix = new Param[String](
     this,
     "suffix",
@@ -286,7 +298,7 @@ class OpenAICompletion(override val uid: String)
         bestOfJson,
         logitBiasJson,
         userJson))
-    val openAIUrlCompletion = "https://api.openai.com/v1/completions"
+    val openAIUrlCompletion = getApiUrlOrDefault + "/completions"
     val annotationsCompletion = jsons.map { json =>
       val response = post(openAIUrlCompletion, json)
       Annotation(DOCUMENT, 0, response.length, response, Map())

--- a/src/main/scala/com/johnsnowlabs/ml/ai/OpenAIEmbeddings.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/OpenAIEmbeddings.scala
@@ -108,7 +108,17 @@ class OpenAIEmbeddings(override val uid: String)
       |    %s
       |}""".stripMargin
 
-  private val openAIUrlEmbeddings = "https://api.openai.com/v1/embeddings"
+  val apiUrl = new Param[String](
+    this,
+    "apiUrl",
+    "Base URL of the OpenAI-compatible API. Defaults to the value of spark.jsl.settings.openai.api.url or https://api.openai.com/v1.")
+
+  def setApiUrl(value: String): this.type = set(apiUrl, value)
+
+  def getApiUrlOrDefault: String = {
+    if (isSet(apiUrl)) $(apiUrl)
+    else ConfigLoader.getConfigStringValue(ConfigHelper.openAIApiUrl)
+  }
 
   override def beforeAnnotate(dataset: Dataset[_]): Dataset[_] = {
     this.setBearerTokenIfNotSet(
@@ -138,7 +148,7 @@ class OpenAIEmbeddings(override val uid: String)
   }
 
   private def post(jsonBody: String): Array[Float] = {
-    val httpPost = new HttpPost(openAIUrlEmbeddings)
+    val httpPost = new HttpPost(getApiUrlOrDefault + "/embeddings")
     httpPost.setEntity(new StringEntity(jsonBody, ContentType.APPLICATION_JSON))
     val bearerToken = getBearerToken
     require(bearerToken.nonEmpty, "OpenAI API Key required")

--- a/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
@@ -69,6 +69,9 @@ object ConfigHelper {
 
   val openAIAPIKey = "spark.jsl.settings.openai.api.key"
 
+  // Base URL of the OpenAI-compatible API used by OpenAI-based annotators
+  val openAIApiUrl = "spark.jsl.settings.openai.api.url"
+
   val vectorDBAPIKey = "spark.jsl.settings.vectordb.api.key"
 
   // Configs for ONNX session

--- a/src/main/scala/com/johnsnowlabs/util/ConfigLoader.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigLoader.scala
@@ -55,6 +55,7 @@ object ConfigLoader {
       getConfigInfo(ConfigHelper.awsExternalRegion, "") ++
       getConfigInfo(ConfigHelper.gcpProjectId, "") ++
       getConfigInfo(ConfigHelper.openAIAPIKey, sys.env.getOrElse("OPENAI_API_KEY", "")) ++
+      getConfigInfo(ConfigHelper.openAIApiUrl, "https://api.openai.com/v1") ++
       getConfigInfo(ConfigHelper.vectorDBAPIKey, sys.env.getOrElse("VECTORDB_API_KEY", "")) ++
       getConfigInfo(ConfigHelper.onnxGpuDeviceId, "0") ++
       getConfigInfo(ConfigHelper.onnxIntraOpNumThreads, "6") ++


### PR DESCRIPTION
Spark NLP's OpenAICompletion and OpenAIEmbeddings annotators currently hardcode `https://api.openai.com/v1`, so users can only reach the OpenAI API. This PR adds an `apiUrl` parameter to both annotators, backed by a new `spark.jsl.settings.openai.api.url` Spark property that defaults to `https://api.openai.com/v1`. Anyone running Spark NLP against an OpenAI-compatible endpoint — like [OrcaRouter](https://www.orcarouter.ai) — can now point these annotators at it with a single setter or Spark property, without touching application code.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding it as a first-class provider means Spark NLP users can use that stack directly, instead of treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The change mirrors how Spark NLP already wires provider configuration through `ConfigHelper`/`ConfigLoader` (e.g. `spark.jsl.settings.openai.api.key`). I verified the new code path against OrcaRouter's live `/v1/embeddings` endpoint (HTTP 200, 3072-dim embedding returned) and kept the default behavior identical to today for anyone not overriding the URL.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
