### PR TITLE
[SPARKNLP-1429] ONNX CUDA Preload Recovery

### DIFF
--- a/docs/en/advanced_settings.md
+++ b/docs/en/advanced_settings.md
@@ -5,7 +5,7 @@ seotitle: Spark NLP - Advanced Settings
 title: Spark NLP - Advanced Settings
 permalink: /docs/en/advanced_settings
 key: docs-install
-modify_date: "2024-07-04"
+modify_date: "2026-08-27"
 show_nav: true
 sidebar:
     nav: sparknlp
@@ -32,8 +32,33 @@ You can change the following Spark NLP configurations via Spark Configuration:
 | `spark.jsl.settings.onnx.intraOpNumThreads`             | `6`                  | Sets the size of the CPU thread pool used for executing a single graph, if executing on a CPU.                                                                                                                                                                                     |
 | `spark.jsl.settings.onnx.optimizationLevel`             | `ALL_OPT`            | Sets the optimization level of this options object, overriding the old setting.                                                                                                                                                                                                    |
 | `spark.jsl.settings.onnx.executionMode`                 | `SEQUENTIAL`         | Sets the execution mode of this options object, overriding the old setting.                                                                                                                                                                                                        |
+| `spark.jsl.settings.onnx.cuda.preload.mode`              | `search`             | Controls failure-first ONNX CUDA native-dependency recovery: `off`, `search`, or `explicit`. Recovery runs only after a recognized CUDA-provider dependency-loading failure.                                                                                                       |
+| `spark.jsl.settings.onnx.cuda.preload.paths`             | Empty                | In `search` mode, a platform path-separated list of trusted directories with highest precedence. In `explicit` mode, the complete ordered list of absolute CUDA library files required by the packaged ONNX Runtime provider.                                                       |
 
 </div><div class="h3-box" markdown="1">
+
+### ONNX CUDA native-dependency recovery
+
+Spark NLP first registers the ONNX Runtime CUDA provider normally. If registration succeeds, it does not inspect preload configuration, search the filesystem, call `System.load`, or retry. If registration fails because a required CUDA shared library cannot be loaded, Spark NLP can preload already-installed libraries inside the executor JVM and retry provider registration once with fresh provider and session-option objects.
+
+- `search` (default): resolve the packaged provider's dependency manifest from trusted operator directories, runtime and linker paths, and a bounded search under generic installation roots. Resolution fails on missing or ambiguous candidates.
+- `explicit`: validate the configured complete ordered list of absolute regular files and load those exact canonical files without searching.
+- `off`: preserve the legacy failure path without reading the paths setting, discovery, preload, or retry.
+
+All enabled modes fail closed. Recovery never silently falls back to CPU, does not install or bundle CUDA, does not use Python discovery, and is independent from model warm-up. Native-library paths are runtime Spark configuration and are not persisted in models.
+
+Before any native load, Spark NLP canonicalizes and validates the complete manifest. Each library must be a readable ELF64 shared object whose architecture and uniquely mapped `DT_SONAME` match the current runtime and required manifest entry. The library and every canonical ancestor must be owned by `root` or the authenticated POSIX executor identity and must not be group- or world-writable; filesystems without POSIX ownership and permission attributes are rejected. Search symlinks must remain inside their approved canonical root, and directory symlinks are not traversed.
+
+Filesystem work is capped across discovery tiers at 20,000 visited entries, including path-list entries and configured directory canonicalization attempts. Configured and runtime-derived path-list text is capped at an aggregate 1 MiB before trimming or splitting. Generic installation-root and linker-configuration traversal has a maximum depth of 6. The aggregate linker-configuration input across the root file and all recursive includes is capped at 1 MiB. Fixed-path `ldconfig -p` output is separately capped at 1 MiB, and `ldconfig` must terminate within 2 seconds after normal completion or forced destruction. Exceeding any limit fails recovery instead of broadening the search.
+
+Example explicit configuration on Linux:
+
+```bash
+--conf spark.jsl.settings.onnx.cuda.preload.mode=explicit \
+--conf spark.jsl.settings.onnx.cuda.preload.paths=/absolute/cuda/libcudart.so.12:/absolute/cuda/libcublasLt.so.12:/absolute/cuda/libcublas.so.12:/absolute/cuda/libcurand.so.10:/absolute/cuda/libcufft.so.11:/absolute/cuda/libcudnn.so.9
+```
+
+The exact SONAME inventory is version-coupled to the ONNX Runtime GPU provider packaged by Spark NLP. Reconcile it against `libonnxruntime_providers_cuda.so` whenever the ONNX Runtime dependency changes.
 
 ### How to set Spark NLP Configuration
 

--- a/src/main/resources/onnx/cuda-provider-dependencies-1.23.0.txt
+++ b/src/main/resources/onnx/cuda-provider-dependencies-1.23.0.txt
@@ -1,0 +1,9 @@
+# ONNX Runtime GPU 1.23.0 linux-x64 provider dependency preload order.
+# Reconcile this file with libonnxruntime_providers_cuda.so using readelf -d
+# whenever project/Dependencies.scala changes onnxRuntimeVersion.
+libcudart.so.12
+libcublasLt.so.12
+libcublas.so.12
+libcurand.so.10
+libcufft.so.11
+libcudnn.so.9

--- a/src/main/scala/com/johnsnowlabs/ml/onnx/CudaProviderRecovery.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/CudaProviderRecovery.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.ml.onnx
+
+import ai.onnxruntime.OrtException
+import ai.onnxruntime.OrtException.OrtErrorCode
+import org.slf4j.LoggerFactory
+import java.util.regex.Pattern
+import scala.util.control.NonFatal
+
+/** Failure-first, one-retry state machine for ONNX Runtime CUDA provider registration. */
+private[onnx] object CudaProviderRecovery {
+
+  private val logger = LoggerFactory.getLogger("CudaProviderRecovery")
+
+  private val recoverableCodes = Set(OrtErrorCode.ORT_FAIL, OrtErrorCode.ORT_EP_FAIL)
+  private val providerLoadAnchor = "failed to load library libonnxruntime_providers_cuda.so"
+
+  def configure[T <: AutoCloseable](
+      mode: => NativeLibraryPreloader.Mode,
+      createOptions: () => T,
+      addCudaProvider: T => Unit,
+      preload: () => Unit): T = {
+    val firstOptions = createOptions()
+    try {
+      addCudaProvider(firstOptions)
+      firstOptions
+    } catch {
+      case original: Throwable =>
+        closeAfterFailure(firstOptions, original)
+        if (!isRecoverable(original)) throw original
+        logger.warn(
+          "ONNX CUDA provider registration failed because a native dependency was unavailable; evaluating recovery configuration")
+        val recoveryMode =
+          try mode
+          catch {
+            case configurationFailure: Throwable =>
+              configurationFailure.addSuppressed(original)
+              throw configurationFailure
+          }
+        if (recoveryMode == NativeLibraryPreloader.Off) throw original
+
+        try preload()
+        catch {
+          case preloadFailure: Throwable =>
+            preloadFailure.addSuppressed(original)
+            throw preloadFailure
+        }
+        val retryOptions =
+          try createOptions()
+          catch {
+            case creationFailure: Throwable =>
+              creationFailure.addSuppressed(original)
+              throw creationFailure
+          }
+        try {
+          addCudaProvider(retryOptions)
+          logger.info(
+            "ONNX CUDA provider registration retry succeeded after native dependency preload")
+          retryOptions
+        } catch {
+          case retryFailure: Throwable =>
+            closeAfterFailure(retryOptions, retryFailure)
+            retryFailure.addSuppressed(original)
+            throw retryFailure
+        }
+    }
+  }
+
+  def isRecoverable(error: Throwable): Boolean =
+    isRecoverable(error, () => NativeLibraryPreloader.packagedDependencies)
+
+  private[onnx] def isRecoverable(error: Throwable, dependencies: () => Seq[String]): Boolean =
+    try {
+      error match {
+        case ortError: OrtException if recoverableCodes.contains(ortError.getCode) =>
+          val message = throwableMessages(ortError).mkString(" ").toLowerCase
+          val namesExactMissingDependency = dependencies().exists { library =>
+            val missingMarker =
+              "(?i)(?:^|[^A-Za-z0-9_.-])" + Pattern.quote(library) +
+                ":\\s*(?:cannot open shared object file|no such file or directory|error loading shared library)"
+            Pattern.compile(missingMarker).matcher(message).find()
+          }
+          message.contains(providerLoadAnchor) && namesExactMissingDependency
+        case _ => false
+      }
+    } catch {
+      case NonFatal(_) => false
+    }
+
+  private val MaxDiagnosticMessageChars = 4096
+
+  private def throwableMessages(error: Throwable): Seq[String] = {
+    val messages = Seq.newBuilder[String]
+    var current = error
+    var depth = 0
+    while (current != null && depth < 8) {
+      messages += Option(current.getMessage).getOrElse("").take(MaxDiagnosticMessageChars)
+      current = current.getCause
+      depth += 1
+    }
+    messages.result()
+  }
+
+  private def closeAfterFailure(resource: AutoCloseable, failure: Throwable): Unit = {
+    if (resource == null) return
+    try resource.close()
+    catch {
+      case closeFailure: Throwable => failure.addSuppressed(closeFailure)
+    }
+  }
+}

--- a/src/main/scala/com/johnsnowlabs/ml/onnx/ElfMetadataInspector.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/ElfMetadataInspector.scala
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.ml.onnx
+
+import java.nio.{ByteBuffer, ByteOrder}
+import java.nio.channels.FileChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Path, StandardOpenOption}
+import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
+
+/** Minimal, bounded ELF parser used to verify native dependency identity before System.load. */
+private[onnx] object ElfMetadataInspector extends NativeLibraryPreloader.ElfInspector {
+
+  private val ElfHeaderSize = 64
+  private val ProgramHeaderSize = 56
+  private val MaxProgramHeaders = 4096
+  private val MaxDynamicEntries = 65536
+  private val MaxSonameBytes = 4096
+
+  private val PtLoad = 1
+  private val PtDynamic = 2
+  private val DtNull = 0L
+  private val DtStrtab = 5L
+  private val DtStrsz = 10L
+  private val DtSoname = 14L
+
+  private final case class Segment(
+      segmentType: Int,
+      fileOffset: Long,
+      virtualAddress: Long,
+      fileSize: Long,
+      memorySize: Long)
+
+  private final case class FileMapping(fileOffset: Long, remainingFileBytes: Long)
+
+  override def validate(path: Path, expectedSoname: String): Unit = {
+    val channel = FileChannel.open(path, StandardOpenOption.READ)
+    try validateOpenFile(channel, expectedSoname)
+    catch {
+      case error: IllegalStateException => throw error
+      case NonFatal(error) =>
+        throw new IllegalStateException(
+          s"ELF validation failed for CUDA library $expectedSoname",
+          error)
+    } finally channel.close()
+  }
+
+  private def validateOpenFile(channel: FileChannel, expectedSoname: String): Unit = {
+    val size = channel.size()
+    val header = read(channel, 0L, ElfHeaderSize, size)
+    if (header.get(0) != 0x7f.toByte || header.get(1) != 'E'.toByte ||
+      header.get(2) != 'L'.toByte || header.get(3) != 'F'.toByte)
+      fail(expectedSoname, "file is not ELF")
+    if (header.get(4) != 2.toByte)
+      fail(expectedSoname, "only ELF64 shared objects are supported")
+
+    val byteOrder = header.get(5) match {
+      case 1 => ByteOrder.LITTLE_ENDIAN
+      case 2 => ByteOrder.BIG_ENDIAN
+      case _ => fail(expectedSoname, "ELF byte order is invalid")
+    }
+    header.order(byteOrder)
+    if (unsignedShort(header.getShort(16)) != 3)
+      fail(expectedSoname, "ELF object is not a shared object")
+
+    val machine = unsignedShort(header.getShort(18))
+    val requiredMachine = expectedMachine(expectedSoname)
+    if (machine != requiredMachine)
+      fail(
+        expectedSoname,
+        s"ELF machine $machine does not match runtime architecture machine $requiredMachine")
+
+    val programHeaderOffset = header.getLong(32)
+    val programHeaderEntrySize = unsignedShort(header.getShort(54))
+    val programHeaderCount = unsignedShort(header.getShort(56))
+    if (programHeaderEntrySize < ProgramHeaderSize || programHeaderCount <= 0 ||
+      programHeaderCount > MaxProgramHeaders)
+      fail(expectedSoname, "ELF program-header table is invalid or exceeds bounds")
+
+    val segments = ArrayBuffer.empty[Segment]
+    var index = 0
+    while (index < programHeaderCount) {
+      val offset = checkedAdd(
+        programHeaderOffset,
+        checkedMultiply(index.toLong, programHeaderEntrySize.toLong, expectedSoname),
+        expectedSoname)
+      val entry = read(channel, offset, ProgramHeaderSize, size).order(byteOrder)
+      val segment = Segment(
+        entry.getInt(0),
+        entry.getLong(8),
+        entry.getLong(16),
+        entry.getLong(32),
+        entry.getLong(40))
+      if (segment.fileOffset < 0 || segment.virtualAddress < 0 || segment.fileSize < 0 ||
+        segment.memorySize < 0 || segment.fileSize > segment.memorySize)
+        fail(expectedSoname, "ELF program segment contains invalid signed ranges")
+      if (segment.segmentType == PtLoad || segment.segmentType == PtDynamic) {
+        val segmentEnd = checkedAdd(segment.fileOffset, segment.fileSize, expectedSoname)
+        if (segmentEnd > size)
+          fail(expectedSoname, "ELF program segment exceeds the file-backed range")
+        checkedAdd(segment.virtualAddress, segment.fileSize, expectedSoname)
+        checkedAdd(segment.virtualAddress, segment.memorySize, expectedSoname)
+      }
+      segments += segment
+      index += 1
+    }
+
+    val loads = segments.filter(_.segmentType == PtLoad)
+    if (loads.isEmpty) fail(expectedSoname, "ELF PT_LOAD segment is missing")
+    val dynamicSegments = segments.filter(_.segmentType == PtDynamic)
+    if (dynamicSegments.size != 1)
+      fail(expectedSoname, "ELF must contain exactly one PT_DYNAMIC segment")
+    val dynamic = dynamicSegments.headOption.getOrElse {
+      fail(expectedSoname, "ELF PT_DYNAMIC segment is missing")
+    }
+    if (dynamic.fileSize <= 0 || dynamic.fileSize % 16L != 0 ||
+      dynamic.fileSize / 16L > MaxDynamicEntries)
+      fail(expectedSoname, "ELF dynamic table is invalid or exceeds bounds")
+
+    val dynamicMapping = virtualAddressToFileMapping(
+      dynamic.virtualAddress,
+      dynamic.fileSize,
+      loads.toSeq,
+      expectedSoname)
+    if (dynamicMapping.fileOffset != dynamic.fileOffset ||
+      dynamic.fileSize > dynamicMapping.remainingFileBytes)
+      fail(expectedSoname, "ELF PT_DYNAMIC mapping does not match a unique PT_LOAD range")
+
+    var stringTableAddress: Option[Long] = None
+    var stringTableSize: Option[Long] = None
+    var sonameIndex: Option[Long] = None
+    var dynamicIndex = 0L
+    var complete = false
+    while (!complete && dynamicIndex < dynamic.fileSize / 16L) {
+      val entryOffset = checkedAdd(
+        dynamic.fileOffset,
+        checkedMultiply(dynamicIndex, 16L, expectedSoname),
+        expectedSoname)
+      val entry = read(channel, entryOffset, 16, size).order(byteOrder)
+      val tag = entry.getLong(0)
+      val value = entry.getLong(8)
+      tag match {
+        case DtNull => complete = true
+        case DtStrtab => stringTableAddress = Some(value)
+        case DtStrsz => stringTableSize = Some(value)
+        case DtSoname => sonameIndex = Some(value)
+        case _ =>
+      }
+      dynamicIndex += 1
+    }
+    if (!complete) fail(expectedSoname, "ELF dynamic table has no bounded terminator")
+
+    val stringAddress = stringTableAddress.getOrElse {
+      fail(expectedSoname, "ELF DT_STRTAB entry is missing")
+    }
+    val nameIndex = sonameIndex.getOrElse {
+      fail(expectedSoname, "ELF DT_SONAME entry is missing")
+    }
+    val tableSize = stringTableSize.getOrElse {
+      fail(expectedSoname, "ELF DT_STRSZ entry is missing")
+    }
+    if (tableSize <= 0)
+      fail(expectedSoname, "ELF DT_STRSZ value is invalid")
+    if (nameIndex < 0 || nameIndex >= tableSize)
+      fail(expectedSoname, "ELF DT_SONAME index is outside DT_STRTAB")
+
+    val stringTableMapping =
+      virtualAddressToFileMapping(stringAddress, tableSize, loads.toSeq, expectedSoname)
+    if (tableSize > stringTableMapping.remainingFileBytes)
+      fail(expectedSoname, "ELF DT_STRTAB exceeds its file-backed PT_LOAD range")
+    val sonameOffset = checkedAdd(stringTableMapping.fileOffset, nameIndex, expectedSoname)
+    val availableByTable = tableSize - nameIndex
+    val availableBySegment = stringTableMapping.remainingFileBytes - nameIndex
+    val availableByFile = size - sonameOffset
+    val readLength = math.min(
+      MaxSonameBytes.toLong,
+      math.min(availableByTable, math.min(availableBySegment, availableByFile)))
+    if (readLength <= 0) fail(expectedSoname, "ELF DT_SONAME value is unavailable")
+
+    val nameBytes = read(channel, sonameOffset, readLength.toInt, size)
+    val terminator = (0 until nameBytes.limit()).find(nameBytes.get(_) == 0.toByte).getOrElse {
+      fail(expectedSoname, "ELF DT_SONAME is not null-terminated within bounds")
+    }
+    val bytes = new Array[Byte](terminator)
+    nameBytes.position(0)
+    nameBytes.get(bytes)
+    val actualSoname = new String(bytes, StandardCharsets.UTF_8)
+    if (actualSoname != expectedSoname)
+      fail(
+        expectedSoname,
+        s"ELF DT_SONAME mismatch: expected $expectedSoname but found $actualSoname")
+  }
+
+  private def virtualAddressToFileMapping(
+      address: Long,
+      requiredBytes: Long,
+      loads: Seq[Segment],
+      expectedSoname: String): FileMapping = {
+    if (address < 0 || requiredBytes <= 0)
+      fail(expectedSoname, "ELF virtual-address range is invalid")
+    val rangeEnd = checkedAdd(address, requiredBytes, expectedSoname)
+    val overlappingLoads = loads.filter { segment =>
+      val segmentMemoryEnd =
+        checkedAdd(segment.virtualAddress, segment.memorySize, expectedSoname)
+      segment.virtualAddress < rangeEnd && segmentMemoryEnd > address
+    }
+    if (overlappingLoads.size != 1)
+      fail(expectedSoname, "ELF virtual-address range does not have a unique PT_LOAD mapping")
+
+    val segment = overlappingLoads.head
+    val segmentFileEnd =
+      checkedAdd(segment.virtualAddress, segment.fileSize, expectedSoname)
+    if (address < segment.virtualAddress || rangeEnd > segmentFileEnd)
+      fail(expectedSoname, "ELF virtual-address range exceeds its file-backed PT_LOAD mapping")
+    val relativeAddress = address - segment.virtualAddress
+    FileMapping(
+      checkedAdd(segment.fileOffset, relativeAddress, expectedSoname),
+      segment.fileSize - relativeAddress)
+  }
+
+  private def read(
+      channel: FileChannel,
+      offset: Long,
+      length: Int,
+      fileSize: Long): ByteBuffer = {
+    if (offset < 0 || length < 0 || offset > fileSize || length.toLong > fileSize - offset)
+      throw new IllegalStateException("ELF structure points outside the file")
+    val buffer = ByteBuffer.allocate(length)
+    var position = offset
+    while (buffer.hasRemaining) {
+      val count = channel.read(buffer, position)
+      if (count <= 0) throw new IllegalStateException("ELF file ended unexpectedly")
+      position += count
+    }
+    buffer.flip()
+    buffer
+  }
+
+  private def expectedMachine(expectedSoname: String): Int =
+    System.getProperty("os.arch").toLowerCase match {
+      case "amd64" | "x86_64" => 62
+      case "aarch64" | "arm64" => 183
+      case other => fail(expectedSoname, s"unsupported runtime architecture: $other")
+    }
+
+  private def unsignedShort(value: Short): Int = value & 0xffff
+
+  private def checkedMultiply(left: Long, right: Long, expectedSoname: String): Long =
+    try Math.multiplyExact(left, right)
+    catch { case _: ArithmeticException => fail(expectedSoname, "ELF offset overflow") }
+
+  private def checkedAdd(left: Long, right: Long, expectedSoname: String): Long =
+    try Math.addExact(left, right)
+    catch { case _: ArithmeticException => fail(expectedSoname, "ELF offset overflow") }
+
+  private def fail(expectedSoname: String, detail: String): Nothing =
+    throw new IllegalStateException(
+      s"ELF validation failed for CUDA library $expectedSoname: $detail")
+}

--- a/src/main/scala/com/johnsnowlabs/ml/onnx/NativeLibraryPreloader.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/NativeLibraryPreloader.scala
@@ -322,6 +322,7 @@ private[onnx] final class NativeLibraryPreloader(
           throw new IllegalStateException(
             s"Refusing CUDA library $library because ${current.getFileName} has an untrusted owner")
 
+        val group = Option(attributes.group()).map(_.getName).getOrElse("")
         val permissions = attributes.permissions()
         if (permissions.contains(PosixFilePermission.OTHERS_WRITE)) {
           if (isLibrary)
@@ -332,10 +333,12 @@ private[onnx] final class NativeLibraryPreloader(
               s"Refusing CUDA library $library because it has a world-writable directory (writable ancestor)")
         }
         if (permissions.contains(PosixFilePermission.GROUP_WRITE)) {
-          if (isLibrary)
+          val isTrustedExecutorPair =
+            isLibrary && securityPolicy.trustedGroupWritableOwnerGroups.contains(owner -> group)
+          if (isLibrary && !isTrustedExecutorPair)
             throw new IllegalStateException(
               s"Refusing group-writable CUDA library file for $library")
-          else
+          else if (!isLibrary)
             throw new IllegalStateException(
               s"Refusing CUDA library $library because it has a group-writable directory (writable ancestor)")
         }
@@ -500,30 +503,40 @@ private[onnx] object NativeLibraryPreloader {
 
   final case class SecurityPolicy(
       trustedOwners: Set[String],
-      readAttributes: Path => PosixFileAttributes)
+      readAttributes: Path => PosixFileAttributes,
+      trustedGroupWritableOwnerGroups: Set[(String, String)] = Set.empty)
 
   object SecurityPolicy {
-    lazy val runtime: SecurityPolicy = SecurityPolicy(
-      trustedOwners = Set(authenticatedProcessOwner(), "root"),
-      readAttributes = path => Files.readAttributes(path, classOf[PosixFileAttributes]))
+    lazy val runtime: SecurityPolicy = {
+      val authenticatedIdentity = authenticatedProcessIdentity()
+      SecurityPolicy(
+        trustedOwners = Set(authenticatedIdentity._1, "root"),
+        readAttributes = path => Files.readAttributes(path, classOf[PosixFileAttributes]),
+        trustedGroupWritableOwnerGroups = Set(authenticatedIdentity))
+    }
   }
 
-  private[onnx] def authenticatedProcessOwner(): String = {
-    val owner =
-      try
-        Files
-          .readAttributes(Paths.get("/proc/self"), classOf[PosixFileAttributes])
-          .owner()
-          .getName
-      catch {
+  private[onnx] def authenticatedProcessOwner(): String = authenticatedProcessIdentity()._1
+
+  private[onnx] def authenticatedProcessIdentity(): (String, String) = {
+    val (owner, group) =
+      try {
+        val attributes =
+          Files.readAttributes(Paths.get("/proc/self"), classOf[PosixFileAttributes])
+        attributes.owner().getName -> attributes.group().getName
+      } catch {
         case NonFatal(error) =>
           throw new IllegalStateException(
             "Unable to establish the authenticated POSIX executor identity",
             error)
       }
-    Option(owner).map(_.trim).filter(_.nonEmpty).getOrElse {
+    val validatedOwner = Option(owner).map(_.trim).filter(_.nonEmpty).getOrElse {
       throw new IllegalStateException("Authenticated POSIX executor identity is empty")
     }
+    val validatedGroup = Option(group).map(_.trim).filter(_.nonEmpty).getOrElse {
+      throw new IllegalStateException("Authenticated POSIX executor group identity is empty")
+    }
+    validatedOwner -> validatedGroup
   }
 
   private val dependencyManifest = "/onnx/cuda-provider-dependencies-1.23.0.txt"

--- a/src/main/scala/com/johnsnowlabs/ml/onnx/NativeLibraryPreloader.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/NativeLibraryPreloader.scala
@@ -1,0 +1,915 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.ml.onnx
+
+import java.io.{ByteArrayOutputStream, File}
+import java.nio.charset.StandardCharsets
+import java.nio.file.attribute.{BasicFileAttributes, PosixFileAttributes, PosixFilePermission}
+import java.nio.file._
+import java.util.concurrent.TimeUnit
+import org.slf4j.LoggerFactory
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.io.Source
+import scala.util.control.NonFatal
+
+/** Resolves and loads the native CUDA dependencies required by ONNX Runtime.
+  *
+  * Resolution is deliberately dormant until the ONNX CUDA provider reports a recognized missing
+  * native dependency. All paths are validated before the first `System.load` call.
+  */
+private[onnx] final class NativeLibraryPreloader(
+    requiredLibraries: Seq[String],
+    sourceProvider: NativeLibraryPreloader.SearchBudget => NativeLibraryPreloader.SearchSources,
+    limits: NativeLibraryPreloader.SearchLimits,
+    libraryLoader: NativeLibraryPreloader.LibraryLoader,
+    securityPolicy: NativeLibraryPreloader.SecurityPolicy =
+      NativeLibraryPreloader.SecurityPolicy.runtime,
+    elfInspector: NativeLibraryPreloader.ElfInspector =
+      NativeLibraryPreloader.ElfInspector.runtime) {
+
+  import NativeLibraryPreloader._
+
+  private val logger = LoggerFactory.getLogger(classOf[NativeLibraryPreloader])
+  @volatile private var loaded = false
+
+  def preload(config: PreloadConfig): Unit = this.synchronized {
+    if (loaded || config.mode == Off) return
+
+    val resolved = config.mode match {
+      case Explicit => resolveExplicit(config.paths)
+      case Search => resolveSearch(config.paths)
+      case Off => Seq.empty
+    }
+
+    // Resolution and validation intentionally finish before native process state is changed.
+    resolved.zip(requiredLibraries).foreach { case (path, library) =>
+      try libraryLoader.load(path)
+      catch {
+        case error: UnsatisfiedLinkError =>
+          throw new IllegalStateException(
+            s"Failed to preload $library from canonical path $path: ${safeMessage(error)}",
+            error)
+        case NonFatal(error) =>
+          throw new IllegalStateException(
+            s"Failed to preload $library from canonical path $path: ${safeMessage(error)}",
+            error)
+      }
+      logger.info(s"Preloaded ONNX CUDA native dependency $library from $path")
+    }
+    loaded = true
+    logger.info(
+      "ONNX CUDA native dependency preload completed for {} libraries",
+      Int.box(resolved.size))
+  }
+
+  private def resolveExplicit(configuredPaths: Seq[String]): Seq[Path] = {
+    if (configuredPaths.size != requiredLibraries.size) {
+      throw new IllegalStateException(
+        s"Explicit ONNX CUDA preload requires ${requiredLibraries.size} ordered absolute files, " +
+          s"but received ${configuredPaths.size}")
+    }
+
+    val characterBudget = new CharacterBudget(MaxConfiguredPathChars)
+    configuredPaths.zip(requiredLibraries).map { case (configuredPath, library) =>
+      characterBudget.record(configuredPath)
+      val path = Paths.get(configuredPath)
+      if (!path.isAbsolute)
+        throw new IllegalStateException(s"CUDA library path must be absolute for $library")
+      validateCandidate(path, library)
+    }
+  }
+
+  private def resolveSearch(operatorPathStrings: Seq[String]): Seq[Path] = {
+    val budget = new SearchBudget(limits.maxVisitedEntries)
+    val characterBudget = new CharacterBudget(MaxConfiguredPathChars)
+    val resolved = mutable.Map.empty[String, Path]
+    val operatorDirectories = operatorPathStrings.map { configuredPath =>
+      budget.recordVisit()
+      characterBudget.record(configuredPath)
+      val path = Paths.get(configuredPath)
+      if (!path.isAbsolute)
+        throw new IllegalStateException(
+          s"ONNX CUDA operator search directory must be absolute: ${path.getFileName}")
+      canonicalDirectory(path, "operator search")
+    }
+
+    def resolveTier(
+        tierName: String,
+        directories: Seq[Path],
+        candidates: Map[String, Seq[Path]]): Option[Seq[Path]] = {
+      requiredLibraries.filterNot(resolved.contains).foreach { library =>
+        resolveFromCandidates(
+          library,
+          candidates.getOrElse(library, Seq.empty),
+          tierName,
+          directories).foreach(path => resolved += library -> path)
+      }
+      if (resolved.size == requiredLibraries.size)
+        Some(requiredLibraries.map(resolved))
+      else None
+    }
+
+    resolveTier(
+      "operator",
+      operatorDirectories,
+      collectDirectoryCandidates(operatorDirectories, budget)).getOrElse {
+      val sources = sourceProvider(budget)
+      val runtimeDirectories = canonicalDirectories(sources.runtimeDirectories, "runtime", budget)
+      resolveTier(
+        "runtime",
+        runtimeDirectories,
+        collectDirectoryCandidates(runtimeDirectories, budget)).getOrElse {
+        val linkerDirectories = canonicalDirectories(sources.linkerDirectories, "linker", budget)
+        resolveTier(
+          "linker",
+          linkerDirectories,
+          collectDirectoryCandidates(linkerDirectories, budget)).getOrElse {
+          val genericRoots = canonicalDirectories(sources.genericRoots, "generic root", budget)
+          resolveTier(
+            "generic roots",
+            genericRoots,
+            collectGenericCandidates(genericRoots, budget)).getOrElse {
+            val missing = requiredLibraries.filterNot(resolved.contains).head
+            throw new IllegalStateException(
+              s"Required CUDA library $missing was not found in approved ONNX CUDA search sources")
+          }
+        }
+      }
+    }
+  }
+
+  private def resolveFromCandidates(
+      library: String,
+      candidates: Seq[Path],
+      tierName: String,
+      approvedRoots: Seq[Path]): Option[Path] = {
+    val exact = candidates.filter(_.getFileName.toString == library)
+    if (exact.nonEmpty) uniqueCandidate(library, exact, tierName, approvedRoots)
+    else uniqueCandidate(library, candidates, tierName, approvedRoots)
+  }
+
+  private def uniqueCandidate(
+      library: String,
+      candidates: Seq[Path],
+      tierName: String,
+      approvedRoots: Seq[Path]): Option[Path] = {
+    val validated = candidates
+      .map(validateCandidate(_, library, approvedRoots))
+      .distinct
+      .sortBy(_.toString)
+    validated match {
+      case Seq() => None
+      case Seq(path) => Some(path)
+      case multiple =>
+        throw new IllegalStateException(
+          s"Ambiguous CUDA library $library in $tierName: ${multiple.size} canonical candidates")
+    }
+  }
+
+  private def collectDirectoryCandidates(
+      directories: Seq[Path],
+      budget: SearchBudget): Map[String, Seq[Path]] = {
+    val found = mutable.Map(requiredLibraries.map(_ -> Array.newBuilder[Path]): _*)
+    directories.sortBy(_.toString).foreach { directory =>
+      val stream = Files.newDirectoryStream(directory)
+      try {
+        val iterator = stream.iterator()
+        while (iterator.hasNext) {
+          val path = iterator.next()
+          budget.recordVisit()
+          if (Files.isRegularFile(path)) {
+            val fileName = path.getFileName.toString
+            requiredLibraries.foreach { library =>
+              if (isCompatibleName(fileName, library)) found(library) += path
+            }
+          }
+        }
+      } catch {
+        case error: IllegalStateException => throw error
+        case NonFatal(error) =>
+          throw new IllegalStateException(
+            s"Failed to enumerate approved ONNX CUDA search directory ${directory.getFileName}",
+            error)
+      } finally stream.close()
+    }
+    found.map { case (library, builder) => library -> builder.result().toSeq }.toMap
+  }
+
+  private def collectGenericCandidates(
+      genericRoots: Seq[Path],
+      budget: SearchBudget): Map[String, Seq[Path]] = {
+    val found = mutable.Map(requiredLibraries.map(_ -> Array.newBuilder[Path]): _*)
+
+    genericRoots.sortBy(_.toString).foreach { root =>
+      Files.walkFileTree(
+        root,
+        java.util.EnumSet.noneOf(classOf[FileVisitOption]),
+        limits.maxDepth,
+        new SimpleFileVisitor[Path]() {
+          override def preVisitDirectory(
+              directory: Path,
+              attributes: BasicFileAttributes): FileVisitResult = {
+            budget.recordVisit()
+            if ((directory != root && Files.isSymbolicLink(directory)) || !Files.isReadable(
+                directory))
+              FileVisitResult.SKIP_SUBTREE
+            else FileVisitResult.CONTINUE
+          }
+
+          override def visitFile(file: Path, attributes: BasicFileAttributes): FileVisitResult = {
+            budget.recordVisit()
+            val isLoadableFile = attributes.isRegularFile ||
+              (attributes.isSymbolicLink && Files.isRegularFile(file))
+            if (isLoadableFile) {
+              val fileName = file.getFileName.toString
+              requiredLibraries.foreach { library =>
+                if (isCompatibleName(fileName, library))
+                  found(library) += file
+              }
+            }
+            FileVisitResult.CONTINUE
+          }
+
+          override def visitFileFailed(
+              file: Path,
+              error: java.io.IOException): FileVisitResult = {
+            budget.recordVisit()
+            FileVisitResult.CONTINUE
+          }
+        })
+    }
+
+    found.map { case (library, builder) => library -> builder.result().toSeq }.toMap
+  }
+
+  private def canonicalDirectories(
+      paths: Seq[Path],
+      sourceName: String,
+      budget: SearchBudget): Seq[Path] =
+    paths.flatMap { path =>
+      budget.recordVisit()
+      if (!path.isAbsolute)
+        throw new IllegalStateException(
+          s"ONNX CUDA $sourceName search directory must be absolute: ${path.getFileName}")
+      try Some(canonicalDirectory(path, sourceName))
+      catch {
+        case _: NoSuchFileException => None
+        case _: AccessDeniedException => None
+        case NonFatal(_) => None
+      }
+    }.distinct
+
+  private def canonicalDirectory(path: Path, sourceName: String): Path = {
+    val canonical = path.toRealPath()
+    if (!Files.isDirectory(canonical) || !Files.isReadable(canonical))
+      throw new IllegalStateException(s"Unreadable ONNX CUDA $sourceName directory")
+    canonical
+  }
+
+  private def validateCandidate(
+      path: Path,
+      library: String,
+      approvedRoots: Seq[Path] = Seq.empty): Path = {
+    val suppliedName = Option(path.getFileName).map(_.toString).getOrElse("")
+    if (!isCompatibleName(suppliedName, library))
+      throw new IllegalStateException(
+        s"CUDA library order mismatch: expected $library but received $suppliedName")
+
+    val canonical =
+      try path.toRealPath()
+      catch {
+        case NonFatal(error) =>
+          throw new IllegalStateException(s"Required CUDA library $library is unavailable", error)
+      }
+
+    val canonicalName = canonical.getFileName.toString
+    if (!isCompatibleName(canonicalName, library))
+      throw new IllegalStateException(
+        s"Canonical CUDA target for $library has an unexpected filename: $canonicalName")
+    if (approvedRoots.nonEmpty && !approvedRoots.exists(canonical.startsWith))
+      throw new IllegalStateException(
+        s"Canonical CUDA target for $library resolves outside its approved search root")
+    if (!Files.isRegularFile(canonical) || !Files.isReadable(canonical))
+      throw new IllegalStateException(
+        s"Required CUDA library $library is not a readable regular file")
+    validateTrustedPath(canonical, library)
+    elfInspector.validate(canonical, library)
+    canonical
+  }
+
+  private def validateTrustedPath(path: Path, library: String): Unit = {
+    try {
+      var current: Path = path
+      var isLibrary = true
+      while (current != null) {
+        val attributes = securityPolicy.readAttributes(current)
+        val owner = Option(attributes.owner()).map(_.getName).getOrElse("")
+        if (!securityPolicy.trustedOwners.contains(owner))
+          throw new IllegalStateException(
+            s"Refusing CUDA library $library because ${current.getFileName} has an untrusted owner")
+
+        val permissions = attributes.permissions()
+        if (permissions.contains(PosixFilePermission.OTHERS_WRITE)) {
+          if (isLibrary)
+            throw new IllegalStateException(
+              s"Refusing world-writable CUDA library file for $library")
+          else
+            throw new IllegalStateException(
+              s"Refusing CUDA library $library because it has a world-writable directory (writable ancestor)")
+        }
+        if (permissions.contains(PosixFilePermission.GROUP_WRITE)) {
+          if (isLibrary)
+            throw new IllegalStateException(
+              s"Refusing group-writable CUDA library file for $library")
+          else
+            throw new IllegalStateException(
+              s"Refusing CUDA library $library because it has a group-writable directory (writable ancestor)")
+        }
+
+        isLibrary = false
+        current = current.getParent
+      }
+    } catch {
+      case error: IllegalStateException => throw error
+      case error: UnsupportedOperationException =>
+        throw new IllegalStateException(
+          s"POSIX ownership and permissions are required to validate CUDA library $library",
+          error)
+      case error: java.io.IOException =>
+        throw new IllegalStateException(
+          s"POSIX ownership and permissions are required to validate CUDA library $library",
+          error)
+      case NonFatal(error) =>
+        throw new IllegalStateException(
+          s"POSIX ownership and permissions are required to validate CUDA library $library",
+          error)
+    }
+  }
+
+  private def isCompatibleName(candidate: String, library: String): Boolean =
+    candidate == library || candidate.matches(
+      java.util.regex.Pattern.quote(library) + "(?:\\.[0-9]+)+")
+
+  private def safeMessage(error: Throwable): String =
+    Option(error.getMessage).getOrElse(error.getClass.getSimpleName).replaceAll("[\\r\\n]+", " ")
+}
+
+private[onnx] object NativeLibraryPreloader {
+
+  sealed trait Mode
+  case object Off extends Mode
+  case object Search extends Mode
+  case object Explicit extends Mode
+
+  final case class PreloadConfig(mode: Mode, paths: Seq[String])
+
+  object PreloadConfig {
+    def parse(modeValue: String, pathValue: String): PreloadConfig = {
+      val mode =
+        Option(modeValue).map(_.trim.toLowerCase).filter(_.nonEmpty).getOrElse("search") match {
+          case "off" => Off
+          case "search" => Search
+          case "explicit" => Explicit
+          case unsupported =>
+            throw new IllegalArgumentException(
+              s"Unsupported ONNX CUDA preload mode '$unsupported'; expected one of: off, search, explicit")
+        }
+      if (mode == Off) return PreloadConfig(Off, Seq.empty)
+
+      val paths = Option(pathValue)
+        .filter(_.nonEmpty)
+        .map { value =>
+          if (value.length > MaxConfiguredPathChars)
+            throw new IllegalArgumentException(
+              s"ONNX CUDA preload paths character limit $MaxConfiguredPathChars was exceeded")
+          val trimmed = value.trim
+          if (trimmed.isEmpty) Seq.empty
+          else {
+            val parsed = trimmed.split(
+              java.util.regex.Pattern.quote(File.pathSeparator),
+              SearchLimits.default.maxVisitedEntries + 1)
+            if (parsed.length > SearchLimits.default.maxVisitedEntries)
+              throw new IllegalArgumentException(
+                s"ONNX CUDA preload path count exceeds ${SearchLimits.default.maxVisitedEntries}")
+            parsed.toSeq
+          }
+        }
+        .getOrElse(Seq.empty)
+      PreloadConfig(mode, paths)
+    }
+  }
+
+  private[onnx] val MaxConfiguredPathChars = 1024 * 1024
+
+  final case class SearchLimits(maxDepth: Int, maxVisitedEntries: Int)
+  object SearchLimits {
+    val default: SearchLimits = SearchLimits(maxDepth = 6, maxVisitedEntries = 20000)
+  }
+
+  final class SearchBudget(maxVisitedEntries: Int) {
+    private var visitedEntries = 0
+
+    def recordVisit(): Unit = {
+      visitedEntries += 1
+      if (visitedEntries > maxVisitedEntries)
+        throw new IllegalStateException(
+          s"ONNX CUDA bounded search entry limit $maxVisitedEntries was exceeded")
+    }
+  }
+
+  final class ByteBudget(maxBytes: Long) {
+    private var consumedBytes = 0L
+
+    def recordByte(): Unit = {
+      consumedBytes += 1L
+      if (consumedBytes > maxBytes)
+        throw new IllegalStateException(
+          s"ONNX CUDA linker-config byte limit $maxBytes was exceeded")
+    }
+  }
+
+  final class CharacterBudget(maxCharacters: Int) {
+    private var consumedCharacters = 0L
+
+    def record(value: String): Unit = {
+      consumedCharacters += value.length.toLong
+      if (consumedCharacters > maxCharacters.toLong)
+        throw new IllegalStateException(
+          s"ONNX CUDA configured-path character limit $maxCharacters was exceeded")
+    }
+  }
+
+  final class SearchSources private (
+      runtimeProvider: () => Seq[Path],
+      linkerProvider: () => Seq[Path],
+      genericProvider: () => Seq[Path]) {
+    lazy val runtimeDirectories: Seq[Path] = runtimeProvider()
+    lazy val linkerDirectories: Seq[Path] = linkerProvider()
+    lazy val genericRoots: Seq[Path] = genericProvider()
+  }
+
+  object SearchSources {
+    def apply(
+        runtimeDirectories: Seq[Path],
+        linkerDirectories: Seq[Path],
+        genericRoots: Seq[Path]): SearchSources =
+      new SearchSources(() => runtimeDirectories, () => linkerDirectories, () => genericRoots)
+
+    def deferred(
+        runtimeDirectories: => Seq[Path],
+        linkerDirectories: => Seq[Path],
+        genericRoots: => Seq[Path]): SearchSources =
+      new SearchSources(() => runtimeDirectories, () => linkerDirectories, () => genericRoots)
+
+    val empty: SearchSources = SearchSources(Seq.empty, Seq.empty, Seq.empty)
+
+    def runtime(budget: SearchBudget, limits: SearchLimits): SearchSources = deferred(
+      runtimeDirectories = runtimeDerivedDirectories(budget),
+      linkerDirectories = linkerConfiguredDirectories(budget, limits),
+      genericRoots = Seq(Paths.get("/opt"), Paths.get("/usr/local")))
+  }
+
+  trait LibraryLoader {
+    def load(path: Path): Unit
+  }
+
+  trait ElfInspector {
+    def validate(path: Path, expectedSoname: String): Unit
+  }
+
+  object ElfInspector {
+    val accepting: ElfInspector = new ElfInspector {
+      override def validate(path: Path, expectedSoname: String): Unit = ()
+    }
+    val runtime: ElfInspector = ElfMetadataInspector
+  }
+
+  final case class SecurityPolicy(
+      trustedOwners: Set[String],
+      readAttributes: Path => PosixFileAttributes)
+
+  object SecurityPolicy {
+    lazy val runtime: SecurityPolicy = SecurityPolicy(
+      trustedOwners = Set(authenticatedProcessOwner(), "root"),
+      readAttributes = path => Files.readAttributes(path, classOf[PosixFileAttributes]))
+  }
+
+  private[onnx] def authenticatedProcessOwner(): String = {
+    val owner =
+      try
+        Files
+          .readAttributes(Paths.get("/proc/self"), classOf[PosixFileAttributes])
+          .owner()
+          .getName
+      catch {
+        case NonFatal(error) =>
+          throw new IllegalStateException(
+            "Unable to establish the authenticated POSIX executor identity",
+            error)
+      }
+    Option(owner).map(_.trim).filter(_.nonEmpty).getOrElse {
+      throw new IllegalStateException("Authenticated POSIX executor identity is empty")
+    }
+  }
+
+  private val dependencyManifest = "/onnx/cuda-provider-dependencies-1.23.0.txt"
+
+  lazy val packagedDependencies: Seq[String] = {
+    val stream = Option(getClass.getResourceAsStream(dependencyManifest)).getOrElse {
+      throw new IllegalStateException(
+        s"Packaged ONNX CUDA dependency manifest is missing: $dependencyManifest")
+    }
+    val source = Source.fromInputStream(stream, "UTF-8")
+    try {
+      val libraries = source
+        .getLines()
+        .map(_.trim)
+        .filter(line => line.nonEmpty && !line.startsWith("#"))
+        .toVector
+      if (libraries.isEmpty || libraries.distinct.size != libraries.size ||
+        libraries.exists(!_.matches("lib[A-Za-z0-9]+\\.so(?:\\.[0-9]+)+"))) {
+        throw new IllegalStateException(
+          s"Packaged ONNX CUDA dependency manifest is invalid: $dependencyManifest")
+      }
+      libraries
+    } finally source.close()
+  }
+
+  private lazy val executorPreloader = new NativeLibraryPreloader(
+    packagedDependencies,
+    budget => SearchSources.runtime(budget, SearchLimits.default),
+    SearchLimits.default,
+    new LibraryLoader {
+      override def load(path: Path): Unit = System.load(path.toString)
+    },
+    SecurityPolicy.runtime,
+    ElfInspector.runtime)
+
+  def preload(config: PreloadConfig): Unit = executorPreloader.preload(config)
+
+  private def runtimeDerivedDirectories(budget: SearchBudget): Seq[Path] = {
+    val characterBudget = new CharacterBudget(MaxConfiguredPathChars)
+    val directPathLists = parseRuntimePathLists(
+      Seq(
+        sys.env.get("LD_LIBRARY_PATH"),
+        Option(System.getProperty("java.library.path"))).flatten,
+      budget,
+      characterBudget)
+
+    val cudaRoots = Seq(sys.env.get("CUDA_HOME"), sys.env.get("CUDA_PATH")).flatten
+      .flatMap { root =>
+        characterBudget.record(root)
+        budget.recordVisit()
+        cudaRootDirectories(Paths.get(root), budget)
+      }
+    val condaDirectories = sys.env
+      .get("CONDA_PREFIX")
+      .map { root =>
+        characterBudget.record(root)
+        budget.recordVisit()
+        Paths.get(root, "lib")
+      }
+      .toSeq
+
+    (directPathLists ++ cudaRoots ++ condaDirectories).filter(_.isAbsolute).distinct
+  }
+
+  private[onnx] def parseRuntimePathLists(
+      pathLists: Seq[String],
+      limits: SearchLimits,
+      maxCharacters: Int): Seq[Path] =
+    parseRuntimePathLists(
+      pathLists,
+      new SearchBudget(limits.maxVisitedEntries),
+      new CharacterBudget(maxCharacters))
+
+  private def parseRuntimePathLists(
+      pathLists: Seq[String],
+      budget: SearchBudget,
+      characterBudget: CharacterBudget): Seq[Path] =
+    pathLists.flatMap { pathList =>
+      characterBudget.record(pathList)
+      val entries = pathList.split(
+        java.util.regex.Pattern.quote(File.pathSeparator),
+        SearchLimits.default.maxVisitedEntries + 1)
+      if (entries.length > SearchLimits.default.maxVisitedEntries)
+        throw new IllegalStateException(
+          s"ONNX CUDA runtime path count exceeds ${SearchLimits.default.maxVisitedEntries}")
+      entries.iterator
+        .map(_.trim)
+        .filter(_.nonEmpty)
+        .map { entry =>
+          budget.recordVisit()
+          Paths.get(entry)
+        }
+        .toSeq
+    }
+
+  private val MaxLdConfigBytes = 1024 * 1024L
+
+  private def linkerConfiguredDirectories(
+      budget: SearchBudget,
+      limits: SearchLimits): Seq[Path] = {
+    val configured = parseLdConfig(
+      Paths.get("/etc/ld.so.conf"),
+      Set.empty,
+      budget,
+      new ByteBudget(MaxLdConfigBytes),
+      depth = 0,
+      limits.maxDepth)
+    (configured ++ ldconfigDirectories(budget)).filter(_.isAbsolute).distinct
+  }
+
+  private[onnx] def linkerConfigDirectories(
+      rootConfig: Path,
+      maxBytes: Long,
+      limits: SearchLimits): Seq[Path] =
+    parseLdConfig(
+      rootConfig,
+      Set.empty,
+      new SearchBudget(limits.maxVisitedEntries),
+      new ByteBudget(maxBytes),
+      depth = 0,
+      limits.maxDepth)
+
+  private def parseLdConfig(
+      path: Path,
+      visited: Set[Path],
+      budget: SearchBudget,
+      byteBudget: ByteBudget,
+      depth: Int,
+      maxDepth: Int): Seq[Path] = {
+    if (depth > maxDepth)
+      throw new IllegalStateException(
+        s"ONNX CUDA linker-config depth limit $maxDepth was exceeded")
+    if (!Files.isRegularFile(path) || !Files.isReadable(path)) return Seq.empty
+    val canonical =
+      try path.toRealPath()
+      catch { case NonFatal(_) => return Seq.empty }
+    if (visited.contains(canonical)) return Seq.empty
+
+    readBoundedConfigLines(canonical, byteBudget).flatMap { rawLine =>
+      budget.recordVisit()
+      val line = rawLine.takeWhile(_ != '#').trim
+      if (line.isEmpty) Seq.empty
+      else if (line.startsWith("include ")) {
+        expandGlob(line.stripPrefix("include ").trim, budget)
+          .flatMap(parseLdConfig(_, visited + canonical, budget, byteBudget, depth + 1, maxDepth))
+      } else {
+        val directory = Paths.get(line)
+        if (directory.isAbsolute) Seq(directory) else Seq.empty
+      }
+    }
+  }
+
+  private def readBoundedConfigLines(path: Path, byteBudget: ByteBudget): Seq[String] = {
+    val input = Files.newInputStream(path)
+    try {
+      val lines = Vector.newBuilder[String]
+      val currentLine = new ByteArrayOutputStream()
+
+      def appendCurrentLine(): Unit = {
+        val bytes = currentLine.toByteArray
+        val length =
+          if (bytes.nonEmpty && bytes.last == '\r'.toByte) bytes.length - 1
+          else bytes.length
+        lines += new String(bytes, 0, length, StandardCharsets.UTF_8)
+        currentLine.reset()
+      }
+
+      var nextByte = input.read()
+      while (nextByte >= 0) {
+        byteBudget.recordByte()
+        if (nextByte == '\n'.toInt) appendCurrentLine()
+        else currentLine.write(nextByte)
+        nextByte = input.read()
+      }
+      if (currentLine.size() > 0) appendCurrentLine()
+      lines.result()
+    } finally input.close()
+  }
+
+  private def expandGlob(pattern: String, budget: SearchBudget): Seq[Path] = {
+    val path = Paths.get(pattern)
+    val parent = Option(path.getParent).getOrElse(Paths.get("."))
+    if (!parent.isAbsolute || !Files.isDirectory(parent)) return Seq.empty
+    val stream = Files.newDirectoryStream(parent, path.getFileName.toString)
+    try
+      stream
+        .iterator()
+        .asScala
+        .map { candidate =>
+          budget.recordVisit()
+          candidate
+        }
+        .toVector
+        .sortBy(_.toString)
+    catch {
+      case error: IllegalStateException => throw error
+      case NonFatal(_) => Seq.empty
+    } finally stream.close()
+  }
+
+  private def ldconfigDirectories(budget: SearchBudget): Seq[Path] = {
+    val executable =
+      firstExecutable(Seq(Paths.get("/sbin/ldconfig"), Paths.get("/usr/sbin/ldconfig")))
+        .getOrElse(return Seq.empty)
+    try
+      runBoundedProcess(
+        executable,
+        Seq("-p"),
+        timeoutMillis = 2000L,
+        maxOutputBytes = 1024 * 1024)
+        .flatMap { line =>
+          budget.recordVisit()
+          val separator = line.indexOf("=>")
+          if (separator < 0) None
+          else {
+            val libraryPath = Paths.get(line.substring(separator + 2).trim)
+            if (libraryPath.isAbsolute) Option(libraryPath.getParent) else None
+          }
+        }
+    catch {
+      case error: IllegalStateException => throw error
+      case NonFatal(_) => Seq.empty
+    }
+  }
+
+  private[onnx] def runBoundedProcess(
+      executable: Path,
+      arguments: Seq[String],
+      timeoutMillis: Long,
+      maxOutputBytes: Int): Seq[String] = {
+    if (!executable.isAbsolute || !Files.isRegularFile(executable) ||
+      !Files.isExecutable(executable))
+      throw new IllegalStateException(
+        "Bounded process executable must be an absolute executable file")
+    if (timeoutMillis <= 0 || maxOutputBytes <= 0)
+      throw new IllegalArgumentException("Bounded process limits must be positive")
+
+    val process = new ProcessBuilder((executable.toString +: arguments): _*)
+      .redirectErrorStream(true)
+      .start()
+    runBoundedProcess(process, timeoutMillis, maxOutputBytes)
+  }
+
+  private[onnx] def runBoundedProcess(
+      process: Process,
+      timeoutMillis: Long,
+      maxOutputBytes: Int): Seq[String] = {
+    if (timeoutMillis <= 0 || maxOutputBytes <= 0)
+      throw new IllegalArgumentException("Bounded process limits must be positive")
+
+    val output = new java.util.concurrent.atomic.AtomicReference[Seq[String]]()
+    val readFailure = new java.util.concurrent.atomic.AtomicReference[Throwable]()
+    val readerThread = new Thread(
+      new Runnable {
+        override def run(): Unit = {
+          val input = process.getInputStream
+          try {
+            val lines = Vector.newBuilder[String]
+            var consumedBytes = 0L
+            val currentLine = new ByteArrayOutputStream()
+
+            def appendCurrentLine(): Unit = {
+              val bytes = currentLine.toByteArray
+              val length =
+                if (bytes.nonEmpty && bytes.last == '\r'.toByte) bytes.length - 1
+                else bytes.length
+              lines += new String(bytes, 0, length, StandardCharsets.UTF_8)
+              currentLine.reset()
+            }
+
+            var nextByte = input.read()
+            while (nextByte >= 0) {
+              consumedBytes += 1L
+              if (consumedBytes > maxOutputBytes)
+                throw new IllegalStateException(
+                  s"Bounded process output exceeded $maxOutputBytes bytes")
+              if (nextByte == '\n'.toInt) appendCurrentLine()
+              else currentLine.write(nextByte)
+              nextByte = input.read()
+            }
+            if (currentLine.size() > 0) appendCurrentLine()
+            output.set(lines.result())
+          } catch {
+            case error: Throwable =>
+              readFailure.set(error)
+              process.destroyForcibly()
+          } finally input.close()
+        }
+      },
+      "onnx-cuda-ldconfig-reader")
+    readerThread.setDaemon(true)
+    readerThread.start()
+
+    var failure: Throwable = null
+    var result: Seq[String] = Seq.empty
+
+    def recordFailure(error: Throwable): Unit =
+      if (failure == null) failure = error else failure.addSuppressed(error)
+
+    try {
+      if (!process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)) {
+        process.destroyForcibly()
+        if (!process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS))
+          throw new IllegalStateException(
+            s"Bounded process did not terminate after forced destruction within $timeoutMillis milliseconds")
+        throw new IllegalStateException(
+          s"Bounded process exceeded timeout of $timeoutMillis milliseconds")
+      }
+      readerThread.join(timeoutMillis)
+      if (readerThread.isAlive) {
+        process.destroyForcibly()
+        if (!process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS))
+          throw new IllegalStateException(
+            s"Bounded process did not terminate after forced destruction within $timeoutMillis milliseconds")
+        throw new IllegalStateException("Bounded process output reader did not terminate")
+      }
+      Option(readFailure.get()).foreach(error => throw error)
+      if (process.exitValue() != 0)
+        throw new IllegalStateException(
+          s"Bounded process exited with status ${process.exitValue()}")
+      result = Option(output.get()).getOrElse(Seq.empty)
+    } catch {
+      case error: Throwable => recordFailure(error)
+    } finally {
+      if (process.isAlive) {
+        try process.destroyForcibly()
+        catch { case error: Throwable => recordFailure(error) }
+        try {
+          if (!process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS))
+            recordFailure(new IllegalStateException(
+              s"Bounded process did not terminate after forced destruction within $timeoutMillis milliseconds"))
+        } catch { case error: Throwable => recordFailure(error) }
+      }
+      Seq(process.getInputStream, process.getOutputStream, process.getErrorStream).foreach {
+        stream =>
+          try stream.close()
+          catch { case error: Throwable => recordFailure(error) }
+      }
+      try readerThread.join(timeoutMillis)
+      catch { case error: Throwable => recordFailure(error) }
+      if (readerThread.isAlive) {
+        readerThread.interrupt()
+        try readerThread.join(timeoutMillis)
+        catch { case error: Throwable => recordFailure(error) }
+        if (readerThread.isAlive)
+          recordFailure(
+            new IllegalStateException("Bounded process output reader did not terminate"))
+      }
+    }
+
+    if (failure != null) throw failure
+    result
+  }
+
+  private[onnx] def cudaRootDirectories(root: Path): Seq[Path] = {
+    val budget = new SearchBudget(SearchLimits.default.maxVisitedEntries)
+    cudaRootDirectories(root, budget)
+  }
+
+  private def cudaRootDirectories(root: Path, budget: SearchBudget): Seq[Path] = {
+    if (!root.isAbsolute) return Seq.empty
+    val targetRoot = root.resolve("targets")
+    val targetLibraries =
+      if (!Files.isDirectory(targetRoot) || !Files.isReadable(targetRoot)) Seq.empty
+      else {
+        val stream = Files.newDirectoryStream(targetRoot)
+        try
+          stream
+            .iterator()
+            .asScala
+            .map { path =>
+              budget.recordVisit()
+              path
+            }
+            .toVector
+            .sortBy(_.toString)
+            .map(_.resolve("lib"))
+        catch {
+          case error: IllegalStateException => throw error
+          case NonFatal(_) => Seq.empty
+        } finally stream.close()
+      }
+    root.resolve("lib64") +: targetLibraries
+  }
+
+  private[onnx] def firstExecutable(candidates: Seq[Path]): Option[Path] =
+    candidates.find(path =>
+      path.isAbsolute && Files.isRegularFile(path) && Files.isExecutable(path))
+}

--- a/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
@@ -82,7 +82,7 @@ object OnnxWrapper {
   private[OnnxWrapper] val logger: Logger = LoggerFactory.getLogger("OnnxWrapper")
 
   // TODO: make sure this.synchronized is needed or it's not a bottleneck
-  private def withSafeOnnxModelLoader(
+  private[onnx] def withSafeOnnxModelLoader(
       sessionOptions: Map[String, String],
       onnxModelPath: Option[String] = None): (OrtSession, OrtEnvironment) =
     this.synchronized {

--- a/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/onnx/OnnxWrapper.scala
@@ -22,7 +22,7 @@ import ai.onnxruntime.providers.OrtCUDAProviderOptions
 import ai.onnxruntime.{OrtEnvironment, OrtSession}
 import com.johnsnowlabs.ml.util.LoadExternalModel
 import com.johnsnowlabs.util.{ConfigHelper, FileHelper, ZipArchiveUtil}
-import org.apache.spark.SparkFiles
+import org.apache.spark.{SparkEnv, SparkFiles}
 import org.apache.spark.sql.SparkSession
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -86,18 +86,19 @@ object OnnxWrapper {
       sessionOptions: Map[String, String],
       onnxModelPath: Option[String] = None): (OrtSession, OrtEnvironment) =
     this.synchronized {
+      val modelPath = onnxModelPath.getOrElse {
+        throw new UnsupportedOperationException("onnxModelPath not defined")
+      }
       val env = OrtEnvironment.getEnvironment()
       val sessionOptionsObject = if (sessionOptions.isEmpty) {
         new SessionOptions()
       } else {
         mapToSessionOptionsObject(sessionOptions)
       }
-      if (onnxModelPath.isDefined) {
-        val session = env.createSession(onnxModelPath.get, sessionOptionsObject)
-        (session, env)
-      } else {
-        throw new UnsupportedOperationException("onnxModelPath not defined")
+      val session = withClosingResource(sessionOptionsObject) { options =>
+        env.createSession(modelPath, options)
       }
+      (session, env)
     }
 
   def read(
@@ -186,13 +187,85 @@ object OnnxWrapper {
     // TODO: add support for multiple GPUs
 
     val gpuDeviceId = sessionOptionsMap(ConfigHelper.onnxGpuDeviceId).toInt
-
-    val sessionOptions = new OrtSession.SessionOptions()
     logger.info(s"ONNX session option gpuDeviceId=$gpuDeviceId")
-    val cudaOpts = new OrtCUDAProviderOptions(gpuDeviceId)
-    sessionOptions.addCUDA(cudaOpts)
 
-    sessionOptions
+    // Runtime-only configuration is intentionally lazy: normal CUDA registration must happen
+    // before preload properties are parsed or any filesystem discovery begins.
+    lazy val preloadConfig = cudaPreloadConfig()
+    CudaProviderRecovery.configure(
+      preloadConfig.mode,
+      () => new OrtSession.SessionOptions(),
+      sessionOptions => addCUDAProvider(sessionOptions, gpuDeviceId),
+      () => NativeLibraryPreloader.preload(preloadConfig))
+  }
+
+  private def addCUDAProvider(sessionOptions: SessionOptions, gpuDeviceId: Int): Unit = {
+    withClosingResource(new OrtCUDAProviderOptions(gpuDeviceId)) { cudaOptions =>
+      sessionOptions.addCUDA(cudaOptions)
+    }
+  }
+
+  private[onnx] def withClosingResource[T <: AutoCloseable, R](resource: T)(
+      operation: T => R): R = {
+    var operationFailure: Throwable = null
+    var operationResult: R = null.asInstanceOf[R]
+    var operationCompleted = false
+    try {
+      operationResult = operation(resource)
+      operationCompleted = true
+      operationResult
+    } catch {
+      case error: Throwable =>
+        operationFailure = error
+        throw error
+    } finally {
+      try resource.close()
+      catch {
+        case closeFailure: Throwable =>
+          if (operationFailure != null) operationFailure.addSuppressed(closeFailure)
+          else {
+            if (operationCompleted)
+              operationResult match {
+                case resultResource: AutoCloseable
+                    if !(resultResource.asInstanceOf[AnyRef] eq resource.asInstanceOf[AnyRef]) =>
+                  try resultResource.close()
+                  catch {
+                    case resultCloseFailure: Throwable =>
+                      closeFailure.addSuppressed(resultCloseFailure)
+                  }
+                case _ =>
+              }
+            throw closeFailure
+          }
+      }
+    }
+  }
+
+  private[onnx] def withCloseOnFailure[T <: AutoCloseable, R](resource: T)(operation: T => R): R =
+    try operation(resource)
+    catch {
+      case operationFailure: Throwable =>
+        try resource.close()
+        catch { case closeFailure: Throwable => operationFailure.addSuppressed(closeFailure) }
+        throw operationFailure
+    }
+
+  private[onnx] def cudaPreloadConfig(): NativeLibraryPreloader.PreloadConfig = {
+    def runtimeValue(key: String): String =
+      SparkSession.getActiveSession
+        .orElse(SparkSession.getDefaultSession)
+        .flatMap(_.conf.getOption(key))
+        .orElse(Option(SparkEnv.get).flatMap(_.conf.getOption(key)))
+        .orElse(Option(System.getProperty(key)))
+        .orNull
+
+    val modeValue = runtimeValue(ConfigHelper.onnxCudaPreloadMode)
+    val modeOnly = NativeLibraryPreloader.PreloadConfig.parse(modeValue, null)
+    if (modeOnly.mode == NativeLibraryPreloader.Off) modeOnly
+    else
+      NativeLibraryPreloader.PreloadConfig.parse(
+        modeValue,
+        runtimeValue(ConfigHelper.onnxCudaPreloadPaths))
   }
 
   private def mapToCPUSessionConfig(sessionOptionsMap: Map[String, String]): SessionOptions = {
@@ -234,15 +307,15 @@ object OnnxWrapper {
     val optimizationLevel = getOptLevel(sessionOptionsMap(ConfigHelper.onnxOptimizationLevel))
     val executionMode = getExecutionMode(sessionOptionsMap(ConfigHelper.onnxExecutionMode))
 
-    val sessionOptions = new OrtSession.SessionOptions()
-    logger.info(s"ONNX session option intraOpNumThreads=$intraOpNumThreads")
-    sessionOptions.setIntraOpNumThreads(intraOpNumThreads)
-    logger.info(s"ONNX session option optimizationLevel=$optimizationLevel")
-    sessionOptions.setOptimizationLevel(optimizationLevel)
-    logger.info(s"ONNX session option executionMode=$executionMode")
-    sessionOptions.setExecutionMode(executionMode)
-
-    sessionOptions
+    withCloseOnFailure(new OrtSession.SessionOptions()) { sessionOptions =>
+      logger.info(s"ONNX session option intraOpNumThreads=$intraOpNumThreads")
+      sessionOptions.setIntraOpNumThreads(intraOpNumThreads)
+      logger.info(s"ONNX session option optimizationLevel=$optimizationLevel")
+      sessionOptions.setOptimizationLevel(optimizationLevel)
+      logger.info(s"ONNX session option executionMode=$executionMode")
+      sessionOptions.setExecutionMode(executionMode)
+      sessionOptions
+    }
   }
 
   case class EncoderDecoderWrappers(

--- a/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoWrapper.scala
+++ b/src/main/scala/com/johnsnowlabs/ml/openvino/OpenvinoWrapper.scala
@@ -87,15 +87,9 @@ object OpenvinoWrapper {
     "INFERENCE_NUM_THREADS" -> availableCores.toString * 2 // 2 threads per core
   )
 
-  val javaProps = new JHashMap[String, Object]()
+  val javaProps = new JHashMap[String, String]()
   properties.foreach { case (key, value) =>
-    val boxedValue: Object = value match {
-      case i: Int => i.asInstanceOf[AnyRef]
-      case b: Boolean => b.asInstanceOf[AnyRef]
-      case s: String => s.asInstanceOf[AnyRef]
-      case other => other.asInstanceOf[AnyRef]
-    }
-    javaProps.put(key, boxedValue)
+    javaProps.put(key, value.toString)
   }
   private val logger: Logger = LoggerFactory.getLogger(this.getClass.toString)
   private[OpenvinoWrapper] val core: Core =
@@ -111,7 +105,7 @@ object OpenvinoWrapper {
 
   try {
     // Set the OpenVINO properties
-    core.set_property_typed("CPU", javaProps)
+    core.set_property("CPU", javaProps)
   } catch {
     case e: Exception =>
       logger.warn("Failed to set CPU NUM_THREADS property, using default value.", e)

--- a/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
+++ b/src/main/scala/com/johnsnowlabs/util/ConfigHelper.scala
@@ -76,6 +76,8 @@ object ConfigHelper {
   val onnxIntraOpNumThreads = "spark.jsl.settings.onnx.intraOpNumThreads"
   val onnxOptimizationLevel = "spark.jsl.settings.onnx.optimizationLevel"
   val onnxExecutionMode = "spark.jsl.settings.onnx.executionMode"
+  val onnxCudaPreloadMode = "spark.jsl.settings.onnx.cuda.preload.mode"
+  val onnxCudaPreloadPaths = "spark.jsl.settings.onnx.cuda.preload.paths"
 
   def getConfigValueOrElse(property: String, defaultValue: String): String = {
     sparkSession.conf.get(property, defaultValue)

--- a/src/test/scala/com/johnsnowlabs/ml/onnx/ElfMetadataTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/onnx/ElfMetadataTestSpec.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.ml.onnx
+
+import com.johnsnowlabs.tags.FastTest
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.nio.{ByteBuffer, ByteOrder}
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+
+class ElfMetadataTestSpec extends AnyFlatSpec {
+
+  "ELF metadata validation" should "accept only the required DT_SONAME" taggedAs FastTest in {
+    val path = syntheticElf("libcudnn.so.9")
+    try {
+      NativeLibraryPreloader.ElfInspector.runtime.validate(path, "libcudnn.so.9")
+
+      val error = intercept[IllegalStateException] {
+        NativeLibraryPreloader.ElfInspector.runtime.validate(path, "libcudnn.so.90")
+      }
+      assert(error.getMessage.contains("DT_SONAME"))
+    } finally Files.deleteIfExists(path)
+  }
+
+  it should "reject non-ELF input" taggedAs FastTest in {
+    val path = secureTempFile()
+    Files.write(path, "not an ELF shared object".getBytes(StandardCharsets.UTF_8))
+    try {
+      val error = intercept[IllegalStateException] {
+        NativeLibraryPreloader.ElfInspector.runtime.validate(path, "libcudnn.so.9")
+      }
+      assert(error.getMessage.contains("ELF"))
+    } finally Files.deleteIfExists(path)
+  }
+
+  it should "reject a SONAME string table without a bounded DT_STRSZ" taggedAs FastTest in {
+    val path = syntheticElf("libcudnn.so.9", includeStringTableSize = false)
+    try {
+      val error = intercept[IllegalStateException] {
+        NativeLibraryPreloader.ElfInspector.runtime.validate(path, "libcudnn.so.9")
+      }
+      assert(error.getMessage.contains("DT_STRSZ"))
+    } finally Files.deleteIfExists(path)
+  }
+
+  it should "reject a SONAME extending beyond its file-backed PT_LOAD range" taggedAs FastTest in {
+    val path = syntheticElf("libcudnn.so.9", truncateLoadBeforeSonameEnd = true)
+    try {
+      val error = intercept[IllegalStateException] {
+        NativeLibraryPreloader.ElfInspector.runtime.validate(path, "libcudnn.so.9")
+      }
+      assert(error.getMessage.contains("PT_LOAD"))
+    } finally Files.deleteIfExists(path)
+  }
+
+  it should "reject a PT_DYNAMIC mapping that disagrees with its PT_LOAD mapping" taggedAs FastTest in {
+    val path = syntheticElf("libcudnn.so.9", inconsistentDynamicMapping = true)
+    try {
+      val error = intercept[IllegalStateException] {
+        NativeLibraryPreloader.ElfInspector.runtime.validate(path, "libcudnn.so.9")
+      }
+      assert(error.getMessage.contains("PT_DYNAMIC"))
+    } finally Files.deleteIfExists(path)
+  }
+
+  it should "reject ambiguously overlapping PT_LOAD mappings" taggedAs FastTest in {
+    val path = syntheticElf("libcudnn.so.9", overlappingLoadMapping = true)
+    try {
+      val error = intercept[IllegalStateException] {
+        ElfMetadataInspector.validate(path, "libcudnn.so.9")
+      }
+      assert(error.getMessage.contains("unique PT_LOAD mapping"))
+    } finally Files.deleteIfExists(path)
+  }
+
+  it should "reject a PT_LOAD overlap beginning inside the dynamic string table" taggedAs FastTest in {
+    val path = syntheticElf("libcudnn.so.9", partialStringTableOverlap = true)
+    try {
+      val error = intercept[IllegalStateException] {
+        ElfMetadataInspector.validate(path, "libcudnn.so.9")
+      }
+      assert(error.getMessage.contains("unique PT_LOAD mapping"))
+    } finally Files.deleteIfExists(path)
+  }
+
+  it should "reject overflowing virtual PT_LOAD ranges" taggedAs FastTest in {
+    val path = syntheticElf("libcudnn.so.9", overflowingLoadRange = true)
+    try {
+      val error = intercept[IllegalStateException] {
+        NativeLibraryPreloader.ElfInspector.runtime.validate(path, "libcudnn.so.9")
+      }
+      assert(error.getMessage.contains("overflow"))
+    } finally Files.deleteIfExists(path)
+  }
+
+  private def syntheticElf(
+      soname: String,
+      includeStringTableSize: Boolean = true,
+      truncateLoadBeforeSonameEnd: Boolean = false,
+      inconsistentDynamicMapping: Boolean = false,
+      overlappingLoadMapping: Boolean = false,
+      partialStringTableOverlap: Boolean = false,
+      overflowingLoadRange: Boolean = false): Path = {
+    val dynamicOffset = 256
+    val stringOffset = 336
+    val stringBytes = ("\u0000" + soname + "\u0000").getBytes(StandardCharsets.UTF_8)
+    val totalSize = stringOffset + stringBytes.length
+    val baseAddress = 0x400000L
+    val buffer = ByteBuffer.allocate(totalSize).order(ByteOrder.LITTLE_ENDIAN)
+
+    buffer.put(0x7f.toByte).put('E'.toByte).put('L'.toByte).put('F'.toByte)
+    buffer.put(2.toByte).put(1.toByte).put(1.toByte)
+    while (buffer.position() < 16) buffer.put(0.toByte)
+    buffer.putShort(3.toShort)
+    buffer.putShort(expectedMachine)
+    buffer.putInt(1)
+    buffer.putLong(0L)
+    buffer.putLong(64L)
+    buffer.putLong(0L)
+    buffer.putInt(0)
+    buffer.putShort(64.toShort)
+    buffer.putShort(56.toShort)
+    val extraLoadCount =
+      Seq(overlappingLoadMapping, partialStringTableOverlap, overflowingLoadRange).count(identity)
+    buffer.putShort((2 + extraLoadCount).toShort)
+    buffer.putShort(0.toShort).putShort(0.toShort).putShort(0.toShort)
+
+    buffer.position(64)
+    val loadFileSize = if (truncateLoadBeforeSonameEnd) stringOffset + 2 else totalSize
+    putProgramHeader(buffer, 1, 0, baseAddress, loadFileSize, 0x1000L)
+    val dynamicSize = if (includeStringTableSize) 64 else 48
+    val dynamicAddress = baseAddress + dynamicOffset + (if (inconsistentDynamicMapping) 16 else 0)
+    putProgramHeader(buffer, 2, dynamicOffset, dynamicAddress, dynamicSize, 8L)
+    if (overlappingLoadMapping)
+      putProgramHeader(buffer, 1, 16, baseAddress, totalSize - 16, 0x1000L)
+    if (partialStringTableOverlap)
+      putProgramHeader(
+        buffer,
+        1,
+        0,
+        baseAddress + stringOffset + 2L,
+        stringBytes.length - 2,
+        0x1000L)
+    if (overflowingLoadRange)
+      putProgramHeader(buffer, 1, 0, Long.MaxValue - 8L, totalSize, 0x1000L)
+
+    buffer.position(dynamicOffset)
+    buffer.putLong(5L).putLong(baseAddress + stringOffset)
+    if (includeStringTableSize) buffer.putLong(10L).putLong(stringBytes.length.toLong)
+    buffer.putLong(14L).putLong(1L)
+    buffer.putLong(0L).putLong(0L)
+    buffer.position(stringOffset)
+    buffer.put(stringBytes)
+
+    val path = secureTempFile()
+    Files.write(path, buffer.array())
+    path
+  }
+
+  private def putProgramHeader(
+      buffer: ByteBuffer,
+      segmentType: Int,
+      fileOffset: Int,
+      virtualAddress: Long,
+      size: Int,
+      alignment: Long): Unit = {
+    buffer.putInt(segmentType)
+    buffer.putInt(4)
+    buffer.putLong(fileOffset.toLong)
+    buffer.putLong(virtualAddress)
+    buffer.putLong(virtualAddress)
+    buffer.putLong(size.toLong)
+    buffer.putLong(size.toLong)
+    buffer.putLong(alignment)
+  }
+
+  private def expectedMachine: Short =
+    System.getProperty("os.arch").toLowerCase match {
+      case "amd64" | "x86_64" => 62.toShort
+      case "aarch64" | "arm64" => 183.toShort
+      case other => throw new IllegalStateException(s"Unsupported test architecture: $other")
+    }
+
+  private def secureTempFile(): Path = {
+    val root = Paths.get(System.getProperty("user.home"), ".cache", "spark-nlp-tests")
+    Files.createDirectories(root)
+    Files.createTempFile(root, "synthetic-elf-", ".so")
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/ml/onnx/NativeLibraryPreloaderTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/onnx/NativeLibraryPreloaderTestSpec.scala
@@ -23,7 +23,14 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, File, InputStream, OutputStream}
 import java.nio.file.{Files, Path, Paths}
-import java.nio.file.attribute.{PosixFileAttributes, PosixFilePermissions}
+import java.nio.file.attribute.{
+  FileTime,
+  GroupPrincipal,
+  PosixFileAttributes,
+  PosixFilePermission,
+  PosixFilePermissions,
+  UserPrincipal
+}
 import java.util.concurrent.TimeUnit
 import scala.collection.mutable.ArrayBuffer
 
@@ -304,18 +311,99 @@ class NativeLibraryPreloaderTestSpec extends AnyFlatSpec with BeforeAndAfterEach
     }
   }
 
-  it should "reject group-writable library files" taggedAs FastTest in {
+  it should "reject group-writable library files outside the authenticated owner/group pair" taggedAs FastTest in {
     val directory = tempDirectory()
     val paths = createLibrarySet(directory)
-    Files.setPosixFilePermissions(paths.head, PosixFilePermissions.fromString("rw-rw-r--"))
+    val groupWritableLibrary = paths.head.toRealPath()
+    val untrustedGroupPolicy = NativeLibraryPreloader.SecurityPolicy(
+      trustedOwners = Set("spark"),
+      readAttributes = path => {
+        val attributes = Files.readAttributes(path, classOf[PosixFileAttributes])
+        val permissions = java.util.EnumSet.copyOf(attributes.permissions())
+        if (path == groupWritableLibrary) permissions.add(PosixFilePermission.GROUP_WRITE)
+        val group = if (path == groupWritableLibrary) "shared" else "spark"
+        posixAttributes(attributes, "spark", group, permissions)
+      },
+      trustedGroupWritableOwnerGroups = Set("spark" -> "spark"))
 
     val error = intercept[IllegalStateException] {
-      testPreloader(ArrayBuffer.empty).preload(
+      testPreloader(ArrayBuffer.empty, securityPolicy = untrustedGroupPolicy).preload(
         NativeLibraryPreloader
           .PreloadConfig(NativeLibraryPreloader.Explicit, paths.map(_.toString)))
     }
 
     assert(error.getMessage.contains("group-writable"))
+  }
+
+  it should "accept a group-writable platform library whose trusted owner and group match" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val paths = createLibrarySet(directory)
+    val groupWritableLibrary = paths.head.toRealPath()
+    val loaded = ArrayBuffer.empty[Path]
+    val platformPolicy = NativeLibraryPreloader.SecurityPolicy(
+      trustedOwners = Set("spark"),
+      readAttributes = path => {
+        val attributes = Files.readAttributes(path, classOf[PosixFileAttributes])
+        val permissions = java.util.EnumSet.copyOf(attributes.permissions())
+        if (path == groupWritableLibrary) permissions.add(PosixFilePermission.GROUP_WRITE)
+        posixAttributes(attributes, "spark", "spark", permissions)
+      },
+      trustedGroupWritableOwnerGroups = Set("spark" -> "spark"))
+
+    testPreloader(loaded, securityPolicy = platformPolicy).preload(
+      NativeLibraryPreloader
+        .PreloadConfig(NativeLibraryPreloader.Explicit, paths.map(_.toString)))
+
+    assert(loaded == paths.map(_.toRealPath()))
+  }
+
+  it should "reject a world-writable library even when its trusted owner and group match" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val paths = createLibrarySet(directory)
+    val writableLibrary = paths.head.toRealPath()
+    val platformPolicy = NativeLibraryPreloader.SecurityPolicy(
+      trustedOwners = Set("spark"),
+      readAttributes = path => {
+        val attributes = Files.readAttributes(path, classOf[PosixFileAttributes])
+        val permissions = java.util.EnumSet.copyOf(attributes.permissions())
+        if (path == writableLibrary) {
+          permissions.add(PosixFilePermission.GROUP_WRITE)
+          permissions.add(PosixFilePermission.OTHERS_WRITE)
+        }
+        posixAttributes(attributes, "spark", "spark", permissions)
+      },
+      trustedGroupWritableOwnerGroups = Set("spark" -> "spark"))
+
+    val error = intercept[IllegalStateException] {
+      testPreloader(ArrayBuffer.empty, securityPolicy = platformPolicy).preload(
+        NativeLibraryPreloader
+          .PreloadConfig(NativeLibraryPreloader.Explicit, paths.map(_.toString)))
+    }
+
+    assert(error.getMessage.contains("world-writable CUDA library file"))
+  }
+
+  it should "reject a group-writable root library when only the executor pair is allowed" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val paths = createLibrarySet(directory)
+    val groupWritableLibrary = paths.head.toRealPath()
+    val platformPolicy = NativeLibraryPreloader.SecurityPolicy(
+      trustedOwners = Set("spark", "root"),
+      readAttributes = path => {
+        val attributes = Files.readAttributes(path, classOf[PosixFileAttributes])
+        val permissions = java.util.EnumSet.copyOf(attributes.permissions())
+        if (path == groupWritableLibrary) permissions.add(PosixFilePermission.GROUP_WRITE)
+        posixAttributes(attributes, "root", "root", permissions)
+      },
+      trustedGroupWritableOwnerGroups = Set("spark" -> "spark"))
+
+    val error = intercept[IllegalStateException] {
+      testPreloader(ArrayBuffer.empty, securityPolicy = platformPolicy).preload(
+        NativeLibraryPreloader
+          .PreloadConfig(NativeLibraryPreloader.Explicit, paths.map(_.toString)))
+    }
+
+    assert(error.getMessage.contains("group-writable CUDA library file"))
   }
 
   it should "reject a library whose owner is outside the trusted-owner policy" taggedAs FastTest in {
@@ -334,14 +422,18 @@ class NativeLibraryPreloaderTestSpec extends AnyFlatSpec with BeforeAndAfterEach
     assert(error.getMessage.contains("untrusted owner"))
   }
 
-  it should "derive the trusted executor owner from the authenticated process identity" taggedAs FastTest in {
+  it should "derive the trusted executor owner and writable group from the authenticated process identity" taggedAs FastTest in {
     val originalUserName = Option(System.getProperty("user.name"))
     val actualOwner = currentOwner(Paths.get("/proc/self"))
+    val actualGroup = currentGroup(Paths.get("/proc/self"))
 
     try {
       System.setProperty("user.name", "attacker-selected-owner")
       assert(NativeLibraryPreloader.authenticatedProcessOwner() == actualOwner)
       assert(NativeLibraryPreloader.authenticatedProcessOwner() != "attacker-selected-owner")
+      assert(
+        NativeLibraryPreloader.SecurityPolicy.runtime.trustedGroupWritableOwnerGroups ==
+          Set(actualOwner -> actualGroup))
     } finally
       originalUserName.fold(System.clearProperty("user.name"))(System.setProperty("user.name", _))
   }
@@ -868,6 +960,33 @@ class NativeLibraryPreloaderTestSpec extends AnyFlatSpec with BeforeAndAfterEach
 
   private def currentOwner(path: Path): String =
     Files.readAttributes(path, classOf[PosixFileAttributes]).owner().getName
+
+  private def currentGroup(path: Path): String =
+    Files.readAttributes(path, classOf[PosixFileAttributes]).group().getName
+
+  private def posixAttributes(
+      delegate: PosixFileAttributes,
+      ownerName: String,
+      groupName: String,
+      filePermissions: java.util.Set[PosixFilePermission]): PosixFileAttributes =
+    new PosixFileAttributes {
+      override def owner(): UserPrincipal = new UserPrincipal {
+        override def getName: String = ownerName
+      }
+      override def group(): GroupPrincipal = new GroupPrincipal {
+        override def getName: String = groupName
+      }
+      override def permissions(): java.util.Set[PosixFilePermission] = filePermissions
+      override def lastModifiedTime(): FileTime = delegate.lastModifiedTime()
+      override def lastAccessTime(): FileTime = delegate.lastAccessTime()
+      override def creationTime(): FileTime = delegate.creationTime()
+      override def isRegularFile: Boolean = delegate.isRegularFile
+      override def isDirectory: Boolean = delegate.isDirectory
+      override def isSymbolicLink: Boolean = delegate.isSymbolicLink
+      override def isOther: Boolean = delegate.isOther
+      override def size(): Long = delegate.size()
+      override def fileKey(): AnyRef = delegate.fileKey()
+    }
 
   private def tempDirectory(): Path = {
     val testRoot = Paths.get(System.getProperty("user.home"), ".cache", "spark-nlp-tests")

--- a/src/test/scala/com/johnsnowlabs/ml/onnx/NativeLibraryPreloaderTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/onnx/NativeLibraryPreloaderTestSpec.scala
@@ -1,0 +1,939 @@
+/*
+ * Copyright 2017-2026 John Snow Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.johnsnowlabs.ml.onnx
+
+import ai.onnxruntime.OrtException
+import ai.onnxruntime.OrtException.OrtErrorCode
+import com.johnsnowlabs.tags.FastTest
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, File, InputStream, OutputStream}
+import java.nio.file.{Files, Path, Paths}
+import java.nio.file.attribute.{PosixFileAttributes, PosixFilePermissions}
+import java.util.concurrent.TimeUnit
+import scala.collection.mutable.ArrayBuffer
+
+class NativeLibraryPreloaderTestSpec extends AnyFlatSpec with BeforeAndAfterEach {
+
+  private val requiredLibraries = Seq(
+    "libcudart.so.12",
+    "libcublasLt.so.12",
+    "libcublas.so.12",
+    "libcurand.so.10",
+    "libcufft.so.11",
+    "libcudnn.so.9")
+
+  private val temporaryDirectories = ArrayBuffer.empty[Path]
+
+  override protected def afterEach(): Unit = {
+    temporaryDirectories.reverseIterator.foreach(deleteRecursively)
+    temporaryDirectories.clear()
+    super.afterEach()
+  }
+
+  "CUDA preload configuration" should "default to search with empty paths" taggedAs FastTest in {
+    val config = NativeLibraryPreloader.PreloadConfig.parse(null, null)
+
+    assert(config.mode == NativeLibraryPreloader.Search)
+    assert(config.paths.isEmpty)
+  }
+
+  it should "parse every supported mode and reject unknown modes" taggedAs FastTest in {
+    assert(
+      NativeLibraryPreloader.PreloadConfig.parse("off", "").mode == NativeLibraryPreloader.Off)
+    assert(
+      NativeLibraryPreloader.PreloadConfig.parse(" explicit ", "/tmp/a").mode ==
+        NativeLibraryPreloader.Explicit)
+
+    val error = intercept[IllegalArgumentException] {
+      NativeLibraryPreloader.PreloadConfig.parse("automatic", "")
+    }
+    assert(error.getMessage.contains("off, search, explicit"))
+  }
+
+  it should "ignore oversized paths in off mode and reject them in enabled modes" taggedAs FastTest in {
+    val oversized = "x" * (NativeLibraryPreloader.MaxConfiguredPathChars + 1)
+
+    assert(
+      NativeLibraryPreloader.PreloadConfig.parse("off", oversized) ==
+        NativeLibraryPreloader.PreloadConfig(NativeLibraryPreloader.Off, Seq.empty))
+    val error = intercept[IllegalArgumentException] {
+      NativeLibraryPreloader.PreloadConfig.parse("search", oversized)
+    }
+    assert(error.getMessage.contains("character limit"))
+  }
+
+  it should "aggregate runtime path-list entry and character budgets" taggedAs FastTest in {
+    val entryError = intercept[IllegalStateException] {
+      NativeLibraryPreloader.parseRuntimePathLists(
+        Seq("/one:/two", "/three"),
+        NativeLibraryPreloader.SearchLimits(maxDepth = 1, maxVisitedEntries = 2),
+        maxCharacters = 100)
+    }
+    assert(entryError.getMessage.contains("entry limit 2"))
+
+    val characterError = intercept[IllegalStateException] {
+      NativeLibraryPreloader.parseRuntimePathLists(
+        Seq("/one:/two", "/three"),
+        NativeLibraryPreloader.SearchLimits(maxDepth = 1, maxVisitedEntries = 10),
+        maxCharacters = 14)
+    }
+    assert(characterError.getMessage.contains("character limit 14"))
+  }
+
+  "packaged CUDA dependency manifest" should "match the ONNX Runtime 1.23 GPU provider order" taggedAs FastTest in {
+    assert(NativeLibraryPreloader.packagedDependencies == requiredLibraries)
+  }
+
+  "runtime CUDA source discovery" should "discover target libraries without platform-specific leaf names" taggedAs FastTest in {
+    val cudaRoot = tempDirectory()
+    val targetLib = Files.createDirectories(
+      cudaRoot.resolve("targets").resolve("custom-platform").resolve("lib"))
+
+    val directories = NativeLibraryPreloader.cudaRootDirectories(cudaRoot)
+
+    assert(directories.contains(cudaRoot.resolve("lib64")))
+    assert(directories.contains(targetLib))
+    assert(!directories.exists(_.toString.contains("x86_64-linux")))
+  }
+
+  it should "select ldconfig only from fixed executable candidates" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val notExecutable = createSecureFile(directory.resolve("ldconfig-disabled"))
+    val executable = createSecureFile(directory.resolve("ldconfig-enabled"))
+    Files.setPosixFilePermissions(executable, PosixFilePermissions.fromString("rwxr-xr-x"))
+
+    assert(
+      NativeLibraryPreloader.firstExecutable(Seq(notExecutable, executable)).contains(executable))
+  }
+
+  it should "drain bounded process output while the child is running" taggedAs FastTest in {
+    val script = tempDirectory().resolve("emit-many-lines")
+    Files.write(
+      script,
+      "#!/bin/sh\ni=0\nwhile [ $i -lt 5000 ]; do echo 'libx.so => /safe/libx.so'; i=$((i+1)); done\n"
+        .getBytes("UTF-8"))
+    Files.setPosixFilePermissions(script, PosixFilePermissions.fromString("rwx------"))
+
+    val lines = NativeLibraryPreloader.runBoundedProcess(
+      script,
+      Seq.empty,
+      timeoutMillis = 5000L,
+      maxOutputBytes = 256 * 1024)
+
+    assert(lines.size == 5000)
+  }
+
+  it should "stop an unterminated process line at the output byte limit" taggedAs FastTest in {
+    val script = tempDirectory().resolve("emit-unterminated-line")
+    Files.write(
+      script,
+      "#!/bin/sh\nhead -c 4096 /dev/zero | tr '\\000' x\nsleep 10\n".getBytes("UTF-8"))
+    Files.setPosixFilePermissions(script, PosixFilePermissions.fromString("rwx------"))
+
+    val error = intercept[IllegalStateException] {
+      NativeLibraryPreloader.runBoundedProcess(
+        script,
+        Seq.empty,
+        timeoutMillis = 5000L,
+        maxOutputBytes = 1024)
+    }
+
+    assert(error.getMessage.contains("output exceeded 1024 bytes"))
+  }
+
+  it should "fail when forced process termination cannot be confirmed" taggedAs FastTest in {
+    val process = new StubbornProcess
+
+    val error = intercept[IllegalStateException] {
+      NativeLibraryPreloader.runBoundedProcess(
+        process,
+        timeoutMillis = 10L,
+        maxOutputBytes = 1024)
+    }
+
+    assert(error.getMessage.contains("did not terminate"))
+    assert(process.destroyAttempted)
+  }
+
+  it should "enforce one aggregate byte limit across included linker configuration files" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val includes = Files.createDirectories(directory.resolve("conf.d"))
+    val firstBytes = (("#" * 80) + "\n/usr/lib\n").getBytes("UTF-8")
+    val secondBytes = (("#" * 80) + "\n/usr/local/lib\n").getBytes("UTF-8")
+    Files.write(includes.resolve("first.conf"), firstBytes)
+    Files.write(includes.resolve("second.conf"), secondBytes)
+    val rootLine = s"include ${includes.toAbsolutePath}/*.conf\n".getBytes("UTF-8")
+    val rootConfig = directory.resolve("ld.so.conf")
+    Files.write(rootConfig, rootLine)
+    val aggregateLimit = rootLine.length + firstBytes.length + secondBytes.length - 1
+
+    val error = intercept[IllegalStateException] {
+      NativeLibraryPreloader.linkerConfigDirectories(
+        rootConfig,
+        maxBytes = aggregateLimit,
+        NativeLibraryPreloader.SearchLimits(maxDepth = 3, maxVisitedEntries = 100))
+    }
+
+    assert(error.getMessage.contains(s"linker-config byte limit $aggregateLimit"))
+  }
+
+  "explicit CUDA preload" should "validate the complete ordered set before loading" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val paths = createLibrarySet(directory).updated(
+      requiredLibraries.size - 1,
+      directory.resolve("missing-libcudnn.so.9"))
+    val loaded = ArrayBuffer.empty[Path]
+    val preloader = testPreloader(loaded)
+
+    val error = intercept[IllegalStateException] {
+      preloader.preload(
+        NativeLibraryPreloader
+          .PreloadConfig(NativeLibraryPreloader.Explicit, paths.map(_.toString)))
+    }
+
+    assert(error.getMessage.contains("libcudnn.so.9"))
+    assert(loaded.isEmpty)
+  }
+
+  it should "canonicalize files and load them in manifest order only once" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val paths = createLibrarySet(directory)
+    val loaded = ArrayBuffer.empty[Path]
+    val preloader = testPreloader(loaded)
+    val config =
+      NativeLibraryPreloader.PreloadConfig(NativeLibraryPreloader.Explicit, paths.map(_.toString))
+
+    preloader.preload(config)
+    preloader.preload(config)
+
+    assert(loaded == paths.map(_.toRealPath()))
+  }
+
+  it should "avoid all search-source discovery in explicit mode" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val paths = createLibrarySet(directory)
+    var sourceReads = 0
+    val preloader = new NativeLibraryPreloader(
+      requiredLibraries,
+      _ => {
+        sourceReads += 1
+        NativeLibraryPreloader.SearchSources.empty
+      },
+      NativeLibraryPreloader.SearchLimits.default,
+      recordingLoader(ArrayBuffer.empty),
+      NativeLibraryPreloader.SecurityPolicy.runtime,
+      NativeLibraryPreloader.ElfInspector.accepting)
+
+    preloader.preload(
+      NativeLibraryPreloader
+        .PreloadConfig(NativeLibraryPreloader.Explicit, paths.map(_.toString)))
+
+    assert(sourceReads == 0)
+  }
+
+  it should "reject relative paths and incorrect library order" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val paths = createLibrarySet(directory)
+    val preloader = testPreloader(ArrayBuffer.empty)
+
+    val relativeError = intercept[IllegalStateException] {
+      preloader.preload(
+        NativeLibraryPreloader.PreloadConfig(
+          NativeLibraryPreloader.Explicit,
+          Seq("libcudart.so.12") ++ paths.drop(1).map(_.toString)))
+    }
+    assert(relativeError.getMessage.contains("must be absolute"))
+
+    val orderError = intercept[IllegalStateException] {
+      preloader.preload(
+        NativeLibraryPreloader.PreloadConfig(
+          NativeLibraryPreloader.Explicit,
+          Seq(paths(1), paths.head) ++ paths.drop(2) map (_.toString)))
+    }
+    assert(orderError.getMessage.contains("expected libcudart.so.12"))
+  }
+
+  it should "reject non-numeric compatible filename suffixes before loading" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val paths = createLibrarySet(directory)
+    Files.delete(paths.last)
+    val invalid = createSecureFile(directory.resolve("libcudnn.so.9.attacker"))
+    val loaded = ArrayBuffer.empty[Path]
+
+    val error = intercept[IllegalStateException] {
+      testPreloader(loaded).preload(
+        NativeLibraryPreloader.PreloadConfig(
+          NativeLibraryPreloader.Explicit,
+          paths.dropRight(1).map(_.toString) :+ invalid.toString))
+    }
+
+    assert(error.getMessage.contains("expected libcudnn.so.9"))
+    assert(loaded.isEmpty)
+  }
+
+  it should "reject libraries stored in a world-writable directory" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val paths = createLibrarySet(directory)
+    Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwxrwxrwx"))
+    val preloader = testPreloader(ArrayBuffer.empty)
+
+    try {
+      val error = intercept[IllegalStateException] {
+        preloader.preload(
+          NativeLibraryPreloader
+            .PreloadConfig(NativeLibraryPreloader.Explicit, paths.map(_.toString)))
+      }
+      assert(error.getMessage.contains("world-writable directory"))
+    } finally {
+      Files.setPosixFilePermissions(directory, PosixFilePermissions.fromString("rwx------"))
+    }
+  }
+
+  it should "reject group-writable library files" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val paths = createLibrarySet(directory)
+    Files.setPosixFilePermissions(paths.head, PosixFilePermissions.fromString("rw-rw-r--"))
+
+    val error = intercept[IllegalStateException] {
+      testPreloader(ArrayBuffer.empty).preload(
+        NativeLibraryPreloader
+          .PreloadConfig(NativeLibraryPreloader.Explicit, paths.map(_.toString)))
+    }
+
+    assert(error.getMessage.contains("group-writable"))
+  }
+
+  it should "reject a library whose owner is outside the trusted-owner policy" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val paths = createLibrarySet(directory)
+    val untrustedPolicy = NativeLibraryPreloader.SecurityPolicy(
+      trustedOwners = Set("owner-that-must-not-exist"),
+      readAttributes = path => Files.readAttributes(path, classOf[PosixFileAttributes]))
+
+    val error = intercept[IllegalStateException] {
+      testPreloader(ArrayBuffer.empty, securityPolicy = untrustedPolicy).preload(
+        NativeLibraryPreloader
+          .PreloadConfig(NativeLibraryPreloader.Explicit, paths.map(_.toString)))
+    }
+
+    assert(error.getMessage.contains("untrusted owner"))
+  }
+
+  it should "derive the trusted executor owner from the authenticated process identity" taggedAs FastTest in {
+    val originalUserName = Option(System.getProperty("user.name"))
+    val actualOwner = currentOwner(Paths.get("/proc/self"))
+
+    try {
+      System.setProperty("user.name", "attacker-selected-owner")
+      assert(NativeLibraryPreloader.authenticatedProcessOwner() == actualOwner)
+      assert(NativeLibraryPreloader.authenticatedProcessOwner() != "attacker-selected-owner")
+    } finally
+      originalUserName.fold(System.clearProperty("user.name"))(System.setProperty("user.name", _))
+  }
+
+  it should "reject replacement through a writable ancestor directory" taggedAs FastTest in {
+    val writableAncestor = tempDirectory()
+    val libraryDirectory =
+      Files.createDirectories(writableAncestor.resolve("secure").resolve("lib"))
+    val paths = createLibrarySet(libraryDirectory)
+    Files.setPosixFilePermissions(writableAncestor, PosixFilePermissions.fromString("rwxrwxr-x"))
+
+    try {
+      val error = intercept[IllegalStateException] {
+        testPreloader(ArrayBuffer.empty).preload(
+          NativeLibraryPreloader
+            .PreloadConfig(NativeLibraryPreloader.Explicit, paths.map(_.toString)))
+      }
+      assert(error.getMessage.contains("writable ancestor"))
+    } finally {
+      Files.setPosixFilePermissions(
+        writableAncestor,
+        PosixFilePermissions.fromString("rwx------"))
+    }
+  }
+
+  it should "fail closed when POSIX ownership attributes are unavailable" taggedAs FastTest in {
+    val directory = tempDirectory()
+    val paths = createLibrarySet(directory)
+    val unavailablePolicy = NativeLibraryPreloader.SecurityPolicy(
+      trustedOwners = Set(currentOwner(directory)),
+      readAttributes = _ => throw new UnsupportedOperationException("POSIX unavailable"))
+
+    val error = intercept[IllegalStateException] {
+      testPreloader(ArrayBuffer.empty, securityPolicy = unavailablePolicy).preload(
+        NativeLibraryPreloader
+          .PreloadConfig(NativeLibraryPreloader.Explicit, paths.map(_.toString)))
+    }
+
+    assert(error.getMessage.contains("POSIX ownership and permissions are required"))
+  }
+
+  "search CUDA preload" should "prefer operator directories and exact SONAME links" taggedAs FastTest in {
+    val operatorDirectory = tempDirectory()
+    val runtimeDirectory = tempDirectory()
+    val operatorPaths = createLibrarySet(operatorDirectory)
+    createLibrarySet(runtimeDirectory, versionSuffix = ".99")
+    val loaded = ArrayBuffer.empty[Path]
+    val sources = NativeLibraryPreloader.SearchSources(
+      runtimeDirectories = Seq(runtimeDirectory),
+      linkerDirectories = Seq.empty,
+      genericRoots = Seq.empty)
+    val preloader = testPreloader(loaded, sources)
+
+    preloader.preload(
+      NativeLibraryPreloader
+        .PreloadConfig(NativeLibraryPreloader.Search, Seq(operatorDirectory.toString)))
+
+    assert(loaded == operatorPaths.map(_.toRealPath()))
+  }
+
+  it should "reject an operator SONAME symlink escaping its approved directory" taggedAs FastTest in {
+    val operatorDirectory = tempDirectory()
+    val outsideDirectory = tempDirectory()
+    val outsideTarget = createSecureFile(outsideDirectory.resolve("libcudart.so.12.1"))
+    Files.createSymbolicLink(operatorDirectory.resolve("libcudart.so.12"), outsideTarget)
+    requiredLibraries
+      .drop(1)
+      .foreach(library => createSecureFile(operatorDirectory.resolve(library)))
+
+    val error = intercept[IllegalStateException] {
+      testPreloader(ArrayBuffer.empty).preload(
+        NativeLibraryPreloader
+          .PreloadConfig(NativeLibraryPreloader.Search, Seq(operatorDirectory.toString)))
+    }
+
+    assert(error.getMessage.contains("outside its approved search root"))
+  }
+
+  it should "not traverse generic roots when operator paths resolve the complete set" taggedAs FastTest in {
+    val operatorDirectory = tempDirectory()
+    val genericRoot = tempDirectory()
+    createLibrarySet(operatorDirectory)
+    (1 to 4).foreach(index => Files.createDirectory(genericRoot.resolve(s"directory-$index")))
+    val loaded = ArrayBuffer.empty[Path]
+    val preloader = testPreloader(
+      loaded,
+      NativeLibraryPreloader.SearchSources(
+        runtimeDirectories = Seq.empty,
+        linkerDirectories = Seq.empty,
+        genericRoots = Seq(genericRoot)),
+      NativeLibraryPreloader.SearchLimits(
+        maxDepth = 3,
+        maxVisitedEntries = requiredLibraries.size + 1))
+
+    preloader.preload(
+      NativeLibraryPreloader
+        .PreloadConfig(NativeLibraryPreloader.Search, Seq(operatorDirectory.toString)))
+
+    assert(loaded.size == requiredLibraries.size)
+  }
+
+  it should "not enumerate lower-priority tiers when operator paths resolve the complete set" taggedAs FastTest in {
+    val operatorDirectory = tempDirectory()
+    val runtimeDirectory = tempDirectory()
+    createLibrarySet(operatorDirectory)
+    (1 to 10).foreach(index => createSecureFile(runtimeDirectory.resolve(s"unrelated-$index.so")))
+    val loaded = ArrayBuffer.empty[Path]
+    val preloader = testPreloader(
+      loaded,
+      NativeLibraryPreloader.SearchSources(
+        runtimeDirectories = Seq(runtimeDirectory),
+        linkerDirectories = Seq.empty,
+        genericRoots = Seq.empty),
+      NativeLibraryPreloader.SearchLimits(
+        maxDepth = 3,
+        maxVisitedEntries = requiredLibraries.size + 1))
+
+    preloader.preload(
+      NativeLibraryPreloader
+        .PreloadConfig(NativeLibraryPreloader.Search, Seq(operatorDirectory.toString)))
+
+    assert(loaded.size == requiredLibraries.size)
+  }
+
+  it should "defer linker and generic discovery when runtime paths resolve the complete set" taggedAs FastTest in {
+    val runtimeDirectory = tempDirectory()
+    createLibrarySet(runtimeDirectory)
+    val loaded = ArrayBuffer.empty[Path]
+    var linkerReads = 0
+    var genericReads = 0
+    val sources = NativeLibraryPreloader.SearchSources.deferred(
+      runtimeDirectories = Seq(runtimeDirectory),
+      linkerDirectories = {
+        linkerReads += 1
+        Seq(tempDirectory())
+      },
+      genericRoots = {
+        genericReads += 1
+        Seq(tempDirectory())
+      })
+    val preloader = testPreloader(loaded, sources)
+
+    preloader.preload(
+      NativeLibraryPreloader.PreloadConfig(NativeLibraryPreloader.Search, Seq.empty))
+
+    assert(loaded.size == requiredLibraries.size)
+    assert(linkerReads == 0)
+    assert(genericReads == 0)
+  }
+
+  it should "charge configured search directories to the shared work budget" taggedAs FastTest in {
+    val directories = Seq(tempDirectory(), tempDirectory(), tempDirectory())
+    val preloader = testPreloader(
+      ArrayBuffer.empty,
+      NativeLibraryPreloader.SearchSources.empty,
+      NativeLibraryPreloader.SearchLimits(maxDepth = 3, maxVisitedEntries = 2))
+
+    val error = intercept[IllegalStateException] {
+      preloader.preload(
+        NativeLibraryPreloader
+          .PreloadConfig(NativeLibraryPreloader.Search, directories.map(_.toString)))
+    }
+
+    assert(error.getMessage.contains("entry limit 2"))
+  }
+
+  it should "fail closed when a source tier has ambiguous compatible files" taggedAs FastTest in {
+    val runtimeDirectory = tempDirectory()
+    requiredLibraries.foreach { library =>
+      if (library == "libcudart.so.12") {
+        createSecureFile(runtimeDirectory.resolve(library + ".1"))
+        createSecureFile(runtimeDirectory.resolve(library + ".2"))
+      } else createSecureFile(runtimeDirectory.resolve(library))
+    }
+    val preloader = testPreloader(
+      ArrayBuffer.empty,
+      NativeLibraryPreloader.SearchSources(
+        runtimeDirectories = Seq(runtimeDirectory),
+        linkerDirectories = Seq.empty,
+        genericRoots = Seq.empty))
+
+    val error = intercept[IllegalStateException] {
+      preloader.preload(
+        NativeLibraryPreloader.PreloadConfig(NativeLibraryPreloader.Search, Seq.empty))
+    }
+
+    assert(error.getMessage.contains("Ambiguous CUDA library libcudart.so.12"))
+  }
+
+  it should "bound direct source-tier enumeration" taggedAs FastTest in {
+    val runtimeDirectory = tempDirectory()
+    createLibrarySet(runtimeDirectory)
+    (1 to 10).foreach(index => createSecureFile(runtimeDirectory.resolve(s"unrelated-$index.so")))
+    val preloader = testPreloader(
+      ArrayBuffer.empty,
+      NativeLibraryPreloader.SearchSources(
+        runtimeDirectories = Seq(runtimeDirectory),
+        linkerDirectories = Seq.empty,
+        genericRoots = Seq.empty),
+      NativeLibraryPreloader.SearchLimits(maxDepth = 3, maxVisitedEntries = 4))
+
+    val error = intercept[IllegalStateException] {
+      preloader.preload(
+        NativeLibraryPreloader.PreloadConfig(NativeLibraryPreloader.Search, Seq.empty))
+    }
+
+    assert(error.getMessage.contains("entry limit"))
+  }
+
+  it should "reject relative runtime-derived search directories" taggedAs FastTest in {
+    val preloader = testPreloader(
+      ArrayBuffer.empty,
+      NativeLibraryPreloader.SearchSources(
+        runtimeDirectories = Seq(Paths.get("relative-cuda-directory")),
+        linkerDirectories = Seq.empty,
+        genericRoots = Seq.empty))
+
+    val error = intercept[IllegalStateException] {
+      preloader.preload(
+        NativeLibraryPreloader.PreloadConfig(NativeLibraryPreloader.Search, Seq.empty))
+    }
+
+    assert(error.getMessage.contains("must be absolute"))
+  }
+
+  it should "prefer an exact SONAME file symlink during generic-root traversal" taggedAs FastTest in {
+    val root = tempDirectory()
+    val libraryDirectory = Files.createDirectory(root.resolve("cuda-libraries"))
+    Files.setPosixFilePermissions(libraryDirectory, PosixFilePermissions.fromString("rwxr-xr-x"))
+    val selectedTarget = createSecureFile(libraryDirectory.resolve("libcudart.so.12.1"))
+    createSecureFile(libraryDirectory.resolve("libcudart.so.12.2"))
+    Files.createSymbolicLink(libraryDirectory.resolve("libcudart.so.12"), selectedTarget)
+    requiredLibraries
+      .drop(1)
+      .foreach(library => createSecureFile(libraryDirectory.resolve(library)))
+    val loaded = ArrayBuffer.empty[Path]
+    val preloader = testPreloader(
+      loaded,
+      NativeLibraryPreloader.SearchSources(
+        runtimeDirectories = Seq.empty,
+        linkerDirectories = Seq.empty,
+        genericRoots = Seq(root)))
+
+    preloader.preload(
+      NativeLibraryPreloader.PreloadConfig(NativeLibraryPreloader.Search, Seq.empty))
+
+    assert(loaded.head == selectedTarget.toRealPath())
+  }
+
+  it should "not follow directory symlinks during bounded generic-root traversal" taggedAs FastTest in {
+    val root = tempDirectory()
+    val outside = tempDirectory()
+    createLibrarySet(outside)
+    Files.createSymbolicLink(root.resolve("linked-cuda"), outside)
+    val preloader = testPreloader(
+      ArrayBuffer.empty,
+      NativeLibraryPreloader.SearchSources(
+        runtimeDirectories = Seq.empty,
+        linkerDirectories = Seq.empty,
+        genericRoots = Seq(root)),
+      NativeLibraryPreloader.SearchLimits(maxDepth = 3, maxVisitedEntries = 100))
+
+    val error = intercept[IllegalStateException] {
+      preloader.preload(
+        NativeLibraryPreloader.PreloadConfig(NativeLibraryPreloader.Search, Seq.empty))
+    }
+
+    assert(error.getMessage.contains("libcudart.so.12"))
+  }
+
+  it should "stop when the generic-root entry budget is exhausted" taggedAs FastTest in {
+    val root = tempDirectory()
+    (1 to 4).foreach(index => Files.createDirectory(root.resolve(s"directory-$index")))
+    val preloader = testPreloader(
+      ArrayBuffer.empty,
+      NativeLibraryPreloader.SearchSources(
+        runtimeDirectories = Seq.empty,
+        linkerDirectories = Seq.empty,
+        genericRoots = Seq(root)),
+      NativeLibraryPreloader.SearchLimits(maxDepth = 3, maxVisitedEntries = 2))
+
+    val error = intercept[IllegalStateException] {
+      preloader.preload(
+        NativeLibraryPreloader.PreloadConfig(NativeLibraryPreloader.Search, Seq.empty))
+    }
+
+    assert(error.getMessage.contains("entry limit"))
+  }
+
+  "CUDA provider failure classification" should "accept only missing native dependencies of the CUDA provider" taggedAs FastTest in {
+    assert(CudaProviderRecovery.isRecoverable(recoverableOrtFailure()))
+    assert(
+      CudaProviderRecovery.isRecoverable(new OrtException(
+        OrtErrorCode.ORT_EP_FAIL,
+        "Failed to load library libonnxruntime_providers_cuda.so with error: libcudnn.so.9: cannot open shared object file")))
+
+    assert(!CudaProviderRecovery.isRecoverable(new RuntimeException(
+      "Failed to load library libonnxruntime_providers_cuda.so with error: libcudnn.so.9: cannot open shared object file")))
+    assert(
+      !CudaProviderRecovery.isRecoverable(new OrtException(
+        OrtErrorCode.ORT_INVALID_ARGUMENT,
+        "Failed to load library libonnxruntime_providers_cuda.so with error: libcudnn.so.9: cannot open shared object file")))
+    assert(
+      !CudaProviderRecovery.isRecoverable(
+        new OrtException(OrtErrorCode.ORT_FAIL, "Failed to find CUDA shared provider")))
+    assert(!CudaProviderRecovery.isRecoverable(new RuntimeException("CUDA out of memory")))
+    assert(!CudaProviderRecovery.isRecoverable(new RuntimeException("Invalid GPU device ID 4")))
+    assert(!CudaProviderRecovery.isRecoverable(new RuntimeException("Unsupported ONNX operator")))
+    assert(!CudaProviderRecovery.isRecoverable(recoverableOrtFailure("libcudnn.so.90")))
+    assert(!CudaProviderRecovery.isRecoverable(recoverableOrtFailure("libcudnn.so.9.attacker")))
+    assert(
+      !CudaProviderRecovery.isRecoverable(
+        recoverableOrtFailure(),
+        () => throw new IllegalStateException("manifest unavailable")))
+  }
+
+  "OnnxWrapper CUDA preload runtime configuration" should "use the documented defaults and system-property overrides" taggedAs FastTest in {
+    val modeKey = "spark.jsl.settings.onnx.cuda.preload.mode"
+    val pathsKey = "spark.jsl.settings.onnx.cuda.preload.paths"
+    val originalMode = Option(System.getProperty(modeKey))
+    val originalPaths = Option(System.getProperty(pathsKey))
+
+    try {
+      System.clearProperty(modeKey)
+      System.clearProperty(pathsKey)
+      assert(
+        OnnxWrapper.cudaPreloadConfig() == NativeLibraryPreloader
+          .PreloadConfig(NativeLibraryPreloader.Search, Seq.empty))
+
+      System.setProperty(modeKey, "explicit")
+      System.setProperty(pathsKey, Seq("/cuda/a", "/cuda/b").mkString(File.pathSeparator))
+      assert(
+        OnnxWrapper.cudaPreloadConfig() == NativeLibraryPreloader
+          .PreloadConfig(NativeLibraryPreloader.Explicit, Seq("/cuda/a", "/cuda/b")))
+    } finally {
+      originalMode.fold(System.clearProperty(modeKey))(System.setProperty(modeKey, _))
+      originalPaths.fold(System.clearProperty(pathsKey))(System.setProperty(pathsKey, _))
+    }
+  }
+
+  "CUDA provider recovery" should "leave the normal success path unchanged" taggedAs FastTest in {
+    val created = ArrayBuffer.empty[TestSessionOptions]
+    var configurationReads = 0
+    var recoveries = 0
+
+    val result = CudaProviderRecovery.configure(
+      {
+        configurationReads += 1
+        NativeLibraryPreloader.Search
+      },
+      () => newOptions(created),
+      (_: TestSessionOptions) => (),
+      () => recoveries += 1)
+
+    assert(result eq created.head)
+    assert(created.size == 1)
+    assert(configurationReads == 0)
+    assert(recoveries == 0)
+    assert(!created.head.closed)
+  }
+
+  it should "close failed options, preload, and retry once with fresh options" taggedAs FastTest in {
+    val created = ArrayBuffer.empty[TestSessionOptions]
+    var additions = 0
+    var recoveries = 0
+
+    val result = CudaProviderRecovery.configure(
+      NativeLibraryPreloader.Search,
+      () => newOptions(created),
+      (_: TestSessionOptions) => {
+        additions += 1
+        if (additions == 1) throw recoverableOrtFailure("libcublasLt.so.12")
+      },
+      () => recoveries += 1)
+
+    assert(created.size == 2)
+    assert(created.head.closed)
+    assert(result eq created(1))
+    assert(!created(1).closed)
+    assert(additions == 2)
+    assert(recoveries == 1)
+  }
+
+  it should "preserve the original failure in off mode without preloading or retrying" taggedAs FastTest in {
+    val created = ArrayBuffer.empty[TestSessionOptions]
+    val original = recoverableOrtFailure("libcublasLt.so.12")
+    var recoveries = 0
+
+    val thrown = intercept[OrtException] {
+      CudaProviderRecovery.configure(
+        NativeLibraryPreloader.Off,
+        () => newOptions(created),
+        (_: TestSessionOptions) => throw original,
+        () => recoveries += 1)
+    }
+
+    assert(thrown eq original)
+    assert(created.size == 1)
+    assert(created.head.closed)
+    assert(recoveries == 0)
+  }
+
+  it should "not recover an unrelated CUDA failure" taggedAs FastTest in {
+    val created = ArrayBuffer.empty[TestSessionOptions]
+    val original = new RuntimeException("CUDA out of memory")
+    var recoveries = 0
+
+    val thrown = intercept[RuntimeException] {
+      CudaProviderRecovery.configure(
+        NativeLibraryPreloader.Search,
+        () => newOptions(created),
+        (_: TestSessionOptions) => throw original,
+        () => recoveries += 1)
+    }
+
+    assert(thrown eq original)
+    assert(created.size == 1)
+    assert(created.head.closed)
+    assert(recoveries == 0)
+  }
+
+  it should "preserve provider diagnostics when failed options closing is interrupted" taggedAs FastTest in {
+    val created = ArrayBuffer.empty[TestSessionOptions]
+    val original = new RuntimeException("CUDA out of memory")
+    val closeFailure = new InterruptedException("close interrupted")
+
+    val thrown = intercept[RuntimeException] {
+      CudaProviderRecovery.configure(
+        NativeLibraryPreloader.Search,
+        () => newOptions(created, Some(closeFailure)),
+        (_: TestSessionOptions) => throw original,
+        () => ())
+    }
+
+    assert(thrown eq original)
+    assert(thrown.getSuppressed.toSeq.contains(closeFailure))
+    assert(created.head.closed)
+  }
+
+  it should "retain the original CUDA error when preloading fails" taggedAs FastTest in {
+    val created = ArrayBuffer.empty[TestSessionOptions]
+    val original = recoverableOrtFailure()
+    val preloadFailure = new IllegalStateException("CUDA dependency resolution failed")
+
+    val thrown = intercept[IllegalStateException] {
+      CudaProviderRecovery.configure(
+        NativeLibraryPreloader.Search,
+        () => newOptions(created),
+        (_: TestSessionOptions) => throw original,
+        () => throw preloadFailure)
+    }
+
+    assert(thrown eq preloadFailure)
+    assert(thrown.getSuppressed.contains(original))
+    assert(created.size == 1)
+    assert(created.head.closed)
+  }
+
+  it should "close retry options and fail instead of falling back when retry fails" taggedAs FastTest in {
+    val created = ArrayBuffer.empty[TestSessionOptions]
+    var additions = 0
+    var recoveries = 0
+
+    val retryFailure = intercept[RuntimeException] {
+      CudaProviderRecovery.configure(
+        NativeLibraryPreloader.Explicit,
+        () => newOptions(created),
+        (_: TestSessionOptions) => {
+          additions += 1
+          if (additions == 1) throw recoverableOrtFailure()
+          else throw new RuntimeException("CUDA provider retry failed")
+        },
+        () => recoveries += 1)
+    }
+
+    assert(retryFailure.getMessage == "CUDA provider retry failed")
+    assert(created.size == 2)
+    assert(created.forall(_.closed))
+    assert(additions == 2)
+    assert(recoveries == 1)
+  }
+
+  it should "preserve the original failure when retry options cannot be created" taggedAs FastTest in {
+    val created = ArrayBuffer.empty[TestSessionOptions]
+    val original = recoverableOrtFailure()
+    val creationFailure = new IllegalStateException("retry options construction failed")
+    var creations = 0
+
+    val thrown = intercept[IllegalStateException] {
+      CudaProviderRecovery.configure(
+        NativeLibraryPreloader.Search,
+        () => {
+          creations += 1
+          if (creations == 1) newOptions(created) else throw creationFailure
+        },
+        (_: TestSessionOptions) => throw original,
+        () => ())
+    }
+
+    assert(thrown eq creationFailure)
+    assert(thrown.getSuppressed.contains(original))
+    assert(created.size == 1)
+    assert(created.head.closed)
+  }
+
+  private def testPreloader(
+      loaded: ArrayBuffer[Path],
+      sources: NativeLibraryPreloader.SearchSources = NativeLibraryPreloader.SearchSources.empty,
+      limits: NativeLibraryPreloader.SearchLimits = NativeLibraryPreloader.SearchLimits.default,
+      securityPolicy: NativeLibraryPreloader.SecurityPolicy =
+        NativeLibraryPreloader.SecurityPolicy.runtime): NativeLibraryPreloader =
+    new NativeLibraryPreloader(
+      requiredLibraries,
+      _ => sources,
+      limits,
+      recordingLoader(loaded),
+      securityPolicy,
+      NativeLibraryPreloader.ElfInspector.accepting)
+
+  private def recordingLoader(loaded: ArrayBuffer[Path]): NativeLibraryPreloader.LibraryLoader =
+    new NativeLibraryPreloader.LibraryLoader {
+      override def load(path: Path): Unit = loaded += path
+    }
+
+  private def currentOwner(path: Path): String =
+    Files.readAttributes(path, classOf[PosixFileAttributes]).owner().getName
+
+  private def tempDirectory(): Path = {
+    val testRoot = Paths.get(System.getProperty("user.home"), ".cache", "spark-nlp-tests")
+    Files.createDirectories(testRoot)
+    Files.setPosixFilePermissions(testRoot, PosixFilePermissions.fromString("rwx------"))
+    val directory = Files.createTempDirectory(testRoot, "onnx-cuda-preload-test-")
+    temporaryDirectories += directory
+    directory
+  }
+
+  private def createSecureFile(path: Path): Path = {
+    val file = Files.createFile(path)
+    Files.setPosixFilePermissions(file, PosixFilePermissions.fromString("rw-r--r--"))
+    file
+  }
+
+  private def createLibrarySet(directory: Path, versionSuffix: String = ""): Seq[Path] =
+    requiredLibraries.map(library => createSecureFile(directory.resolve(library + versionSuffix)))
+
+  private def deleteRecursively(path: Path): Unit = {
+    if (Files.exists(path)) {
+      val stream = Files.walk(path)
+      try stream.sorted(java.util.Comparator.reverseOrder()).forEach(Files.deleteIfExists(_))
+      finally stream.close()
+    }
+  }
+
+  private def newOptions(
+      created: ArrayBuffer[TestSessionOptions],
+      closeFailure: Option[Throwable] = None): TestSessionOptions = {
+    val options = new TestSessionOptions(closeFailure)
+    created += options
+    options
+  }
+
+  private def recoverableOrtFailure(missingLibrary: String = "libcudnn.so.9"): OrtException =
+    new OrtException(
+      OrtErrorCode.ORT_FAIL,
+      s"Failed to load library libonnxruntime_providers_cuda.so with error: $missingLibrary: cannot open shared object file")
+
+  private final class StubbornProcess extends Process {
+    private val input = new ByteArrayInputStream(Array.emptyByteArray)
+    private val error = new ByteArrayInputStream(Array.emptyByteArray)
+    private val output = new ByteArrayOutputStream()
+    var destroyAttempted = false
+
+    override def getOutputStream: OutputStream = output
+    override def getInputStream: InputStream = input
+    override def getErrorStream: InputStream = error
+    override def waitFor(): Int = throw new InterruptedException("stubborn process")
+    override def waitFor(timeout: Long, unit: TimeUnit): Boolean = false
+    override def exitValue(): Int = throw new IllegalThreadStateException("still running")
+    override def destroy(): Unit = destroyAttempted = true
+    override def destroyForcibly(): Process = {
+      destroyAttempted = true
+      this
+    }
+    override def isAlive: Boolean = true
+  }
+
+  private final class TestSessionOptions(closeFailure: Option[Throwable] = None)
+      extends AutoCloseable {
+    var closed: Boolean = false
+    override def close(): Unit = {
+      closed = true
+      closeFailure.foreach(throw _)
+    }
+  }
+}

--- a/src/test/scala/com/johnsnowlabs/ml/onnx/OnnxWrapperTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/onnx/OnnxWrapperTestSpec.scala
@@ -86,4 +86,108 @@ class OnnxWrapperTestSpec extends AnyFlatSpec with BeforeAndAfter {
     assert(new File(tmpFolder, "modelFromTest.zip").exists())
   }
 
+  "ONNX CUDA preload configuration" should "prefer SparkSession runtime values" taggedAs FastTest in {
+    val modeKey = "spark.jsl.settings.onnx.cuda.preload.mode"
+    val pathsKey = "spark.jsl.settings.onnx.cuda.preload.paths"
+    val spark = ResourceHelper.spark
+    val originalMode = spark.conf.getOption(modeKey)
+    val originalPaths = spark.conf.getOption(pathsKey)
+    val originalSystemMode = Option(System.getProperty(modeKey))
+    val originalSystemPaths = Option(System.getProperty(pathsKey))
+
+    try {
+      System.setProperty(modeKey, "search")
+      System.setProperty(pathsKey, "/system/path")
+      spark.conf.set(modeKey, "explicit")
+      spark.conf.set(pathsKey, Seq("/runtime/a", "/runtime/b").mkString(File.pathSeparator))
+
+      assert(
+        OnnxWrapper.cudaPreloadConfig() == NativeLibraryPreloader
+          .PreloadConfig(NativeLibraryPreloader.Explicit, Seq("/runtime/a", "/runtime/b")))
+    } finally {
+      originalMode.fold(spark.conf.unset(modeKey))(spark.conf.set(modeKey, _))
+      originalPaths.fold(spark.conf.unset(pathsKey))(spark.conf.set(pathsKey, _))
+      originalSystemMode.fold(System.clearProperty(modeKey))(System.setProperty(modeKey, _))
+      originalSystemPaths.fold(System.clearProperty(pathsKey))(System.setProperty(pathsKey, _))
+    }
+  }
+
+  it should "ignore the paths setting when preload mode is off" taggedAs FastTest in {
+    val modeKey = "spark.jsl.settings.onnx.cuda.preload.mode"
+    val pathsKey = "spark.jsl.settings.onnx.cuda.preload.paths"
+    val spark = ResourceHelper.spark
+    val originalMode = spark.conf.getOption(modeKey)
+    val originalPaths = spark.conf.getOption(pathsKey)
+
+    try {
+      spark.conf.set(modeKey, "off")
+      spark.conf.set(pathsKey, Seq.fill(20001)("/irrelevant").mkString(File.pathSeparator))
+
+      assert(
+        OnnxWrapper.cudaPreloadConfig() == NativeLibraryPreloader
+          .PreloadConfig(NativeLibraryPreloader.Off, Seq.empty))
+    } finally {
+      originalMode.fold(spark.conf.unset(modeKey))(spark.conf.set(modeKey, _))
+      originalPaths.fold(spark.conf.unset(pathsKey))(spark.conf.set(pathsKey, _))
+    }
+  }
+
+  "ONNX option lifecycle" should "close options after a successful operation" taggedAs FastTest in {
+    val options = new RecordingCloseable()
+
+    val result = OnnxWrapper.withClosingResource(options)(_ => "created")
+
+    assert(result == "created")
+    assert(options.closed)
+  }
+
+  it should "preserve the operation failure when closing also fails" taggedAs FastTest in {
+    val operationFailure = new RuntimeException("provider registration failed")
+    val closeFailure = new RuntimeException("provider options close failed")
+    val options = new RecordingCloseable(Some(closeFailure))
+
+    val thrown = intercept[RuntimeException] {
+      OnnxWrapper.withClosingResource(options)(_ => throw operationFailure)
+    }
+
+    assert(thrown eq operationFailure)
+    assert(thrown.getSuppressed.toSeq.contains(closeFailure))
+    assert(options.closed)
+  }
+
+  it should "close a successful AutoCloseable result when options closing fails" taggedAs FastTest in {
+    val closeFailure = new RuntimeException("session options close failed")
+    val options = new RecordingCloseable(Some(closeFailure))
+    val session = new RecordingCloseable()
+
+    val thrown = intercept[RuntimeException] {
+      OnnxWrapper.withClosingResource(options)(_ => session)
+    }
+
+    assert(thrown eq closeFailure)
+    assert(options.closed)
+    assert(session.closed)
+  }
+
+  it should "close a partially configured option object without masking its failure" taggedAs FastTest in {
+    val options = new RecordingCloseable()
+    val configurationFailure = new InterruptedException("setter interrupted")
+
+    val thrown = intercept[InterruptedException] {
+      OnnxWrapper.withCloseOnFailure(options)(_ => throw configurationFailure)
+    }
+
+    assert(thrown eq configurationFailure)
+    assert(options.closed)
+  }
+
+  private class RecordingCloseable(closeFailure: Option[Throwable] = None) extends AutoCloseable {
+    var closed = false
+
+    override def close(): Unit = {
+      closed = true
+      closeFailure.foreach(throw _)
+    }
+  }
+
 }

--- a/src/test/scala/com/johnsnowlabs/ml/onnx/OnnxWrapperTestSpec.scala
+++ b/src/test/scala/com/johnsnowlabs/ml/onnx/OnnxWrapperTestSpec.scala
@@ -77,6 +77,17 @@ class OnnxWrapperTestSpec extends AnyFlatSpec with BeforeAndAfter {
     dummyOnnxWrapper.getSession(onnxSessionOptions)
   }
 
+  "the shared ONNX session loader" should "be reusable by wrappers in the ONNX package" taggedAs FastTest in {
+    val absoluteModelPath = Paths.get(modelPath).toAbsolutePath.toString
+    val (session, environment) =
+      OnnxWrapper.withSafeOnnxModelLoader(onnxSessionOptions, Some(absoluteModelPath))
+
+    try {
+      assert(session != null)
+      assert(environment != null)
+    } finally session.close()
+  }
+
   "a dummy onnx wrapper" should "saveToFile correctly" taggedAs FastTest in {
     ResourceHelper.spark.sparkContext.addFile(modelPath)
     val onnxFileName = Some(new File(modelPath).getName)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Adds a failure-first ONNX CUDA provider recovery path: validate and preload the required CUDA/cuDNN dependencies, then retry provider registration once with fresh options.
- Validates canonical paths, ownership, permissions, ELF metadata, and manifest order before any native load. The Dataproc-compatible exception permits a group-writable library only when its owner/group exactly matches the authenticated executor identity; world-writable files and writable ancestors still fail closed.
- Exposes the shared ONNX session loader and restores GPU OpenVINO build compatibility.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dataproc Serverless L4 can expose trusted platform CUDA libraries as executor-owned `0775` files. ONNX Runtime may fail to load its CUDA provider even though these dependencies are present. This change recovers only the classified missing-native-dependency case without broadening trust or falling back to CPU.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `NativeLibraryPreloaderTestSpec`: 47/47 passed; focused ONNX suites: 64/64 passed.
- Full Open Source suite: 1,406/1,406 passed across 314 suites.
- Built and verified the exact OS candidate artifacts and GPU assembly.
- Dataproc Serverless L4 candidate run exercised the recovery path: classified provider failure, six manifest-order preloads, one completion, one successful retry, and successful Healthcare inference.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
