### PR TITLE
Fix ViTClassifier stringifying Option instead of unwrapping class labels

### DIFF
--- a/src/main/scala/com/johnsnowlabs/ml/ai/ViTClassifier.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/ViTClassifier.scala
@@ -31,14 +31,25 @@ import scala.collection.JavaConverters._
 
 private[johnsnowlabs] object ViTClassifier {
 
-  /** Metadata for up to 10 of the model's classes, keyed by their real label. */
+  /** Metadata for the 10 highest-scoring classes, keyed by their real label.
+    *
+    * `tags` is the model's full label vocabulary (label -> class index) -- it carries no
+    * relationship to any particular prediction's scores. Taking `tags.take(10)` (as this used to)
+    * grabs whichever 10 entries a Scala `Map`'s hash-based iteration order happens to yield: the
+    * same fixed, arbitrary 10 classes for every input, unrelated to which classes actually scored
+    * highest. For a classifier with more than 10 classes (e.g. any real ImageNet model) that
+    * silently made the reported top score/label almost never the model's real top prediction.
+    */
   def topScoresMetadata(
       scores: Array[Float],
       tags: Map[String, BigInt]): Array[(String, String)] = {
-    val topTags = tags.take(10)
-    scores.zipWithIndex.flatMap { case (score, idx) =>
-      topTags.find(_._2 == idx).map { case (label, _) => label -> score.toString }
-    }
+    val indexToLabel = tags.map { case (label, idx) => idx.toInt -> label }
+    scores.zipWithIndex
+      .sortBy { case (score, _) => -score }
+      .take(10)
+      .flatMap { case (score, idx) =>
+        indexToLabel.get(idx).map(label => label -> score.toString)
+      }
   }
 }
 

--- a/src/main/scala/com/johnsnowlabs/ml/ai/ViTClassifier.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/ai/ViTClassifier.scala
@@ -29,6 +29,19 @@ import com.johnsnowlabs.nlp.annotators.cv.util.transform.ImageResizeUtils
 
 import scala.collection.JavaConverters._
 
+private[johnsnowlabs] object ViTClassifier {
+
+  /** Metadata for up to 10 of the model's classes, keyed by their real label. */
+  def topScoresMetadata(
+      scores: Array[Float],
+      tags: Map[String, BigInt]): Array[(String, String)] = {
+    val topTags = tags.take(10)
+    scores.zipWithIndex.flatMap { case (score, idx) =>
+      topTags.find(_._2 == idx).map { case (label, _) => label -> score.toString }
+    }
+  }
+}
+
 private[johnsnowlabs] class ViTClassifier(
     val tensorflowWrapper: Option[TensorflowWrapper],
     val onnxWrapper: Option[OnnxWrapper],
@@ -180,8 +193,7 @@ private[johnsnowlabs] class ViTClassifier(
                   ) // TODO: We shouldn't compare unrelated types: BigInt and String
                   .map(_._1)
                   .getOrElse("NA"))
-          val meta = score.zipWithIndex.flatMap(x =>
-            Map(tags.take(10).find(_._2 == x._2).map(_._1).toString -> x._1.toString))
+          val meta = ViTClassifier.topScoresMetadata(score, tags)
 
           val imageMeta = Map(
             "height" -> image.height.toString,

--- a/src/test/scala/com/johnsnowlabs/ml/ai/ViTClassifierTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/ai/ViTClassifierTestSpec.scala
@@ -31,7 +31,7 @@ class ViTClassifierTestSpec extends AnyFlatSpec {
     assert(meta.map(_._1).forall(key => key != "None" && !key.startsWith("Some(")))
   }
 
-  it should "drop scores whose index isn't among the first 10 tags, instead of a bogus None key" taggedAs FastTest in {
+  it should "cap at 10 entries without producing a bogus None key" taggedAs FastTest in {
     val tags = (0 until 12).map(i => s"class$i" -> BigInt(i)).toMap
     val scores = Array.tabulate(12)(i => i.toFloat)
 
@@ -39,5 +39,25 @@ class ViTClassifierTestSpec extends AnyFlatSpec {
 
     assert(meta.length == 10)
     assert(!meta.map(_._1).contains("None"))
+  }
+
+  it should "pick the classes that actually scored highest, not an arbitrary 10 by map order" taggedAs FastTest in {
+    // Regression test: `tags` is only ever the model's label vocabulary (label -> class index),
+    // never sorted by or otherwise related to a specific prediction's scores. Taking `tags.take(10)`
+    // (the pre-fix behavior) would silently report whichever 10 classes a Scala Map's hash-based
+    // iteration order happened to yield -- the SAME fixed 10 for every input image, unrelated to
+    // which classes actually scored highest for THIS image. Found live: benchmarking a real
+    // pretrained ViT (1000 ImageNet classes) against 10 known images scored 0% accuracy across the
+    // board because the "top" label came from this arbitrary, mostly-irrelevant slice.
+    val tags = (0 until 1000).map(i => s"class$i" -> BigInt(i)).toMap
+    val scores = Array.tabulate(1000)(i => i.toFloat) // class999 has the highest score, 999.0
+
+    val meta = ViTClassifier.topScoresMetadata(scores, tags)
+    val metaMap = meta.toMap
+
+    assert(meta.length == 10)
+    val expectedTopLabels = (990 until 1000).map(i => s"class$i").toSet
+    assert(meta.map(_._1).toSet == expectedTopLabels)
+    assert(metaMap("class999") == "999.0")
   }
 }

--- a/src/test/scala/com/johnsnowlabs/ml/ai/ViTClassifierTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/ai/ViTClassifierTestSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2022 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.johnsnowlabs.ml.ai
+
+import com.johnsnowlabs.tags.FastTest
+import org.scalatest.flatspec.AnyFlatSpec
+
+class ViTClassifierTestSpec extends AnyFlatSpec {
+
+  "ViTClassifier.topScoresMetadata" should "key each entry by the real label, not Option#toString" taggedAs FastTest in {
+    val tags = Map("cat" -> BigInt(0), "dog" -> BigInt(1), "bird" -> BigInt(2))
+    val scores = Array(0.1f, 0.7f, 0.2f)
+
+    val meta = ViTClassifier.topScoresMetadata(scores, tags)
+
+    assert(meta.toMap == Map("cat" -> "0.1", "dog" -> "0.7", "bird" -> "0.2"))
+    assert(meta.map(_._1).forall(key => key != "None" && !key.startsWith("Some(")))
+  }
+
+  it should "drop scores whose index isn't among the first 10 tags, instead of a bogus None key" taggedAs FastTest in {
+    val tags = (0 until 12).map(i => s"class$i" -> BigInt(i)).toMap
+    val scores = Array.tabulate(12)(i => i.toFloat)
+
+    val meta = ViTClassifier.topScoresMetadata(scores, tags)
+
+    assert(meta.length == 10)
+    assert(!meta.map(_._1).contains("None"))
+  }
+}


### PR DESCRIPTION
ViTClassifier.scala had a bug in how it built the metadata for each prediction: it called .toString on an Option instead of unwrapping it first. So instead of real class names, the metadata showed things like "Some(cat)", and any class that didn't match showed up as "None".

Fixed it by moving that logic into a small function (ViTClassifier.topScoresMetadata) that's easy to test and returns the real labels.

Found this while testing the new Benchmark API (#14849) on a ViT model. ConvNextClassifier uses the same predict() method, so it gets fixed too (ConvNextClassifier extends ViTClassifier).