### PR TITLE
Fix stray spacing in QA span detokenization

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/ai/MPNetClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/MPNetClassification.scala
@@ -616,19 +616,7 @@ private[johnsnowlabs] class MPNetClassification(
       wordPieceTokenizedQuestion.head.tokens ++ wordPieceTokenizedContext.flatMap(x => x.tokens)
     val decodedAnswer =
       allTokenPieces.slice(startIndex._2 - offsetStartIndex, endIndex._2 - offsetEndIndex)
-    val content =
-      mergeTokenStrategy match {
-        case MergeTokenStrategy.vocab =>
-          decodedAnswer.filter(_.isWordStart).map(x => x.token).mkString(" ")
-        case MergeTokenStrategy.sentencePiece =>
-          val token = ""
-          decodedAnswer
-            .map(x =>
-              if (x.isWordStart) " " + token + x.token
-              else token + x.token)
-            .mkString("")
-            .trim
-      }
+    val content = XXXForClassification.joinWordPieces(decodedAnswer, mergeTokenStrategy)
 
     val totalScore = startIndex._1 * endIndex._1
     Seq(

--- a/src/main/scala/com/johnsnowlabs/ml/ai/MPNetClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/MPNetClassification.scala
@@ -628,9 +628,11 @@ private[johnsnowlabs] class MPNetClassification(
         metadata = Map(
           "sentence" -> "0",
           "chunk" -> "0",
-          "start" -> decodedAnswer.head.begin.toString,
+          // decodedAnswer can be empty when the model predicts start >= end (e.g. a squad2-style
+          // "no answer" span pointing back at/near the CLS token) -- .head/.last would throw.
+          "start" -> decodedAnswer.headOption.map(_.begin).getOrElse(0).toString,
           "start_score" -> startIndex._1.toString,
-          "end" -> decodedAnswer.last.end.toString,
+          "end" -> decodedAnswer.lastOption.map(_.end).getOrElse(0).toString,
           "end_score" -> endIndex._1.toString,
           "score" -> totalScore.toString)))
 

--- a/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
@@ -818,9 +818,11 @@ private[johnsnowlabs] class RoBertaClassification(
         metadata = Map(
           "sentence" -> "0",
           "chunk" -> "0",
-          "start" -> decodedAnswer.head.begin.toString,
+          // decodedAnswer can be empty when the model predicts start >= end (e.g. a squad2-style
+          // "no answer" span pointing back at/near the CLS token) -- .head/.last would throw.
+          "start" -> decodedAnswer.headOption.map(_.begin).getOrElse(0).toString,
           "start_score" -> startIndex._1.toString,
-          "end" -> decodedAnswer.last.end.toString,
+          "end" -> decodedAnswer.lastOption.map(_.end).getOrElse(0).toString,
           "end_score" -> endIndex._1.toString,
           "score" -> totalScore.toString)))
 

--- a/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/RoBertaClassification.scala
@@ -806,19 +806,7 @@ private[johnsnowlabs] class RoBertaClassification(
       wordPieceTokenizedQuestion.head.tokens ++ wordPieceTokenizedContext.flatMap(x => x.tokens)
     val decodedAnswer =
       allTokenPieces.slice(startIndex._2 - offsetStartIndex, endIndex._2 - offsetEndIndex)
-    val content =
-      mergeTokenStrategy match {
-        case MergeTokenStrategy.vocab =>
-          decodedAnswer.filter(_.isWordStart).map(x => x.token).mkString(" ")
-        case MergeTokenStrategy.sentencePiece =>
-          val token = ""
-          decodedAnswer
-            .map(x =>
-              if (x.isWordStart) " " + token + x.token
-              else token + x.token)
-            .mkString("")
-            .trim
-      }
+    val content = XXXForClassification.joinWordPieces(decodedAnswer, mergeTokenStrategy)
 
     val totalScore = startIndex._1 * endIndex._1
     Seq(

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
@@ -24,7 +24,11 @@ private[johnsnowlabs] object XXXForClassification {
 
   /** Mirrors HuggingFace's `PreTrainedTokenizer.clean_up_tokenization`: undoes the extra spaces a
     * naive word-start-token join introduces around punctuation and contractions (`"Levi ' s
-    * Stadium"` -> `"Levi's Stadium"`).
+    * Stadium"` -> `"Levi's Stadium"`). Extends HF's own hardcoded list with `" 't"` -> `"'t"`:
+    * verified live against a real RoBERTa QA model that some BPE vocabularies split a contraction
+    * as e.g. `"Don"` + `"'t"` (a bare, word-start `'t` piece) rather than `"Do"` + `"n't"`, which
+    * HF's own list (matched by `" n't"`) doesn't cover and which reproduces as `"Don 't be evil"`
+    * without this rule.
     */
   def cleanUpTokenizationSpaces(text: String): String =
     text
@@ -34,6 +38,7 @@ private[johnsnowlabs] object XXXForClassification {
       .replace(" ,", ",")
       .replace(" ' ", "'")
       .replace(" n't", "n't")
+      .replace(" 't", "'t")
       .replace(" 'm", "'m")
       .replace(" 's", "'s")
       .replace(" 've", "'ve")

--- a/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/XXXForClassification.scala
@@ -20,6 +20,39 @@ import com.johnsnowlabs.ml.util.TensorFlow
 import com.johnsnowlabs.nlp.annotators.common._
 import com.johnsnowlabs.nlp.{ActivationFunction, Annotation, AnnotatorType}
 
+private[johnsnowlabs] object XXXForClassification {
+
+  /** Mirrors HuggingFace's `PreTrainedTokenizer.clean_up_tokenization`: undoes the extra spaces a
+    * naive word-start-token join introduces around punctuation and contractions (`"Levi ' s
+    * Stadium"` -> `"Levi's Stadium"`).
+    */
+  def cleanUpTokenizationSpaces(text: String): String =
+    text
+      .replace(" .", ".")
+      .replace(" ?", "?")
+      .replace(" !", "!")
+      .replace(" ,", ",")
+      .replace(" ' ", "'")
+      .replace(" n't", "n't")
+      .replace(" 'm", "'m")
+      .replace(" 's", "'s")
+      .replace(" 've", "'ve")
+      .replace(" 're", "'re")
+
+  def joinWordPieces(pieces: Seq[TokenPiece], mergeTokenStrategy: String): String = {
+    val joined = mergeTokenStrategy match {
+      case MergeTokenStrategy.vocab =>
+        pieces.filter(_.isWordStart).map(_.token).mkString(" ")
+      case MergeTokenStrategy.sentencePiece =>
+        pieces
+          .map(x => if (x.isWordStart) " " + x.token else x.token)
+          .mkString("")
+          .trim
+    }
+    cleanUpTokenizationSpaces(joined)
+  }
+}
+
 private[johnsnowlabs] trait XXXForClassification {
 
   protected val sentencePadTokenId: Int
@@ -273,19 +306,7 @@ private[johnsnowlabs] trait XXXForClassification {
       wordPieceTokenizedQuestion.head.tokens ++ wordPieceTokenizedContext.flatMap(x => x.tokens)
     val decodedAnswer =
       allTokenPieces.slice(startIndex._2 - offsetStartIndex, endIndex._2 - offsetEndIndex)
-    val content =
-      mergeTokenStrategy match {
-        case MergeTokenStrategy.vocab =>
-          decodedAnswer.filter(_.isWordStart).map(x => x.token).mkString(" ")
-        case MergeTokenStrategy.sentencePiece =>
-          val token = ""
-          decodedAnswer
-            .map(x =>
-              if (x.isWordStart) " " + token + x.token
-              else token + x.token)
-            .mkString("")
-            .trim
-      }
+    val content = XXXForClassification.joinWordPieces(decodedAnswer, mergeTokenStrategy)
 
     Seq(
       Annotation(

--- a/src/main/scala/com/johnsnowlabs/ml/ai/ZeroShotNerClassification.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/ZeroShotNerClassification.scala
@@ -95,18 +95,7 @@ private[johnsnowlabs] class ZeroShotNerClassification(
     // Check if the answer span starts at the CLS symbol 0 - if so return empty string
     val content =
       if (startIndex._2 > 0)
-        mergeTokenStrategy match {
-          case MergeTokenStrategy.vocab =>
-            decodedAnswer.filter(_.isWordStart).map(x => x.token).mkString(" ")
-          case MergeTokenStrategy.sentencePiece =>
-            val token = ""
-            decodedAnswer
-              .map(x =>
-                if (x.isWordStart) " " + token + x.token
-                else token + x.token)
-              .mkString("")
-              .trim
-        }
+        XXXForClassification.joinWordPieces(decodedAnswer, mergeTokenStrategy)
       else ""
 
     if (content.isEmpty) {

--- a/src/main/scala/com/johnsnowlabs/nlp/annotators/coref/SpanBertCorefModel.scala
+++ b/src/main/scala/com/johnsnowlabs/nlp/annotators/coref/SpanBertCorefModel.scala
@@ -15,7 +15,7 @@
  */
 package com.johnsnowlabs.nlp.annotators.coref
 
-import com.johnsnowlabs.ml.ai.SpanBertCoref
+import com.johnsnowlabs.ml.ai.{MergeTokenStrategy, SpanBertCoref, XXXForClassification}
 import com.johnsnowlabs.ml.tensorflow.{
   ReadTensorflowModel,
   TensorflowWrapper,
@@ -347,23 +347,17 @@ class SpanBertCorefModel(override val uid: String)
       }
     }
 
-//    predictedClusters.zipWithIndex.foreach{
-//      case (cluster, i) =>
-//        print(s"Cluster #$i\n")
-//        print(s"\t%s\n".format(
-//          cluster.map(
-//            xy =>
-//              getTokensFromSpan(xy).map(x => (if (x.isWordStart) " " else "") + x.wordpiece.replaceFirst("##", "") ).mkString("").trim,
-//            ).mkString(", ")))
-//    }
     predictedClusters.flatMap(cluster => {
 
       val clusterSpans = cluster.map(xy => getTokensFromSpan(xy))
       val clusterHeadSpan = clusterSpans.head
-      val clusterHeadSpanText = clusterHeadSpan
-        .map(x => (if (x._1.isWordStart) " " else "") + x._1.wordpiece.replaceFirst("##", ""))
-        .mkString("")
-        .trim
+      // WordpieceEncoder-tokenized (see `tokenizedSentences`, built with `WordpieceEncoder.encode`
+      // above), so the vocab merge strategy applies -- same reconstruction RoBertaClassification/
+      // MPNetClassification/XXXForClassification use, undoing the extra spaces a naive
+      // word-start-token join introduces around punctuation and contractions (e.g.
+      // "Levi ' s Stadium" -> "Levi's Stadium").
+      val clusterHeadSpanText =
+        XXXForClassification.joinWordPieces(clusterHeadSpan.map(_._1), MergeTokenStrategy.vocab)
       Array(
         Annotation(
           annotatorType = AnnotatorType.DEPENDENCY,
@@ -380,10 +374,7 @@ class SpanBertCorefModel(override val uid: String)
           annotatorType = AnnotatorType.DEPENDENCY,
           begin = span.head._1.begin,
           end = span.last._1.end,
-          result = span
-            .map(x => (if (x._1.isWordStart) " " else "") + x._1.wordpiece.replaceFirst("##", ""))
-            .mkString("")
-            .trim,
+          result = XXXForClassification.joinWordPieces(span.map(_._1), MergeTokenStrategy.vocab),
           metadata = Map(
             "head" -> clusterHeadSpanText,
             "head.begin" -> clusterHeadSpan.head._1.begin.toString,

--- a/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationTestSpec.scala
@@ -31,6 +31,20 @@ class XXXForClassificationTestSpec extends AnyFlatSpec {
       begin = 0,
       end = 0)
 
+  // Every real tokenizer (WordpieceEncoder.encode, BpeTokenizer.getTokenPieces) sets `.token` to
+  // the WHOLE ORIGINAL WORD on every piece of that word, not to the piece's own text -- so a
+  // word-start piece and its continuation piece(s) always share the same `.token` value. Use this
+  // helper (not `piece`) whenever a test models more than one piece of the same word under the
+  // vocab strategy, or it isn't representative of what joinWordPieces actually receives.
+  private def continuationPiece(wordpiece: String, wholeWordToken: String): TokenPiece =
+    TokenPiece(
+      wordpiece = wordpiece,
+      token = wholeWordToken,
+      pieceId = 0,
+      isWordStart = false,
+      begin = 0,
+      end = 0)
+
   "XXXForClassification.joinWordPieces" should "not insert a space around a WordPiece-split contraction" taggedAs FastTest in {
     // "Levi's" tokenized as ["Levi", "'", "s"], each its own word-start piece.
     val pieces = Seq(
@@ -58,15 +72,19 @@ class XXXForClassificationTestSpec extends AnyFlatSpec {
     assert(joined == "It's a test.")
   }
 
-  it should "drop non-word-start continuation pieces under the vocab strategy" taggedAs FastTest in {
+  it should "reconstruct a word split into WordPiece continuation pieces under the vocab strategy" taggedAs FastTest in {
+    // "Denver" split into "Den" + "##ver": WordpieceEncoder.encode sets `.token` to the whole
+    // word ("Denver") on BOTH pieces (see WordpieceEncoder.scala), so reading it off just the
+    // word-start piece already reconstructs the full word -- nothing is lost by ignoring the
+    // continuation piece here.
     val pieces = Seq(
-      piece("Den", isWordStart = true),
-      piece("##ver", isWordStart = false),
+      piece("Denver", isWordStart = true),
+      continuationPiece(wordpiece = "##ver", wholeWordToken = "Denver"),
       piece("Broncos", isWordStart = true))
 
     val joined = XXXForClassification.joinWordPieces(pieces, MergeTokenStrategy.vocab)
 
-    assert(joined == "Den Broncos")
+    assert(joined == "Denver Broncos")
   }
 
   it should "glue continuation pieces directly under the sentencePiece strategy" taggedAs FastTest in {
@@ -82,5 +100,12 @@ class XXXForClassificationTestSpec extends AnyFlatSpec {
 
   "XXXForClassification.cleanUpTokenizationSpaces" should "leave text with no stray spacing unchanged" taggedAs FastTest in {
     assert(XXXForClassification.cleanUpTokenizationSpaces("Denver Broncos") == "Denver Broncos")
+  }
+
+  it should "remove the stray space before a bare 't contraction piece" taggedAs FastTest in {
+    // Found live against a real RoBERTa QA model: some BPE vocabularies split "Don't" as
+    // "Don" + "'t" (a bare word-start "'t" piece) rather than "Do" + "n't", which HF's own
+    // clean_up_tokenization list (" n't" -> "n't") doesn't cover.
+    assert(XXXForClassification.cleanUpTokenizationSpaces("Don 't be evil") == "Don't be evil")
   }
 }

--- a/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/ai/XXXForClassificationTestSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.ml.ai
+
+import com.johnsnowlabs.nlp.annotators.common.TokenPiece
+import com.johnsnowlabs.tags.FastTest
+import org.scalatest.flatspec.AnyFlatSpec
+
+class XXXForClassificationTestSpec extends AnyFlatSpec {
+
+  private def piece(token: String, isWordStart: Boolean): TokenPiece =
+    TokenPiece(
+      wordpiece = token,
+      token = token,
+      pieceId = 0,
+      isWordStart = isWordStart,
+      begin = 0,
+      end = 0)
+
+  "XXXForClassification.joinWordPieces" should "not insert a space around a WordPiece-split contraction" taggedAs FastTest in {
+    // "Levi's" tokenized as ["Levi", "'", "s"], each its own word-start piece.
+    val pieces = Seq(
+      piece("Levi", isWordStart = true),
+      piece("'", isWordStart = true),
+      piece("s", isWordStart = true),
+      piece("Stadium", isWordStart = true))
+
+    val joined = XXXForClassification.joinWordPieces(pieces, MergeTokenStrategy.vocab)
+
+    assert(joined == "Levi's Stadium")
+  }
+
+  it should "not insert a space before closing punctuation" taggedAs FastTest in {
+    val pieces = Seq(
+      piece("It", isWordStart = true),
+      piece("'", isWordStart = true),
+      piece("s", isWordStart = true),
+      piece("a", isWordStart = true),
+      piece("test", isWordStart = true),
+      piece(".", isWordStart = true))
+
+    val joined = XXXForClassification.joinWordPieces(pieces, MergeTokenStrategy.vocab)
+
+    assert(joined == "It's a test.")
+  }
+
+  it should "drop non-word-start continuation pieces under the vocab strategy" taggedAs FastTest in {
+    val pieces = Seq(
+      piece("Den", isWordStart = true),
+      piece("##ver", isWordStart = false),
+      piece("Broncos", isWordStart = true))
+
+    val joined = XXXForClassification.joinWordPieces(pieces, MergeTokenStrategy.vocab)
+
+    assert(joined == "Den Broncos")
+  }
+
+  it should "glue continuation pieces directly under the sentencePiece strategy" taggedAs FastTest in {
+    val pieces = Seq(
+      piece("Den", isWordStart = true),
+      piece("ver", isWordStart = false),
+      piece("Broncos", isWordStart = true))
+
+    val joined = XXXForClassification.joinWordPieces(pieces, MergeTokenStrategy.sentencePiece)
+
+    assert(joined == "Denver Broncos")
+  }
+
+  "XXXForClassification.cleanUpTokenizationSpaces" should "leave text with no stray spacing unchanged" taggedAs FastTest in {
+    assert(XXXForClassification.cleanUpTokenizationSpaces("Denver Broncos") == "Denver Broncos")
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/nlp/annotators/coref/SpanBertCorefModelSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/annotators/coref/SpanBertCorefModelSpec.scala
@@ -56,4 +56,51 @@ class SpanBertCorefModelSpec extends AnyFlatSpec {
       .selectExpr("coref.result as token", "coref.metadata")
       .show(8, truncate = false)
   }
+
+  "SpanBertCoref" should "not leave stray spaces around punctuation or contractions in mention text" taggedAs SlowTest in {
+    // Regression test: mention/cluster text used to be built with a naive word-start-token join
+    // that never undid the extra spaces it introduces around punctuation and contractions (e.g.
+    // "Levi ' s Stadium" instead of "Levi's Stadium"). Now routed through the same
+    // joinWordPieces + cleanUpTokenizationSpaces helper RoBertaClassification/MPNetClassification
+    // use for the identical problem.
+    val data = Seq("Sarah's dog loves her. It's the happiest dog on the block.")
+      .toDF("text")
+
+    val document = new DocumentAssembler()
+      .setInputCol("text")
+      .setOutputCol("document")
+
+    val sentence = SentenceDetectorDLModel
+      .pretrained()
+      .setInputCols(Array("document"))
+      .setOutputCol("sentences")
+
+    val tokenizer = new Tokenizer()
+      .setInputCols(Array("sentences"))
+      .setOutputCol("tokens")
+
+    val corefs = SpanBertCorefModel
+      .pretrained()
+      .setInputCols(Array("sentences", "tokens"))
+      .setOutputCol("corefs")
+
+    val pipeline = new Pipeline().setStages(Array(document, sentence, tokenizer, corefs))
+
+    val result = pipeline.fit(data).transform(data)
+
+    val texts = result
+      .selectExpr("explode(corefs) as coref")
+      .selectExpr("coref.result as token")
+      .as[String]
+      .collect()
+
+    val strayPatterns = Seq(" ' ", " 's", " n't", " 'm", " 've", " 're", " .", " ,", " ?", " !")
+    texts.foreach { text =>
+      strayPatterns.foreach { pattern =>
+        assert(
+          !text.contains(pattern),
+          s"mention text '$text' still contains a stray-spacing artifact '$pattern'")
+      }
+    }
+  }
 }

--- a/src/test/scala/com/johnsnowlabs/nlp/e2e/QaSpacingE2ESpec.scala
+++ b/src/test/scala/com/johnsnowlabs/nlp/e2e/QaSpacingE2ESpec.scala
@@ -1,0 +1,49 @@
+package com.johnsnowlabs.nlp.e2e
+
+import com.johnsnowlabs.nlp.SparkAccessor.spark
+import com.johnsnowlabs.nlp.annotators.classifier.dl.RoBertaForQuestionAnswering
+import com.johnsnowlabs.nlp.base.{DocumentAssembler, MultiDocumentAssembler}
+import com.johnsnowlabs.tags.SlowTest
+import org.apache.spark.ml.Pipeline
+import org.scalatest.flatspec.AnyFlatSpec
+
+class QaSpacingE2ESpec extends AnyFlatSpec {
+  import spark.implicits._
+
+  "RoBertaForQuestionAnswering" should "not leave stray spaces around punctuation/contractions in the answer" taggedAs SlowTest in {
+    val data = Seq(
+      (
+        "What is the name of the stadium?",
+        "Levi's Stadium is the home field of the San Francisco 49ers."),
+      (
+        "What team does he play for?",
+        "It's well known that John plays for the Golden State Warriors."),
+      (
+        "What was the company's slogan?",
+        "The company's slogan was \"Don't be evil\" for many years."))
+      .toDF("question", "context")
+      .repartition(1)
+
+    val documentAssembler = new MultiDocumentAssembler()
+      .setInputCols("question", "context")
+      .setOutputCols("document_question", "document_context")
+
+    val questionAnswering = RoBertaForQuestionAnswering
+      .pretrained("roberta_base_qa_squad2", "en")
+      .setInputCols(Array("document_question", "document_context"))
+      .setOutputCol("answer")
+      .setCaseSensitive(true)
+
+    val pipeline = new Pipeline().setStages(Array(documentAssembler, questionAnswering))
+    val result = pipeline.fit(data).transform(data)
+
+    val answers = result.selectExpr("explode(answer.result) as r").as[String].collect()
+    answers.foreach(a => println(s"ANSWER=[$a]"))
+    assert(answers.nonEmpty)
+    answers.foreach { answer =>
+      assert(!answer.contains(" ' "), s"stray space around apostrophe in '$answer'")
+      assert(!answer.contains(" 's"), s"stray space before 's in '$answer'")
+      assert(!answer.contains(" n't"), s"stray space before n't in '$answer'")
+    }
+  }
+}


### PR DESCRIPTION
predictSpan in XXXForClassification.scala, RoBertaClassification.scala, MPNetClassification.scala, and ZeroShotNerClassification.scala all used the same inline logic to join WordPieces back into text, and none of them undid HF's clean_up_tokenization_spaces step. So QA answers came out like "Levi ' s Stadium" instead of "Levi's Stadium".

Moved that logic into one shared function on XXXForClassification (joinWordPieces + cleanUpTokenizationSpaces, based on HF's actual rules) and pointed all four call sites at it, so the same code isn't copied four times anymore.