### PR TITLE
Support forward-compatible Spark 4 Maven coordinate resolution

### DIFF
--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -111,7 +111,9 @@ The same Python wheel supports the declared Spark 3 and Spark 4 runtime lanes. `
 |---|---|
 | Spark 3.x | `spark-nlp_2.12` |
 | Spark 4.0.0 | `spark-nlp-spark400_2.13` |
-| Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2 | `spark-nlp_2.13` |
+| Later Spark 4.x releases | `spark-nlp_2.13` |
+
+Automatic selection accepts release versions in `major.minor.patch` format and does not imply that every Spark 4.x release has been validated.
 
 The selected hardware option is applied to the same lane. For example, `sparknlp.start(gpu=True)` selects the corresponding `spark-nlp-gpu` artifact. Only one of `gpu`, `apple_silicon`, or `aarch64` may be enabled.
 
@@ -132,7 +134,7 @@ spark = SparkSession.builder \
     .getOrCreate()
 ```
 
-The manual example above is for Spark 3.x. For Spark 4.0.0 use `spark-nlp-spark400_2.13`; for Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2 use `spark-nlp_2.13`.
+The manual example above is for Spark 3.x. For Spark 4.0.0 use `spark-nlp-spark400_2.13`; for later Spark 4.x releases use `spark-nlp_2.13`.
 
 If using local jars, you can use `spark.jars` instead for comma-delimited jar files. For cluster setups, of course,
 you'll have to put the jars in a reachable location for all driver and executor nodes.

--- a/python/docs/getting_started/index.rst
+++ b/python/docs/getting_started/index.rst
@@ -137,7 +137,10 @@ The same Python wheel supports the declared Spark 3 and Spark 4 lanes.
 
 * Spark 3.x to ``spark-nlp_2.12``
 * Spark 4.0.0 to ``spark-nlp-spark400_2.13``
-* Spark 4.0.1, 4.1.0, 4.1.1, and 4.1.2 to ``spark-nlp_2.13``
+* Later Spark 4.x releases to ``spark-nlp_2.13``
+
+Automatic selection accepts release versions in ``major.minor.patch`` format
+and does not imply that every Spark 4.x release has been validated.
 
 The ``gpu``, ``apple_silicon``, and ``aarch64`` options select the corresponding
 hardware artifact in the same runtime lane. Only one hardware option may be enabled.
@@ -164,4 +167,4 @@ you can manually start the SparkSession with:
 
 The manual example above is for Spark 3.x. Use
 ``spark-nlp-spark400_2.13`` for Spark 4.0.0 or ``spark-nlp_2.13`` for
-Spark 4.0.1, 4.1.0, 4.1.1, or 4.1.2.
+later Spark 4.x releases.

--- a/python/sparknlp/__init__.py
+++ b/python/sparknlp/__init__.py
@@ -138,7 +138,9 @@ def start(gpu=False,
     -----
     The Maven artifact is selected from the installed PySpark version. Spark 3.x
     uses Scala 2.12. Spark 4.0.0 uses the dedicated ``spark400`` Scala 2.13
-    artifact. Spark 4.0.1, 4.1.0, 4.1.1, and 4.1.2 use the default Scala 2.13 artifact.
+    artifact. Later Spark 4.x releases use the default Scala 2.13 artifact.
+    Automatic artifact selection does not imply that every release has been
+    validated. Only release versions in major.minor.patch format are accepted.
 
     Returns
     -------

--- a/python/sparknlp/_maven.py
+++ b/python/sparknlp/_maven.py
@@ -15,10 +15,6 @@
 import re
 
 
-SUPPORTED_FORWARD_SPARK4_VERSIONS = frozenset(
-    {"4.0.1", "4.1.0", "4.1.1", "4.1.2"}
-)
-
 _VARIANT_ARTIFACTS = {
     "cpu": "spark-nlp",
     "gpu": "spark-nlp-gpu",
@@ -64,7 +60,7 @@ def resolve_spark_nlp_coordinate(
     elif normalized_version == "4.0.0":
         scala_binary_version = "2.13"
         profile_suffix = "-spark400"
-    elif normalized_version in SUPPORTED_FORWARD_SPARK4_VERSIONS:
+    elif spark_major == 4:
         scala_binary_version = "2.13"
         profile_suffix = ""
     else:
@@ -76,11 +72,9 @@ def resolve_spark_nlp_coordinate(
 
 
 def _unsupported_pyspark_version(pyspark_version):
-    supported_spark4_versions = ", ".join(
-        ["4.0.0"] + sorted(SUPPORTED_FORWARD_SPARK4_VERSIONS)
-    )
     return ValueError(
         f"Unsupported PySpark version '{pyspark_version}'. "
-        "Spark NLP supports Spark 3.x with Scala 2.12 and the validated "
-        f"Spark 4 versions {supported_spark4_versions} with Scala 2.13."
+        "Automatic Maven coordinate resolution accepts release versions "
+        "in major.minor.patch format for Spark 3.x (Scala 2.12) "
+        "and Spark 4.x (Scala 2.13)."
     )

--- a/python/test/maven_coordinate_resolver_test.py
+++ b/python/test/maven_coordinate_resolver_test.py
@@ -119,6 +119,9 @@ def resolve_coordinate(*args, **kwargs):
         ("4.1.0", "spark-nlp_2.13"),
         ("4.1.1", "spark-nlp_2.13"),
         ("4.1.2", "spark-nlp_2.13"),
+        ("4.0.2", "spark-nlp_2.13"),
+        ("4.1.3", "spark-nlp_2.13"),
+        ("4.2.0", "spark-nlp_2.13"),
     ],
 )
 def test_resolves_cpu_artifact_from_pyspark_version(spark_version, expected_artifact):
@@ -177,10 +180,11 @@ def test_resolves_all_spark400_hardware_variants(variant_flags, expected_base_ar
         ({"aarch64": True}, "spark-nlp-aarch64"),
     ],
 )
+@pytest.mark.parametrize("spark_version", ["4.1.2", "4.0.2", "4.1.3", "4.2.0"])
 def test_resolves_all_forward_spark4_hardware_variants(
-    variant_flags, expected_base_artifact
+    spark_version, variant_flags, expected_base_artifact
 ):
-    coordinate = resolve_coordinate("4.1.2", SPARK_NLP_MAVEN_VERSION, **variant_flags)
+    coordinate = resolve_coordinate(spark_version, SPARK_NLP_MAVEN_VERSION, **variant_flags)
 
     assert coordinate == (
         f"com.johnsnowlabs.nlp:{expected_base_artifact}_2.13:"
@@ -191,9 +195,9 @@ def test_resolves_all_forward_spark4_hardware_variants(
 @pytest.mark.fast
 @pytest.mark.parametrize(
     "spark_version",
-    ["2.4.8", "4.0.2", "4.2.0", "5.0.0", "4.0.0.dev1", "invalid"],
+    ["2.4.8", "5.0.0", "4.0.0.dev1", "4.2.0rc1", "4.2.0-vendor", "invalid"],
 )
-def test_rejects_unsupported_or_unvalidated_pyspark_versions(spark_version):
+def test_rejects_unsupported_or_nonrelease_pyspark_versions(spark_version):
     with pytest.raises(ValueError, match="Unsupported PySpark version"):
         resolve_coordinate(spark_version, SPARK_NLP_MAVEN_VERSION)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update PySpark-to-Maven coordinate resolution so release-form Spark 4 versions are routed to the default Scala 2.13 Spark NLP artifact without requiring an allowlist entry for each patch or minor release.

Spark 4.0.0 continues to use the dedicated `spark-nlp-spark400_2.13` artifact. Other release-form Spark 4.x versions use `spark-nlp_2.13`, including CPU, GPU, Apple Silicon, and AArch64 variants. Spark 3.x continues to use the Scala 2.12 artifact, while Spark 5+, Spark 2.x, prerelease, vendor-suffixed, and otherwise invalid versions remain rejected.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous resolver accepted only a fixed set of Spark 4 versions, causing newer release-form versions such as 4.0.2, 4.1.3, and 4.2.0 to be rejected before coordinate selection. Removing the patch allowlist provides forward-compatible routing while avoiding a claim that every routed Spark release has been validated.

Related discussion: https://github.com/JohnSnowLabs/spark-nlp/pull/14802#discussion_r3942466862

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Python 3.11 isolated `uv` environments with the repository source loaded through `PYTHONPATH=python`:

- PySpark 3.5.6: **PASS** — 48 tests passed.
- PySpark 4.0.1: **PASS** — 48 tests passed.
- `python3 -m py_compile` for `_maven.py`, `__init__.py`, and the resolver test: **PASS**.
- `git diff --check`: **PASS**.

The tests cover Spark 3 routing, Spark 4.0.0 special-artifact routing, forward Spark 4 versions, all hardware coordinate variants, and rejection of unsupported or non-release version strings.

## Screenshots (if appropriate):
Not applicable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvements with no or little impact
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://sparknlp.org/contribute.html) page.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
