### PR TITLE
Add Databricks retrieval benchmark notebook

### DIFF
--- a/examples/python/annotation/text/english/text-similarity/high-volume-retrieval/BEIR_HotpotQA_Databricks_Benchmark.ipynb
+++ b/examples/python/annotation/text/english/text-similarity/high-volume-retrieval/BEIR_HotpotQA_Databricks_Benchmark.ipynb
@@ -1,0 +1,3404 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "1db22085-2d7d-4afa-8e40-68c76ae3a4f3",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "# Scalable semantic document retrieval with BEIR HotpotQA\n",
+    "\n",
+    "This notebook measures how Spark NLP semantic retrieval changes as a Databricks cluster\n",
+    "gains workers. It uses the same real BEIR HotpotQA data as the Colab walkthrough, but\n",
+    "stores data and embeddings in a shared Unity Catalog Volume so every worker can\n",
+    "participate.\n",
+    "\n",
+    "The workflow is:\n",
+    "\n",
+    "1. Prepare the real HotpotQA corpus in a Unity Catalog Volume once.\n",
+    "2. Select qrel-backed questions and a reproducible corpus sample.\n",
+    "3. Embed passages in parallel with E5 and store embeddings in Delta.\n",
+    "4. Broadcast the small query batch and score query-passage pairs with\n",
+    "   `PairwiseVectorSimilarity`.\n",
+    "5. Rank the top passages, measure Recall@K, and save a benchmark result.\n",
+    "\n",
+    "## How to demonstrate scalability\n",
+    "\n",
+    "Run this notebook on otherwise identical clusters with **1, 2, 4, and 8 workers**.\n",
+    "Keep the corpus size, query count, top-K, model, and `partition_count` unchanged.\n",
+    "Compare the saved median latency and embedding throughput. Start at 100K passages and\n",
+    "10 queries (1 million exact comparisons), then use the full corpus with 10 queries\n",
+    "(roughly 52 million comparisons).\n",
+    "\n",
+    "> This notebook is an **exact-retrieval** benchmark: every selected query is compared\n",
+    "> with every selected passage. It establishes quality and scale-out baselines. For large\n",
+    "> query batches, use BM25, LSH, or ANN candidate generation before semantic reranking.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "8791e444-0086-4cc9-8365-df1992d7f5a7",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 1. Install the Spark NLP artifacts\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788324560002,
+     "inputWidgets": {},
+     "nuid": "0ca15aef-a3a8-46a6-a92a-dd3f12bb554a",
+     "showTitle": false,
+     "startTime": 1788324547003,
+     "submitTime": 1788324525384,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processing /Volumes/main/default/libsahmed/spark_nlp-6.4.2-py2.py3-none-any.whl\nInstalling collected packages: spark-nlp\nSuccessfully installed spark-nlp-6.4.2\n\u001B[43mNote: you may need to restart the kernel using %restart_python or dbutils.library.restartPython() to use updated packages.\u001B[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    " %pip install spark-nlp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788324565638,
+     "inputWidgets": {},
+     "nuid": "b6e3ecd5-c0af-4773-9cc6-92570abbb7b1",
+     "showTitle": false,
+     "startTime": 1788324560088,
+     "submitTime": 1788324532902,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dbutils.library.restartPython()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "bf97099c-9abb-4827-b79c-b41d801a18c8",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 2. Import the retrieval libraries\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788324566136,
+     "inputWidgets": {},
+     "nuid": "d08c574a-3f8a-4ac6-9299-0c516aaff7c4",
+     "showTitle": false,
+     "startTime": 1788324565667,
+     "submitTime": 1788324533554,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Spark version: 3.5.2\nDefault parallelism: 16\n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import shutil\n",
+    "import statistics\n",
+    "import time\n",
+    "from datetime import datetime, timezone\n",
+    "from pathlib import Path\n",
+    "from urllib.request import urlretrieve\n",
+    "from zipfile import ZipFile\n",
+    "\n",
+    "from pyspark import StorageLevel\n",
+    "from pyspark.ml import Pipeline\n",
+    "from pyspark.sql import functions as F\n",
+    "from pyspark.sql.types import (\n",
+    "    ArrayType,\n",
+    "    BooleanType,\n",
+    "    DoubleType,\n",
+    "    LongType,\n",
+    "    StringType,\n",
+    "    StructField,\n",
+    "    StructType,\n",
+    ")\n",
+    "from pyspark.sql.window import Window\n",
+    "from sparknlp.annotator import E5Embeddings, PairwiseVectorSimilarity\n",
+    "from sparknlp.base import DocumentAssembler\n",
+    "\n",
+    "print(\"Spark version:\", spark.version)\n",
+    "print(\"Default parallelism:\", spark.sparkContext.defaultParallelism)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "31bce36a-52a3-4d25-a73f-866a0fcc45f7",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 3. Configure the shared Unity Catalog Volume\n",
+    "\n",
+    "Update `data_volume` in the next cell to point to a Unity Catalog Volume that is\n",
+    "writable by you. This Volume holds the downloaded HotpotQA files, Delta embeddings,\n",
+    "and benchmark results. It can be the same Volume containing the JAR and wheel.\n",
+    "Do not use restricted `dbfs:/FileStore` storage with this access mode.\n",
+    "\n",
+    "You need `READ VOLUME` and `WRITE VOLUME` permissions on this Volume.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788324568241,
+     "inputWidgets": {},
+     "nuid": "06618460-a0b1-4563-b7f9-30e7da852c8b",
+     "showTitle": false,
+     "startTime": 1788324566162,
+     "submitTime": 1788324533922,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shared benchmark data Volume: /Volumes/main/default/libsahmed\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Update this path to your Unity Catalog Volume.\n",
+    "# This Volume holds raw HotpotQA data, Delta embeddings, and benchmark results.\n",
+    "# It can be the same Volume where you uploaded the JAR and wheel.\n",
+    "data_volume = \"/Volumes/main/default\"\n",
+    "\n",
+    "RAW_ROOT = f\"{data_volume}/beir/hotpotqa/raw\"\n",
+    "DELTA_ROOT = f\"{data_volume}/beir/hotpotqa/delta\"\n",
+    "RESULTS_PATH = f\"{DELTA_ROOT}/benchmark-results\"\n",
+    "LOCAL_ARCHIVE = Path(\"/local_disk0/tmp/hotpotqa.zip\")\n",
+    "LOCAL_EXTRACTION = Path(\"/local_disk0/tmp/beir\")\n",
+    "BEIR_URL = \"https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/hotpotqa.zip\"\n",
+    "\n",
+    "print(\"Shared benchmark data Volume:\", data_volume)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "19ae5531-90f3-4d93-81d3-8d803042ce9d",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 4. Download HotpotQA to the shared Unity Catalog Volume once\n",
+    "\n",
+    "The first run downloads the official BEIR archive to the driver and copies the three\n",
+    "required files to the configured Unity Catalog Volume. The Volume is shared by the\n",
+    "cluster, so later benchmark runs—on this or another cluster—reuse the same data.\n",
+    "Download time is deliberately excluded from all benchmark measurements.\n",
+    "\n",
+    "You need `READ VOLUME` and `WRITE VOLUME` permissions for `data_volume`. If this cell\n",
+    "reports an access error, ask a workspace administrator to grant those permissions or use\n",
+    "a writable Volume. Set `prepare_raw_data=True` only for the first run; afterwards, set it\n",
+    "to `False` to reuse the shared copy.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788324699330,
+     "inputWidgets": {},
+     "nuid": "a999854c-ce79-496b-822c-5a7f053bcda2",
+     "showTitle": false,
+     "startTime": 1788324568264,
+     "submitTime": 1788324534432,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HotpotQA is ready in: /Volumes/main/default/libsahmed/beir/hotpotqa/raw\n"
+     ]
+    }
+   ],
+   "source": [
+    "prepare_raw_data = True\n",
+    "\n",
+    "if prepare_raw_data:\n",
+    "    LOCAL_EXTRACTION.mkdir(parents=True, exist_ok=True)\n",
+    "    urlretrieve(BEIR_URL, LOCAL_ARCHIVE)\n",
+    "    with ZipFile(LOCAL_ARCHIVE) as archive:\n",
+    "        archive.extractall(LOCAL_EXTRACTION)\n",
+    "    raw_root_path = Path(RAW_ROOT)\n",
+    "    raw_root_path.mkdir(parents=True, exist_ok=True)\n",
+    "    for relative_path in (\"corpus.jsonl\", \"queries.jsonl\", \"qrels/test.tsv\"):\n",
+    "        source = LOCAL_EXTRACTION / \"hotpotqa\" / relative_path\n",
+    "        destination = raw_root_path / relative_path\n",
+    "        destination.parent.mkdir(parents=True, exist_ok=True)\n",
+    "        shutil.copy2(source, destination)\n",
+    "\n",
+    "print(\"HotpotQA is ready in:\", RAW_ROOT)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "15cf5431-c925-494c-86cc-3b2cf2d0d56a",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 5. Load the searchable passages, questions, and answer key\n",
+    "\n",
+    "BEIR supplies `corpus.jsonl` (passages), `queries.jsonl` (questions), and\n",
+    "`qrels/test.tsv` (relevance judgments). We rename their columns to make the retrieval\n",
+    "pipeline easier to read:\n",
+    "\n",
+    "- `chunk_id` and `chunk_text`: the searchable passage.\n",
+    "- `query_id` and `query_text`: the search request.\n",
+    "- Positive qrels: passages known to be relevant to a query.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788324745906,
+     "inputWidgets": {},
+     "nuid": "7c835dd8-4e2c-42a0-92b6-9c17bc4ae376",
+     "showTitle": false,
+     "startTime": 1788324699357,
+     "submitTime": 1788324536157,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Available passages: 5,233,329\nAvailable queries: 97,852\nPositive relevance labels: 14,810\n"
+     ]
+    }
+   ],
+   "source": [
+    "corpus = (\n",
+    "    spark.read.json(f\"{RAW_ROOT}/corpus.jsonl\")\n",
+    "    .select(\n",
+    "        F.col(\"_id\").alias(\"chunk_id\"),\n",
+    "        F.coalesce(F.col(\"title\"), F.lit(\"\")).alias(\"title\"),\n",
+    "        F.col(\"text\").alias(\"chunk_text\"),\n",
+    "    )\n",
+    ")\n",
+    "queries = (\n",
+    "    spark.read.json(f\"{RAW_ROOT}/queries.jsonl\")\n",
+    "    .select(F.col(\"_id\").alias(\"query_id\"), F.col(\"text\").alias(\"query_text\"))\n",
+    ")\n",
+    "positive_qrels = (\n",
+    "    spark.read.option(\"header\", True).option(\"sep\", \"\\t\")\n",
+    "    .csv(f\"{RAW_ROOT}/qrels/test.tsv\")\n",
+    "    .select(\n",
+    "        F.col(\"query-id\").alias(\"query_id\"),\n",
+    "        F.col(\"corpus-id\").alias(\"chunk_id\"),\n",
+    "        F.col(\"score\").cast(\"int\").alias(\"relevance\"),\n",
+    "    )\n",
+    "    .where(F.col(\"relevance\") > 0)\n",
+    ")\n",
+    "\n",
+    "print(f\"Available passages: {corpus.count():,}\")\n",
+    "print(f\"Available queries: {queries.count():,}\")\n",
+    "print(f\"Positive relevance labels: {positive_qrels.count():,}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "5119f4d1-3f5a-4828-8657-4200834bc502",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 6. Choose parameters for this benchmark run\n",
+    "\n",
+    "Edit the plain values in the next cell . For fair 1-, 2-,\n",
+    "4-, and 8-worker comparisons, keep every value except `run_label` fixed. Keep\n",
+    "`partition_count=128` fixed as well: it gives every cluster the same number of corpus\n",
+    "tasks, while larger clusters can run more of them concurrently.\n",
+    "\n",
+    "Use `rebuild_embeddings=True` when measuring distributed embedding throughput. Set it to\n",
+    "`False` for retrieval-only comparisons that reuse the saved Delta embeddings.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788324746065,
+     "inputWidgets": {},
+     "nuid": "7c32d0d4-2d21-438d-bdc8-83eed7b39b91",
+     "showTitle": false,
+     "startTime": 1788324745939,
+     "submitTime": 1788324537127,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n  \"run_label\": \"workers-4\",\n  \"corpus_size\": \"100000\",\n  \"query_count\": 10,\n  \"top_k\": 10,\n  \"partition_count\": 128,\n  \"rebuild_embeddings\": true\n}\n"
+     ]
+    }
+   ],
+   "source": [
+    "corpus_size = \"100000\"  # Choose \"10000\", \"100000\", or \"full\".\n",
+    "query_count = 10\n",
+    "top_k = 10\n",
+    "partition_count = 128\n",
+    "run_label = \"workers-4\"\n",
+    "rebuild_embeddings = True\n",
+    "\n",
+    "if query_count < 1 or top_k < 1 or partition_count < 1:\n",
+    "    raise ValueError(\"query_count, top_k, and partition_count must be positive.\")\n",
+    "\n",
+    "print(\n",
+    "    json.dumps(\n",
+    "        {\n",
+    "            \"run_label\": run_label,\n",
+    "            \"corpus_size\": corpus_size,\n",
+    "            \"query_count\": query_count,\n",
+    "            \"top_k\": top_k,\n",
+    "            \"partition_count\": partition_count,\n",
+    "            \"rebuild_embeddings\": rebuild_embeddings,\n",
+    "        },\n",
+    "        indent=2,\n",
+    "    )\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "f31df6d0-909b-46bb-a753-ead8b198badd",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 7. Choose queries with known relevant passages\n",
+    "\n",
+    "We select a deterministic batch of questions with positive qrels. Keeping the same query\n",
+    "batch for every worker-count run makes Recall@K and latency directly comparable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788324754984,
+     "inputWidgets": {},
+     "nuid": "efab053d-e1cf-462f-873d-5a66daa27d30",
+     "showTitle": false,
+     "startTime": 1788324746084,
+     "submitTime": 1788324538006,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Selected queries: 10\nPositive qrels retained: 20\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>query_id</th><th>query_text</th></tr></thead><tbody><tr><td>5a70eee85542994082a3e3f0</td><td>Which group of people in West Africa with significant populations in Ghana, Ivory Coast, Liberia and Sierra Leone use the Ida?</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>Which dialect spoken in the province of Scania calls Spettekaka, \"spiddekaga\"?</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>Which of these universities, Northwestern University or Johns Hopkins University, have a campus outside of the United States territories?</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>Which dog breed, the Schapendoes or the Bull Terrier, has its origins in a greater number of other dog breeds?</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>Which piece did Ludwig van Beethoven publish in 1801 that was dedicated to Count Moritz von Fries?</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>What is the name of the independent candidate in Maine's 2010 gubernatorial race who finished ahead of Libby Mitchell?</td></tr><tr><td>5a70f4695542994082a3e435</td><td>Which canal was built between 1836 and 1847, Washington City Canal or Whitewater Canal?</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>Which Italian-American composer and librettist wrote the English language opera, Maria Golovin?</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>Renamed in 2014, what was the vehicle offered as a prize to contestants on the first season of The Amazing Race Canada?</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>Which magazine is published more in a year, Essence or Alt for Damerne?</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         "5a70eee85542994082a3e3f0",
+         "Which group of people in West Africa with significant populations in Ghana, Ivory Coast, Liberia and Sierra Leone use the Ida?"
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         "Which dialect spoken in the province of Scania calls Spettekaka, \"spiddekaga\"?"
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         "Which of these universities, Northwestern University or Johns Hopkins University, have a campus outside of the United States territories?"
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         "Which dog breed, the Schapendoes or the Bull Terrier, has its origins in a greater number of other dog breeds?"
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         "Which piece did Ludwig van Beethoven publish in 1801 that was dedicated to Count Moritz von Fries?"
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         "What is the name of the independent candidate in Maine's 2010 gubernatorial race who finished ahead of Libby Mitchell?"
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         "Which canal was built between 1836 and 1847, Washington City Canal or Whitewater Canal?"
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         "Which Italian-American composer and librettist wrote the English language opera, Maria Golovin?"
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         "Renamed in 2014, what was the vehicle offered as a prize to contestants on the first season of The Amazing Race Canada?"
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         "Which magazine is published more in a year, Essence or Alt for Damerne?"
+        ]
+       ],
+       "datasetInfos": [],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {},
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "query_id",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "query_text",
+         "type": "\"string\""
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "selected_query_ids = (\n",
+    "    positive_qrels.select(\"query_id\").distinct().orderBy(\"query_id\").limit(query_count)\n",
+    ")\n",
+    "selected_queries = (\n",
+    "    queries.join(selected_query_ids, \"query_id\")\n",
+    "    .persist(StorageLevel.MEMORY_AND_DISK)\n",
+    ")\n",
+    "selected_qrels = (\n",
+    "    positive_qrels.join(selected_query_ids, \"query_id\")\n",
+    "    .select(\"query_id\", \"chunk_id\")\n",
+    "    .persist(StorageLevel.MEMORY_AND_DISK)\n",
+    ")\n",
+    "\n",
+    "actual_query_count = selected_queries.count()\n",
+    "print(f\"Selected queries: {actual_query_count}\")\n",
+    "print(f\"Positive qrels retained: {selected_qrels.count()}\")\n",
+    "display(selected_queries.orderBy(\"query_id\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "0ecda544-b8fe-42bf-aac7-2876794db001",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 8. Build the corpus for this benchmark run\n",
+    "\n",
+    "`full` uses every HotpotQA passage. The 10K and 100K modes always retain all passages\n",
+    "judged relevant to the selected queries, then add unrelated passages based on a stable\n",
+    "hash of `chunk_id`. This preserves the answer key while ensuring every rerun receives\n",
+    "the same corpus.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788324770620,
+     "inputWidgets": {},
+     "nuid": "f0573df9-c370-4a9b-b671-05b91c57caa5",
+     "showTitle": false,
+     "startTime": 1788324755126,
+     "submitTime": 1788324538417,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Benchmark passages: 100,000\nQueries: 10\nExact query-passage comparisons per retrieval run: 1,000,000\nFixed corpus partitions: 128\n"
+     ]
+    }
+   ],
+   "source": [
+    "relevant_chunk_ids = selected_qrels.select(\"chunk_id\").distinct()\n",
+    "target_passages = None\n",
+    "\n",
+    "if corpus_size == \"full\":\n",
+    "    benchmark_corpus = corpus.repartition(partition_count)\n",
+    "else:\n",
+    "    target_passages = int(corpus_size)\n",
+    "    relevant_chunks = corpus.join(relevant_chunk_ids, \"chunk_id\")\n",
+    "    relevant_count = relevant_chunks.count()\n",
+    "    if relevant_count >= target_passages:\n",
+    "        raise ValueError(\n",
+    "            f\"{relevant_count} relevant passages exceed requested corpus size {target_passages}.\"\n",
+    "        )\n",
+    "    distractors = (\n",
+    "        corpus.join(relevant_chunk_ids, \"chunk_id\", \"left_anti\")\n",
+    "        .where(F.pmod(F.xxhash64(\"chunk_id\"), F.lit(10_000)) < 500)\n",
+    "        .limit(target_passages - relevant_count)\n",
+    "    )\n",
+    "    benchmark_corpus = relevant_chunks.unionByName(distractors).repartition(\n",
+    "        partition_count\n",
+    "    )\n",
+    "\n",
+    "benchmark_corpus = benchmark_corpus.persist(StorageLevel.MEMORY_AND_DISK)\n",
+    "corpus_count = benchmark_corpus.count()\n",
+    "if target_passages and corpus_count != target_passages:\n",
+    "    raise RuntimeError(\n",
+    "        f\"Expected {target_passages} passages after sampling, found {corpus_count}.\"\n",
+    "    )\n",
+    "\n",
+    "pair_count = corpus_count * actual_query_count\n",
+    "print(f\"Benchmark passages: {corpus_count:,}\")\n",
+    "print(f\"Queries: {actual_query_count:,}\")\n",
+    "print(f\"Exact query-passage comparisons per retrieval run: {pair_count:,}\")\n",
+    "print(f\"Fixed corpus partitions: {benchmark_corpus.rdd.getNumPartitions()}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "aafd7f99-363e-4335-b2d5-aa576daa8cee",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 9. Create the E5 embedding pipeline\n",
+    "\n",
+    "E5 converts text into numerical embeddings that represent meaning. The `passage: ` and\n",
+    "`query: ` prefixes tell E5 whether the input is searchable content or a search request.\n",
+    "The same fitted pipeline is used for both, so vectors share the same representation.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788324798889,
+     "inputWidgets": {},
+     "nuid": "f8cabf7a-b85c-4e9f-8743-396d034fda49",
+     "showTitle": false,
+     "startTime": 1788324770648,
+     "submitTime": 1788324538975,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "e5_small_v2 download started this may take some time.\nApproximate size to download 76.2 MB\n\r[ | ]\r[ / ]\r[ — ]\r[ \\ ]\r[OK!]\nEmbedding model: e5_small_v2\n"
+     ]
+    }
+   ],
+   "source": [
+    "document_assembler = (\n",
+    "    DocumentAssembler().setInputCol(\"text\").setOutputCol(\"document\")\n",
+    ")\n",
+    "e5_embeddings = (\n",
+    "    E5Embeddings.pretrained(\"e5_small_v2\", \"en\")\n",
+    "    .setInputCols([\"document\"])\n",
+    "    .setOutputCol(\"embeddings\")\n",
+    ")\n",
+    "embedding_pipeline = Pipeline(stages=[document_assembler, e5_embeddings])\n",
+    "embedding_model = embedding_pipeline.fit(\n",
+    "    benchmark_corpus.select(\n",
+    "        F.concat(F.lit(\"passage: \"), F.col(\"chunk_text\")).alias(\"text\")\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "print(\"Embedding model: e5_small_v2\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "ae3cd338-419d-4c0f-a898-6932b71651e4",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 10. Embed passages and persist the distributed index as Delta\n",
+    "\n",
+    "Set `rebuild_embeddings=True` to measure indexing speed. Spark partitions the corpus and\n",
+    "sends embedding work to the cluster executors. The completed vectors are written as a\n",
+    "Delta table, allowing retrieval-only worker-count runs to reuse the exact same vectors.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788326304387,
+     "inputWidgets": {},
+     "nuid": "6f939354-0513-4eaa-98d3-b233d8e06492",
+     "showTitle": false,
+     "startTime": 1788324798920,
+     "submitTime": 1788324539447,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Corpus embedding time: 1498.452 seconds\nCorpus embedding throughput: 66.74 passages/second\nEmbedding index partitions: 128\n"
+     ]
+    }
+   ],
+   "source": [
+    "embedding_path = (\n",
+    "    f\"{DELTA_ROOT}/embeddings-{corpus_size}-{query_count}-queries-{partition_count}-partitions\"\n",
+    ")\n",
+    "embedding_seconds = None\n",
+    "\n",
+    "if rebuild_embeddings:\n",
+    "    embedding_started = time.perf_counter()\n",
+    "    corpus_embeddings_to_save = (\n",
+    "        embedding_model.transform(\n",
+    "            benchmark_corpus.withColumn(\n",
+    "                \"text\", F.concat(F.lit(\"passage: \"), F.col(\"chunk_text\"))\n",
+    "            )\n",
+    "        )\n",
+    "        .select(\n",
+    "            \"chunk_id\",\n",
+    "            \"title\",\n",
+    "            \"chunk_text\",\n",
+    "            F.col(\"embeddings\").alias(\"chunk_embeddings\"),\n",
+    "        )\n",
+    "    )\n",
+    "    corpus_embeddings_to_save.write.format(\"delta\").mode(\"overwrite\").save(\n",
+    "        embedding_path\n",
+    "    )\n",
+    "    embedding_seconds = time.perf_counter() - embedding_started\n",
+    "    print(f\"Corpus embedding time: {embedding_seconds:.3f} seconds\")\n",
+    "    print(\n",
+    "        f\"Corpus embedding throughput: {corpus_count / embedding_seconds:.2f} passages/second\"\n",
+    "    )\n",
+    "\n",
+    "corpus_embeddings = (\n",
+    "    spark.read.format(\"delta\").load(embedding_path)\n",
+    "    .repartition(partition_count)\n",
+    "    .persist(StorageLevel.MEMORY_AND_DISK)\n",
+    ")\n",
+    "corpus_embeddings.count()\n",
+    "print(f\"Embedding index partitions: {corpus_embeddings.rdd.getNumPartitions()}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "8e857cf4-4c16-44af-bd78-2d178ca64518",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 11. Embed the query batch\n",
+    "\n",
+    "There are only a few queries, so this phase is normally small. We persist them because\n",
+    "each repeated retrieval benchmark run uses the same query vectors.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788326306595,
+     "inputWidgets": {},
+     "nuid": "99946cb3-be63-433d-8dfe-a0c579690081",
+     "showTitle": false,
+     "startTime": 1788326304445,
+     "submitTime": 1788324539887,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Query embedding time: 1.602 seconds\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>query_id</th><th>query_text</th></tr></thead><tbody><tr><td>5a70eee85542994082a3e3f0</td><td>Which group of people in West Africa with significant populations in Ghana, Ivory Coast, Liberia and Sierra Leone use the Ida?</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>Which dialect spoken in the province of Scania calls Spettekaka, \"spiddekaga\"?</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>Which of these universities, Northwestern University or Johns Hopkins University, have a campus outside of the United States territories?</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>Which dog breed, the Schapendoes or the Bull Terrier, has its origins in a greater number of other dog breeds?</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>Which piece did Ludwig van Beethoven publish in 1801 that was dedicated to Count Moritz von Fries?</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>What is the name of the independent candidate in Maine's 2010 gubernatorial race who finished ahead of Libby Mitchell?</td></tr><tr><td>5a70f4695542994082a3e435</td><td>Which canal was built between 1836 and 1847, Washington City Canal or Whitewater Canal?</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>Which Italian-American composer and librettist wrote the English language opera, Maria Golovin?</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>Renamed in 2014, what was the vehicle offered as a prize to contestants on the first season of The Amazing Race Canada?</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>Which magazine is published more in a year, Essence or Alt for Damerne?</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         "5a70eee85542994082a3e3f0",
+         "Which group of people in West Africa with significant populations in Ghana, Ivory Coast, Liberia and Sierra Leone use the Ida?"
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         "Which dialect spoken in the province of Scania calls Spettekaka, \"spiddekaga\"?"
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         "Which of these universities, Northwestern University or Johns Hopkins University, have a campus outside of the United States territories?"
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         "Which dog breed, the Schapendoes or the Bull Terrier, has its origins in a greater number of other dog breeds?"
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         "Which piece did Ludwig van Beethoven publish in 1801 that was dedicated to Count Moritz von Fries?"
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         "What is the name of the independent candidate in Maine's 2010 gubernatorial race who finished ahead of Libby Mitchell?"
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         "Which canal was built between 1836 and 1847, Washington City Canal or Whitewater Canal?"
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         "Which Italian-American composer and librettist wrote the English language opera, Maria Golovin?"
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         "Renamed in 2014, what was the vehicle offered as a prize to contestants on the first season of The Amazing Race Canada?"
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         "Which magazine is published more in a year, Essence or Alt for Damerne?"
+        ]
+       ],
+       "datasetInfos": [],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {},
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "query_id",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "query_text",
+         "type": "\"string\""
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "query_embedding_started = time.perf_counter()\n",
+    "query_embeddings = (\n",
+    "    embedding_model.transform(\n",
+    "        selected_queries.withColumn(\n",
+    "            \"text\", F.concat(F.lit(\"query: \"), F.col(\"query_text\"))\n",
+    "        )\n",
+    "    )\n",
+    "    .select(\n",
+    "        \"query_id\",\n",
+    "        \"query_text\",\n",
+    "        F.col(\"embeddings\").alias(\"query_embeddings\"),\n",
+    "    )\n",
+    "    .persist(StorageLevel.MEMORY_AND_DISK)\n",
+    ")\n",
+    "query_embeddings.count()\n",
+    "query_embedding_seconds = time.perf_counter() - query_embedding_started\n",
+    "\n",
+    "print(f\"Query embedding time: {query_embedding_seconds:.3f} seconds\")\n",
+    "display(query_embeddings.select(\"query_id\", \"query_text\").orderBy(\"query_id\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "521483a8-e062-4938-835d-99b17d9a844c",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 12. Confirm how Spark will distribute the retrieval work\n",
+    "\n",
+    "The corpus has a fixed number of partitions. Spark schedules those partitions as tasks\n",
+    "across available workers; a larger cluster can execute more tasks at the same time. The\n",
+    "query batch is broadcast because it is small, so Spark avoids moving the large embedding\n",
+    "index across the network.\n",
+    "\n",
+    "Run the next cell and inspect the Spark UI **Stages** tab while the benchmark runs. The\n",
+    "`BroadcastNestedLoopJoin` in the physical plan is expected: this is the exact\n",
+    "query-passage comparison strategy.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788326308304,
+     "inputWidgets": {},
+     "nuid": "df19132d-760f-48d6-935e-a25a18624aed",
+     "showTitle": false,
+     "startTime": 1788326306631,
+     "submitTime": 1788324540337,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Spark default parallelism: 16\nCorpus embedding partitions: 128\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>partition_id</th><th>count</th></tr></thead><tbody><tr><td>0</td><td>783</td></tr><tr><td>1</td><td>783</td></tr><tr><td>2</td><td>783</td></tr><tr><td>3</td><td>783</td></tr><tr><td>4</td><td>783</td></tr><tr><td>5</td><td>782</td></tr><tr><td>6</td><td>782</td></tr><tr><td>7</td><td>782</td></tr><tr><td>8</td><td>782</td></tr><tr><td>9</td><td>782</td></tr><tr><td>10</td><td>781</td></tr><tr><td>11</td><td>780</td></tr><tr><td>12</td><td>781</td></tr><tr><td>13</td><td>781</td></tr><tr><td>14</td><td>781</td></tr><tr><td>15</td><td>781</td></tr><tr><td>16</td><td>781</td></tr><tr><td>17</td><td>781</td></tr><tr><td>18</td><td>781</td></tr><tr><td>19</td><td>781</td></tr><tr><td>20</td><td>781</td></tr><tr><td>21</td><td>781</td></tr><tr><td>22</td><td>781</td></tr><tr><td>23</td><td>781</td></tr><tr><td>24</td><td>781</td></tr><tr><td>25</td><td>781</td></tr><tr><td>26</td><td>781</td></tr><tr><td>27</td><td>781</td></tr><tr><td>28</td><td>781</td></tr><tr><td>29</td><td>782</td></tr><tr><td>30</td><td>782</td></tr><tr><td>31</td><td>783</td></tr><tr><td>32</td><td>783</td></tr><tr><td>33</td><td>783</td></tr><tr><td>34</td><td>783</td></tr><tr><td>35</td><td>783</td></tr><tr><td>36</td><td>782</td></tr><tr><td>37</td><td>782</td></tr><tr><td>38</td><td>782</td></tr><tr><td>39</td><td>782</td></tr><tr><td>40</td><td>782</td></tr><tr><td>41</td><td>782</td></tr><tr><td>42</td><td>782</td></tr><tr><td>43</td><td>782</td></tr><tr><td>44</td><td>782</td></tr><tr><td>45</td><td>782</td></tr><tr><td>46</td><td>782</td></tr><tr><td>47</td><td>782</td></tr><tr><td>48</td><td>782</td></tr><tr><td>49</td><td>782</td></tr><tr><td>50</td><td>782</td></tr><tr><td>51</td><td>782</td></tr><tr><td>52</td><td>782</td></tr><tr><td>53</td><td>782</td></tr><tr><td>54</td><td>782</td></tr><tr><td>55</td><td>780</td></tr><tr><td>56</td><td>779</td></tr><tr><td>57</td><td>780</td></tr><tr><td>58</td><td>780</td></tr><tr><td>59</td><td>780</td></tr><tr><td>60</td><td>780</td></tr><tr><td>61</td><td>780</td></tr><tr><td>62</td><td>780</td></tr><tr><td>63</td><td>780</td></tr><tr><td>64</td><td>780</td></tr><tr><td>65</td><td>780</td></tr><tr><td>66</td><td>779</td></tr><tr><td>67</td><td>779</td></tr><tr><td>68</td><td>779</td></tr><tr><td>69</td><td>779</td></tr><tr><td>70</td><td>779</td></tr><tr><td>71</td><td>779</td></tr><tr><td>72</td><td>777</td></tr><tr><td>73</td><td>776</td></tr><tr><td>74</td><td>776</td></tr><tr><td>75</td><td>776</td></tr><tr><td>76</td><td>777</td></tr><tr><td>77</td><td>778</td></tr><tr><td>78</td><td>781</td></tr><tr><td>79</td><td>781</td></tr><tr><td>80</td><td>781</td></tr><tr><td>81</td><td>781</td></tr><tr><td>82</td><td>781</td></tr><tr><td>83</td><td>781</td></tr><tr><td>84</td><td>781</td></tr><tr><td>85</td><td>781</td></tr><tr><td>86</td><td>781</td></tr><tr><td>87</td><td>781</td></tr><tr><td>88</td><td>781</td></tr><tr><td>89</td><td>782</td></tr><tr><td>90</td><td>782</td></tr><tr><td>91</td><td>782</td></tr><tr><td>92</td><td>781</td></tr><tr><td>93</td><td>781</td></tr><tr><td>94</td><td>783</td></tr><tr><td>95</td><td>783</td></tr><tr><td>96</td><td>783</td></tr><tr><td>97</td><td>784</td></tr><tr><td>98</td><td>784</td></tr><tr><td>99</td><td>783</td></tr><tr><td>100</td><td>783</td></tr><tr><td>101</td><td>782</td></tr><tr><td>102</td><td>782</td></tr><tr><td>103</td><td>781</td></tr><tr><td>104</td><td>781</td></tr><tr><td>105</td><td>781</td></tr><tr><td>106</td><td>781</td></tr><tr><td>107</td><td>781</td></tr><tr><td>108</td><td>781</td></tr><tr><td>109</td><td>781</td></tr><tr><td>110</td><td>781</td></tr><tr><td>111</td><td>781</td></tr><tr><td>112</td><td>781</td></tr><tr><td>113</td><td>781</td></tr><tr><td>114</td><td>781</td></tr><tr><td>115</td><td>781</td></tr><tr><td>116</td><td>781</td></tr><tr><td>117</td><td>782</td></tr><tr><td>118</td><td>782</td></tr><tr><td>119</td><td>782</td></tr><tr><td>120</td><td>782</td></tr><tr><td>121</td><td>782</td></tr><tr><td>122</td><td>782</td></tr><tr><td>123</td><td>783</td></tr><tr><td>124</td><td>783</td></tr><tr><td>125</td><td>783</td></tr><tr><td>126</td><td>783</td></tr><tr><td>127</td><td>783</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         0,
+         783
+        ],
+        [
+         1,
+         783
+        ],
+        [
+         2,
+         783
+        ],
+        [
+         3,
+         783
+        ],
+        [
+         4,
+         783
+        ],
+        [
+         5,
+         782
+        ],
+        [
+         6,
+         782
+        ],
+        [
+         7,
+         782
+        ],
+        [
+         8,
+         782
+        ],
+        [
+         9,
+         782
+        ],
+        [
+         10,
+         781
+        ],
+        [
+         11,
+         780
+        ],
+        [
+         12,
+         781
+        ],
+        [
+         13,
+         781
+        ],
+        [
+         14,
+         781
+        ],
+        [
+         15,
+         781
+        ],
+        [
+         16,
+         781
+        ],
+        [
+         17,
+         781
+        ],
+        [
+         18,
+         781
+        ],
+        [
+         19,
+         781
+        ],
+        [
+         20,
+         781
+        ],
+        [
+         21,
+         781
+        ],
+        [
+         22,
+         781
+        ],
+        [
+         23,
+         781
+        ],
+        [
+         24,
+         781
+        ],
+        [
+         25,
+         781
+        ],
+        [
+         26,
+         781
+        ],
+        [
+         27,
+         781
+        ],
+        [
+         28,
+         781
+        ],
+        [
+         29,
+         782
+        ],
+        [
+         30,
+         782
+        ],
+        [
+         31,
+         783
+        ],
+        [
+         32,
+         783
+        ],
+        [
+         33,
+         783
+        ],
+        [
+         34,
+         783
+        ],
+        [
+         35,
+         783
+        ],
+        [
+         36,
+         782
+        ],
+        [
+         37,
+         782
+        ],
+        [
+         38,
+         782
+        ],
+        [
+         39,
+         782
+        ],
+        [
+         40,
+         782
+        ],
+        [
+         41,
+         782
+        ],
+        [
+         42,
+         782
+        ],
+        [
+         43,
+         782
+        ],
+        [
+         44,
+         782
+        ],
+        [
+         45,
+         782
+        ],
+        [
+         46,
+         782
+        ],
+        [
+         47,
+         782
+        ],
+        [
+         48,
+         782
+        ],
+        [
+         49,
+         782
+        ],
+        [
+         50,
+         782
+        ],
+        [
+         51,
+         782
+        ],
+        [
+         52,
+         782
+        ],
+        [
+         53,
+         782
+        ],
+        [
+         54,
+         782
+        ],
+        [
+         55,
+         780
+        ],
+        [
+         56,
+         779
+        ],
+        [
+         57,
+         780
+        ],
+        [
+         58,
+         780
+        ],
+        [
+         59,
+         780
+        ],
+        [
+         60,
+         780
+        ],
+        [
+         61,
+         780
+        ],
+        [
+         62,
+         780
+        ],
+        [
+         63,
+         780
+        ],
+        [
+         64,
+         780
+        ],
+        [
+         65,
+         780
+        ],
+        [
+         66,
+         779
+        ],
+        [
+         67,
+         779
+        ],
+        [
+         68,
+         779
+        ],
+        [
+         69,
+         779
+        ],
+        [
+         70,
+         779
+        ],
+        [
+         71,
+         779
+        ],
+        [
+         72,
+         777
+        ],
+        [
+         73,
+         776
+        ],
+        [
+         74,
+         776
+        ],
+        [
+         75,
+         776
+        ],
+        [
+         76,
+         777
+        ],
+        [
+         77,
+         778
+        ],
+        [
+         78,
+         781
+        ],
+        [
+         79,
+         781
+        ],
+        [
+         80,
+         781
+        ],
+        [
+         81,
+         781
+        ],
+        [
+         82,
+         781
+        ],
+        [
+         83,
+         781
+        ],
+        [
+         84,
+         781
+        ],
+        [
+         85,
+         781
+        ],
+        [
+         86,
+         781
+        ],
+        [
+         87,
+         781
+        ],
+        [
+         88,
+         781
+        ],
+        [
+         89,
+         782
+        ],
+        [
+         90,
+         782
+        ],
+        [
+         91,
+         782
+        ],
+        [
+         92,
+         781
+        ],
+        [
+         93,
+         781
+        ],
+        [
+         94,
+         783
+        ],
+        [
+         95,
+         783
+        ],
+        [
+         96,
+         783
+        ],
+        [
+         97,
+         784
+        ],
+        [
+         98,
+         784
+        ],
+        [
+         99,
+         783
+        ],
+        [
+         100,
+         783
+        ],
+        [
+         101,
+         782
+        ],
+        [
+         102,
+         782
+        ],
+        [
+         103,
+         781
+        ],
+        [
+         104,
+         781
+        ],
+        [
+         105,
+         781
+        ],
+        [
+         106,
+         781
+        ],
+        [
+         107,
+         781
+        ],
+        [
+         108,
+         781
+        ],
+        [
+         109,
+         781
+        ],
+        [
+         110,
+         781
+        ],
+        [
+         111,
+         781
+        ],
+        [
+         112,
+         781
+        ],
+        [
+         113,
+         781
+        ],
+        [
+         114,
+         781
+        ],
+        [
+         115,
+         781
+        ],
+        [
+         116,
+         781
+        ],
+        [
+         117,
+         782
+        ],
+        [
+         118,
+         782
+        ],
+        [
+         119,
+         782
+        ],
+        [
+         120,
+         782
+        ],
+        [
+         121,
+         782
+        ],
+        [
+         122,
+         782
+        ],
+        [
+         123,
+         783
+        ],
+        [
+         124,
+         783
+        ],
+        [
+         125,
+         783
+        ],
+        [
+         126,
+         783
+        ],
+        [
+         127,
+         783
+        ]
+       ],
+       "datasetInfos": [],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {},
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "partition_id",
+         "type": "\"integer\""
+        },
+        {
+         "metadata": "{}",
+         "name": "count",
+         "type": "\"long\""
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "partition_sizes = (\n",
+    "    corpus_embeddings.withColumn(\"partition_id\", F.spark_partition_id())\n",
+    "    .groupBy(\"partition_id\")\n",
+    "    .count()\n",
+    "    .orderBy(\"partition_id\")\n",
+    ")\n",
+    "print(f\"Spark default parallelism: {spark.sparkContext.defaultParallelism}\")\n",
+    "print(f\"Corpus embedding partitions: {corpus_embeddings.rdd.getNumPartitions()}\")\n",
+    "display(partition_sizes)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "39398a74-6379-44e0-823b-bffcc7e46a76",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 13. Score and rank every query-passage pair\n",
+    "\n",
+    "`PairwiseVectorSimilarity` needs a query embedding and a passage embedding on the same\n",
+    "row. `crossJoin` creates one row for every combination; with 10 queries and 100K\n",
+    "passages this creates one million exact comparisons. Cosine similarity assigns a higher\n",
+    "score to semantically closer pairs. A window then retains the top-K passages **per\n",
+    "query**, rather than one global top-K list.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788326309506,
+     "inputWidgets": {},
+     "nuid": "69c51469-da16-4e4b-aefe-e29aa6a9e1d0",
+     "showTitle": false,
+     "startTime": 1788326308332,
+     "submitTime": 1788324540976,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exact comparisons per run: 1,000,000\n== Physical Plan ==\nSort (43)\n+- Exchange (42)\n   +- * Filter (41)\n      +- * RunningWindowFunction (40)\n         +- WindowGroupLimit (39)\n            +- Sort (38)\n               +- Exchange (37)\n                  +- WindowGroupLimit (36)\n                     +- * Sort (35)\n                        +- * Project (34)\n                           +- * Generate (33)\n                              +- * Project (32)\n                                 +- * BroadcastNestedLoopJoin Inner BuildLeft (31)\n                                    :- BroadcastExchange (25)\n                                    :  +- InMemoryTableScan (1)\n                                    :        +- InMemoryRelation (2)\n                                    :              +- * Project (24)\n                                    :                 +- * SerializeFromObject (23)\n                                    :                    +- MapPartitions (22)\n                                    :                       +- DeserializeToObject (21)\n                                    :                          +- * Project (20)\n                                    :                             +- * Project (19)\n                                    :                                +- InMemoryTableScan (3)\n                                    :                                      +- InMemoryRelation (4)\n                                    :                                            +- * Project (18)\n                                    :                                               +- * BroadcastHashJoin Inner BuildRight (17)\n                                    :                                                  :- * Project (7)\n                                    :                                                  :  +- * Filter (6)\n                                    :                                                  :     +- Scan json  (5)\n                                    :                                                  +- BroadcastExchange (16)\n                                    :                                                     +- * Filter (15)\n                                    :                                                        +- TakeOrderedAndProject (14)\n                                    :                                                           +- * HashAggregate (13)\n                                    :                                                              +- Exchange (12)\n                                    :                                                                 +- * HashAggregate (11)\n                                    :                                                                    +- * Project (10)\n                                    :                                                                       +- * Filter (9)\n                                    :                                                                          +- Scan csv  (8)\n                                    +- InMemoryTableScan (26)\n                                          +- InMemoryRelation (27)\n                                                +- Exchange (30)\n                                                   +- * ColumnarToRow (29)\n                                                      +- Scan parquet  (28)\n\n\n(1) InMemoryTableScan\nOutput [3]: [query_id#1602, query_text#1609, query_embeddings#1643]\nArguments: [query_id#1602, query_text#1609, query_embeddings#1643]\n\n(2) InMemoryRelation\nArguments: [query_id#1602, query_text#1609, query_embeddings#1643], CachedRDDBuilder(org.apache.spark.sql.execution.columnar.DefaultCachedBatchSerializer@52de4586,StorageLevel(disk, memory, 1 replicas),*(2) Project [query_id#1596, query_text#1597, embeddings#1600 AS query_embeddings#1643]\n+- *(2) SerializeFromObject [if (invoke(assertnotnull(input[0, org.apache.spark.sql.Row, true]).isNullAt(0))) null else static_invoke(UTF8String.fromString(validateexternaltype(getexternalrowfield(assertnotnull(input[0, org.apache.spark.sql.Row, true]), 0, query_id), StringType, ObjectType(class java.lang.String)))) AS query_id#1596, if (invoke(assertnotnull(input[0, org.apache.spark.sql.Row, true]).isNullAt(1))) null else static_invoke(UTF8String.fromString(validateexternaltype(getexternalrowfield(assertnotnull(input[0, org.apache.spark.sql.Row, true]), 1, query_text), StringType, ObjectType(class java.lang.String)))) AS query_text#1597, if (invoke(assertnotnull(input[0, org.apache.spark.sql.Row, true]).isNullAt(4))) null else mapobjects(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), if (isnull(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)))) null else named_struct(annotatorType, if (invoke(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)).isNullAt(0))) null else static_invoke(UTF8String.fromString(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 0, annotatorType), StringType, ObjectType(class java.lang.String)))), begin, assertnotnull(invoke(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 1, begin), IntegerType, ObjectType(class java.lang.Integer)).intValue())), end, assertnotnull(invoke(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 2, end), IntegerType, ObjectType(class java.lang.Integer)).intValue())), result, if (invoke(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)).isNullAt(3))) null else static_invoke(UTF8String.fromString(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 3, result), StringType, ObjectType(class java.lang.String)))), metadata, if (invoke(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)).isNullAt(4))) null else externalmaptocatalyst(lambdavariable(ExternalMapToCatalyst_key, ObjectType(class java.lang.Object), true, -2), static_invoke(UTF8String.fromString(validateexternaltype(lambdavariable(ExternalMapToCatalyst_key, ObjectType(class java.lang.Object), true, -2), StringType, ObjectType(class java.lang.String)))), lambdavariable(ExternalMapToCatalyst_value, ObjectType(class java.lang.Object), true, -3), static_invoke(UTF8String.fromString(validateexternaltype(lambdavariable(ExternalMapToCatalyst_value, ObjectType(class java.lang.Object), true, -3), StringType, ObjectType(class java.lang.String)))), validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 4, metadata), MapType(StringType,StringType,true), ObjectType(interface scala.collection.Map))), embeddings, if (invoke(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)).isNullAt(5))) null else if (invoke(class [F.isInstance(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 5, embeddings), ArrayType(FloatType,false), ObjectType(class java.lang.Object))))) static_invoke(ArrayData.toArrayData(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 5, embeddings), ArrayType(FloatType,false), ObjectType(class java.lang.Object)))) else mapobjects(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -4), assertnotnull(invoke(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -4), FloatType, ObjectType(class java.lang.Float)).floatValue())), validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 5, embeddings), ArrayType(FloatType,false), ObjectType(class java.lang.Object)), None)), validateexternaltype(getexternalrowfield(assertnotnull(input[0, org.apache.spark.sql.Row, true]), 4, embeddings), ArrayType(StructType(StructField(annotatorType,StringType,true),StructField(begin,IntegerType,false),StructField(end,IntegerType,false),StructField(result,StringType,true),StructField(metadata,MapType(StringType,StringType,true),true),StructField(embeddings,ArrayType(FloatType,false),true)),true), ObjectType(class java.lang.Object)), None) AS embeddings#1600]\n   +- MapPartitions com.johnsnowlabs.nlp.AnnotatorModel$$Lambda$15966/0x00007f50b15dd000@6e5259b7, obj#1595: org.apache.spark.sql.Row\n      +- DeserializeToObject createexternalrow(invoke(query_id#39.toString()), invoke(query_text#40.toString()), invoke(text#1574.toString()), mapobjects(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5), if (isnull(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5))) null else createexternalrow(if (invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).isNullAt(0))) null else invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).annotatorType.toString()), if (invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).isNullAt(1))) null else static_invoke(java.lang.Integer.valueOf(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).begin)), if (invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).isNullAt(2))) null else static_invoke(java.lang.Integer.valueOf(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).end)), if (invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).isNullAt(3))) null else invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).result.toString()), if (invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).isNullAt(4))) null else catalysttoexternalmap(lambdavariable(CatalystToExternalMap_key, StringType, false, -6), invoke(lambdavariable(CatalystToExternalMap_key, StringType, false, -6).toString()), lambdavariable(CatalystToExternalMap_value, StringType, true, -7), invoke(lambdavariable(CatalystToExternalMap_value, StringType, true, -7).toString()), lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).metadata, interface scala.collection.Map), if (invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).isNullAt(5))) null else mapobjects(lambdavariable(MapObject, FloatType, false, -8), static_invoke(java.lang.Float.valueOf(lambdavariable(MapObject, FloatType, false, -8))), lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).embeddings, Some(class scala.collection.mutable.WrappedArray)), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true)), document#1581, Some(class scala.collection.mutable.WrappedArray)), StructField(query_id,StringType,true), StructField(query_text,StringType,true), StructField(text,StringType,true), StructField(document,ArrayType(StructType(StructField(annotatorType,StringType,true),StructField(begin,IntegerType,false),StructField(end,IntegerType,false),StructField(result,StringType,true),StructField(metadata,MapType(StringType,StringType,true),true),StructField(embeddings,ArrayType(FloatType,false),true)),true),true)), obj#1594: org.apache.spark.sql.Row\n         +- *(1) Project [query_id#39, query_text#40, text#1574, UDF(text#1574) AS document#1581]\n            +- *(1) Project [query_id#39, query_text#40, concat(query: , query_text#40) AS text#1574]\n               +- InMemoryTableScan [query_id#39, query_text#40]\n                     +- InMemoryRelation [query_id#39, query_text#40], StorageLevel(disk, memory, 1 replicas)\n                           +- *(4) Project [query_id#39, query_text#40]\n                              +- *(4) BroadcastHashJoin [query_id#39], [query_id#67], Inner, BuildRight, false, false\n                                 :- *(4) Project [_id#33 AS query_id#39, text#35 AS query_text#40]\n                                 :  +- *(4) Filter isnotnull(_id#33)\n                                 :     +- FileScan json [_id#33,text#35] Batched: false, DataFilters: [isnotnull(_id#33)], Format: JSON, Location: InMemoryFileIndex(1 paths)[dbfs:/Volumes/main/default/libsahmed/beir/hotpotqa/raw/queries.jsonl], PartitionFilters: [], PushedFilters: [IsNotNull(_id)], ReadSchema: struct<_id:string,text:string>\n                                 +- BroadcastExchange HashedRelationBroadcastMode(ArrayBuffer(input[0, string, false]),false), [plan_id=1486]\n                                    +- *(3) Filter isnotnull(query_id#67)\n                                       +- TakeOrderedAndProject(limit=10, orderBy=[query_id#67 ASC NULLS FIRST], output=[query_id#67])\n                                          +- *(2) HashAggregate(keys=[query_id#67], functions=[], output=[query_id#67])\n                                             +- Exchange hashpartitioning(query_id#67, 128), ENSURE_REQUIREMENTS, [plan_id=1478]\n                                                +- *(1) HashAggregate(keys=[query_id#67], functions=[], output=[query_id#67])\n                                                   +- *(1) Project [query-id#61 AS query_id#67]\n                                                      +- *(1) Filter (isnotnull(score#63) AND (cast(score#63 as int) > 0))\n                                                         +- FileScan csv [query-id#61,score#63] Batched: false, DataFilters: [isnotnull(score#63), (cast(score#63 as int) > 0)], Format: CSV, Location: InMemoryFileIndex(1 paths)[dbfs:/Volumes/main/default/libsahmed/beir/hotpotqa/raw/qrels/test.tsv], PartitionFilters: [], PushedFilters: [IsNotNull(score)], ReadSchema: struct<query-id:string,score:string>\n,None,Project [query_id#1602, query_text#1609, embeddings#1637 AS query_embeddings#1643]\n+- Project [query_id#1602, query_text#1609, text#1616, document#1623, embeddings#1630 AS embeddings#1637]\n   +- Project [query_id#1602, query_text#1609, text#1616, document#1623, embeddings#1600 AS embeddings#1630]\n      +- Project [query_id#1602, query_text#1609, text#1616, document#1599 AS document#1623, embeddings#1600]\n         +- Project [query_id#1602, query_text#1609, text#1598 AS text#1616, document#1599, embeddings#1600]\n            +- Project [query_id#1602, query_text#1597 AS query_text#1609, text#1598, document#1599, embeddings#1600]\n               +- Project [query_id#1596 AS query_id#1602, query_text#1597, text#1598, document#1599, embeddings#1600]\n                  +- SerializeFromObject [if (invoke(assertnotnull(input[0, org.apache.spark.sql.Row, true]).isNullAt(0))) null else static_invoke(UTF8String.fromString(validateexternaltype(getexternalrowfield(assertnotnull(input[0, org.apache.spark.sql.Row, true]), 0, query_id), StringType, ObjectType(class java.lang.String)))) AS query_id#1596, if (invoke(assertnotnull(input[0, org.apache.spark.sql.Row, true]).isNullAt(1))) null else static_invoke(UTF8String.fromString(validateexternaltype(getexternalrowfield(assertnotnull(input[0, org.apache.spark.sql.Row, true]), 1, query_text), StringType, ObjectType(class java.lang.String)))) AS query_text#1597, if (invoke(assertnotnull(input[0, org.apache.spark.sql.Row, true]).isNullAt(2))) null else static_invoke(UTF8String.fromString(validateexternaltype(getexternalrowfield(assertnotnull(input[0, org.apache.spark.sql.Row, true]), 2, text), StringType, ObjectType(class java.lang.String)))) AS text#1598, if (invoke(assertnotnull(input[0, org.apache.spark.sql.Row, true]).isNullAt(3))) null else mapobjects(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, 290), if (isnull(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, 290), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)))) null else named_struct(annotatorType, if (invoke(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, 290), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)).isNullAt(0))) null else static_invoke(UTF8String.fromString(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, 290), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(i\n\n*** WARNING: max output size exceeded, skipping output. ***\n\n67)\n         +- TakeOrderedAndProject(limit=10, orderBy=[query_id#67 ASC NULLS FIRST], output=[query_id#67])\n            +- *(2) HashAggregate(keys=[query_id#67], functions=[], output=[query_id#67])\n               +- Exchange hashpartitioning(query_id#67, 128), ENSURE_REQUIREMENTS, [plan_id=208]\n                  +- *(1) HashAggregate(keys=[query_id#67], functions=[], output=[query_id#67])\n                     +- *(1) Project [query-id#61 AS query_id#67]\n                        +- *(1) Filter (isnotnull(score#63) AND (cast(score#63 as int) > 0))\n                           +- FileScan csv [query-id#61,score#63] Batched: false, DataFilters: [isnotnull(score#63), (cast(score#63 as int) > 0)], Format: CSV, Location: InMemoryFileIndex(1 paths)[dbfs:/Volumes/main/default/libsahmed/beir/hotpotqa/raw/qrels/test.tsv], PartitionFilters: [], PushedFilters: [IsNotNull(score)], ReadSchema: struct<query-id:string,score:string>\n,None,Project [query_id#39, query_text#40]\n+- Join Inner, (query_id#39 = query_id#67)\n   :- Project [_id#33 AS query_id#39, text#35 AS query_text#40]\n   :  +- Relation [_id#33,metadata#34,text#35] json\n   +- GlobalLimit 10\n      +- LocalLimit 10\n         +- Sort [query_id#67 ASC NULLS FIRST], true\n            +- Deduplicate [query_id#67]\n               +- Project [query_id#67]\n                  +- Filter (relevance#69 > 0)\n                     +- Project [query-id#61 AS query_id#67, corpus-id#62 AS chunk_id#68, cast(score#63 as int) AS relevance#69]\n                        +- Relation [query-id#61,corpus-id#62,score#63] csv\n)\n\n(5) Scan json \nOutput [2]: [_id#33, text#35]\nBatched: false\nLocation: InMemoryFileIndex [dbfs:/Volumes/main/default/libsahmed/beir/hotpotqa/raw/queries.jsonl]\nPushedFilters: [IsNotNull(_id)]\nReadSchema: struct<_id:string,text:string>\n\n(6) Filter [codegen id : 4]\nInput [2]: [_id#33, text#35]\nCondition : isnotnull(_id#33)\n\n(7) Project [codegen id : 4]\nOutput [2]: [_id#33 AS query_id#39, text#35 AS query_text#40]\nInput [2]: [_id#33, text#35]\n\n(8) Scan csv \nOutput [2]: [query-id#61, score#63]\nBatched: false\nLocation: InMemoryFileIndex [dbfs:/Volumes/main/default/libsahmed/beir/hotpotqa/raw/qrels/test.tsv]\nPushedFilters: [IsNotNull(score)]\nReadSchema: struct<query-id:string,score:string>\n\n(9) Filter [codegen id : 1]\nInput [2]: [query-id#61, score#63]\nCondition : (isnotnull(score#63) AND (cast(score#63 as int) > 0))\n\n(10) Project [codegen id : 1]\nOutput [1]: [query-id#61 AS query_id#67]\nInput [2]: [query-id#61, score#63]\n\n(11) HashAggregate [codegen id : 1]\nInput [1]: [query_id#67]\nKeys [1]: [query_id#67]\nFunctions: []\nAggregate Attributes: []\nResults [1]: [query_id#67]\n\n(12) Exchange\nInput [1]: [query_id#67]\nArguments: hashpartitioning(query_id#67, 128), ENSURE_REQUIREMENTS, [plan_id=1478]\n\n(13) HashAggregate [codegen id : 2]\nInput [1]: [query_id#67]\nKeys [1]: [query_id#67]\nFunctions: []\nAggregate Attributes: []\nResults [1]: [query_id#67]\n\n(14) TakeOrderedAndProject\nInput [1]: [query_id#67]\nArguments: 10, [query_id#67 ASC NULLS FIRST], [query_id#67]\n\n(15) Filter [codegen id : 3]\nInput [1]: [query_id#67]\nCondition : isnotnull(query_id#67)\n\n(16) BroadcastExchange\nInput [1]: [query_id#67]\nArguments: HashedRelationBroadcastMode(ArrayBuffer(input[0, string, false]),false), [plan_id=1486]\n\n(17) BroadcastHashJoin [codegen id : 4]\nLeft keys [1]: [query_id#39]\nRight keys [1]: [query_id#67]\nJoin type: Inner\nJoin condition: None\n\n(18) Project [codegen id : 4]\nOutput [2]: [query_id#39, query_text#40]\nInput [3]: [query_id#39, query_text#40, query_id#67]\n\n(19) Project [codegen id : 1]\nOutput [3]: [query_id#39, query_text#40, concat(query: , query_text#40) AS text#1574]\nInput [2]: [query_id#39, query_text#40]\n\n(20) Project [codegen id : 1]\nOutput [4]: [query_id#39, query_text#40, text#1574, UDF(text#1574) AS document#1581]\nInput [3]: [query_id#39, query_text#40, text#1574]\n\n(21) DeserializeToObject\nInput [4]: [query_id#39, query_text#40, text#1574, document#1581]\nArguments: createexternalrow(invoke(query_id#39.toString()), invoke(query_text#40.toString()), invoke(text#1574.toString()), mapobjects(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5), if (isnull(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5))) null else createexternalrow(if (invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).isNullAt(0))) null else invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).annotatorType.toString()), if (invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).isNullAt(1))) null else static_invoke(java.lang.Integer.valueOf(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).begin)), if (invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).isNullAt(2))) null else static_invoke(java.lang.Integer.valueOf(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).end)), if (invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).isNullAt(3))) null else invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).result.toString()), if (invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).isNullAt(4))) null else catalysttoexternalmap(lambdavariable(CatalystToExternalMap_key, StringType, false, -6), invoke(lambdavariable(CatalystToExternalMap_key, StringType, false, -6).toString()), lambdavariable(CatalystToExternalMap_value, StringType, true, -7), invoke(lambdavariable(CatalystToExternalMap_value, StringType, true, -7).toString()), lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).metadata, interface scala.collection.Map), if (invoke(lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).isNullAt(5))) null else mapobjects(lambdavariable(MapObject, FloatType, false, -8), static_invoke(java.lang.Float.valueOf(lambdavariable(MapObject, FloatType, false, -8))), lambdavariable(MapObject, StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), true, -5).embeddings, Some(class scala.collection.mutable.WrappedArray)), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true)), document#1581, Some(class scala.collection.mutable.WrappedArray)), StructField(query_id,StringType,true), StructField(query_text,StringType,true), StructField(text,StringType,true), StructField(document,ArrayType(StructType(StructField(annotatorType,StringType,true),StructField(begin,IntegerType,false),StructField(end,IntegerType,false),StructField(result,StringType,true),StructField(metadata,MapType(StringType,StringType,true),true),StructField(embeddings,ArrayType(FloatType,false),true)),true),true)), obj#1594: org.apache.spark.sql.Row\n\n(22) MapPartitions\nInput [1]: [obj#1594]\nArguments: com.johnsnowlabs.nlp.AnnotatorModel$$Lambda$15966/0x00007f50b15dd000@6e5259b7, obj#1595: org.apache.spark.sql.Row\n\n(23) SerializeFromObject [codegen id : 2]\nInput [1]: [obj#1595]\nArguments: [if (invoke(assertnotnull(input[0, org.apache.spark.sql.Row, true]).isNullAt(0))) null else static_invoke(UTF8String.fromString(validateexternaltype(getexternalrowfield(assertnotnull(input[0, org.apache.spark.sql.Row, true]), 0, query_id), StringType, ObjectType(class java.lang.String)))) AS query_id#1596, if (invoke(assertnotnull(input[0, org.apache.spark.sql.Row, true]).isNullAt(1))) null else static_invoke(UTF8String.fromString(validateexternaltype(getexternalrowfield(assertnotnull(input[0, org.apache.spark.sql.Row, true]), 1, query_text), StringType, ObjectType(class java.lang.String)))) AS query_text#1597, if (invoke(assertnotnull(input[0, org.apache.spark.sql.Row, true]).isNullAt(4))) null else mapobjects(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), if (isnull(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)))) null else named_struct(annotatorType, if (invoke(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)).isNullAt(0))) null else static_invoke(UTF8String.fromString(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 0, annotatorType), StringType, ObjectType(class java.lang.String)))), begin, assertnotnull(invoke(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 1, begin), IntegerType, ObjectType(class java.lang.Integer)).intValue())), end, assertnotnull(invoke(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 2, end), IntegerType, ObjectType(class java.lang.Integer)).intValue())), result, if (invoke(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)).isNullAt(3))) null else static_invoke(UTF8String.fromString(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 3, result), StringType, ObjectType(class java.lang.String)))), metadata, if (invoke(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)).isNullAt(4))) null else externalmaptocatalyst(lambdavariable(ExternalMapToCatalyst_key, ObjectType(class java.lang.Object), true, -2), static_invoke(UTF8String.fromString(validateexternaltype(lambdavariable(ExternalMapToCatalyst_key, ObjectType(class java.lang.Object), true, -2), StringType, ObjectType(class java.lang.String)))), lambdavariable(ExternalMapToCatalyst_value, ObjectType(class java.lang.Object), true, -3), static_invoke(UTF8String.fromString(validateexternaltype(lambdavariable(ExternalMapToCatalyst_value, ObjectType(class java.lang.Object), true, -3), StringType, ObjectType(class java.lang.String)))), validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 4, metadata), MapType(StringType,StringType,true), ObjectType(interface scala.collection.Map))), embeddings, if (invoke(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)).isNullAt(5))) null else if (invoke(class [F.isInstance(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 5, embeddings), ArrayType(FloatType,false), ObjectType(class java.lang.Object))))) static_invoke(ArrayData.toArrayData(validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 5, embeddings), ArrayType(FloatType,false), ObjectType(class java.lang.Object)))) else mapobjects(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -4), assertnotnull(invoke(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -4), FloatType, ObjectType(class java.lang.Float)).floatValue())), validateexternaltype(getexternalrowfield(validateexternaltype(lambdavariable(MapObject, ObjectType(class java.lang.Object), true, -1), StructField(annotatorType,StringType,true), StructField(begin,IntegerType,false), StructField(end,IntegerType,false), StructField(result,StringType,true), StructField(metadata,MapType(StringType,StringType,true),true), StructField(embeddings,ArrayType(FloatType,false),true), ObjectType(interface org.apache.spark.sql.Row)), 5, embeddings), ArrayType(FloatType,false), ObjectType(class java.lang.Object)), None)), validateexternaltype(getexternalrowfield(assertnotnull(input[0, org.apache.spark.sql.Row, true]), 4, embeddings), ArrayType(StructType(StructField(annotatorType,StringType,true),StructField(begin,IntegerType,false),StructField(end,IntegerType,false),StructField(result,StringType,true),StructField(metadata,MapType(StringType,StringType,true),true),StructField(embeddings,ArrayType(FloatType,false),true)),true), ObjectType(class java.lang.Object)), None) AS embeddings#1600]\n\n(24) Project [codegen id : 2]\nOutput [3]: [query_id#1596, query_text#1597, embeddings#1600 AS query_embeddings#1643]\nInput [3]: [query_id#1596, query_text#1597, embeddings#1600]\n\n(25) BroadcastExchange\nInput [3]: [query_id#1602, query_text#1609, query_embeddings#1643]\nArguments: IdentityBroadcastMode, [plan_id=1665]\n\n(26) InMemoryTableScan\nOutput [4]: [chunk_id#1206, title#1207, chunk_text#1208, chunk_embeddings#1209]\nArguments: [chunk_id#1206, title#1207, chunk_text#1208, chunk_embeddings#1209]\n\n(27) InMemoryRelation\nArguments: [chunk_id#1206, title#1207, chunk_text#1208, chunk_embeddings#1209], CachedRDDBuilder(org.apache.spark.sql.execution.columnar.DefaultCachedBatchSerializer@52de4586,StorageLevel(disk, memory, 1 replicas),Exchange RoundRobinPartitioning(128), REPARTITION_BY_NUM, [plan_id=1359]\n+- *(1) ColumnarToRow\n   +- FileScan parquet [chunk_id#1206,title#1207,chunk_text#1208,chunk_embeddings#1209] Batched: true, DataFilters: [], Format: Parquet, Location: PreparedDeltaFileIndex(1 paths)[dbfs:/Volumes/main/default/libsahmed/beir/hotpotqa/delta/embeddin..., PartitionFilters: [], PushedFilters: [], ReadSchema: struct<chunk_id:string,title:string,chunk_text:string,chunk_embeddings:array<struct<annotatorType...\n,None,Repartition 128, true\n+- Relation [chunk_id#1206,title#1207,chunk_text#1208,chunk_embeddings#1209] parquet\n)\n\n(28) Scan parquet \nOutput [4]: [chunk_id#1206, title#1207, chunk_text#1208, chunk_embeddings#1209]\nBatched: true\nLocation: PreparedDeltaFileIndex [dbfs:/Volumes/main/default/libsahmed/beir/hotpotqa/delta/embeddings-100000-10-queries-128-partitions]\nReadSchema: struct<chunk_id:string,title:string,chunk_text:string,chunk_embeddings:array<struct<annotatorType:string,begin:int,end:int,result:string,metadata:map<string,string>,embeddings:array<float>>>>\n\n(29) ColumnarToRow [codegen id : 1]\nInput [4]: [chunk_id#1206, title#1207, chunk_text#1208, chunk_embeddings#1209]\n\n(30) Exchange\nInput [4]: [chunk_id#1206, title#1207, chunk_text#1208, chunk_embeddings#1209]\nArguments: RoundRobinPartitioning(128), REPARTITION_BY_NUM, [plan_id=1848]\n\n(31) BroadcastNestedLoopJoin [codegen id : 1]\nJoin type: Inner\nJoin condition: ((size(UDF(array(query_embeddings#1643, chunk_embeddings#1209)), true) > 0) AND isnotnull(UDF(array(query_embeddings#1643, chunk_embeddings#1209))))\n\n(32) Project [codegen id : 1]\nOutput [6]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, UDF(array(query_embeddings#1643, chunk_embeddings#1209)).result AS _extract_result#2160]\nInput [7]: [query_id#1602, query_text#1609, query_embeddings#1643, chunk_id#1206, title#1207, chunk_text#1208, chunk_embeddings#1209]\n\n(33) Generate [codegen id : 1]\nInput [6]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, _extract_result#2160]\nArguments: explode(_extract_result#2160), [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208], false, [similarity_annotation#2050]\n\n(34) Project [codegen id : 1]\nOutput [6]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, cast(similarity_annotation#2050 as double) AS score#2057]\nInput [6]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, similarity_annotation#2050]\n\n(35) Sort [codegen id : 1]\nInput [6]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, score#2057]\nArguments: [query_id#1602 ASC NULLS FIRST, score#2057 DESC NULLS LAST, chunk_id#1206 ASC NULLS FIRST], false, 0\n\n(36) WindowGroupLimit\nInput [6]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, score#2057]\nArguments: [query_id#1602], [score#2057 DESC NULLS LAST, chunk_id#1206 ASC NULLS FIRST], row_number(), 10, Partial\n\n(37) Exchange\nInput [6]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, score#2057]\nArguments: hashpartitioning(query_id#1602, 128), ENSURE_REQUIREMENTS, [plan_id=1793]\n\n(38) Sort\nInput [6]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, score#2057]\nArguments: [query_id#1602 ASC NULLS FIRST, score#2057 DESC NULLS LAST, chunk_id#1206 ASC NULLS FIRST], false, 0\n\n(39) WindowGroupLimit\nInput [6]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, score#2057]\nArguments: [query_id#1602], [score#2057 DESC NULLS LAST, chunk_id#1206 ASC NULLS FIRST], row_number(), 10, Final\n\n(40) RunningWindowFunction [codegen id : 2]\nInput [6]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, score#2057]\nArguments: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, score#2057, row_number() windowspecdefinition(query_id#1602, score#2057 DESC NULLS LAST, chunk_id#1206 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rank#2065], [query_id#1602], [score#2057 DESC NULLS LAST, chunk_id#1206 ASC NULLS FIRST], false\n\n(41) Filter [codegen id : 2]\nInput [7]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, score#2057, rank#2065]\nCondition : (rank#2065 <= 10)\n\n(42) Exchange\nInput [7]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, score#2057, rank#2065]\nArguments: rangepartitioning(query_id#1602 ASC NULLS FIRST, rank#2065 ASC NULLS FIRST, 128), ENSURE_REQUIREMENTS, [plan_id=1800]\n\n(43) Sort\nInput [7]: [query_id#1602, query_text#1609, chunk_id#1206, title#1207, chunk_text#1208, score#2057, rank#2065]\nArguments: [query_id#1602 ASC NULLS FIRST, rank#2065 ASC NULLS FIRST], true, 0\n\n\n"
+     ]
+    }
+   ],
+   "source": [
+    "similarity = (\n",
+    "    PairwiseVectorSimilarity()\n",
+    "    .setInputCols([\"query_embeddings\", \"chunk_embeddings\"])\n",
+    "    .setOutputCol(\"similarity\")\n",
+    "    .setSimilarityMethod(\"cosine\")\n",
+    ")\n",
+    "ranking_window = Window.partitionBy(\"query_id\").orderBy(\n",
+    "    F.desc(\"score\"), F.asc(\"chunk_id\")\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def retrieve_top_k():\n",
+    "    scored_pairs = (\n",
+    "        similarity.transform(F.broadcast(query_embeddings).crossJoin(corpus_embeddings))\n",
+    "        .select(\n",
+    "            \"query_id\",\n",
+    "            \"query_text\",\n",
+    "            \"chunk_id\",\n",
+    "            \"title\",\n",
+    "            \"chunk_text\",\n",
+    "            F.explode(\"similarity\").alias(\"similarity_annotation\"),\n",
+    "        )\n",
+    "        .select(\n",
+    "            \"query_id\",\n",
+    "            \"query_text\",\n",
+    "            \"chunk_id\",\n",
+    "            \"title\",\n",
+    "            \"chunk_text\",\n",
+    "            F.col(\"similarity_annotation.result\").cast(\"double\").alias(\"score\"),\n",
+    "        )\n",
+    "    )\n",
+    "    return (\n",
+    "        scored_pairs.withColumn(\"rank\", F.row_number().over(ranking_window))\n",
+    "        .where(F.col(\"rank\") <= top_k)\n",
+    "        .orderBy(\"query_id\", \"rank\")\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "print(f\"Exact comparisons per run: {pair_count:,}\")\n",
+    "retrieve_top_k().explain(\"formatted\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "ee524c17-cfb7-4702-9088-001afba9e34b",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 14. Inspect the retrieved passages\n",
+    "\n",
+    "This cell performs one retrieval run and displays the ranked results. The next two\n",
+    "sections evaluate quality and measure repeated warm retrieval latency separately.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788326327953,
+     "inputWidgets": {},
+     "nuid": "60515a6c-4798-4ac3-8458-8f022fe4bed6",
+     "showTitle": false,
+     "startTime": 1788326309564,
+     "submitTime": 1788324541429,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>query_id</th><th>rank</th><th>score</th><th>title</th><th>chunk_text</th></tr></thead><tbody><tr><td>5a70eee85542994082a3e3f0</td><td>1</td><td>0.8357010105617351</td><td>Ida (sword)</td><td>The Ida is a kind of sword used by the Yoruba people of West Africa. It is a long sword with a narrow to wide blade and sheathe. The sword is sharp, and cuts on contact but typically begins to dull if not sharpened regularly. It can be single-edged or double-edged. These blades are typically heavier by the tip of the blade.</td></tr><tr><td>5a70eee85542994082a3e3f0</td><td>2</td><td>0.8305645319328019</td><td>Bwa people</td><td>The Bwa or Bwaba (plural), or Bobo-Wule (Bobo-Oule), are an ethnic group indigenous to central Burkina Faso and Mali. Their population is approximately 300,000. They are known for their use of masks, made from leaves or wood, used in performative rituals.</td></tr><tr><td>5a70eee85542994082a3e3f0</td><td>3</td><td>0.823844555528344</td><td>Abiriw</td><td>\"'Abiriw\" is a town in the Eastern Region of Ghana.</td></tr><tr><td>5a70eee85542994082a3e3f0</td><td>4</td><td>0.8218920412255326</td><td>HIV/AIDS in Ivory Coast</td><td>The infection rate of HIV/AIDS in Ivory Coast is estimated at 3,46% in adults ages 15–49. Ivory Coast has a generalized HIV epidemic with the highest prevalence rate in the West African region. The prevalence rate appears to have remained relatively stable for the past decade, with recent declines among pregnant women in urban areas. Civil conflict in the country continues to hinder the collection of new national HIV-related data.</td></tr><tr><td>5a70eee85542994082a3e3f0</td><td>5</td><td>0.8211901986543511</td><td>Kwele people</td><td>The Kwele people are a tribal group of eastern Gabon, Republic of the Congo, and Cameroons in West Africa. They fled the coastal area of West Africa during the 19th century, after their traditional enemies acquired firearms from the slave traders. This altercation is often called the \"Poupou\" war. The Kwele then settled into lands between the Dja and Ivindo rivers. The Kwele are noted for their ceremonial masks which are collected as art objects.</td></tr><tr><td>5a70eee85542994082a3e3f0</td><td>6</td><td>0.817446511736989</td><td>Grands-Ponts</td><td>Grands-Ponts Region (also originally known as Leboutou Region) is one of the 31 regions of Ivory Coast. Since its establishment in 2011, it has been one of three regions in Lagunes District. The seat of the region is Dabou and the region's population in the 2014 census was 356,495.</td></tr><tr><td>5a70eee85542994082a3e3f0</td><td>7</td><td>0.8151509337637883</td><td>Politics of Sierra Leone</td><td>Sierra Leone is a country located in West Africa, known officially as the Republic of Sierra Leone.</td></tr><tr><td>5a70eee85542994082a3e3f0</td><td>8</td><td>0.814935732387725</td><td>ID Ghana</td><td>Initiative Development Ghana (or ID Ghana) is a Ghanaian MicroFinance Institution (MFI) based in the Dansoman neighborhood of Accra, Ghana. Founded in 1998, ID Ghana offers loans, voluntary savings, and a host of business support services and financial literacy training to people living in the Greater Accra region. ID Ghana is registered as a Financial NGO (FNGO) in Ghana.</td></tr><tr><td>5a70eee85542994082a3e3f0</td><td>9</td><td>0.8136762629757193</td><td>West Africa cricket team</td><td>The West African cricket team was a team representing the countries of Gambia, Ghana, Nigeria and Sierra Leone in international cricket matches whilst they were an associate member of the International Cricket Council between 1976 and 2003. They played in the ICC Trophy on three occasions, in 1982, 1994 and 1997, withdrawing shortly before the start of the 2001 tournament. The team was broken up into its constituent parts in 2003, with Nigeria becoming an associate member of the ICC, the other three affiliates.</td></tr><tr><td>5a70eee85542994082a3e3f0</td><td>10</td><td>0.8120638310126919</td><td>Idalia National Park</td><td>Idalia is a national park in South West Queensland, Australia, 893 km west of Brisbane. Idalia National Park is located near the town of Blackall in the Queensland outback. The park protects 144,000 hectares of mulga lands with conservation value. Idalia National Park was opened in 1990 by Prince Phillip.</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>1</td><td>0.9050525594111908</td><td>Spettekaka</td><td>Spettekaka or spettkaka (\"spiddekaga\" in native Scanian) is a local dessert of the southern parts of Sweden, chiefly in the province of Scania (Skåne) but also in Halland. It is an important part of the Scanian culinary heritage. The name means \"cake on a spit\", and this describes the method of preparation: it is the Swedish variation on the spit cake.</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>2</td><td>0.8386346692523237</td><td>Scanian dialect</td><td>Scanian (   ) is a closely related group of South Swedish dialects spoken in the province of Scania in southern Sweden. Scanian formed part of the old Scandinavian dialect continuum and are by most historical linguists considered to be an East Danish dialect group, but due to the modern-era influence from Standard Swedish in the region and because traditional dialectology in the Scandinavian countries normally has not considered isoglosses that cut across state borders, the Scanian dialects have normally been treated as a South Swedish dialect group in Swedish dialect research. However, many of the early Scandinavian linguists, including Adolf Noreen and G. Sjöstedt, classified it as \"South Scandinavian\", and some linguists, such as Elias Wessén, also considered Old Scanian a separate language, classified apart from both Old Danish and Old Swedish.</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>3</td><td>0.8282030377112617</td><td>Scanzorosciate</td><td>Scanzorosciate is a \"comune\" (municipality) in the Province of Bergamo in the Italian region of Lombardy, located about 50 km northeast of Milan and about 6 km northeast of Bergamo. As of 30 April 2013, it had a population of 10,018 and an area of 10.8 km2 .</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>4</td><td>0.8270491045750099</td><td>Spodnja Sorica</td><td>Spodnja Sorica (] ; German: \"Unterzarz\" ) is a village in the Municipality of Železniki in the Upper Carniola region of Slovenia.</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>5</td><td>0.8208583031364045</td><td>Spodnja Luša</td><td>Spodnja Luša (] ; German: \"Unterluscha\" ) is a settlement in the Municipality of Škofja Loka in the Upper Carniola region of Slovenia.</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>6</td><td>0.8180776100990428</td><td>Giuseppa Scandola</td><td>Maria Giuseppa Scandola, M.S.V., (26 January 1849 - 1 September 1903) was an Italian member of the Missionary Sisters of Verona, also known as the Comboni Missionary Sisters. She served in what is now South Sudan, where she offered up her life in 1903.</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>7</td><td>0.8172193297231304</td><td>Karelia</td><td>Karelia (Karelian, Finnish and Estonian: \"Karjala\"; Russian: Карелия , \"Kareliya\"; Swedish: \"Karelen\" ), the land of the Karelian peoples, is an area in Northern Europe of historical significance for Finland, Russia, and Sweden. It is currently divided between the Russian Republic of Karelia, the Russian Leningrad Oblast, and Finland (the regions of South Karelia and North Karelia).</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>8</td><td>0.8167386210480114</td><td>Spiewak</td><td>Spiewak or Śpiewak ( ) is a Polish-language surname, which literally means \"singer\". It is found across Poland, particularly in central and southern regions. It is related to the Ukrainian surname Spivak. Spiewak may refer to:</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>9</td><td>0.8165218739839697</td><td>Grodno</td><td>Grodno or Hrodna (Belarusian: Гродна , \"Hrodna\" ] ; Russian: Гродно , \"Grodno\"; ] , see also other names) is a city in western Belarus. It is located on the Neman close to the borders of Poland and Lithuania (about 20 km and 30 km away respectively). It has 365,610 inhabitants (2016 census). It is the capital of Grodno Region and Grodno District.</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>10</td><td>0.816438127440181</td><td>Szpon, Pomeranian Voivodeship</td><td>Szpon (German: \"Spohn\" ) is a village in the administrative district of Gmina Nowa Karczma, within Kościerzyna County, Pomeranian Voivodeship, in northern Poland. It lies approximately 6 km north of Nowa Karczma, 17 km north-east of Kościerzyna, and 35 km south-west of the regional capital Gdańsk.</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>1</td><td>0.8818209939615932</td><td>Johns Hopkins University</td><td>The Johns Hopkins University (commonly referred to as Johns Hopkins, JHU, or simply Hopkins) is an American private research university in Baltimore, Maryland. Founded in 1876, the university was named for its first benefactor, the American entrepreneur, abolitionist, and philanthropist Johns Hopkins. His $7 million bequest—of which half financed the establishment of Johns Hopkins Hospital—was the largest philanthropic gift in the history of the United States at that time. Daniel Coit Gilman, who was inaugurated as the institution's first president on February 22, 1876, led the university to revolutionize higher education in the U.S. by integrating teaching and research. Adopting the concept of a graduate school from Germany's ancient Heidelberg University, Johns Hopkins University is considered the first research university in the United States.</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>2</td><td>0.8492832583816095</td><td>Northwestern University</td><td>Northwestern University (NU) is a private research university based in Evanston, Illinois, with other campuses located in Chicago and Doha, Qatar, and academic programs and facilities in Washington, D.C., and San Francisco, California.</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>3</td><td>0.8253483765210617</td><td>Hippocrates Med Review</td><td>The Hippocrates Med Review (\"HMR\") is an independent student journal at the Johns Hopkins University (JHU) in Baltimore, Maryland. Founded in 2016, it is one of the nation's first medical journals that educates patients of breaking medical news. The journal is the flagship publication of the Alexander Grass Humanities Institute. They are the winners of the JHU \"Ten by Twenty\" Idealab Challenge.</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>4</td><td>0.8187159612184257</td><td>Hopkins Emergency Response Organization</td><td>The Hopkins Emergency Response Organization (HERO) is the Johns Hopkins University's student-run emergency medical services organization, providing care to the Homewood community in Baltimore, MD. HERO consists of an operational arm, the Hopkins Emergency Response Unit which provides patient care under the director of the Organization's Board of Directors.</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>5</td><td>0.8175351369987515</td><td>Rene J. Bienvenu</td><td>Rene Joseph Bienvenu, Jr. (March 19, 1923 – January 27, 1983), was an American scientist and academic who wound up his career from 1977-1982 as the president of Northwestern State University in Natchitoches, Louisiana.</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>6</td><td>0.8143502846977002</td><td>Neapolis University Paphos</td><td>The Neapolis University Paphos (NUP) is a private university in Paphos, Cyprus, that offers graduate and undergraduate degrees in Economic and Business Studies, Law, Health Sciences, Architecture & Land and Environmental Sciences,Theology and Greek Civilization.</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>7</td><td>0.8126591200451695</td><td>John F. Richards</td><td>John F. Richards (November 3, 1938 - August 23, 2007) was a historian of South Asia and in particular of the Mughal Empire. He was Professor of History at Duke University, North Carolina, and a recipient in 2007 of the Distinguished Contributions to Asian Studies Award. He participated in and encouraged a multi-disciplinary, multi-regional approach to studies.</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>8</td><td>0.8122529241850506</td><td>Taipei National University of the Arts</td><td>The Taipei National University of the Arts (TNUA; ) is a national university in Guandu, Beitou District, Taipei, Taiwan.</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>9</td><td>0.8122082577887149</td><td>Shandong University</td><td>Shandong University (, abbreviated as Shanda, , English acronym SDU) is a public comprehensive university in Shandong, China. It is one of the largest universities in China by student population (57,500 full-time students in 2009) and is supported directly by the national government.</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>10</td><td>0.8074678047123283</td><td>Weinberg College of Arts and Sciences</td><td>The Judd A. and Marjorie Weinberg College of Arts and Sciences (WCAS or Weinberg College) is the largest of the twelve schools comprising Northwestern University, located in Evanston, Illinois and downtown Chicago, Illinois. It was established in 1851 and today comprises 25 departments and many specialty programs.</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>1</td><td>0.9049785371240842</td><td>Schapendoes</td><td>The Schapendoes (] ) or Dutch Sheepdog, is a breed of dog originating in the Netherlands. The Schapendoes was originally a herding dog and general farm dog, but today also participates in dog sports such as agility and flyball.</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>2</td><td>0.8585393017994878</td><td>Bull Terrier (Miniature)</td><td>The Bull Terrier (Miniature) is a breed with origins in the extinct English White Terrier, the Dalmatian and the Bulldog. The first existence is documented 1872 in \"The Dogs of British Island\".</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>3</td><td>0.8160460067446754</td><td>FCI Terrier Group</td><td>The Terrier Group is a designation used by most all-breed dog registries (or kennel clubs) for a Group of dog breeds consisting almost entirely of terriers. See Terrier Group for information related to most kennel clubs.</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>4</td><td>0.8007129866255341</td><td>Working terrier</td><td>A working terrier is a small type of dog which pursues its quarry into the earth. According to the \"Oxford English Dictionary\", the name dates back to at least 1440, derived from French \"chien terrier\" 'digging dog', from Medieval Latin \"terrarius\", ultimately from Latin \"terra\" (earth).</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>5</td><td>0.7982481126304996</td><td>Bull Run (novel)</td><td>Bull Run is a historical novel for children by Paul Fleischman, published in 1993. It consists of sixteen monologues by participants in the First Battle of Bull Run in 1861. The novel has won several awards.</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>6</td><td>0.7970952019860366</td><td>Cormocephalus inermipes</td><td>Cormocephalus inermipes is a species of centipedes in the family Scolopendridae. It is endemic to Sri Lanka.</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>7</td><td>0.7952681751572301</td><td>Bullworker</td><td>The Bullworker is an isometric exercise device used for strength training originally marketed and sold in the early 1960s. Designed and patented by German inventor Gert F. Kölbel, it continues to sell in Europe, Asia and the United States. Over 9 million units have been sold worldwide.</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>8</td><td>0.7932695840921482</td><td>Scathophaga suilla</td><td>Scathophaga suilla is a species of fly in the family Scathophagidae. It is found in the Palearctic .</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>9</td><td>0.7926799946568786</td><td>Entlebucher Mountain Dog</td><td>The Entlebucher Sennenhund or Entlebucher Mountain Dog is a medium-sized herding dog, it is the smallest of the four Sennenhunds, a dog type that includes four regional breeds. The name Sennenhund refers to people called \"Senn\", herders in the Swiss Alps. Entlebuch is a region in the canton of Lucerne in Switzerland. The breed is also known in English as the Entelbuch Mountain Dog, Entelbucher Cattle Dog, and similar combinations.</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>10</td><td>0.7899917851201379</td><td>Schagen</td><td>Schagen (] ) is a city and municipality in the northwestern Netherlands. It is located between Alkmaar and Den Helder, in the region of West Friesland and the province of North Holland. It received city rights in 1415. In 2013, Schagen merged with Zijpe and Harenkarspel. Together they have formed a new municipality, which is also called Schagen. The townhall is located in the main town of Schagen.</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>1</td><td>0.8800891828306882</td><td>Violin Sonata No. 5 (Beethoven)</td><td>The Violin Sonata No. 5 in F major, Opus 24, is a violin sonata by Ludwig van Beethoven. It is often known as the \"Spring Sonata\" (\"Frühlingssonate\"), and was published in 1801. Its dedicatee was Count Moritz von Fries, a patron to whom Beethoven also dedicated two other works of the same year—the C major string quintet and the fourth violin sonata—as well as his later seventh symphony.</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>2</td><td>0.8739594037003815</td><td>Symphony No. 7 (Beethoven)</td><td>The Symphony No. 7 in A major, Op. 92, is a symphony in four movements composed by Ludwig van Beethoven between 1811 and 1812, while improving his health in the Bohemian spa town of Teplice. The work is dedicated to Count Moritz von Fries.</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>3</td><td>0.8498243275486705</td><td>Johann Georg von Browne</td><td>Count Johann Georg von Browne (or Johann Georg von Browne-Camus; 20 September 1767 – January 1827) was an officer in the Russian army, and settled in Vienna where he was a patron of Ludwig van Beethoven during the composer's early career.</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>4</td><td>0.8415384096166302</td><td>Count Ferdinand Ernst Gabriel von Waldstein</td><td>Count Ferdinand Ernst Joseph Gabriel von Waldstein und Wartenberg (24 March 1762 – 26 May 1823) was a German nobleman and patron of the arts. A member of the Bohemian House of Waldstein and an early patron of Ludwig van Beethoven, his political and military roles included the office of a \"Geheimrat\" in Bonn, commander (\"Komtur\") of the Teutonic Order, and (briefly) colonel of a light infantry regiment that he had raised.</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>5</td><td>0.8360617832521864</td><td>Symphony No. 9 (Beethoven)</td><td>The Symphony No. 9 in D minor, Op. 125, is the final complete symphony composed from 1822 to 1824 by the German composer Ludwig van Beethoven. It was first performed in Vienna on 7 May 1824. The symphony is one of the best-known works in common practice music. It is widely viewed by critics as one of Beethoven's greatest works, the pinnacle of musical Classicism, and one of the greatest compositions in the western musical canon. The symphony was the first example of a major composer using voices in a symphony (thus making it a choral symphony). The words are sung during the final movement by four vocal soloists and a chorus. They were taken from the \"Ode to Joy\", a poem written by Friedrich Schiller in 1785 and revised in 1803, with text additions made by the composer. In the 2010s, it stands as one of the most performed symphonies in the world.</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>6</td><td>0.8300473548540678</td><td>Faust, Part One</td><td>Faust: A Tragedy (German: \"Faust. Eine Tragödie\" , or retrospectively \"Faust. Der Tragödie / erster Teil \") is the first part of \"Faust\" by Johann Wolfgang von Goethe, and is considered by many as the greatest work of German literature. It was first published in 1808.</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>7</td><td>0.8291952615582061</td><td>Gustav Hartenstein</td><td>Gustav Hartenstein (18 March 1808 – 2 February 1890) was a German philosopher and author. He was one of the most gifted followers of Johann Friedrich Herbart.</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>8</td><td>0.8266059232340072</td><td>Fidelio</td><td>Fidelio (originally titled Leonore, oder Der Triumph der ehelichen Liebe ; English: \"Leonore, or The Triumph of Marital Love\"), Op. 72, is Ludwig van Beethoven's only opera. The German libretto was originally prepared by Joseph Sonnleithner from the French of Jean-Nicolas Bouilly, with the work premiering at Vienna's Theater an der Wien on 20 November 1805. The following year, helped shorten the work from three acts to two. After further work on the libretto by Georg Friedrich Treitschke, a final version was performed at the Kärntnertortheater on 23 May 1814. By convention, both of the first two versions are referred to as \"Leonore\".</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>9</td><td>0.8252619560064053</td><td>Hungarian Rhapsody No. 4</td><td>Hungarian Rhapsody No. 4, S.244/4, in E-flat major, is the fourth in a set of nineteen Hungarian Rhapsodies composed by Franz Liszt for solo piano. It was composed in 1847 and published in 1853.</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>10</td><td>0.8249528943967508</td><td>Margravine Friederike of Brandenburg-Schwedt</td><td>Friederike of Brandenburg-Schwedt (Friederike Sophia Dorothea; 18 December 1736 – 9 March 1798) was Duchess of Württemberg (now in Germany) and ancestor to many European royals of the 19th and 20th century.</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>1</td><td>0.9008436831543724</td><td>Libby Mitchell</td><td>Elizabeth H. \"Libby\" Mitchell (born Elizabeth Anne Harrill on June 22, 1940) is an American politician from Maine. Mitchell, a Democrat, represented part of Kennebec County in the Maine Senate from 2004 to 2010. Mitchell was also the Democrats' 2010 candidate for the office of Governor of Maine. She finished in third place behind Republican Paul LePage and unenrolled attorney Eliot Cutler. She is the only woman in United States history to have been elected as both speaker of her state house of representatives and president of her state senate.</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>2</td><td>0.8740335796433423</td><td>Eliot Cutler</td><td>Eliot Cutler (born July 29, 1946) is an American lawyer who was an Independent candidate in Maine's 2010 and 2014 gubernatorial races.</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>3</td><td>0.8300469299589537</td><td>Old Town, Maine</td><td>Old Town is a city in Penobscot County, Maine, United States. The population was 7,840 at the 2010 census. The city's developed area is chiefly located on relatively large Marsh Island, though its boundaries extend beyond that. The island is surrounded and defined by the Penobscot River to the east, and the Stillwater River to the west.</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>4</td><td>0.8268964423552418</td><td>Clifton, Maine</td><td>Clifton is a town in Penobscot County, Maine, United States. The population was 921 at the 2010 census. It is part of the Bangor Metropolitan Statistical Area.</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>5</td><td>0.8250899793287662</td><td>Tom Saviello</td><td>Thomas B. Saviello (born August 29, 1950) is an American politician. Saviello is a Republican State Senator from Maine's 18th District, representing part of Kennebec and Franklin Counties, including the population center of Farmington and his residence in Wilton. He was first elected to the Maine State Senate in 2010 after serving for 8 years (4 terms) in the Maine House of Representatives and two years on the District 9 School Board. His private experience is primarily in the field of forestry; Saviello works as a manager for International Paper. He was born in Englewood, New Jersey and is a graduate of the University of Tennessee and the University of Maine.</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>6</td><td>0.824473237542688</td><td>Corinna, Maine</td><td>Corinna is a town in Penobscot County, Maine, United States. The population was 2,198 at the 2010 census. It is part of the Bangor metropolitan statistical area.</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>7</td><td>0.8164022375574654</td><td>Dora Pinkham</td><td>Dora (Bradbury) Pinkham (September 27, 1891 — November 19, 1941) born in New Limerick, Maine was a Republican politician and the first woman elected to the Maine Legislature. She served in both the Maine House of Representatives and Maine Senate.</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>8</td><td>0.8145159469046664</td><td>Anne Haskell</td><td>Anne M. Haskell (born August 12, 1943) is an American politician from Maine. A Democrat, Haskell represents part of Portland and Westbrook in the Maine Senate.</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>9</td><td>0.8143922536130805</td><td>Alna, Maine</td><td>Alna is a town in Lincoln County, Maine, United States. The population was 709 at the 2010 census. Home to the Wiscasset, Waterville & Farmington Railway Museum, Alna includes the early mill village of Head Tide, noted for its historic architecture.</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>10</td><td>0.8130643189899882</td><td>Paul Mitchell (politician)</td><td>Paul Mitchell (born May 8, 1961) is an American politician from the state of Michigan. A member of the Republican Party, Mitchell is the U.S. Representative for Michigan 's 10 congressional district .</td></tr><tr><td>5a70f4695542994082a3e435</td><td>1</td><td>0.8447265519913401</td><td>Whitewater Canal</td><td>The Whitewater Canal, which was built between 1836 and 1847, spanned a distance of seventy-six miles and stretched from Lawrenceburg, Indiana on the Ohio River to Hagerstown, Indiana.</td></tr><tr><td>5a70f4695542994082a3e435</td><td>2</td><td>0.8297321410936981</td><td>Washington City Canal</td><td>The Washington City Canal operated from 1815 until the mid-1850s in Washington, D.C. The canal connected the Anacostia River, called the \"Eastern Branch\" at that time, to Tiber Creek, the Potomac River, and later the Chesapeake and Ohio Canal (C&O). The canal fell into disuse in the late 19th century and the city government covered over or filled in various sections.</td></tr><tr><td>5a70f4695542994082a3e435</td><td>3</td><td>0.8273370781897478</td><td>Soap Lake, Washington</td><td>Soap Lake is a city in Grant County, Washington, on the shores of Soap Lake. The population was 1,514 at the 2010 census. In 2002, the city announced preliminary plans to construct the world's largest lava lamp (60 feet in height) as a tourist attraction.</td></tr><tr><td>5a70f4695542994082a3e435</td><td>4</td><td>0.8220313549066681</td><td>White Salmon, Washington</td><td>White Salmon is a city in Klickitat County, Washington, United States. It is located in the Columbia River Gorge. The population was 2,193 at the 2000 census and increased 1.4% to 2,224 at the 2010 census.</td></tr><tr><td>5a70f4695542994082a3e435</td><td>5</td><td>0.8203513693498494</td><td>DeWitt Clinton</td><td>DeWitt Clinton (March 2, 1769February 11, 1828) was an American politician and naturalist who served as a United States Senator, Mayor of New York City and sixth Governor of New York. In this last capacity, he was largely responsible for the construction of the Erie Canal. Clinton was a major candidate for the American presidency in the election of 1812, challenging incumbent James Madison.</td></tr><tr><td>5a70f4695542994082a3e435</td><td>6</td><td>0.8192690236306244</td><td>Salmon Bay</td><td>Salmon Bay is a portion of the Lake Washington Ship Canal—a canal which passes through the city of Seattle, linking Lake Washington to Puget Sound—that lies west of the Fremont Cut. It is the westernmost section of the canal, and empties into Puget Sound's Shilshole Bay. Because of the Hiram M. Chittenden Locks, the smaller, western half of the bay is salt water, and the eastern half is fresh water (though not without saline contamination—see Lake Union). Before construction of the Ship Canal, Salmon Bay was entirely salt water.</td></tr><tr><td>5a70f4695542994082a3e435</td><td>7</td><td>0.8186757449142237</td><td>Bill Morley (baseball)</td><td>William M. Morley (born \"William Morley Jennings\") was a Major League Baseball second baseman. He played in two games for the Washington Senators in 1913 , going 0-for-3.</td></tr><tr><td>5a70f4695542994082a3e435</td><td>8</td><td>0.8140307140660191</td><td>White, Washington</td><td>White is an unincorporated community in King County, in the U.S. state of Washington.</td></tr><tr><td>5a70f4695542994082a3e435</td><td>9</td><td>0.8115137299835566</td><td>Wamesit Canal-Whipple Mill Industrial Complex</td><td>The Wamesit Canal-Whipple Mill Industrial Complex is a historic mill and canal at 576 Lawrence Street in Lowell, Massachusetts. This industrial area of Lowell, located on the Concord River, underwent a major expansion from a more modest millworks in the mid-19th century by Oliver Whipple, a manufacturer of gunpowder. Whipple undertook the construction of a canal along that river to provide power for a number of mills he erected in the area, consulting with engineer Loammi Baldwin, Jr. on the matter. The area was further developed in the second half of the 19th century by the Wamesit Power Company, which acquired most of Whipple's properties and water rights. A mill built by Whipple in the 1820s, of which portions survive, is one of the oldest surviving industrial structures in the city.</td></tr><tr><td>5a70f4695542994082a3e435</td><td>10</td><td>0.8114744664991391</td><td>Waterways, Alberta</td><td>Waterways is a locality within the Regional Municipality of Wood Buffalo in northern Alberta, Canada. It is now a neighbourhood within the Fort McMurray urban service area along the west bank of the Clearwater River, south of the river's confluence with the Athabasca River.</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>1</td><td>0.888647207337187</td><td>Maria Golovin</td><td>Maria Golovin is an English language opera in three acts by Gian Carlo Menotti. It is through-composed and centers on a romantic encounter between a blind recluse named Donato and the title character, a married woman living in a European country a few years after a recent war. The work was commissioned by Peter Herman Adler of the NBC Opera Theatre.</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>2</td><td>0.8495679523327158</td><td>Gian Carlo Menotti</td><td>Gian Carlo Menotti (] ; July 7, 1911 – February 1, 2007) was an Italian-American composer and librettist. Although he often referred to himself as an American composer, he kept his Italian citizenship. He wrote the classic Christmas opera \"Amahl and the Night Visitors\", along with over two dozen other operas intended to appeal to popular taste.</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>3</td><td>0.8334830300809545</td><td>Domenico Gilardoni</td><td>Domenico Gilardoni (1798–1831) was an Italian opera librettist, most well known for his collaborations with the composers Vincenzo Bellini (his first work) and Gaetano Donizetti.</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>4</td><td>0.8279297968811251</td><td>Melodramma</td><td>Melodramma (plural: \"melodrammi\") is a 17th-century Italian term for a text to be set as an opera, or the opera itself. In the 19th-century, it was used in a much narrower sense by English writers to discuss developments in the early Italian libretto, e.g., \"Rigoletto\" and \"Un ballo in maschera\". Characteristic are the influence of French bourgeois drama, female instead of male protagonists, and the practice of opening the action with a chorus.</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>5</td><td>0.8278153424494707</td><td>Ugolino of Forlì</td><td>Ugolino of Forlì or Ugolino of Orvieto (Italian: Ugolino da Orvieto or Urbevetano or Ugolino da Forlì) (Forlì, c. 1380 - Ferrara, c. 1457) was an Italian composer and musical theorist of the Renaissance.</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>6</td><td>0.8268356671854027</td><td>Paul Creston</td><td>Paul Creston (born Giuseppe Guttoveggio; October 10, 1906 – August 24, 1985) was an Italian American composer of classical music.</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>7</td><td>0.8250525042614982</td><td>Maria Waldmann</td><td>Maria Waldmann (19 November 1845 – 6 November 1920) was an Austrian mezzo-soprano who had a noted association with Giuseppe Verdi.</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>8</td><td>0.8198912179177469</td><td>Nicolò Gabrielli</td><td>Count Nicolò Gabrielli di Quercita (21 February 1814 – 14 June 1891) was an Italian opera composer.</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>9</td><td>0.8184736178686307</td><td>Matthew Aucoin</td><td>Matthew Aucoin (born 1990) is an American composer, conductor, pianist, and writer best known for his operas. Aucoin has received commissions from the Metropolitan Opera, Carnegie Hall, Lyric Opera of Chicago, the American Repertory Theater, the Peabody Essex Museum, Harvard University, and NPR's \"This American Life\". As a young musical virtuoso, Aucoin has been compared to Wolfgang Amadeus Mozart, Richard Wagner, and Leonard Bernstein. Additionally, he is the youngest assistant conductor in the history of the Metropolitan Opera. He was appointed as Los Angeles Opera's first-ever Artist-in-Residence in 2016.</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>10</td><td>0.818226821580564</td><td>Angelo Mariani (conductor)</td><td>Angelo Maurizio Gaspare Mariani (11 October 182113 June 1873) was an Italian opera conductor and composer. His work as a conductor drew praise from Giuseppe Verdi, Giacomo Meyerbeer, Gioachino Rossini and Richard Wagner, and he was a longtime personal friend of Verdi's, although they had a falling out towards the end of Mariani's life. He conducted at least two world premieres (Verdi's \"Aroldo\" and Faccio's \"Amleto\"); and at least 4 Italian premieres (Meyerbeer's \"L'Africana\", Verdi's \"Don Carlo\", and \"Lohengrin\" and \"Tannhäuser\" by Wagner).</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>1</td><td>0.8416197526695911</td><td>The Amazing Race Canada 1</td><td>The first season of The Amazing Race Canada was a reality game show based on the American series \"The Amazing Race\". It featured nine teams of two with pre-existing relationships who raced around Canada for CA$ , two Chevrolet Corvette Stingrays and an unlimited air travel for a year with Air Canada. The show was produced by Insight Productions, in association with Bell Media and was broadcast on CTV. The show was hosted by Canadian Olympian Jon Montgomery.</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>2</td><td>0.835907150258378</td><td>Amazing Race (France)</td><td>Amazing Race : la plus grande course autour du monde ! (English: Amazing Race: the biggest race around the world! ) is a French version of the American reality show \"The Amazing Race\". Hosted by , it features nine teams of two with a pre-existing relationship, in a race around the world to win €50,000.</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>3</td><td>0.8159086940027129</td><td>I Supermodel (season 1)</td><td>I Supermodel 1 is the first season of the Chinese reality show and modeling competition of the same name. Filming for the show took place in Melbourne, Australia. The show featured 14 contestants in the final cast and began to air on television on March 21, 2015. The winner of the competition was 26-year-old Kang Qian Wen, better known professionally as Kiki Kang.</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>4</td><td>0.815505759473752</td><td>Pontiac Montana</td><td>The Pontiac Montana is a minivan that was sold by Pontiac. Prior to the 1997 model year, it was known as Pontiac Trans Sport. In 1997, the Trans Sport added the Montana moniker as part of an available trim package. The package proved so popular the line was renamed Montana in 1999 for the US and 2000 for Canada. For 2005, the van was redesigned with a higher, less aerodynamic nose to resemble an SUV. The Montana name was also changed to Montana SV6. It was discontinued after the 2006 model year in the United States because of slow sales, but continued to be sold in Mexico until the 2009 model year and in Canada until the 2010 model year because of GM phasing out the Pontiac brand after the 2010 model year. Since their introduction, the Pontiac minivans were General Motors' most popular minivans among consumers in Canada.</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>5</td><td>0.809825472838822</td><td>All-terrain vehicle</td><td>An all-terrain vehicle (ATV), also known as a quad, quad bike, three-wheeler, four-wheeler or quadricycle as defined by the American National Standards Institute (ANSI) is a vehicle that travels on low-pressure tires, with a seat that is straddled by the operator, along with handlebars for steering control. As the name implies, it is designed to handle a wider variety of terrain than most other vehicles. Although it is a street-legal vehicle in some countries, it is not street-legal within most states and provinces of Australia, the United States or Canada.</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>6</td><td>0.8089352724103067</td><td>BattleBots (season 6)</td><td>Season 6 (also referred to as Season 1 on ABC) of the American competitive television series BattleBots premiered on ABC on June 21, 2015.</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>7</td><td>0.8081526936283757</td><td>Nissan Juke</td><td>The Nissan Juke is a subcompact crossover SUV produced by the Japanese manufacturer Nissan since 2010. The production version made its debut at the 2010 Geneva Motor Show in March, and was introduced to North America at the 2010 New York International Auto Show to be sold for the 2011 model year. The name \"\"juke\"\" means to dance or change directions demonstrating agility.</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>8</td><td>0.8080075497099704</td><td>Chevrolet Corvette (C7)</td><td>The Chevrolet Corvette (C7) is a sports car produced by Chevrolet. The seventh generation Corvette was introduced for the 2014 model year as the first to bear the Corvette Stingray name since the 1968 third generation model. The first C7 Corvette was delivered in the third quarter of 2013.</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>9</td><td>0.8075594456221945</td><td>Angus Fogg</td><td>Angus Fogg (born 26 August 1967) is a championship winning New Zealand racecar driver who competes in the New Zealand V8SuperTourer Championship.</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>10</td><td>0.807279776667905</td><td>HumanTown</td><td>HumanTown is a Canadian sketch comedy troupe, best known for winning the Canadian Broadcasting Corporation's ComedyCoup seed accelerator competition in 2014. Based in Vancouver, the troupe consists of Kajetan Kwiatkowski, Jack Heyes, Liam MacLeod, Kane Stewart, Miles Chalmers, and Daniel Doheny.</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>1</td><td>0.8761139403780055</td><td>Alt for Damerne</td><td>ALT for Damerne (meaning \"All for the Ladies\" in English) is a Danish language weekly women's magazine published in Copenhagen, Denmark.</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>2</td><td>0.836904866559799</td><td>Essence (magazine)</td><td>Essence is a monthly magazine for African American women between the ages of 18 and 49. It is the only magazine that focuses on reaching an audience of black women, revolves around the black woman experience, and has remained for a long period of time. The magazine covers fashion, lifestyle and beauty, with an intimate girlfriend-to-girlfriend tone, and its slogan \"Fierce, Fun, and Fabulous\" suggests the magazine's goal of empowering African-American women. The topics the magazine discusses range from celebrities, to fashion, to point-of-view pieces addressing current issues in the African-American community. A number of its readers engage closely and personally with the publication, and it claims to be the magazine \"for and about Black women\".</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>3</td><td>0.8146218548204954</td><td>Gemma Lavender</td><td>Gemma Lavender (born 13 September 1986) is a British astronomer, author and journalist. She currently serves as the Editor of All About Space, a monthly scientific magazine owned by British publisher Imagine Publishing based in Bournemouth, United Kingdom.</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>4</td><td>0.812250963385372</td><td>Ken Wilber</td><td>Kenneth Earl \"Ken\" Wilber II (born January 31, 1949) is an American writer on transpersonal psychology and his own integral theory, a four-quadrant grid which suggests the synthesis of all human knowledge and experience.</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>5</td><td>0.8117825244016397</td><td>Soul Asylum</td><td>Soul Asylum is an American alternative rock band formed in 1981 in Minneapolis, Minnesota. The band began using their official name in 1983..</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>6</td><td>0.8116743978978015</td><td>Barbara Seaman</td><td>Barbara Seaman (September 11, 1935 – February 27, 2008) was an American author, activist, and journalist, and a principal founder of the women's health feminism movement.</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>7</td><td>0.8113797778819566</td><td>Lee Everett Alkin</td><td>Lee Everett or Lee Everett Alkin (born Audrey Valentine Middleton 14 February 1937) is a British spiritual healer and businesswoman, who was previously a pop singer and celebrity psychic under the stage name Lady Lee.</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>8</td><td>0.8101829410937911</td><td>New Internationalist</td><td>New Internationalist (\"NI\") is an independent, non-profit, publishing co-operative, based in Oxford, United Kingdom. Predominantly known for its monthly independent magazine, it describes itself as existing to 'cover stories the mainstream media sidestep and provide alternative perspectives on today's global critical issues.' It covers social and environmental issues through its magazine, books and digital platforms.</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>9</td><td>0.8093833931173772</td><td>Occult or Exact Science?</td><td>Occult or Exact Science? is an article published in two parts, in April and May 1886, in the theosophical magazine \"The Theosophist\"; it was compiled by Helena Blavatsky. It was included in the 7th volume of the author's \"Collected Writings.\"</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>10</td><td>0.8088809617040785</td><td>Louis Althusser</td><td>Louis Pierre Althusser (] ; 16 October 1918 – 22 October 1990) was a French Marxist philosopher. He was born in Algeria and studied at the École Normale Supérieure in Paris, where he eventually became Professor of Philosophy.</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         "5a70eee85542994082a3e3f0",
+         1,
+         0.8357010105617351,
+         "Ida (sword)",
+         "The Ida is a kind of sword used by the Yoruba people of West Africa. It is a long sword with a narrow to wide blade and sheathe. The sword is sharp, and cuts on contact but typically begins to dull if not sharpened regularly. It can be single-edged or double-edged. These blades are typically heavier by the tip of the blade."
+        ],
+        [
+         "5a70eee85542994082a3e3f0",
+         2,
+         0.8305645319328019,
+         "Bwa people",
+         "The Bwa or Bwaba (plural), or Bobo-Wule (Bobo-Oule), are an ethnic group indigenous to central Burkina Faso and Mali. Their population is approximately 300,000. They are known for their use of masks, made from leaves or wood, used in performative rituals."
+        ],
+        [
+         "5a70eee85542994082a3e3f0",
+         3,
+         0.823844555528344,
+         "Abiriw",
+         "\"'Abiriw\" is a town in the Eastern Region of Ghana."
+        ],
+        [
+         "5a70eee85542994082a3e3f0",
+         4,
+         0.8218920412255326,
+         "HIV/AIDS in Ivory Coast",
+         "The infection rate of HIV/AIDS in Ivory Coast is estimated at 3,46% in adults ages 15–49. Ivory Coast has a generalized HIV epidemic with the highest prevalence rate in the West African region. The prevalence rate appears to have remained relatively stable for the past decade, with recent declines among pregnant women in urban areas. Civil conflict in the country continues to hinder the collection of new national HIV-related data."
+        ],
+        [
+         "5a70eee85542994082a3e3f0",
+         5,
+         0.8211901986543511,
+         "Kwele people",
+         "The Kwele people are a tribal group of eastern Gabon, Republic of the Congo, and Cameroons in West Africa. They fled the coastal area of West Africa during the 19th century, after their traditional enemies acquired firearms from the slave traders. This altercation is often called the \"Poupou\" war. The Kwele then settled into lands between the Dja and Ivindo rivers. The Kwele are noted for their ceremonial masks which are collected as art objects."
+        ],
+        [
+         "5a70eee85542994082a3e3f0",
+         6,
+         0.817446511736989,
+         "Grands-Ponts",
+         "Grands-Ponts Region (also originally known as Leboutou Region) is one of the 31 regions of Ivory Coast. Since its establishment in 2011, it has been one of three regions in Lagunes District. The seat of the region is Dabou and the region's population in the 2014 census was 356,495."
+        ],
+        [
+         "5a70eee85542994082a3e3f0",
+         7,
+         0.8151509337637883,
+         "Politics of Sierra Leone",
+         "Sierra Leone is a country located in West Africa, known officially as the Republic of Sierra Leone."
+        ],
+        [
+         "5a70eee85542994082a3e3f0",
+         8,
+         0.814935732387725,
+         "ID Ghana",
+         "Initiative Development Ghana (or ID Ghana) is a Ghanaian MicroFinance Institution (MFI) based in the Dansoman neighborhood of Accra, Ghana. Founded in 1998, ID Ghana offers loans, voluntary savings, and a host of business support services and financial literacy training to people living in the Greater Accra region. ID Ghana is registered as a Financial NGO (FNGO) in Ghana."
+        ],
+        [
+         "5a70eee85542994082a3e3f0",
+         9,
+         0.8136762629757193,
+         "West Africa cricket team",
+         "The West African cricket team was a team representing the countries of Gambia, Ghana, Nigeria and Sierra Leone in international cricket matches whilst they were an associate member of the International Cricket Council between 1976 and 2003. They played in the ICC Trophy on three occasions, in 1982, 1994 and 1997, withdrawing shortly before the start of the 2001 tournament. The team was broken up into its constituent parts in 2003, with Nigeria becoming an associate member of the ICC, the other three affiliates."
+        ],
+        [
+         "5a70eee85542994082a3e3f0",
+         10,
+         0.8120638310126919,
+         "Idalia National Park",
+         "Idalia is a national park in South West Queensland, Australia, 893 km west of Brisbane. Idalia National Park is located near the town of Blackall in the Queensland outback. The park protects 144,000 hectares of mulga lands with conservation value. Idalia National Park was opened in 1990 by Prince Phillip."
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         1,
+         0.9050525594111908,
+         "Spettekaka",
+         "Spettekaka or spettkaka (\"spiddekaga\" in native Scanian) is a local dessert of the southern parts of Sweden, chiefly in the province of Scania (Skåne) but also in Halland. It is an important part of the Scanian culinary heritage. The name means \"cake on a spit\", and this describes the method of preparation: it is the Swedish variation on the spit cake."
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         2,
+         0.8386346692523237,
+         "Scanian dialect",
+         "Scanian (   ) is a closely related group of South Swedish dialects spoken in the province of Scania in southern Sweden. Scanian formed part of the old Scandinavian dialect continuum and are by most historical linguists considered to be an East Danish dialect group, but due to the modern-era influence from Standard Swedish in the region and because traditional dialectology in the Scandinavian countries normally has not considered isoglosses that cut across state borders, the Scanian dialects have normally been treated as a South Swedish dialect group in Swedish dialect research. However, many of the early Scandinavian linguists, including Adolf Noreen and G. Sjöstedt, classified it as \"South Scandinavian\", and some linguists, such as Elias Wessén, also considered Old Scanian a separate language, classified apart from both Old Danish and Old Swedish."
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         3,
+         0.8282030377112617,
+         "Scanzorosciate",
+         "Scanzorosciate is a \"comune\" (municipality) in the Province of Bergamo in the Italian region of Lombardy, located about 50 km northeast of Milan and about 6 km northeast of Bergamo. As of 30 April 2013, it had a population of 10,018 and an area of 10.8 km2 ."
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         4,
+         0.8270491045750099,
+         "Spodnja Sorica",
+         "Spodnja Sorica (] ; German: \"Unterzarz\" ) is a village in the Municipality of Železniki in the Upper Carniola region of Slovenia."
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         5,
+         0.8208583031364045,
+         "Spodnja Luša",
+         "Spodnja Luša (] ; German: \"Unterluscha\" ) is a settlement in the Municipality of Škofja Loka in the Upper Carniola region of Slovenia."
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         6,
+         0.8180776100990428,
+         "Giuseppa Scandola",
+         "Maria Giuseppa Scandola, M.S.V., (26 January 1849 - 1 September 1903) was an Italian member of the Missionary Sisters of Verona, also known as the Comboni Missionary Sisters. She served in what is now South Sudan, where she offered up her life in 1903."
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         7,
+         0.8172193297231304,
+         "Karelia",
+         "Karelia (Karelian, Finnish and Estonian: \"Karjala\"; Russian: Карелия , \"Kareliya\"; Swedish: \"Karelen\" ), the land of the Karelian peoples, is an area in Northern Europe of historical significance for Finland, Russia, and Sweden. It is currently divided between the Russian Republic of Karelia, the Russian Leningrad Oblast, and Finland (the regions of South Karelia and North Karelia)."
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         8,
+         0.8167386210480114,
+         "Spiewak",
+         "Spiewak or Śpiewak ( ) is a Polish-language surname, which literally means \"singer\". It is found across Poland, particularly in central and southern regions. It is related to the Ukrainian surname Spivak. Spiewak may refer to:"
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         9,
+         0.8165218739839697,
+         "Grodno",
+         "Grodno or Hrodna (Belarusian: Гродна , \"Hrodna\" ] ; Russian: Гродно , \"Grodno\"; ] , see also other names) is a city in western Belarus. It is located on the Neman close to the borders of Poland and Lithuania (about 20 km and 30 km away respectively). It has 365,610 inhabitants (2016 census). It is the capital of Grodno Region and Grodno District."
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         10,
+         0.816438127440181,
+         "Szpon, Pomeranian Voivodeship",
+         "Szpon (German: \"Spohn\" ) is a village in the administrative district of Gmina Nowa Karczma, within Kościerzyna County, Pomeranian Voivodeship, in northern Poland. It lies approximately 6 km north of Nowa Karczma, 17 km north-east of Kościerzyna, and 35 km south-west of the regional capital Gdańsk."
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         1,
+         0.8818209939615932,
+         "Johns Hopkins University",
+         "The Johns Hopkins University (commonly referred to as Johns Hopkins, JHU, or simply Hopkins) is an American private research university in Baltimore, Maryland. Founded in 1876, the university was named for its first benefactor, the American entrepreneur, abolitionist, and philanthropist Johns Hopkins. His $7 million bequest—of which half financed the establishment of Johns Hopkins Hospital—was the largest philanthropic gift in the history of the United States at that time. Daniel Coit Gilman, who was inaugurated as the institution's first president on February 22, 1876, led the university to revolutionize higher education in the U.S. by integrating teaching and research. Adopting the concept of a graduate school from Germany's ancient Heidelberg University, Johns Hopkins University is considered the first research university in the United States."
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         2,
+         0.8492832583816095,
+         "Northwestern University",
+         "Northwestern University (NU) is a private research university based in Evanston, Illinois, with other campuses located in Chicago and Doha, Qatar, and academic programs and facilities in Washington, D.C., and San Francisco, California."
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         3,
+         0.8253483765210617,
+         "Hippocrates Med Review",
+         "The Hippocrates Med Review (\"HMR\") is an independent student journal at the Johns Hopkins University (JHU) in Baltimore, Maryland. Founded in 2016, it is one of the nation's first medical journals that educates patients of breaking medical news. The journal is the flagship publication of the Alexander Grass Humanities Institute. They are the winners of the JHU \"Ten by Twenty\" Idealab Challenge."
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         4,
+         0.8187159612184257,
+         "Hopkins Emergency Response Organization",
+         "The Hopkins Emergency Response Organization (HERO) is the Johns Hopkins University's student-run emergency medical services organization, providing care to the Homewood community in Baltimore, MD. HERO consists of an operational arm, the Hopkins Emergency Response Unit which provides patient care under the director of the Organization's Board of Directors."
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         5,
+         0.8175351369987515,
+         "Rene J. Bienvenu",
+         "Rene Joseph Bienvenu, Jr. (March 19, 1923 – January 27, 1983), was an American scientist and academic who wound up his career from 1977-1982 as the president of Northwestern State University in Natchitoches, Louisiana."
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         6,
+         0.8143502846977002,
+         "Neapolis University Paphos",
+         "The Neapolis University Paphos (NUP) is a private university in Paphos, Cyprus, that offers graduate and undergraduate degrees in Economic and Business Studies, Law, Health Sciences, Architecture & Land and Environmental Sciences,Theology and Greek Civilization."
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         7,
+         0.8126591200451695,
+         "John F. Richards",
+         "John F. Richards (November 3, 1938 - August 23, 2007) was a historian of South Asia and in particular of the Mughal Empire. He was Professor of History at Duke University, North Carolina, and a recipient in 2007 of the Distinguished Contributions to Asian Studies Award. He participated in and encouraged a multi-disciplinary, multi-regional approach to studies."
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         8,
+         0.8122529241850506,
+         "Taipei National University of the Arts",
+         "The Taipei National University of the Arts (TNUA; ) is a national university in Guandu, Beitou District, Taipei, Taiwan."
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         9,
+         0.8122082577887149,
+         "Shandong University",
+         "Shandong University (, abbreviated as Shanda, , English acronym SDU) is a public comprehensive university in Shandong, China. It is one of the largest universities in China by student population (57,500 full-time students in 2009) and is supported directly by the national government."
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         10,
+         0.8074678047123283,
+         "Weinberg College of Arts and Sciences",
+         "The Judd A. and Marjorie Weinberg College of Arts and Sciences (WCAS or Weinberg College) is the largest of the twelve schools comprising Northwestern University, located in Evanston, Illinois and downtown Chicago, Illinois. It was established in 1851 and today comprises 25 departments and many specialty programs."
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         1,
+         0.9049785371240842,
+         "Schapendoes",
+         "The Schapendoes (] ) or Dutch Sheepdog, is a breed of dog originating in the Netherlands. The Schapendoes was originally a herding dog and general farm dog, but today also participates in dog sports such as agility and flyball."
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         2,
+         0.8585393017994878,
+         "Bull Terrier (Miniature)",
+         "The Bull Terrier (Miniature) is a breed with origins in the extinct English White Terrier, the Dalmatian and the Bulldog. The first existence is documented 1872 in \"The Dogs of British Island\"."
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         3,
+         0.8160460067446754,
+         "FCI Terrier Group",
+         "The Terrier Group is a designation used by most all-breed dog registries (or kennel clubs) for a Group of dog breeds consisting almost entirely of terriers. See Terrier Group for information related to most kennel clubs."
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         4,
+         0.8007129866255341,
+         "Working terrier",
+         "A working terrier is a small type of dog which pursues its quarry into the earth. According to the \"Oxford English Dictionary\", the name dates back to at least 1440, derived from French \"chien terrier\" 'digging dog', from Medieval Latin \"terrarius\", ultimately from Latin \"terra\" (earth)."
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         5,
+         0.7982481126304996,
+         "Bull Run (novel)",
+         "Bull Run is a historical novel for children by Paul Fleischman, published in 1993. It consists of sixteen monologues by participants in the First Battle of Bull Run in 1861. The novel has won several awards."
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         6,
+         0.7970952019860366,
+         "Cormocephalus inermipes",
+         "Cormocephalus inermipes is a species of centipedes in the family Scolopendridae. It is endemic to Sri Lanka."
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         7,
+         0.7952681751572301,
+         "Bullworker",
+         "The Bullworker is an isometric exercise device used for strength training originally marketed and sold in the early 1960s. Designed and patented by German inventor Gert F. Kölbel, it continues to sell in Europe, Asia and the United States. Over 9 million units have been sold worldwide."
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         8,
+         0.7932695840921482,
+         "Scathophaga suilla",
+         "Scathophaga suilla is a species of fly in the family Scathophagidae. It is found in the Palearctic ."
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         9,
+         0.7926799946568786,
+         "Entlebucher Mountain Dog",
+         "The Entlebucher Sennenhund or Entlebucher Mountain Dog is a medium-sized herding dog, it is the smallest of the four Sennenhunds, a dog type that includes four regional breeds. The name Sennenhund refers to people called \"Senn\", herders in the Swiss Alps. Entlebuch is a region in the canton of Lucerne in Switzerland. The breed is also known in English as the Entelbuch Mountain Dog, Entelbucher Cattle Dog, and similar combinations."
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         10,
+         0.7899917851201379,
+         "Schagen",
+         "Schagen (] ) is a city and municipality in the northwestern Netherlands. It is located between Alkmaar and Den Helder, in the region of West Friesland and the province of North Holland. It received city rights in 1415. In 2013, Schagen merged with Zijpe and Harenkarspel. Together they have formed a new municipality, which is also called Schagen. The townhall is located in the main town of Schagen."
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         1,
+         0.8800891828306882,
+         "Violin Sonata No. 5 (Beethoven)",
+         "The Violin Sonata No. 5 in F major, Opus 24, is a violin sonata by Ludwig van Beethoven. It is often known as the \"Spring Sonata\" (\"Frühlingssonate\"), and was published in 1801. Its dedicatee was Count Moritz von Fries, a patron to whom Beethoven also dedicated two other works of the same year—the C major string quintet and the fourth violin sonata—as well as his later seventh symphony."
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         2,
+         0.8739594037003815,
+         "Symphony No. 7 (Beethoven)",
+         "The Symphony No. 7 in A major, Op. 92, is a symphony in four movements composed by Ludwig van Beethoven between 1811 and 1812, while improving his health in the Bohemian spa town of Teplice. The work is dedicated to Count Moritz von Fries."
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         3,
+         0.8498243275486705,
+         "Johann Georg von Browne",
+         "Count Johann Georg von Browne (or Johann Georg von Browne-Camus; 20 September 1767 – January 1827) was an officer in the Russian army, and settled in Vienna where he was a patron of Ludwig van Beethoven during the composer's early career."
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         4,
+         0.8415384096166302,
+         "Count Ferdinand Ernst Gabriel von Waldstein",
+         "Count Ferdinand Ernst Joseph Gabriel von Waldstein und Wartenberg (24 March 1762 – 26 May 1823) was a German nobleman and patron of the arts. A member of the Bohemian House of Waldstein and an early patron of Ludwig van Beethoven, his political and military roles included the office of a \"Geheimrat\" in Bonn, commander (\"Komtur\") of the Teutonic Order, and (briefly) colonel of a light infantry regiment that he had raised."
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         5,
+         0.8360617832521864,
+         "Symphony No. 9 (Beethoven)",
+         "The Symphony No. 9 in D minor, Op. 125, is the final complete symphony composed from 1822 to 1824 by the German composer Ludwig van Beethoven. It was first performed in Vienna on 7 May 1824. The symphony is one of the best-known works in common practice music. It is widely viewed by critics as one of Beethoven's greatest works, the pinnacle of musical Classicism, and one of the greatest compositions in the western musical canon. The symphony was the first example of a major composer using voices in a symphony (thus making it a choral symphony). The words are sung during the final movement by four vocal soloists and a chorus. They were taken from the \"Ode to Joy\", a poem written by Friedrich Schiller in 1785 and revised in 1803, with text additions made by the composer. In the 2010s, it stands as one of the most performed symphonies in the world."
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         6,
+         0.8300473548540678,
+         "Faust, Part One",
+         "Faust: A Tragedy (German: \"Faust. Eine Tragödie\" , or retrospectively \"Faust. Der Tragödie / erster Teil \") is the first part of \"Faust\" by Johann Wolfgang von Goethe, and is considered by many as the greatest work of German literature. It was first published in 1808."
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         7,
+         0.8291952615582061,
+         "Gustav Hartenstein",
+         "Gustav Hartenstein (18 March 1808 – 2 February 1890) was a German philosopher and author. He was one of the most gifted followers of Johann Friedrich Herbart."
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         8,
+         0.8266059232340072,
+         "Fidelio",
+         "Fidelio (originally titled Leonore, oder Der Triumph der ehelichen Liebe ; English: \"Leonore, or The Triumph of Marital Love\"), Op. 72, is Ludwig van Beethoven's only opera. The German libretto was originally prepared by Joseph Sonnleithner from the French of Jean-Nicolas Bouilly, with the work premiering at Vienna's Theater an der Wien on 20 November 1805. The following year, helped shorten the work from three acts to two. After further work on the libretto by Georg Friedrich Treitschke, a final version was performed at the Kärntnertortheater on 23 May 1814. By convention, both of the first two versions are referred to as \"Leonore\"."
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         9,
+         0.8252619560064053,
+         "Hungarian Rhapsody No. 4",
+         "Hungarian Rhapsody No. 4, S.244/4, in E-flat major, is the fourth in a set of nineteen Hungarian Rhapsodies composed by Franz Liszt for solo piano. It was composed in 1847 and published in 1853."
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         10,
+         0.8249528943967508,
+         "Margravine Friederike of Brandenburg-Schwedt",
+         "Friederike of Brandenburg-Schwedt (Friederike Sophia Dorothea; 18 December 1736 – 9 March 1798) was Duchess of Württemberg (now in Germany) and ancestor to many European royals of the 19th and 20th century."
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         1,
+         0.9008436831543724,
+         "Libby Mitchell",
+         "Elizabeth H. \"Libby\" Mitchell (born Elizabeth Anne Harrill on June 22, 1940) is an American politician from Maine. Mitchell, a Democrat, represented part of Kennebec County in the Maine Senate from 2004 to 2010. Mitchell was also the Democrats' 2010 candidate for the office of Governor of Maine. She finished in third place behind Republican Paul LePage and unenrolled attorney Eliot Cutler. She is the only woman in United States history to have been elected as both speaker of her state house of representatives and president of her state senate."
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         2,
+         0.8740335796433423,
+         "Eliot Cutler",
+         "Eliot Cutler (born July 29, 1946) is an American lawyer who was an Independent candidate in Maine's 2010 and 2014 gubernatorial races."
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         3,
+         0.8300469299589537,
+         "Old Town, Maine",
+         "Old Town is a city in Penobscot County, Maine, United States. The population was 7,840 at the 2010 census. The city's developed area is chiefly located on relatively large Marsh Island, though its boundaries extend beyond that. The island is surrounded and defined by the Penobscot River to the east, and the Stillwater River to the west."
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         4,
+         0.8268964423552418,
+         "Clifton, Maine",
+         "Clifton is a town in Penobscot County, Maine, United States. The population was 921 at the 2010 census. It is part of the Bangor Metropolitan Statistical Area."
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         5,
+         0.8250899793287662,
+         "Tom Saviello",
+         "Thomas B. Saviello (born August 29, 1950) is an American politician. Saviello is a Republican State Senator from Maine's 18th District, representing part of Kennebec and Franklin Counties, including the population center of Farmington and his residence in Wilton. He was first elected to the Maine State Senate in 2010 after serving for 8 years (4 terms) in the Maine House of Representatives and two years on the District 9 School Board. His private experience is primarily in the field of forestry; Saviello works as a manager for International Paper. He was born in Englewood, New Jersey and is a graduate of the University of Tennessee and the University of Maine."
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         6,
+         0.824473237542688,
+         "Corinna, Maine",
+         "Corinna is a town in Penobscot County, Maine, United States. The population was 2,198 at the 2010 census. It is part of the Bangor metropolitan statistical area."
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         7,
+         0.8164022375574654,
+         "Dora Pinkham",
+         "Dora (Bradbury) Pinkham (September 27, 1891 — November 19, 1941) born in New Limerick, Maine was a Republican politician and the first woman elected to the Maine Legislature. She served in both the Maine House of Representatives and Maine Senate."
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         8,
+         0.8145159469046664,
+         "Anne Haskell",
+         "Anne M. Haskell (born August 12, 1943) is an American politician from Maine. A Democrat, Haskell represents part of Portland and Westbrook in the Maine Senate."
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         9,
+         0.8143922536130805,
+         "Alna, Maine",
+         "Alna is a town in Lincoln County, Maine, United States. The population was 709 at the 2010 census. Home to the Wiscasset, Waterville & Farmington Railway Museum, Alna includes the early mill village of Head Tide, noted for its historic architecture."
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         10,
+         0.8130643189899882,
+         "Paul Mitchell (politician)",
+         "Paul Mitchell (born May 8, 1961) is an American politician from the state of Michigan. A member of the Republican Party, Mitchell is the U.S. Representative for Michigan 's 10 congressional district ."
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         1,
+         0.8447265519913401,
+         "Whitewater Canal",
+         "The Whitewater Canal, which was built between 1836 and 1847, spanned a distance of seventy-six miles and stretched from Lawrenceburg, Indiana on the Ohio River to Hagerstown, Indiana."
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         2,
+         0.8297321410936981,
+         "Washington City Canal",
+         "The Washington City Canal operated from 1815 until the mid-1850s in Washington, D.C. The canal connected the Anacostia River, called the \"Eastern Branch\" at that time, to Tiber Creek, the Potomac River, and later the Chesapeake and Ohio Canal (C&O). The canal fell into disuse in the late 19th century and the city government covered over or filled in various sections."
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         3,
+         0.8273370781897478,
+         "Soap Lake, Washington",
+         "Soap Lake is a city in Grant County, Washington, on the shores of Soap Lake. The population was 1,514 at the 2010 census. In 2002, the city announced preliminary plans to construct the world's largest lava lamp (60 feet in height) as a tourist attraction."
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         4,
+         0.8220313549066681,
+         "White Salmon, Washington",
+         "White Salmon is a city in Klickitat County, Washington, United States. It is located in the Columbia River Gorge. The population was 2,193 at the 2000 census and increased 1.4% to 2,224 at the 2010 census."
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         5,
+         0.8203513693498494,
+         "DeWitt Clinton",
+         "DeWitt Clinton (March 2, 1769February 11, 1828) was an American politician and naturalist who served as a United States Senator, Mayor of New York City and sixth Governor of New York. In this last capacity, he was largely responsible for the construction of the Erie Canal. Clinton was a major candidate for the American presidency in the election of 1812, challenging incumbent James Madison."
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         6,
+         0.8192690236306244,
+         "Salmon Bay",
+         "Salmon Bay is a portion of the Lake Washington Ship Canal—a canal which passes through the city of Seattle, linking Lake Washington to Puget Sound—that lies west of the Fremont Cut. It is the westernmost section of the canal, and empties into Puget Sound's Shilshole Bay. Because of the Hiram M. Chittenden Locks, the smaller, western half of the bay is salt water, and the eastern half is fresh water (though not without saline contamination—see Lake Union). Before construction of the Ship Canal, Salmon Bay was entirely salt water."
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         7,
+         0.8186757449142237,
+         "Bill Morley (baseball)",
+         "William M. Morley (born \"William Morley Jennings\") was a Major League Baseball second baseman. He played in two games for the Washington Senators in 1913 , going 0-for-3."
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         8,
+         0.8140307140660191,
+         "White, Washington",
+         "White is an unincorporated community in King County, in the U.S. state of Washington."
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         9,
+         0.8115137299835566,
+         "Wamesit Canal-Whipple Mill Industrial Complex",
+         "The Wamesit Canal-Whipple Mill Industrial Complex is a historic mill and canal at 576 Lawrence Street in Lowell, Massachusetts. This industrial area of Lowell, located on the Concord River, underwent a major expansion from a more modest millworks in the mid-19th century by Oliver Whipple, a manufacturer of gunpowder. Whipple undertook the construction of a canal along that river to provide power for a number of mills he erected in the area, consulting with engineer Loammi Baldwin, Jr. on the matter. The area was further developed in the second half of the 19th century by the Wamesit Power Company, which acquired most of Whipple's properties and water rights. A mill built by Whipple in the 1820s, of which portions survive, is one of the oldest surviving industrial structures in the city."
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         10,
+         0.8114744664991391,
+         "Waterways, Alberta",
+         "Waterways is a locality within the Regional Municipality of Wood Buffalo in northern Alberta, Canada. It is now a neighbourhood within the Fort McMurray urban service area along the west bank of the Clearwater River, south of the river's confluence with the Athabasca River."
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         1,
+         0.888647207337187,
+         "Maria Golovin",
+         "Maria Golovin is an English language opera in three acts by Gian Carlo Menotti. It is through-composed and centers on a romantic encounter between a blind recluse named Donato and the title character, a married woman living in a European country a few years after a recent war. The work was commissioned by Peter Herman Adler of the NBC Opera Theatre."
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         2,
+         0.8495679523327158,
+         "Gian Carlo Menotti",
+         "Gian Carlo Menotti (] ; July 7, 1911 – February 1, 2007) was an Italian-American composer and librettist. Although he often referred to himself as an American composer, he kept his Italian citizenship. He wrote the classic Christmas opera \"Amahl and the Night Visitors\", along with over two dozen other operas intended to appeal to popular taste."
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         3,
+         0.8334830300809545,
+         "Domenico Gilardoni",
+         "Domenico Gilardoni (1798–1831) was an Italian opera librettist, most well known for his collaborations with the composers Vincenzo Bellini (his first work) and Gaetano Donizetti."
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         4,
+         0.8279297968811251,
+         "Melodramma",
+         "Melodramma (plural: \"melodrammi\") is a 17th-century Italian term for a text to be set as an opera, or the opera itself. In the 19th-century, it was used in a much narrower sense by English writers to discuss developments in the early Italian libretto, e.g., \"Rigoletto\" and \"Un ballo in maschera\". Characteristic are the influence of French bourgeois drama, female instead of male protagonists, and the practice of opening the action with a chorus."
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         5,
+         0.8278153424494707,
+         "Ugolino of Forlì",
+         "Ugolino of Forlì or Ugolino of Orvieto (Italian: Ugolino da Orvieto or Urbevetano or Ugolino da Forlì) (Forlì, c. 1380 - Ferrara, c. 1457) was an Italian composer and musical theorist of the Renaissance."
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         6,
+         0.8268356671854027,
+         "Paul Creston",
+         "Paul Creston (born Giuseppe Guttoveggio; October 10, 1906 – August 24, 1985) was an Italian American composer of classical music."
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         7,
+         0.8250525042614982,
+         "Maria Waldmann",
+         "Maria Waldmann (19 November 1845 – 6 November 1920) was an Austrian mezzo-soprano who had a noted association with Giuseppe Verdi."
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         8,
+         0.8198912179177469,
+         "Nicolò Gabrielli",
+         "Count Nicolò Gabrielli di Quercita (21 February 1814 – 14 June 1891) was an Italian opera composer."
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         9,
+         0.8184736178686307,
+         "Matthew Aucoin",
+         "Matthew Aucoin (born 1990) is an American composer, conductor, pianist, and writer best known for his operas. Aucoin has received commissions from the Metropolitan Opera, Carnegie Hall, Lyric Opera of Chicago, the American Repertory Theater, the Peabody Essex Museum, Harvard University, and NPR's \"This American Life\". As a young musical virtuoso, Aucoin has been compared to Wolfgang Amadeus Mozart, Richard Wagner, and Leonard Bernstein. Additionally, he is the youngest assistant conductor in the history of the Metropolitan Opera. He was appointed as Los Angeles Opera's first-ever Artist-in-Residence in 2016."
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         10,
+         0.818226821580564,
+         "Angelo Mariani (conductor)",
+         "Angelo Maurizio Gaspare Mariani (11 October 182113 June 1873) was an Italian opera conductor and composer. His work as a conductor drew praise from Giuseppe Verdi, Giacomo Meyerbeer, Gioachino Rossini and Richard Wagner, and he was a longtime personal friend of Verdi's, although they had a falling out towards the end of Mariani's life. He conducted at least two world premieres (Verdi's \"Aroldo\" and Faccio's \"Amleto\"); and at least 4 Italian premieres (Meyerbeer's \"L'Africana\", Verdi's \"Don Carlo\", and \"Lohengrin\" and \"Tannhäuser\" by Wagner)."
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         1,
+         0.8416197526695911,
+         "The Amazing Race Canada 1",
+         "The first season of The Amazing Race Canada was a reality game show based on the American series \"The Amazing Race\". It featured nine teams of two with pre-existing relationships who raced around Canada for CA$ , two Chevrolet Corvette Stingrays and an unlimited air travel for a year with Air Canada. The show was produced by Insight Productions, in association with Bell Media and was broadcast on CTV. The show was hosted by Canadian Olympian Jon Montgomery."
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         2,
+         0.835907150258378,
+         "Amazing Race (France)",
+         "Amazing Race : la plus grande course autour du monde ! (English: Amazing Race: the biggest race around the world! ) is a French version of the American reality show \"The Amazing Race\". Hosted by , it features nine teams of two with a pre-existing relationship, in a race around the world to win €50,000."
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         3,
+         0.8159086940027129,
+         "I Supermodel (season 1)",
+         "I Supermodel 1 is the first season of the Chinese reality show and modeling competition of the same name. Filming for the show took place in Melbourne, Australia. The show featured 14 contestants in the final cast and began to air on television on March 21, 2015. The winner of the competition was 26-year-old Kang Qian Wen, better known professionally as Kiki Kang."
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         4,
+         0.815505759473752,
+         "Pontiac Montana",
+         "The Pontiac Montana is a minivan that was sold by Pontiac. Prior to the 1997 model year, it was known as Pontiac Trans Sport. In 1997, the Trans Sport added the Montana moniker as part of an available trim package. The package proved so popular the line was renamed Montana in 1999 for the US and 2000 for Canada. For 2005, the van was redesigned with a higher, less aerodynamic nose to resemble an SUV. The Montana name was also changed to Montana SV6. It was discontinued after the 2006 model year in the United States because of slow sales, but continued to be sold in Mexico until the 2009 model year and in Canada until the 2010 model year because of GM phasing out the Pontiac brand after the 2010 model year. Since their introduction, the Pontiac minivans were General Motors' most popular minivans among consumers in Canada."
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         5,
+         0.809825472838822,
+         "All-terrain vehicle",
+         "An all-terrain vehicle (ATV), also known as a quad, quad bike, three-wheeler, four-wheeler or quadricycle as defined by the American National Standards Institute (ANSI) is a vehicle that travels on low-pressure tires, with a seat that is straddled by the operator, along with handlebars for steering control. As the name implies, it is designed to handle a wider variety of terrain than most other vehicles. Although it is a street-legal vehicle in some countries, it is not street-legal within most states and provinces of Australia, the United States or Canada."
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         6,
+         0.8089352724103067,
+         "BattleBots (season 6)",
+         "Season 6 (also referred to as Season 1 on ABC) of the American competitive television series BattleBots premiered on ABC on June 21, 2015."
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         7,
+         0.8081526936283757,
+         "Nissan Juke",
+         "The Nissan Juke is a subcompact crossover SUV produced by the Japanese manufacturer Nissan since 2010. The production version made its debut at the 2010 Geneva Motor Show in March, and was introduced to North America at the 2010 New York International Auto Show to be sold for the 2011 model year. The name \"\"juke\"\" means to dance or change directions demonstrating agility."
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         8,
+         0.8080075497099704,
+         "Chevrolet Corvette (C7)",
+         "The Chevrolet Corvette (C7) is a sports car produced by Chevrolet. The seventh generation Corvette was introduced for the 2014 model year as the first to bear the Corvette Stingray name since the 1968 third generation model. The first C7 Corvette was delivered in the third quarter of 2013."
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         9,
+         0.8075594456221945,
+         "Angus Fogg",
+         "Angus Fogg (born 26 August 1967) is a championship winning New Zealand racecar driver who competes in the New Zealand V8SuperTourer Championship."
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         10,
+         0.807279776667905,
+         "HumanTown",
+         "HumanTown is a Canadian sketch comedy troupe, best known for winning the Canadian Broadcasting Corporation's ComedyCoup seed accelerator competition in 2014. Based in Vancouver, the troupe consists of Kajetan Kwiatkowski, Jack Heyes, Liam MacLeod, Kane Stewart, Miles Chalmers, and Daniel Doheny."
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         1,
+         0.8761139403780055,
+         "Alt for Damerne",
+         "ALT for Damerne (meaning \"All for the Ladies\" in English) is a Danish language weekly women's magazine published in Copenhagen, Denmark."
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         2,
+         0.836904866559799,
+         "Essence (magazine)",
+         "Essence is a monthly magazine for African American women between the ages of 18 and 49. It is the only magazine that focuses on reaching an audience of black women, revolves around the black woman experience, and has remained for a long period of time. The magazine covers fashion, lifestyle and beauty, with an intimate girlfriend-to-girlfriend tone, and its slogan \"Fierce, Fun, and Fabulous\" suggests the magazine's goal of empowering African-American women. The topics the magazine discusses range from celebrities, to fashion, to point-of-view pieces addressing current issues in the African-American community. A number of its readers engage closely and personally with the publication, and it claims to be the magazine \"for and about Black women\"."
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         3,
+         0.8146218548204954,
+         "Gemma Lavender",
+         "Gemma Lavender (born 13 September 1986) is a British astronomer, author and journalist. She currently serves as the Editor of All About Space, a monthly scientific magazine owned by British publisher Imagine Publishing based in Bournemouth, United Kingdom."
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         4,
+         0.812250963385372,
+         "Ken Wilber",
+         "Kenneth Earl \"Ken\" Wilber II (born January 31, 1949) is an American writer on transpersonal psychology and his own integral theory, a four-quadrant grid which suggests the synthesis of all human knowledge and experience."
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         5,
+         0.8117825244016397,
+         "Soul Asylum",
+         "Soul Asylum is an American alternative rock band formed in 1981 in Minneapolis, Minnesota. The band began using their official name in 1983.."
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         6,
+         0.8116743978978015,
+         "Barbara Seaman",
+         "Barbara Seaman (September 11, 1935 – February 27, 2008) was an American author, activist, and journalist, and a principal founder of the women's health feminism movement."
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         7,
+         0.8113797778819566,
+         "Lee Everett Alkin",
+         "Lee Everett or Lee Everett Alkin (born Audrey Valentine Middleton 14 February 1937) is a British spiritual healer and businesswoman, who was previously a pop singer and celebrity psychic under the stage name Lady Lee."
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         8,
+         0.8101829410937911,
+         "New Internationalist",
+         "New Internationalist (\"NI\") is an independent, non-profit, publishing co-operative, based in Oxford, United Kingdom. Predominantly known for its monthly independent magazine, it describes itself as existing to 'cover stories the mainstream media sidestep and provide alternative perspectives on today's global critical issues.' It covers social and environmental issues through its magazine, books and digital platforms."
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         9,
+         0.8093833931173772,
+         "Occult or Exact Science?",
+         "Occult or Exact Science? is an article published in two parts, in April and May 1886, in the theosophical magazine \"The Theosophist\"; it was compiled by Helena Blavatsky. It was included in the 7th volume of the author's \"Collected Writings.\""
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         10,
+         0.8088809617040785,
+         "Louis Althusser",
+         "Louis Pierre Althusser (] ; 16 October 1918 – 22 October 1990) was a French Marxist philosopher. He was born in Algeria and studied at the École Normale Supérieure in Paris, where he eventually became Professor of Philosophy."
+        ]
+       ],
+       "datasetInfos": [],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {},
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "query_id",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "rank",
+         "type": "\"integer\""
+        },
+        {
+         "metadata": "{}",
+         "name": "score",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "title",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "chunk_text",
+         "type": "\"string\""
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ranked_results = retrieve_top_k().persist(StorageLevel.MEMORY_AND_DISK)\n",
+    "ranked_results.count()\n",
+    "display(\n",
+    "    ranked_results.select(\n",
+    "        \"query_id\", \"rank\", \"score\", \"title\", \"chunk_text\"\n",
+    "    )\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "ff6d726b-a874-4658-a3d3-10b1050a9889",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 15. Evaluate quality with Recall@K\n",
+    "\n",
+    "BEIR's qrels identify passages judged relevant to every selected query. Recall@K is the\n",
+    "fraction of these known relevant passages that appear in the top-K results. Latency\n",
+    "without quality can be misleading, so compare Recall@K alongside every worker-count run.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788326333677,
+     "inputWidgets": {},
+     "nuid": "ac5b1487-7ae2-4793-b09f-25c79b6ffc71",
+     "showTitle": false,
+     "startTime": 1788326327991,
+     "submitTime": 1788324541953,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Recall@10: 0.950\n"
+     ]
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>query_id</th><th>relevant_passages</th><th>retrieved_relevant_passages</th><th>recall_at_k</th></tr></thead><tbody><tr><td>5a70eee85542994082a3e3f0</td><td>2</td><td>1</td><td>0.5</td></tr><tr><td>5a70f0a75542994082a3e403</td><td>2</td><td>2</td><td>1.0</td></tr><tr><td>5a70f0e75542994082a3e408</td><td>2</td><td>2</td><td>1.0</td></tr><tr><td>5a70f11a5542994082a3e40b</td><td>2</td><td>2</td><td>1.0</td></tr><tr><td>5a70f1685542994082a3e40f</td><td>2</td><td>2</td><td>1.0</td></tr><tr><td>5a70f39c5542994082a3e429</td><td>2</td><td>2</td><td>1.0</td></tr><tr><td>5a70f4695542994082a3e435</td><td>2</td><td>2</td><td>1.0</td></tr><tr><td>5a70f4c45542994082a3e437</td><td>2</td><td>2</td><td>1.0</td></tr><tr><td>5a70f6425542994082a3e44c</td><td>2</td><td>2</td><td>1.0</td></tr><tr><td>5a70f9335542994082a3e46a</td><td>2</td><td>2</td><td>1.0</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         "5a70eee85542994082a3e3f0",
+         2,
+         1,
+         0.5
+        ],
+        [
+         "5a70f0a75542994082a3e403",
+         2,
+         2,
+         1.0
+        ],
+        [
+         "5a70f0e75542994082a3e408",
+         2,
+         2,
+         1.0
+        ],
+        [
+         "5a70f11a5542994082a3e40b",
+         2,
+         2,
+         1.0
+        ],
+        [
+         "5a70f1685542994082a3e40f",
+         2,
+         2,
+         1.0
+        ],
+        [
+         "5a70f39c5542994082a3e429",
+         2,
+         2,
+         1.0
+        ],
+        [
+         "5a70f4695542994082a3e435",
+         2,
+         2,
+         1.0
+        ],
+        [
+         "5a70f4c45542994082a3e437",
+         2,
+         2,
+         1.0
+        ],
+        [
+         "5a70f6425542994082a3e44c",
+         2,
+         2,
+         1.0
+        ],
+        [
+         "5a70f9335542994082a3e46a",
+         2,
+         2,
+         1.0
+        ]
+       ],
+       "datasetInfos": [],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {},
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "query_id",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "relevant_passages",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "retrieved_relevant_passages",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "recall_at_k",
+         "type": "\"double\""
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "relevant_per_query = selected_qrels.groupBy(\"query_id\").agg(\n",
+    "    F.countDistinct(\"chunk_id\").alias(\"relevant_passages\")\n",
+    ")\n",
+    "retrieved_relevant = (\n",
+    "    ranked_results.join(selected_qrels, [\"query_id\", \"chunk_id\"])\n",
+    "    .groupBy(\"query_id\")\n",
+    "    .agg(F.countDistinct(\"chunk_id\").alias(\"retrieved_relevant_passages\"))\n",
+    ")\n",
+    "recall_by_query = (\n",
+    "    relevant_per_query.join(retrieved_relevant, \"query_id\", \"left\")\n",
+    "    .fillna(0, [\"retrieved_relevant_passages\"])\n",
+    "    .withColumn(\n",
+    "        \"recall_at_k\",\n",
+    "        F.col(\"retrieved_relevant_passages\") / F.col(\"relevant_passages\"),\n",
+    "    )\n",
+    ")\n",
+    "recall_at_k = recall_by_query.agg(F.avg(\"recall_at_k\").alias(\"recall\")).first()[\n",
+    "    \"recall\"\n",
+    "]\n",
+    "\n",
+    "print(f\"Recall@{top_k}: {recall_at_k:.3f}\")\n",
+    "display(recall_by_query.orderBy(\"query_id\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "f76b103c-87a3-4bb9-9413-abdb26dc03da",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 16. Benchmark warm exact retrieval\n",
+    "\n",
+    "The corpus and query embeddings are cached. One unmeasured warm-up run is discarded;\n",
+    "five measured runs each rebuild the exact cross join, score every pair, and rank top-K.\n",
+    "This excludes model download and embedding/indexing from retrieval latency.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788326414035,
+     "inputWidgets": {},
+     "nuid": "62384aa3-68b2-437a-b847-9c6e67461b3f",
+     "showTitle": false,
+     "startTime": 1788326333711,
+     "submitTime": 1788324542521,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Distributed exact retrieval benchmark\n----------------------------------------\nRun label: workers-4\nCorpus passages: 100,000\nQueries: 10\nPairs scored per run: 1,000,000\nFixed corpus partitions: 128\nMeasured retrieval runs: [13.498, 12.652, 12.918, 13.34, 12.566]\nMedian retrieval latency: 12.918 seconds\np95 retrieval latency: 13.498 seconds\nPair throughput: 77,409 pairs/second\nQuery throughput: 0.77 queries/second\nRecall@10: 0.950\n"
+     ]
+    }
+   ],
+   "source": [
+    "warmup_runs = 1\n",
+    "measured_runs = 5\n",
+    "\n",
+    "for _ in range(warmup_runs):\n",
+    "    retrieve_top_k().count()\n",
+    "\n",
+    "retrieval_seconds = []\n",
+    "for _ in range(measured_runs):\n",
+    "    retrieval_started = time.perf_counter()\n",
+    "    retrieve_top_k().count()\n",
+    "    retrieval_seconds.append(time.perf_counter() - retrieval_started)\n",
+    "\n",
+    "median_seconds = statistics.median(retrieval_seconds)\n",
+    "p95_seconds = max(retrieval_seconds)\n",
+    "\n",
+    "print(\"Distributed exact retrieval benchmark\")\n",
+    "print(\"-\" * 40)\n",
+    "print(f\"Run label: {run_label}\")\n",
+    "print(f\"Corpus passages: {corpus_count:,}\")\n",
+    "print(f\"Queries: {actual_query_count:,}\")\n",
+    "print(f\"Pairs scored per run: {pair_count:,}\")\n",
+    "print(f\"Fixed corpus partitions: {partition_count}\")\n",
+    "print(f\"Measured retrieval runs: {[round(value, 3) for value in retrieval_seconds]}\")\n",
+    "print(f\"Median retrieval latency: {median_seconds:.3f} seconds\")\n",
+    "print(f\"p95 retrieval latency: {p95_seconds:.3f} seconds\")\n",
+    "print(f\"Pair throughput: {pair_count / median_seconds:,.0f} pairs/second\")\n",
+    "print(f\"Query throughput: {actual_query_count / median_seconds:.2f} queries/second\")\n",
+    "print(f\"Recall@{top_k}: {recall_at_k:.3f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "9d6c5969-4768-43c1-914b-21c73a126a2d",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 17. Save a benchmark result for cross-cluster comparison\n",
+    "\n",
+    "Each run appends one row to a shared Delta table. After running `workers-1`,\n",
+    "`workers-2`, `workers-4`, and `workers-8`, open the table below to compare the median\n",
+    "latency and calculate speedup:\n",
+    "\n",
+    "```text\n",
+    "speedup = workers-1 median latency / current median latency\n",
+    "```\n",
+    "\n",
+    "Only compare rows with the same corpus size, query count, top-K, model, and partition\n",
+    "count. `embedding_seconds` is null for retrieval-only runs that reused the Delta index.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "finishTime": 1788326418453,
+     "height": "240",
+     "inputWidgets": {},
+     "nuid": "282e221a-5574-4864-8c57-87acd7fffb9a",
+     "showTitle": false,
+     "startTime": 1788326414048,
+     "submitTime": 1788324542931,
+     "tableResultSettingsMap": {},
+     "title": "",
+     "width": "847"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": [
+       "<style scoped>\n",
+       "  .table-result-container {\n",
+       "    max-height: 300px;\n",
+       "    overflow: auto;\n",
+       "  }\n",
+       "  table, th, td {\n",
+       "    border: 1px solid black;\n",
+       "    border-collapse: collapse;\n",
+       "  }\n",
+       "  th, td {\n",
+       "    padding: 5px;\n",
+       "  }\n",
+       "  th {\n",
+       "    text-align: left;\n",
+       "  }\n",
+       "</style><div class='table-result-container'><table class='table-result'><thead style='background-color: white'><tr><th>run_timestamp_utc</th><th>run_label</th><th>corpus_size_setting</th><th>corpus_passages</th><th>queries</th><th>pairs_scored</th><th>top_k</th><th>partition_count</th><th>default_parallelism</th><th>spark_version</th><th>embedding_rebuilt</th><th>embedding_seconds</th><th>query_embedding_seconds</th><th>retrieval_seconds</th><th>retrieval_median_seconds</th><th>retrieval_p95_seconds</th><th>pair_throughput_per_second</th><th>query_throughput_per_second</th><th>recall_at_k</th></tr></thead><tbody><tr><td>2026-09-01T18:37:05.427357+00:00</td><td>workers-8</td><td>100000</td><td>100000</td><td>10</td><td>1000000</td><td>10</td><td>128</td><td>32</td><td>3.5.2</td><td>true</td><td>766.6835686530012</td><td>1.6089644099993166</td><td>List(7.4083684730012465, 7.596972618001018, 7.931801591001204, 7.309874364998905, 6.781602031000148)</td><td>7.4083684730012465</td><td>7.931801591001204</td><td>134982.48685177564</td><td>1.3498248685177565</td><td>0.95</td></tr><tr><td>2026-09-02T05:20:14.078248+00:00</td><td>workers-4</td><td>100000</td><td>100000</td><td>10</td><td>1000000</td><td>10</td><td>128</td><td>16</td><td>3.5.2</td><td>true</td><td>1498.451540258</td><td>1.6022845490006148</td><td>List(13.497693342003913, 12.651708433004387, 12.918452607998915, 13.340244944003643, 12.566032408001774)</td><td>12.918452607998915</td><td>13.497693342003913</td><td>77408.65182110238</td><td>0.7740865182110238</td><td>0.95</td></tr><tr><td>2026-09-02T04:06:20.928949+00:00</td><td>workers-2</td><td>100000</td><td>100000</td><td>10</td><td>1000000</td><td>10</td><td>128</td><td>8</td><td>3.5.2</td><td>true</td><td>2802.0400406109984</td><td>1.322334119999141</td><td>List(22.420158685999922, 22.246764726995025, 21.437068298000668, 22.057966535998276, 21.358414337002614)</td><td>22.057966535998276</td><td>22.420158685999922</td><td>45335.09461844612</td><td>0.4533509461844612</td><td>0.9</td></tr><tr><td>2026-09-01T18:00:55.657916+00:00</td><td>workers-1</td><td>100000</td><td>100000</td><td>10</td><td>1000000</td><td>10</td><td>128</td><td>4</td><td>3.5.2</td><td>true</td><td>5808.216586648</td><td>1.4520239249995939</td><td>List(41.587336869000865, 41.553626246999556, 41.76752383600069, 41.83274922799865, 42.10881661699932)</td><td>41.76752383600069</td><td>42.10881661699932</td><td>23942.046550963354</td><td>0.23942046550963353</td><td>0.9</td></tr></tbody></table></div>"
+      ]
+     },
+     "metadata": {
+      "application/vnd.databricks.v1+output": {
+       "addedWidgets": {},
+       "aggData": [],
+       "aggError": "",
+       "aggOverflow": false,
+       "aggSchema": [],
+       "aggSeriesLimitReached": false,
+       "aggType": "",
+       "arguments": {},
+       "columnCustomDisplayInfos": {},
+       "data": [
+        [
+         "2026-09-01T18:37:05.427357+00:00",
+         "workers-8",
+         "100000",
+         100000,
+         10,
+         1000000,
+         10,
+         128,
+         32,
+         "3.5.2",
+         true,
+         766.6835686530012,
+         1.6089644099993166,
+         [
+          7.4083684730012465,
+          7.596972618001018,
+          7.931801591001204,
+          7.309874364998905,
+          6.781602031000148
+         ],
+         7.4083684730012465,
+         7.931801591001204,
+         134982.48685177564,
+         1.3498248685177565,
+         0.95
+        ],
+        [
+         "2026-09-02T05:20:14.078248+00:00",
+         "workers-4",
+         "100000",
+         100000,
+         10,
+         1000000,
+         10,
+         128,
+         16,
+         "3.5.2",
+         true,
+         1498.451540258,
+         1.6022845490006148,
+         [
+          13.497693342003913,
+          12.651708433004387,
+          12.918452607998915,
+          13.340244944003643,
+          12.566032408001774
+         ],
+         12.918452607998915,
+         13.497693342003913,
+         77408.65182110238,
+         0.7740865182110238,
+         0.95
+        ],
+        [
+         "2026-09-02T04:06:20.928949+00:00",
+         "workers-2",
+         "100000",
+         100000,
+         10,
+         1000000,
+         10,
+         128,
+         8,
+         "3.5.2",
+         true,
+         2802.0400406109984,
+         1.322334119999141,
+         [
+          22.420158685999922,
+          22.246764726995025,
+          21.437068298000668,
+          22.057966535998276,
+          21.358414337002614
+         ],
+         22.057966535998276,
+         22.420158685999922,
+         45335.09461844612,
+         0.4533509461844612,
+         0.9
+        ],
+        [
+         "2026-09-01T18:00:55.657916+00:00",
+         "workers-1",
+         "100000",
+         100000,
+         10,
+         1000000,
+         10,
+         128,
+         4,
+         "3.5.2",
+         true,
+         5808.216586648,
+         1.4520239249995939,
+         [
+          41.587336869000865,
+          41.553626246999556,
+          41.76752383600069,
+          41.83274922799865,
+          42.10881661699932
+         ],
+         41.76752383600069,
+         42.10881661699932,
+         23942.046550963354,
+         0.23942046550963353,
+         0.9
+        ]
+       ],
+       "datasetInfos": [],
+       "dbfsResultPath": null,
+       "isJsonSchema": true,
+       "metadata": {},
+       "overflow": false,
+       "plotOptions": {
+        "customPlotOptions": {},
+        "displayType": "table",
+        "pivotAggregation": null,
+        "pivotColumns": null,
+        "xColumns": null,
+        "yColumns": null
+       },
+       "removedWidgets": [],
+       "schema": [
+        {
+         "metadata": "{}",
+         "name": "run_timestamp_utc",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "run_label",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "corpus_size_setting",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "corpus_passages",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "queries",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "pairs_scored",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "top_k",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "partition_count",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "default_parallelism",
+         "type": "\"long\""
+        },
+        {
+         "metadata": "{}",
+         "name": "spark_version",
+         "type": "\"string\""
+        },
+        {
+         "metadata": "{}",
+         "name": "embedding_rebuilt",
+         "type": "\"boolean\""
+        },
+        {
+         "metadata": "{}",
+         "name": "embedding_seconds",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "query_embedding_seconds",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "retrieval_seconds",
+         "type": "{\"type\":\"array\",\"elementType\":\"double\",\"containsNull\":true}"
+        },
+        {
+         "metadata": "{}",
+         "name": "retrieval_median_seconds",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "retrieval_p95_seconds",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "pair_throughput_per_second",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "query_throughput_per_second",
+         "type": "\"double\""
+        },
+        {
+         "metadata": "{}",
+         "name": "recall_at_k",
+         "type": "\"double\""
+        }
+       ],
+       "type": "table"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "summary = {\n",
+    "    \"run_timestamp_utc\": datetime.now(timezone.utc).isoformat(),\n",
+    "    \"run_label\": run_label,\n",
+    "    \"corpus_size_setting\": corpus_size,\n",
+    "    \"corpus_passages\": corpus_count,\n",
+    "    \"queries\": actual_query_count,\n",
+    "    \"pairs_scored\": pair_count,\n",
+    "    \"top_k\": top_k,\n",
+    "    \"partition_count\": partition_count,\n",
+    "    \"default_parallelism\": spark.sparkContext.defaultParallelism,\n",
+    "    \"spark_version\": spark.version,\n",
+    "    \"embedding_rebuilt\": rebuild_embeddings,\n",
+    "    \"embedding_seconds\": embedding_seconds,\n",
+    "    \"query_embedding_seconds\": query_embedding_seconds,\n",
+    "    \"retrieval_seconds\": retrieval_seconds,\n",
+    "    \"retrieval_median_seconds\": median_seconds,\n",
+    "    \"retrieval_p95_seconds\": p95_seconds,\n",
+    "    \"pair_throughput_per_second\": pair_count / median_seconds,\n",
+    "    \"query_throughput_per_second\": actual_query_count / median_seconds,\n",
+    "    \"recall_at_k\": recall_at_k,\n",
+    "}\n",
+    "\n",
+    "summary_schema = StructType(\n",
+    "    [\n",
+    "        StructField(\"run_timestamp_utc\", StringType(), False),\n",
+    "        StructField(\"run_label\", StringType(), False),\n",
+    "        StructField(\"corpus_size_setting\", StringType(), False),\n",
+    "        StructField(\"corpus_passages\", LongType(), False),\n",
+    "        StructField(\"queries\", LongType(), False),\n",
+    "        StructField(\"pairs_scored\", LongType(), False),\n",
+    "        StructField(\"top_k\", LongType(), False),\n",
+    "        StructField(\"partition_count\", LongType(), False),\n",
+    "        StructField(\"default_parallelism\", LongType(), False),\n",
+    "        StructField(\"spark_version\", StringType(), False),\n",
+    "        StructField(\"embedding_rebuilt\", BooleanType(), False),\n",
+    "        StructField(\"embedding_seconds\", DoubleType(), True),\n",
+    "        StructField(\"query_embedding_seconds\", DoubleType(), False),\n",
+    "        StructField(\"retrieval_seconds\", ArrayType(DoubleType(), False), False),\n",
+    "        StructField(\"retrieval_median_seconds\", DoubleType(), False),\n",
+    "        StructField(\"retrieval_p95_seconds\", DoubleType(), False),\n",
+    "        StructField(\"pair_throughput_per_second\", DoubleType(), False),\n",
+    "        StructField(\"query_throughput_per_second\", DoubleType(), False),\n",
+    "        StructField(\"recall_at_k\", DoubleType(), False),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "spark.createDataFrame([summary], schema=summary_schema).write.format(\"delta\").mode(\"append\").save(\n",
+    "    RESULTS_PATH\n",
+    ")\n",
+    "display(\n",
+    "    spark.read.format(\"delta\")\n",
+    "    .load(RESULTS_PATH)\n",
+    "    .where(\n",
+    "        (F.col(\"corpus_size_setting\") == corpus_size)\n",
+    "        & (F.col(\"queries\") == actual_query_count)\n",
+    "        & (F.col(\"top_k\") == top_k)\n",
+    "        & (F.col(\"partition_count\") == partition_count)\n",
+    "    )\n",
+    "    .orderBy(F.desc(\"run_label\"))\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "b4344ab0-5a2e-4111-a3df-3d17ef80f7b3",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "## 18. Scaling checklist\n",
+    "\n",
+    "Repeat this notebook with the following settings:\n",
+    "\n",
+    "| Run label | Workers | `corpus_size` | `query_count` | `partition_count` | `rebuild_embeddings` |\n",
+    "|---|---:|---:|---:|---:|---|\n",
+    "| `workers-1` | 1 | 100000 | 10 | 128 | `true` |\n",
+    "| `workers-2` | 2 | 100000 | 10 | 128 | `true` |\n",
+    "| `workers-4` | 4 | 100000 | 10 | 128 | `true` |\n",
+    "| `workers-8` | 8 | 100000 | 10 | 128 | `true` |\n",
+    "\n",
+    "Then repeat the four runs with `rebuild_embeddings=false` to isolate retrieval latency.\n",
+    "After confirming the 100K runs complete, switch all four to `corpus_size=full`. Watch\n",
+    "the Spark UI during sections 9 and 15: more workers should allow more corpus partitions\n",
+    "to execute concurrently.\n",
+    "\n",
+    "Do not compare a worker-count result with different instance types, corpus/query sizes,\n",
+    "partition counts, or embedding settings. For larger query batches, switch to a\n",
+    "two-stage BM25/ANN + `PairwiseVectorSimilarity` reranking design instead of exact\n",
+    "all-pairs retrieval.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "5fd19044-965e-40df-a99b-d2f41aee9aad",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "5"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "experimentId": "2833745341031798",
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "BEIR_HotpotQA_Databricks_Benchmark",
+   "widgets": {}
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Adds a Databricks notebook demonstrating scalable, high-volume semantic document retrieval with Spark NLP and the BEIR HotpotQA dataset. The notebook prepares real retrieval data in Unity Catalog Volumes, embeds passages and queries with E5, and uses  PairwiseVectorSimilarity  for exact cosine-similarity scoring. It ranks the top results for each query, evaluates Recall@K against BEIR relevance labels, and records benchmark metrics including embedding throughput, retrieval latency, and pair throughput. The walkthrough supports reproducible 10K, 100K, and full-corpus tests, with guidance for comparing fixed 1-, 2-, 4-, and 8-worker Databricks clusters.